### PR TITLE
Upgrade Django actions to decorator syntax

### DIFF
--- a/app/store_project/products/admin.py
+++ b/app/store_project/products/admin.py
@@ -33,6 +33,9 @@ class ProgramAdmin(admin.ModelAdmin):
             kwargs["queryset"] = User.objects.filter(is_staff=True)
         return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
+    @admin.action(
+        description="Mark selected programs as public"
+    )
     def make_public(self, request, queryset):
         updated = queryset.update(status=Program.PUBLIC)
         self.message_user(
@@ -45,6 +48,9 @@ class ProgramAdmin(admin.ModelAdmin):
             messages.SUCCESS,
         )
 
+    @admin.action(
+        description="Mark selected programs as draft"
+    )
     def make_draft(self, request, queryset):
         updated = queryset.update(status=Program.DRAFT)
         self.message_user(
@@ -57,6 +63,9 @@ class ProgramAdmin(admin.ModelAdmin):
             messages.SUCCESS,
         )
 
+    @admin.action(
+        description="Mark selected programs as private"
+    )
     def make_private(self, request, queryset):
         updated = queryset.update(status=Program.PRIVATE)
         self.message_user(
@@ -69,9 +78,6 @@ class ProgramAdmin(admin.ModelAdmin):
             messages.SUCCESS,
         )
 
-    make_public.short_description = "Mark selected programs as public"
-    make_draft.short_description = "Mark selected programs as draft"
-    make_private.short_description = "Mark selected programs as private"
 
 
 @admin.register(Book)
@@ -99,6 +105,9 @@ class BookAdmin(admin.ModelAdmin):
             kwargs["queryset"] = User.objects.filter(is_staff=True)
         return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
+    @admin.action(
+        description="Mark selected books as public"
+    )
     def make_public(self, request, queryset):
         updated = queryset.update(status=Book.PUBLIC)
         self.message_user(
@@ -111,6 +120,9 @@ class BookAdmin(admin.ModelAdmin):
             messages.SUCCESS,
         )
 
+    @admin.action(
+        description="Mark selected books as draft"
+    )
     def make_draft(self, request, queryset):
         updated = queryset.update(status=Book.DRAFT)
         self.message_user(
@@ -123,6 +135,9 @@ class BookAdmin(admin.ModelAdmin):
             messages.SUCCESS,
         )
 
+    @admin.action(
+        description="Mark selected books as private"
+    )
     def make_private(self, request, queryset):
         updated = queryset.update(status=Book.PRIVATE)
         self.message_user(
@@ -135,9 +150,6 @@ class BookAdmin(admin.ModelAdmin):
             messages.SUCCESS,
         )
 
-    make_public.short_description = "Mark selected books as public"
-    make_draft.short_description = "Mark selected books as draft"
-    make_private.short_description = "Mark selected books as private"
 
 
 @admin.register(Category)


### PR DESCRIPTION
Done by running django-upgrade with:

```
git ls-files '*.py' | xargs django-upgrade --target-version 3.2
```

The only changes came from the `@admin.action` fixer: https://github.com/adamchainz/django-upgrade#adminaction