### PR TITLE
Add estimated completion time to challenges

### DIFF
--- a/app/store_project/challenges/models.py
+++ b/app/store_project/challenges/models.py
@@ -1,7 +1,8 @@
+import statistics
+
 from django.db import models
 from django.urls import reverse
 from taggit.managers import TaggableManager
-import statistics
 
 
 class DifficultyLevel(models.TextChoices):
@@ -58,16 +59,17 @@ class Challenge(models.Model):
     @property
     def estimated_completion_time(self):
         """Return the median completion time for all records of this challenge."""
-        time_scores = self.records.values_list('time_score', flat=True)
+        time_scores = self.records.values_list("time_score", flat=True)
         if not time_scores:
             return None
-        
+
         # Convert to total seconds for calculation
         time_seconds = [score.total_seconds() for score in time_scores]
         median_seconds = statistics.median(time_seconds)
-        
+
         # Round to nearest second and convert back to a timedelta
         from datetime import timedelta
+
         return timedelta(seconds=round(median_seconds))
 
 

--- a/app/store_project/challenges/models.py
+++ b/app/store_project/challenges/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.urls import reverse
 from taggit.managers import TaggableManager
+import statistics
 
 
 class DifficultyLevel(models.TextChoices):
@@ -53,6 +54,21 @@ class Challenge(models.Model):
             DifficultyLevel.ADVANCED: "danger",
         }
         return mapping.get(self.difficulty_level, "info")
+
+    @property
+    def estimated_completion_time(self):
+        """Return the median completion time for all records of this challenge."""
+        time_scores = self.records.values_list('time_score', flat=True)
+        if not time_scores:
+            return None
+        
+        # Convert to total seconds for calculation
+        time_seconds = [score.total_seconds() for score in time_scores]
+        median_seconds = statistics.median(time_seconds)
+        
+        # Round to nearest second and convert back to a timedelta
+        from datetime import timedelta
+        return timedelta(seconds=round(median_seconds))
 
 
 class Record(models.Model):

--- a/app/store_project/challenges/templatetags/duration_filters.py
+++ b/app/store_project/challenges/templatetags/duration_filters.py
@@ -1,5 +1,6 @@
-from django import template
 from datetime import timedelta
+
+from django import template
 
 register = template.Library()
 

--- a/app/store_project/challenges/templatetags/duration_filters.py
+++ b/app/store_project/challenges/templatetags/duration_filters.py
@@ -1,0 +1,27 @@
+from django import template
+from datetime import timedelta
+
+register = template.Library()
+
+
+@register.filter
+def duration_humanize(value):
+    """Convert a timedelta object to a human-readable format like '21m 7s'."""
+    if not isinstance(value, timedelta):
+        return value
+
+    total_seconds = int(value.total_seconds())
+
+    seconds = total_seconds % 60
+
+    parts = []
+    if hours := total_seconds // 3600:
+        parts.append(f"{hours}h")
+    if minutes := (total_seconds % 3600) // 60:
+        parts.append(f"{minutes}m")
+    if (
+        seconds or not parts
+    ):  # Show seconds if it's the only unit or if there are remaining seconds
+        parts.append(f"{seconds}s")
+
+    return " ".join(parts)

--- a/app/store_project/templates/challenges/challenge_detail.html
+++ b/app/store_project/templates/challenges/challenge_detail.html
@@ -1,5 +1,6 @@
 {% extends '_base.html' %}
 {% load static %}
+{% load duration_filters %}
 
 {% block head_title %}{{ challenge.name }}{% endblock head_title %}
 
@@ -31,6 +32,19 @@
           <h1 class="margin-0">{{ challenge.name }}</h1>
           <span class="difficulty-indicator difficulty-{{ challenge.difficulty_level }}" title="{{ challenge.get_difficulty_level_display }}">&#x25cf;</span>
         </div>
+
+        {% with estimated_time=challenge.estimated_completion_time %}
+          {% if estimated_time %}
+            <div style="background: var(--color-light); padding: var(--s-1); border-radius: var(--border-radius); margin-bottom: var(--s0);">
+              <div style="font-weight: bold; color: var(--color-dark);">
+                Estimated completion time: {{ estimated_time|duration_humanize }}
+              </div>
+              <div style="font-size: var(--s-1); color: var(--color-gray);">
+                Based on median of {{ challenge.records.count }} record{{ challenge.records.count|pluralize }}
+              </div>
+            </div>
+          {% endif %}
+        {% endwith %}
 
         <div class="box">
           <div class="stack">

--- a/app/store_project/templates/challenges/challenge_filtered_list.html
+++ b/app/store_project/templates/challenges/challenge_filtered_list.html
@@ -1,5 +1,6 @@
 {% extends '_base.html' %}
 {% load crispy_forms_tags %}
+{% load duration_filters %}
 
 {% block head_title %}Challenges{% endblock head_title %}
 
@@ -97,9 +98,12 @@
                     {% endif %}
 
                     <div style="font-size: var(--s-1); color: var(--color-gray);">
-                      {% with record_count=challenge.records.count %}
+                      {% with record_count=challenge.records.count estimated_time=challenge.estimated_completion_time %}
                         {% if record_count %}
                           {{ record_count }} record{{ record_count|pluralize }}
+                          {% if estimated_time %}
+                            • Est. {{ estimated_time|duration_humanize }}
+                          {% endif %}
                         {% else %}
                           No records yet
                         {% endif %}


### PR DESCRIPTION
- Introduce a new property `estimated_completion_time` in the Challenge model to calculate the median completion time based on records.
- Update challenge detail and filtered list templates to display the estimated completion time, enhancing user experience with additional challenge insights.
- Utilize custom duration filters for better formatting of the estimated time display.
