### PR TITLE
Allow logout on GET request

### DIFF
--- a/app/config/settings/base.py
+++ b/app/config/settings/base.py
@@ -218,6 +218,7 @@ SITE_ID = 1
 AUTH_USER_MODEL = "users.User"
 LOGIN_URL = "/accounts/login/"
 ACCOUNT_LOGOUT_REDIRECT_URL = "/accounts/login/"
+ACCOUNT_LOGOUT_ON_GET = True
 LOGIN_REDIRECT_URL = "/users/profile/"
 
 ACCOUNT_USER_DISPLAY = "store_project.users.display.get_email"

--- a/app/store_project/users/tests/test_logout.py
+++ b/app/store_project/users/tests/test_logout.py
@@ -1,0 +1,19 @@
+import pytest
+from django.test import Client
+
+from store_project.users.models import User
+
+pytestmark = pytest.mark.django_db
+
+
+def test_logout_on_get():
+    User.objects.create_user(
+        username="logoutuser",
+        email="logout@example.com",
+        password="testpass123",
+    )
+    client = Client()
+    client.login(email="logout@example.com", password="testpass123")
+    response = client.get("/accounts/logout/")
+    assert response.status_code == 302
+    assert response.url == "/accounts/login/"


### PR DESCRIPTION
## Summary
- allow Django allauth logout via GET requests
- add a regression test ensuring the logout URL works with GET

## Testing
- `ruff format app/config/settings/base.py app/store_project/users/tests/test_logout.py`
- `ruff check app/config/settings/base.py app/store_project/users/tests/test_logout.py`
- `pytest app/store_project/users/tests/test_logout.py` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_687d351c047483319e637af21a0782fe