### PR TITLE
Set local AWS defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,9 +33,10 @@ GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 
 # AWS credentials for S3
+# Optional for local development (defaults to dummy keys)
 # https://console.aws.amazon.com/iam/home?region=us-east-1#/security_credentials
-AWS_ACCESS_KEY_ID=
-AWS_SECRET_ACCESS_KEY=
+AWS_ACCESS_KEY_ID=local-access-key
+AWS_SECRET_ACCESS_KEY=local-secret-key
 
 # Google reCAPTCHA for forms
 # https://www.google.com/recaptcha/admin/create

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ python manage.py shell
 ### Environment Variables
 
 Be sure to include [Stripe test mode publishable and secret keys](https://stripe.com/docs/test-mode) in `.env.dev`.
+AWS credentials are optional when running locally because `settings/local.py` now sets
+`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to dummy values if they are not
+provided.
 
 ### Docker Compose
 

--- a/app/config/settings/local.py
+++ b/app/config/settings/local.py
@@ -1,6 +1,21 @@
+import os
 import socket
 
+# Set default AWS credentials for local development
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "local-access-key")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "local-secret-key")
+
 from .base import *  # noqa
+
+# Use the local filesystem instead of S3 for storage
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
+}
 
 # ALLOWED_HOSTS in .env.dev
 


### PR DESCRIPTION
## Summary
- default AWS creds in development settings
- note new optional AWS settings in `.env.example`
- update README about local AWS defaults

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest` *(fails: missing pytest-django)*

------
https://chatgpt.com/codex/tasks/task_b_687cffedad3c833189bf994419ca5b16