### PR TITLE
[records] Allow anonymous users to view challenge detail page, messages template refactoring

### DIFF
--- a/app/store_project/challenges/tests.py
+++ b/app/store_project/challenges/tests.py
@@ -238,7 +238,8 @@ class ChallengeTests(TestCase):
     def test_challenge_detail_view_for_logged_out_user(self):
         self.client.logout()
         response = self.client.get(self.challenge.get_absolute_url())
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "/accounts/login/")
 
     def test_challenge_detail_view_record_create_form(self):
         # make sure logged in user can submit record
@@ -697,12 +698,12 @@ class ChallengeURLLoadingTests(TestCase):
         self.assertContains(response, "Test challenge description")
 
     def test_challenge_detail_url_redirects_for_unauthenticated_user(self):
-        """Test that challenge detail URL redirects unauthenticated users."""
+        """Unauthenticated users should still access detail page but see login form."""
         response = self.client.get(
             reverse("challenges:challenge_detail", kwargs={"slug": self.challenge.slug})
         )
-        self.assertEqual(response.status_code, 302)
-        self.assertIn("/accounts/login/", response.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "/accounts/login/")
 
     def test_challenge_create_url_loads_for_admin_user(self):
         """Test that challenge create URL loads for admin users with permissions."""

--- a/app/store_project/static/css/base.css
+++ b/app/store_project/static/css/base.css
@@ -1656,6 +1656,10 @@ ul.grid {
   background-color: var(--main-color-light-gray);
 }
 
+.messages {
+  margin-bottom: var(--s1);
+}
+
 .messages ul {
   list-style-type: none;
   padding: 0;

--- a/app/store_project/templates/_base.html
+++ b/app/store_project/templates/_base.html
@@ -41,15 +41,7 @@
       {% block layout %}
         {# Default: reading-width layout for content pages #}
         <div class="stack center">
-          {% if messages %}
-            <div class="center messages">
-              <ul>
-                {% for message in messages %}
-                  <li class="box {% if message.tags %}{{ message.tags }}{% endif %}">{{message}}</li>
-                {% endfor %}
-              </ul>
-            </div>
-          {% endif %}
+          {% include '_messages.html' %}
 
           {% block content %}
         <!-- No content available -->

--- a/app/store_project/templates/_base_full.html
+++ b/app/store_project/templates/_base_full.html
@@ -38,15 +38,7 @@
 
   <!-- THE CONTENT -->
     <main class="content">
-      {% if messages %}
-        <div class="center messages">
-          <ul>
-            {% for message in messages %}
-              <li class="box {% if message.tags %}{{ message.tags }}{% endif %}">{{message}}</li>
-            {% endfor %}
-          </ul>
-        </div>
-      {% endif %}
+      {% include '_messages.html' %}
 
       {% block content %}
     <!-- No content available -->

--- a/app/store_project/templates/_base_wide.html
+++ b/app/store_project/templates/_base_wide.html
@@ -36,15 +36,7 @@
 <!-- THE CONTENT -->
     <main class="content">
       <div class="stack center max-width:measure*2">
-        {% if messages %}
-          <div class="center messages">
-            <ul>
-              {% for message in messages %}
-                <li class="box {% if message.tags %}{{ message.tags }}{% endif %}">{{message}}</li>
-              {% endfor %}
-            </ul>
-          </div>
-        {% endif %}
+        {% include '_messages.html' %}
 
         {% block content %}
     <!-- No content available -->

--- a/app/store_project/templates/_messages.html
+++ b/app/store_project/templates/_messages.html
@@ -1,0 +1,9 @@
+{% if messages %}
+  <div class="center messages">
+    <ul>
+      {% for message in messages %}
+        <li class="box {% if message.tags %}{{ message.tags }}{% endif %}">{{message}}</li>
+      {% endfor %}
+    </ul>
+  </div>
+{% endif %}

--- a/app/store_project/templates/account/snippets/login_box.html
+++ b/app/store_project/templates/account/snippets/login_box.html
@@ -1,0 +1,44 @@
+{% load i18n account socialaccount %}
+{% get_providers as socialaccount_providers %}
+<div class="stack">
+  <h3>{% trans "Login" %}</h3>
+  <p class="text-center">{% trans "No account? Then please "%}<a href="{% url 'account_signup' %}">{% trans "sign up" %}</a>.</p>
+  <a class="box login facebook" id="facebook" href="{% provider_login_url 'facebook' method='js_sdk' %}">
+    <h4>Login with Facebook</h4>
+  </a>
+  <a class="box login google" id="google" href="{% provider_login_url 'google' %}">
+    <h4>Sign in with Google</h4>
+  </a>
+  <div class="or-separator">
+    <div></div>
+    <i>or</i>
+    <div></div>
+  </div>
+  <div class="stack-auth-form">
+    <h4 class="text-center font-size:smallish">Sign in with email</h4>
+    <form class="login center" method="POST" action="{% url 'account_login' %}">
+      {% csrf_token %}
+      <div class="messages">
+        {{ login_form.non_field_errors }}
+      </div>
+      <p>
+        <label class="stack" for="{{ login_form.login.id_for_label }}">
+          <span>Email</span>
+          {{ login_form.login }}
+          {{ login_form.login.errors }}
+        </label>
+      </p>
+      <p>
+        <label class="stack" for="{{ login_form.password.id_for_label }}">
+          <span>Password</span>
+          {{ login_form.password }}
+          {{ login_form.password.errors }}
+        </label>
+      </p>
+      <input type="hidden" name="next" value="{{ request.get_full_path }}" />
+      <p>
+        <button class="primaryAction button" type="submit">{% trans "Sign In" %}</button>
+      </p>
+    </form>
+  </div>
+</div>

--- a/app/store_project/templates/account/snippets/login_box.html
+++ b/app/store_project/templates/account/snippets/login_box.html
@@ -3,9 +3,6 @@
 <div class="stack">
   <h3>{% trans "Login" %}</h3>
   <p class="text-center">{% trans "No account? Then please "%}<a href="{% url 'account_signup' %}">{% trans "sign up" %}</a>.</p>
-  <a class="box login facebook" id="facebook" href="{% provider_login_url 'facebook' method='js_sdk' %}">
-    <h4>Login with Facebook</h4>
-  </a>
   <a class="box login google" id="google" href="{% provider_login_url 'google' %}">
     <h4>Sign in with Google</h4>
   </a>

--- a/app/store_project/templates/challenges/challenge_detail.html
+++ b/app/store_project/templates/challenges/challenge_detail.html
@@ -5,15 +5,7 @@
 {% block head_title %}{{ challenge.name }}{% endblock head_title %}
 
 {% block layout %}
-  {% if messages %}
-    <div class="center messages">
-      <ul>
-        {% for message in messages %}
-          <li class="box {% if message.tags %}{{ message.tags }}{% endif %}">{{message}}</li>
-        {% endfor %}
-      </ul>
-    </div>
-  {% endif %}
+  {% include '_messages.html' %}
 
   <div class="functional-width">
     <div class="sidebar-main-layout">

--- a/app/store_project/templates/challenges/challenge_detail.html
+++ b/app/store_project/templates/challenges/challenge_detail.html
@@ -19,7 +19,11 @@
     <div class="sidebar-main-layout">
       <!-- Left sidebar with submit score and filter forms -->
       <div>
-        {% include "challenges/sidebar.html" %}
+        {% if user.is_authenticated %}
+          {% include "challenges/sidebar.html" %}
+        {% else %}
+          {% include "account/snippets/login_box.html" %}
+        {% endif %}
       </div>
 
       <!-- Main content area -->

--- a/app/store_project/templates/challenges/challenge_filtered_list.html
+++ b/app/store_project/templates/challenges/challenge_filtered_list.html
@@ -7,15 +7,7 @@
 {% block layout %}
   {# Override default layout for functional page #}
   <div class="stack functional-width">
-    {% if messages %}
-      <div class="center messages">
-        <ul>
-          {% for message in messages %}
-            <li class="box {% if message.tags %}{{ message.tags }}{% endif %}">{{message}}</li>
-          {% endfor %}
-        </ul>
-      </div>
-    {% endif %}
+    {% include '_messages.html' %}
 
     <div class="sidebar-main-layout">
       <!-- Sidebar with filtering -->

--- a/app/store_project/templates/exercises/index.html
+++ b/app/store_project/templates/exercises/index.html
@@ -7,15 +7,7 @@
 {% block layout %}
   {# Override default layout for functional page #}
   <div class="stack functional-width">
-    {% if messages %}
-      <div class="center messages">
-        <ul>
-          {% for message in messages %}
-            <li class="box {% if message.tags %}{{ message.tags }}{% endif %}">{{message}}</li>
-          {% endfor %}
-        </ul>
-      </div>
-    {% endif %}
+    {% include '_messages.html' %}
 
     <div class="stack">
       <div>

--- a/app/store_project/templates/pages/home.html
+++ b/app/store_project/templates/pages/home.html
@@ -62,15 +62,7 @@
   <!-- THE CONTENT -->
     <div class="stack-page full-width">
 
-      {% if messages %}
-        <div class="center messages">
-          <ul>
-            {% for message in messages %}
-              <li class="box {% if message.tags %}{{ message.tags }}{% endif %}">{{message}}</li>
-            {% endfor %}
-          </ul>
-        </div>
-      {% endif %}
+      {% include '_messages.html' %}
 
       {% block content %}
 

--- a/app/store_project/templates/products/product_list.html
+++ b/app/store_project/templates/products/product_list.html
@@ -15,15 +15,7 @@
 {% block layout %}
   {# Override default layout for functional page #}
   <div class="stack functional-width">
-    {% if messages %}
-      <div class="center messages">
-        <ul>
-          {% for message in messages %}
-            <li class="box {% if message.tags %}{{ message.tags }}{% endif %}">{{message}}</li>
-          {% endfor %}
-        </ul>
-      </div>
-    {% endif %}
+    {% include '_messages.html' %}
 
     <div class="stack">
       <div>


### PR DESCRIPTION
- **allow viewing the challenge detail page without logging in**
- **Remove login with Facebook option**
- **Add margin to messages section in CSS for improved spacing**
- **Refactor message display by creating a separate '_messages.html' template for improved code reuse across multiple templates**
