### PR TITLE
fix: improve challenge sorting to handle variations correctly

### DIFF
--- a/app/store_project/challenges/models.py
+++ b/app/store_project/challenges/models.py
@@ -51,8 +51,11 @@ DIFFICULTY_COLOR_MAPPING = {
 }
 
 # Regex patterns for challenge variations (L1, L2, etc.)
-VARIATION_SUFFIX_PATTERN = r"\s*\(L\d+\)$"
-VARIATION_NUMBER_PATTERN = r"\(L(\d+)\)$"
+# Suffix pattern removes everything starting from the variation marker to the end
+# so it works for names like "Name (L1)" and "Name (L1) - Level 1"
+VARIATION_SUFFIX_PATTERN = r"\s*\(L\d+\).*$"
+# Number pattern matches the variation number wherever it appears in the name
+VARIATION_NUMBER_PATTERN = r"\(L(\d+)\)"
 
 
 class ChallengeQuerySet(models.QuerySet):

--- a/app/store_project/challenges/models.py
+++ b/app/store_project/challenges/models.py
@@ -65,9 +65,13 @@ class ChallengeQuerySet(models.QuerySet):
             base_name = challenge.base_name
             grouped.setdefault(base_name, []).append(challenge)
 
-        # Sort each group by difficulty level (beginner first, then intermediate, then advanced)
+        # Sort each group by difficulty level first, then by variation number, then alphabetically
         for challenges in grouped.values():
-            challenges.sort(key=lambda c: DIFFICULTY_ORDER.get(c.difficulty_level, 99))
+            challenges.sort(key=lambda c: (
+                DIFFICULTY_ORDER.get(c.difficulty_level, 99),  # Primary: difficulty level
+                c.variation_number or 0,  # Secondary: variation number (L1, L2, etc.)
+                c.name  # Tertiary: alphabetical by full name
+            ))
 
         return grouped
 

--- a/app/store_project/challenges/models.py
+++ b/app/store_project/challenges/models.py
@@ -69,12 +69,9 @@ class ChallengeQuerySet(models.QuerySet):
         for challenges in grouped.values():
             challenges.sort(
                 key=lambda c: (
-                    DIFFICULTY_ORDER.get(
-                        c.difficulty_level, 99
-                    ),  # Primary: difficulty level
-                    c.variation_number
-                    or 0,  # Secondary: variation number (L1, L2, etc.)
-                    c.name,  # Tertiary: alphabetical by full name
+                    DIFFICULTY_ORDER.get(c.difficulty_level, 99),  # fmt: skip
+                    c.variation_number or 0,  # fmt: skip
+                    c.name,
                 )
             )
 

--- a/app/store_project/challenges/models.py
+++ b/app/store_project/challenges/models.py
@@ -67,11 +67,16 @@ class ChallengeQuerySet(models.QuerySet):
 
         # Sort each group by difficulty level first, then by variation number, then alphabetically
         for challenges in grouped.values():
-            challenges.sort(key=lambda c: (
-                DIFFICULTY_ORDER.get(c.difficulty_level, 99),  # Primary: difficulty level
-                c.variation_number or 0,  # Secondary: variation number (L1, L2, etc.)
-                c.name  # Tertiary: alphabetical by full name
-            ))
+            challenges.sort(
+                key=lambda c: (
+                    DIFFICULTY_ORDER.get(
+                        c.difficulty_level, 99
+                    ),  # Primary: difficulty level
+                    c.variation_number
+                    or 0,  # Secondary: variation number (L1, L2, etc.)
+                    c.name,  # Tertiary: alphabetical by full name
+                )
+            )
 
         return grouped
 

--- a/app/store_project/challenges/tests.py
+++ b/app/store_project/challenges/tests.py
@@ -145,6 +145,50 @@ class ChallengeTests(TestCase):
         )
         self.assertEqual(plank_challenges[2].difficulty_level, DifficultyLevel.ADVANCED)
 
+    def test_challenge_queryset_grouped_method_with_variation_sorting(self):
+        """Test that grouped() method sorts challenges with variations correctly."""
+        # Create Summer Requests challenges like in the issue with same difficulty levels
+        Challenge.objects.create(
+            name="Summer Requests (L1) - Level 1",
+            description="Test L1",
+            slug="summer-requests-l1",
+            difficulty_level=DifficultyLevel.BEGINNER,
+        )
+        Challenge.objects.create(
+            name="Summer Requests (L2) - Level 2", 
+            description="Test L2",
+            slug="summer-requests-l2",
+            difficulty_level=DifficultyLevel.INTERMEDIATE,
+        )
+        Challenge.objects.create(
+            name="Summer Requests (L4) - Level 4",
+            description="Test L4", 
+            slug="summer-requests-l4",
+            difficulty_level=DifficultyLevel.ADVANCED,
+        )
+        Challenge.objects.create(
+            name="Summer Requests (L3) - Level 3",
+            description="Test L3",
+            slug="summer-requests-l3", 
+            difficulty_level=DifficultyLevel.ADVANCED,
+        )
+
+        grouped = Challenge.objects.grouped()
+        
+        # Should have Summer Requests group
+        self.assertIn("Summer Requests", grouped)
+        summer_challenges = grouped["Summer Requests"]
+        
+        # Should have all 4 challenges
+        self.assertEqual(len(summer_challenges), 4)
+        
+        # Should be sorted by difficulty first, then by variation number
+        # L1 (beginner), L2 (intermediate), L3 (advanced), L4 (advanced)
+        self.assertEqual(summer_challenges[0].name, "Summer Requests (L1) - Level 1") 
+        self.assertEqual(summer_challenges[1].name, "Summer Requests (L2) - Level 2")
+        self.assertEqual(summer_challenges[2].name, "Summer Requests (L3) - Level 3")
+        self.assertEqual(summer_challenges[3].name, "Summer Requests (L4) - Level 4")
+
     def test_difficulty_constants(self):
         """Test that difficulty-related constants are properly defined."""
         # Test DIFFICULTY_ORDER constant

--- a/app/store_project/challenges/tests.py
+++ b/app/store_project/challenges/tests.py
@@ -155,36 +155,36 @@ class ChallengeTests(TestCase):
             difficulty_level=DifficultyLevel.BEGINNER,
         )
         Challenge.objects.create(
-            name="Summer Requests (L2) - Level 2", 
+            name="Summer Requests (L2) - Level 2",
             description="Test L2",
             slug="summer-requests-l2",
             difficulty_level=DifficultyLevel.INTERMEDIATE,
         )
         Challenge.objects.create(
             name="Summer Requests (L4) - Level 4",
-            description="Test L4", 
+            description="Test L4",
             slug="summer-requests-l4",
             difficulty_level=DifficultyLevel.ADVANCED,
         )
         Challenge.objects.create(
             name="Summer Requests (L3) - Level 3",
             description="Test L3",
-            slug="summer-requests-l3", 
+            slug="summer-requests-l3",
             difficulty_level=DifficultyLevel.ADVANCED,
         )
 
         grouped = Challenge.objects.grouped()
-        
+
         # Should have Summer Requests group
         self.assertIn("Summer Requests", grouped)
         summer_challenges = grouped["Summer Requests"]
-        
+
         # Should have all 4 challenges
         self.assertEqual(len(summer_challenges), 4)
-        
+
         # Should be sorted by difficulty first, then by variation number
         # L1 (beginner), L2 (intermediate), L3 (advanced), L4 (advanced)
-        self.assertEqual(summer_challenges[0].name, "Summer Requests (L1) - Level 1") 
+        self.assertEqual(summer_challenges[0].name, "Summer Requests (L1) - Level 1")
         self.assertEqual(summer_challenges[1].name, "Summer Requests (L2) - Level 2")
         self.assertEqual(summer_challenges[2].name, "Summer Requests (L3) - Level 3")
         self.assertEqual(summer_challenges[3].name, "Summer Requests (L4) - Level 4")


### PR DESCRIPTION
Fixes challenge sorting issue where Level 4 challenges appeared before Level 3 due to lexicographic string sorting.

Changes:
- Updated ChallengeQuerySet.grouped() to sort by difficulty, then variation number, then alphabetically
- Added comprehensive test case to verify correct sorting order

Fixes #229

Generated with [Claude Code](https://claude.ai/code)