### PR TITLE
Show full description in challenge view cards

### DIFF
--- a/app/store_project/templates/challenges/_challenge_group.html
+++ b/app/store_project/templates/challenges/_challenge_group.html
@@ -61,16 +61,7 @@
                 {% if challenge.summary %}
                   <p style="margin: 0; color: var(--color-gray); font-size: var(--s-1);">{{ challenge.summary }}</p>
                 {% else %}
-                  {% with description_lines=challenge.description.splitlines %}
-                    {% if description_lines %}
-                      <p style="margin: 0; color: var(--color-gray); font-size: var(--s-1);">
-                        {{ description_lines.0|truncatewords:20 }}
-                        {% if description_lines|length > 1 or description_lines.0|length > 120 %}
-                          ...
-                        {% endif %}
-                      </p>
-                    {% endif %}
-                  {% endwith %}
+                  <p style="margin: 0; color: var(--color-gray); font-size: var(--s-1);">{{ challenge.description }}</p>
                 {% endif %}
               </div>
 

--- a/app/store_project/templates/challenges/_single_challenge_card.html
+++ b/app/store_project/templates/challenges/_single_challenge_card.html
@@ -12,16 +12,7 @@
         {% if challenge.summary %}
           <p style="margin: 0; color: var(--color-gray);">{{ challenge.summary }}</p>
         {% else %}
-          {% with description_lines=challenge.description.splitlines %}
-            {% if description_lines %}
-              <p style="margin: 0; color: var(--color-gray);">
-                {{ description_lines.0|truncatewords:25 }}
-                {% if description_lines|length > 1 or description_lines.0|length > 150 %}
-                  ...
-                {% endif %}
-              </p>
-            {% endif %}
-          {% endwith %}
+          <p style="margin: 0; color: var(--color-gray);">{{ challenge.description }}</p>
         {% endif %}
       </div>
 


### PR DESCRIPTION
Show full description in challenge view cards instead of truncated preview

- Remove truncatewords filter and '...' from challenge card templates
- Display complete description when summary is not available
- Ensures users see full challenge descriptions in list/group views

Fixes #224

Generated with [Claude Code](https://claude.ai/code)