### PR TITLE
Remove sys.path hack

### DIFF
--- a/app/manage.py
+++ b/app/manage.py
@@ -2,7 +2,6 @@
 """Django's command-line utility for administrative tasks."""
 import os
 import sys
-from pathlib import Path
 
 
 def main():
@@ -16,11 +15,6 @@ def main():
             "available on your PYTHONPATH environment variable? Did you "
             "forget to activate a virtual environment?"
         ) from exc
-
-    # This allows easy placement of apps within the interior
-    # store_project/ directory.
-    current_path = Path(__file__).parent.resolve()
-    sys.path.append(str(current_path / "store_project"))
 
     execute_from_command_line(sys.argv)
 


### PR DESCRIPTION
This change is not a good idea, as it makes modules importable *twice* at two different locations, like ``store_project.users`` and ``users``. Python would treat both as different modules, with different classes, functions, etc., which could lead to confusion.

Since you haven’t got the same hack in your ``wsgi.py`` file or your pytest setup, I don’t think you’re actually relying on it.