### PR TITLE
Remove TEST_RUNNER setting

### DIFF
--- a/app/config/settings/local.py
+++ b/app/config/settings/local.py
@@ -20,9 +20,6 @@ INTERNAL_IPS = [
 hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
 INTERNAL_IPS += [".".join(ip.split(".")[:-1] + ["1"]) for ip in ips]
 
-# https://docs.djangoproject.com/en/dev/ref/settings/#test-runner
-TEST_RUNNER = "django.test.runner.DiscoverRunner"
-
 # Email
 # EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 EMAIL_BACKEND = "django.core.mail.backends.filebased.EmailBackend"

--- a/app/config/settings/test.py
+++ b/app/config/settings/test.py
@@ -4,9 +4,6 @@ With these settings, tests run faster.
 
 from .base import *  # noqa
 
-# https://docs.djangoproject.com/en/dev/ref/settings/#test-runner
-TEST_RUNNER = "django.test.runner.DiscoverRunner"
-
 # CACHES
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#caches


### PR DESCRIPTION
This was only being set to the default: https://docs.djangoproject.com/en/4.1/ref/settings/#std:setting-TEST_RUNNER