### PR TITLE
Used REDIS_URL instead of REDIS_TLS_URL for cache

### DIFF
--- a/app/config/settings/base.py
+++ b/app/config/settings/base.py
@@ -275,10 +275,7 @@ DEFAULT_CACHE_TIMEOUT = 604800  # one week
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.redis.RedisCache",
-        "LOCATION": os.environ.get("REDIS_TLS_URL", "redis://localhost:6379/0"),
-        "OPTIONS": {
-            "ssl_cert_reqs": ssl.CERT_NONE,
-        },
+        "LOCATION": os.environ.get("REDIS_URL", "redis://localhost:6379/0"),
     }
 }
 

--- a/app/config/settings/base.py
+++ b/app/config/settings/base.py
@@ -1,4 +1,5 @@
 import os
+import ssl
 import sys
 from pathlib import Path
 
@@ -273,10 +274,10 @@ DEFAULT_CACHE_TIMEOUT = 604800  # one week
 
 CACHES = {
     "default": {
-        "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": os.environ.get("REDIS_URL", "redis://localhost:6379/0"),
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
+        "LOCATION": os.environ.get("REDIS_TLS_URL", "redis://localhost:6379/0"),
         "OPTIONS": {
-            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "ssl_cert_reqs": ssl.CERT_NONE,
         },
     }
 }

--- a/requirements.in
+++ b/requirements.in
@@ -9,7 +9,6 @@ django-browser-reload
 django-cors-headers
 django-debug-toolbar
 django-lifecycle
-django-redis
 django-clearcache
 django-embed-video
 django-markdownx
@@ -19,6 +18,7 @@ django-storages[s3]
 factory_boy
 flake8-isort
 gunicorn
+hiredis
 ipython
 ipdb
 Markdown
@@ -29,6 +29,7 @@ pytest
 pytest-sugar
 pytest-django
 python-dotenv
+redis
 sentry-sdk
 scout-apm
 stripe

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,7 +65,6 @@ django==5.1.2
     #   django-embed-video
     #   django-lifecycle
     #   django-markdownx
-    #   django-redis
     #   django-ses
     #   django-storages
 django-allauth==65.1.0
@@ -84,8 +83,6 @@ django-lifecycle==1.2.4
     # via -r requirements.in
 django-markdownx==4.0.7
     # via -r requirements.in
-django-redis==5.4.0
-    # via -r requirements.in
 django-ses==4.1.1
     # via -r requirements.in
 django-storages==1.14.4
@@ -103,6 +100,8 @@ flake8==7.1.1
 flake8-isort==6.1.1
     # via -r requirements.in
 gunicorn==23.0.0
+    # via -r requirements.in
+hiredis==3.0.0
     # via -r requirements.in
 idna==3.10
     # via requests
@@ -213,7 +212,7 @@ python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
     # via -r requirements.in
 redis==5.1.1
-    # via django-redis
+    # via -r requirements.in
 requests==2.32.3
     # via
     #   django-allauth


### PR DESCRIPTION
- **Update redis to use built-in Django support, remove django-redis (#137)**
- **change cache env var to REDIS_URL**
