### PR TITLE
Add DOMAIN to .deployment.env for Caddy site substitution

### DIFF
--- a/.deployment.env
+++ b/.deployment.env
@@ -6,6 +6,12 @@ BRANCH=main
 COMPOSE_FILE=/srv/fitness-store/docker-compose.production.yml
 WEB_SERVICE=web
 
+# Real domain for the Caddy site. project-deploy.sh copies caddy/fitness-store.caddy
+# into /opt/caddy/sites/ and rewrites the "yourdomain.com" placeholder to this
+# value in the COPY, leaving the committed source untouched. Without it the
+# deploy skips the Caddy update rather than installing the placeholder domain.
+DOMAIN=mastering.fitness
+
 # Sandbox file ownership to the per-app system user created by `repo create`.
 # (repo name "fitness-store" -> system user "fitness_store".)
 APP_USER=fitness_store


### PR DESCRIPTION
Part of the fix for #263 (paired with **lancegoyke/deploy#41**).

## What

Adds `DOMAIN=mastering.fitness` to `.deployment.env`.

## Why

The committed `caddy/fitness-store.caddy` ships the `yourdomain.com` placeholder. With deploy#41, `project-deploy.sh` copies that file into `/opt/caddy/sites/` and rewrites the placeholder to `DOMAIN` **in the copy** (leaving the committed source pristine, which is what unbreaks `git pull --ff-only` — see #263). It sources `DOMAIN` from this file; when unset, the deploy *skips* the Caddy update rather than installing the placeholder domain. So this value is required for the site config to keep resolving to the real domain once the box source is cleaned.

## Rollout ordering

This is safe to merge independently — `DOMAIN` is inert until deploy#41 is live on the box. Full resolution of #263 also needs deploy#41 merged + a one-time box remediation (clean the dirty `/srv/fitness-store/caddy/fitness-store.caddy`). #263 will be closed once all three are done.