### PR TITLE
Add pre-commit to CI

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -52,6 +52,11 @@ jobs:
       - name: Install Python dependencies
         run: uv sync --all-extras
 
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --all-files --color=always
+
       - name: run system checks
         run: cd app && uv run python manage.py check --deploy
 

--- a/README.md
+++ b/README.md
@@ -187,3 +187,9 @@ To see coverage report:
 coverage run -m pytest
 coverage report -m
 ```
+
+### Pre-commit Hooks
+
+This project uses [pre-commit](https://pre-commit.com/) to run
+formatting and linting checks. The GitHub Actions workflow automatically
+executes these hooks on every pull request.


### PR DESCRIPTION
## Summary
- run pre-commit in GitHub Actions
- document pre-commit hooks in README

## Testing
- `pre-commit run --files README.md .github/workflows/django.yml` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest -k '' -v` *(fails: unrecognized arguments --ds=config.settings.test)*

------
https://chatgpt.com/codex/tasks/task_b_687d051561e08331b39da13d4e928ef3