### PR TITLE
Meso program designer — Claude Design prototype

### DIFF
--- a/app/config/settings/base.py
+++ b/app/config/settings/base.py
@@ -101,6 +101,7 @@ INSTALLED_APPS = [
     # Local
     "store_project.admin_honeypot",
     "store_project.cardio.apps.CardioConfig",
+    "store_project.meso.apps.MesoConfig",
     "store_project.challenges.apps.ChallengesConfig",
     "store_project.exercises.apps.ExercisesConfig",
     "store_project.notifications.apps.NotificationsConfig",

--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -35,6 +35,7 @@ urlpatterns = [
     path("backside/clearcache/", include("clearcache.urls")),
     path("backside/", admin.site.urls),
     path("cardio/", include("store_project.cardio.urls")),
+    path("meso/", include("store_project.meso.urls", namespace="meso")),
     path(
         "challenges/", include("store_project.challenges.urls", namespace="challenges")
     ),

--- a/app/store_project/meso/apps.py
+++ b/app/store_project/meso/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+from django.utils.translation import gettext_lazy as _
+
+
+class MesoConfig(AppConfig):
+    name = "store_project.meso"
+    verbose_name = _("Meso Program Designer")

--- a/app/store_project/meso/urls.py
+++ b/app/store_project/meso/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+
+from .views import MesoDesignerView
+
+app_name = "meso"
+urlpatterns = [
+    path("", MesoDesignerView.as_view(), name="designer"),
+]

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -1,0 +1,13 @@
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.views.generic import TemplateView
+
+
+class MesoDesignerView(LoginRequiredMixin, TemplateView):
+    """The Meso AI strength-training program designer.
+
+    A self-contained, full-screen coach tool. All program/agent state lives
+    client-side (Alpine.js); the view only serves the shell. Wiring it to real
+    athlete profiles, logged sets, and a live agent is a future step.
+    """
+
+    template_name = "meso/designer.html"

--- a/app/store_project/static/css/meso.css
+++ b/app/store_project/static/css/meso.css
@@ -1,0 +1,164 @@
+/* Meso — AI strength-training program designer.
+   Ported from the Meso.dc.html Claude Design prototype. The root container in
+   the template carries the design tokens as CSS custom properties (--bg, --ink,
+   --accent, ...); this file holds the global resets, fonts, scrollbar styling,
+   and keyframes that the prototype declared in its <helmet>. */
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body.meso {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+}
+
+body.meso {
+  background: #f5f6f7;
+  font-family: "Hanken Grotesk", system-ui, -apple-system, sans-serif;
+}
+
+.meso input,
+.meso textarea {
+  font-family: inherit;
+}
+
+.meso ::placeholder {
+  color: #abb0b6;
+}
+
+.meso *::-webkit-scrollbar {
+  width: 11px;
+  height: 11px;
+}
+
+.meso *::-webkit-scrollbar-thumb {
+  background: rgba(20, 24, 30, 0.16);
+  border-radius: 7px;
+  border: 3px solid transparent;
+  background-clip: content-box;
+}
+
+.meso *::-webkit-scrollbar-thumb:hover {
+  background: rgba(20, 24, 30, 0.28);
+  border: 3px solid transparent;
+  background-clip: content-box;
+}
+
+.meso *::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+@keyframes msgIn {
+  from {
+    opacity: 0;
+    transform: translateY(7px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes blink {
+  0%,
+  80%,
+  100% {
+    opacity: 0.2;
+  }
+  40% {
+    opacity: 1;
+  }
+}
+
+@keyframes toastIn {
+  from {
+    opacity: 0;
+    transform: translate(-50%, -10px);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+}
+
+/* Hover/focus affordances that the prototype expressed as inline style-hover /
+   style-focus attributes (not real CSS). Re-expressed here as real rules. */
+.meso [data-hover="rail"]:hover {
+  background: var(--rail);
+}
+.meso [data-hover="brighten"]:hover {
+  filter: brightness(1.06);
+}
+.meso [data-hover="chip"]:hover {
+  background: var(--soft);
+  border-color: var(--soft-line);
+}
+.meso [data-hover="add"]:hover {
+  background: var(--rail);
+  color: var(--accent);
+}
+.meso .meso-cell:focus {
+  background: var(--soft);
+  box-shadow: inset 0 0 0 1px var(--soft-line);
+}
+.meso .meso-note:focus {
+  background: var(--soft);
+  box-shadow: inset 0 0 0 1px var(--soft-line);
+  color: var(--ink);
+}
+.meso .meso-phone-input:focus {
+  border-color: var(--soft-line);
+  background: var(--surface);
+}
+.meso .meso-composer:focus-within {
+  border-color: var(--soft-line);
+  box-shadow: 0 0 0 3px var(--soft);
+}
+
+/* Display helper for elements toggled by x-show. Alpine resets style.display to
+   "" when revealing, which would drop an inline `display:flex`; sourcing the
+   flex from a class makes that reset fall back to flex instead of block. */
+.meso .meso-flex {
+  display: flex;
+}
+
+/* Segmented controls (mode / view / period toggles). The prototype rendered an
+   on + off variant per button; here one button styles itself via .is-on. */
+.meso .meso-seg {
+  display: inline-flex;
+  background: var(--rail);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 3px;
+  gap: 2px;
+}
+.meso .meso-seg-btn {
+  appearance: none;
+  border: 0;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 550;
+  letter-spacing: -0.01em;
+  padding: 5px 12px;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--dim);
+}
+.meso .meso-seg-btn.is-on {
+  background: var(--surface);
+  color: var(--ink);
+  font-weight: 650;
+  box-shadow: 0 1px 2px rgba(16, 18, 22, 0.09);
+}
+.meso .meso-seg-btn--v {
+  font-size: 12.5px;
+  padding: 5px 13px;
+}
+.meso .meso-seg-btn--p {
+  font-size: 12px;
+  padding: 4px 11px;
+}

--- a/app/store_project/static/js/meso.js
+++ b/app/store_project/static/js/meso.js
@@ -1,0 +1,493 @@
+/* Meso — AI strength-training program designer.
+ *
+ * A faithful port of the Meso.dc.html Claude Design prototype to Alpine.js.
+ * All program/agent state is client-side; the "agent" is a canned intent
+ * engine (swap-knee / lower-volume / progress / deload) that mutates the
+ * in-memory program, exactly as the original prototype did. Replacing
+ * dispatch()/applyIntent() with a real backend call is the seam to make this
+ * live.
+ */
+document.addEventListener("alpine:init", () => {
+  Alpine.data("meso", () => ({
+    // ---- design tokens (the prototype exposed these as editor props) ----
+    accent: "Cobalt",
+    theme: "Clinical",
+    unit: "kg",
+
+    // ---- ui state ----
+    mode: "individual", // individual | group
+    view: "week", // week | block | athlete
+    periodStyle: "timeline", // timeline | ladder | calendar
+    inputText: "",
+    agentTyping: false,
+    delivered: false,
+    checks: {},
+    exSeq: 1,
+
+    messages: [
+      {
+        id: 1,
+        role: "agent",
+        text: "Here's Week 2 of Maya's hypertrophy block — 3 sessions, all knee-safe. I used box squats to parallel instead of back squats and kept deep knee flexion out of the loaded work.",
+        change: {
+          title: "Drafted Week 2 · 3 sessions",
+          detail: "Honors: avoid deep knee flexion under load",
+        },
+      },
+      {
+        id: 2,
+        role: "coach",
+        text: "Nice. Bump her trap-bar pull — she sat at RPE 6 last block.",
+      },
+      {
+        id: 3,
+        role: "agent",
+        text: "Done. Progressed the trap-bar deadlift to 92.5 kg. She logged 4×6 @ 90 / RPE 6 last session, so this lands around RPE 7 — right in the hypertrophy window.",
+        change: {
+          title: "Trap-Bar Deadlift → 92.5 kg",
+          detail: "From logged 4×6 @ 90 kg · RPE 6",
+        },
+      },
+    ],
+
+    program: [
+      {
+        id: "d1",
+        n: 1,
+        name: "Lower",
+        bias: "Quad bias · knee-safe",
+        exercises: [
+          {
+            id: "e1",
+            name: "Box Squat (to parallel)",
+            sets: "4",
+            reps: "6",
+            load: "70",
+            rpe: "7",
+            note: "",
+            last: "4×6 · 70kg · RPE6",
+            tag: "knee-safe",
+            adj: "Maya → box",
+          },
+          {
+            id: "e2",
+            name: "Bulgarian Split Squat (DB)",
+            sets: "3",
+            reps: "10",
+            load: "18",
+            rpe: "7",
+            note: "",
+            last: "3×10 · 16kg",
+          },
+          {
+            id: "e3",
+            name: "Leg Press (controlled ROM)",
+            sets: "3",
+            reps: "12",
+            load: "110",
+            rpe: "8",
+            note: "",
+          },
+          {
+            id: "e4",
+            name: "Seated Leg Curl",
+            sets: "3",
+            reps: "12",
+            load: "41",
+            rpe: "8",
+            note: "",
+          },
+          {
+            id: "e5",
+            name: "Standing Calf Raise",
+            sets: "4",
+            reps: "15",
+            load: "60",
+            rpe: "—",
+            note: "",
+          },
+        ],
+      },
+      {
+        id: "d2",
+        n: 2,
+        name: "Upper",
+        bias: "Push / pull",
+        exercises: [
+          {
+            id: "e6",
+            name: "Incline DB Press",
+            sets: "4",
+            reps: "8",
+            load: "24",
+            rpe: "7",
+            note: "monitor shoulder",
+            adj: "Devon → neutral grip",
+          },
+          {
+            id: "e7",
+            name: "Chest-Supported Row",
+            sets: "4",
+            reps: "10",
+            load: "27",
+            rpe: "7",
+            note: "",
+          },
+          {
+            id: "e8",
+            name: "Lat Pulldown",
+            sets: "3",
+            reps: "12",
+            load: "52",
+            rpe: "8",
+            note: "",
+          },
+          {
+            id: "e9",
+            name: "DB Shoulder Press",
+            sets: "3",
+            reps: "10",
+            load: "16",
+            rpe: "7",
+            note: "neutral grip",
+          },
+          {
+            id: "e10",
+            name: "Cable Lateral Raise",
+            sets: "3",
+            reps: "15",
+            load: "9",
+            rpe: "—",
+            note: "",
+          },
+        ],
+      },
+      {
+        id: "d3",
+        n: 3,
+        name: "Posterior",
+        bias: "Hinge",
+        exercises: [
+          {
+            id: "e11",
+            name: "Trap-Bar Deadlift",
+            sets: "4",
+            reps: "6",
+            load: "92.5",
+            rpe: "7",
+            note: "",
+            last: "4×6 · 90kg · RPE6",
+            adj: "Lena → RDL",
+          },
+          {
+            id: "e12",
+            name: "Hip Thrust",
+            sets: "3",
+            reps: "10",
+            load: "80",
+            rpe: "8",
+            note: "",
+          },
+          {
+            id: "e13",
+            name: "Romanian Deadlift (3-1-1)",
+            sets: "3",
+            reps: "8",
+            load: "60",
+            rpe: "7",
+            note: "tempo eccentric",
+          },
+          {
+            id: "e14",
+            name: "Reverse Lunge (DB)",
+            sets: "3",
+            reps: "12",
+            load: "14",
+            rpe: "—",
+            note: "knee-monitored",
+            tag: "knee-safe",
+          },
+          {
+            id: "e15",
+            name: "Hanging Knee Raise",
+            sets: "3",
+            reps: "12",
+            load: "BW",
+            rpe: "—",
+            note: "",
+          },
+        ],
+      },
+    ],
+
+    weeks: [
+      {
+        label: "Wk 1",
+        phase: "Accum",
+        vol: 70,
+        inten: 62,
+        deload: false,
+        current: false,
+      },
+      {
+        label: "Wk 2",
+        phase: "Accum",
+        vol: 85,
+        inten: 68,
+        deload: false,
+        current: true,
+      },
+      {
+        label: "Wk 3",
+        phase: "Accum",
+        vol: 100,
+        inten: 73,
+        deload: false,
+        current: false,
+      },
+      {
+        label: "Wk 4",
+        phase: "Deload",
+        vol: 55,
+        inten: 70,
+        deload: true,
+        current: false,
+      },
+    ],
+
+    phases: [
+      { name: "Base / GPP", weeks: "4 wk", state: "done" },
+      { name: "Hypertrophy", weeks: "4 wk", state: "current" },
+      { name: "Strength", weeks: "4 wk", state: "next" },
+      { name: "Peak / Test", weeks: "2 wk", state: "future" },
+    ],
+
+    chips: [
+      { label: "Lower Day 2 volume", intent: "lower-volume-d2" },
+      { label: "Swap a knee-sensitive lift", intent: "swap-knee" },
+      { label: "Progress from last block", intent: "progress" },
+      { label: "Add a deload week", intent: "deload" },
+    ],
+
+    calDays: ["M", "T", "W", "T", "F", "S", "S"],
+    sessionDays: [0, 2, 4],
+
+    // ---- derived ----
+    get isGroup() {
+      return this.mode === "group";
+    },
+    get isIndividual() {
+      return this.mode !== "group";
+    },
+
+    // ---- helpers ----
+    numeric(v) {
+      const s = String(v == null ? "" : v).trim();
+      return s !== "" && /^[0-9.]+$/.test(s);
+    },
+    round25(n) {
+      return Math.round(n / 2.5) * 2.5;
+    },
+    barH(pct, track) {
+      return Math.max(6, (pct / 100) * track) + "px";
+    },
+    loadSuffix(load) {
+      return this.numeric(load) ? this.unit : "";
+    },
+
+    // ---- periodization "calendar" chart cell helpers ----
+    cellOn(w, ci) {
+      return this.sessionDays.indexOf(ci) >= 0 && !(w.deload && ci === 4);
+    },
+    cellStyle(w, ci) {
+      const on = this.cellOn(w, ci);
+      const border = w.current ? "var(--soft-line)" : "var(--line)";
+      const bg = on
+        ? w.current
+          ? "var(--accent)"
+          : "var(--soft)"
+        : "var(--rail)";
+      return (
+        "height:34px;border-radius:7px;border:1px solid " +
+        border +
+        ";background:" +
+        bg +
+        ";display:flex;align-items:center;justify-content:center"
+      );
+    },
+
+    // ---- athlete (phone) view: first day, first three lifts ----
+    get athleteDay() {
+      const day = this.program[0];
+      return day.exercises.slice(0, 3).map((x, xi) => {
+        const setN = parseInt(x.sets, 10) || 3;
+        const rows = [];
+        for (let i = 0; i < setN; i++) {
+          const k = "a0-" + xi + "-" + i;
+          const target =
+            x.reps +
+            " × " +
+            (this.numeric(x.load) ? x.load + " " + this.unit : x.load);
+          rows.push({ k, n: i + 1, target, done: !!this.checks[k] });
+        }
+        return { id: x.id, name: x.name, target: x.sets + "×" + x.reps, rows };
+      });
+    },
+    get aTotal() {
+      return this.athleteDay.reduce((acc, e) => acc + e.rows.length, 0);
+    },
+    get aDone() {
+      return this.athleteDay.reduce(
+        (acc, e) => acc + e.rows.filter((r) => r.done).length,
+        0,
+      );
+    },
+
+    // ---- navigation ----
+    scrollThread() {
+      this.$nextTick(() => {
+        const t = this.$refs.thread;
+        if (t) t.scrollTop = t.scrollHeight;
+      });
+    },
+
+    toggleCheck(k) {
+      this.checks[k] = !this.checks[k];
+    },
+
+    onDeliver() {
+      this.delivered = true;
+      setTimeout(() => {
+        this.delivered = false;
+      }, 2800);
+    },
+
+    addExercise(di) {
+      this.program[di].exercises.push({
+        id: "n" + this.exSeq++,
+        name: "New exercise",
+        sets: "3",
+        reps: "10",
+        load: "",
+        rpe: "7",
+        note: "",
+      });
+    },
+
+    // ---- agent chat ----
+    pushCoach(text) {
+      this.messages.push({ id: Date.now(), role: "coach", text });
+      this.scrollThread();
+    },
+    onInputKey(e) {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        this.onSend();
+      }
+    },
+    onSend() {
+      const t = (this.inputText || "").trim();
+      if (!t) return;
+      this.pushCoach(t);
+      this.inputText = "";
+      this.dispatch(this.detectIntent(t));
+    },
+    onChip(intent, label) {
+      this.pushCoach(label);
+      this.dispatch(intent);
+    },
+
+    detectIntent(t) {
+      const s = t.toLowerCase();
+      if (/knee|meniscus|swap|substitut|replace/.test(s)) return "swap-knee";
+      if (/deload|recover|fatigue|back off/.test(s)) return "deload";
+      if (/volume|lighter|reduce|less|trim|drop a set/.test(s))
+        return "lower-volume-d2";
+      if (/progress|heavier|bump|increase|overload|add (weight|load)/.test(s))
+        return "progress";
+      return "generic";
+    },
+
+    dispatch(intent) {
+      this.agentTyping = true;
+      this.scrollThread();
+      setTimeout(() => this.applyIntent(intent), 780);
+    },
+
+    applyIntent(intent) {
+      let msg;
+
+      if (intent === "swap-knee") {
+        const d = this.program[0];
+        const ix = d.exercises.findIndex((x) => /bulgarian/i.test(x.name));
+        const tgt = ix >= 0 ? ix : 1;
+        Object.assign(d.exercises[tgt], {
+          name: "Box Step-Down (low)",
+          load: "14",
+          tag: "knee-safe",
+          note: "pain-free ROM, slow eccentric",
+        });
+        msg = {
+          text: "Swapped the Bulgarian split squat for a low box step-down. Same single-leg quad stimulus, but the knee tracks through a shorter, controlled range — a better fit for the meniscus history.",
+          change: {
+            title: "Bulgarian Split Squat → Box Step-Down",
+            detail: "Single-leg quad work · controlled ROM",
+          },
+        };
+      } else if (intent === "lower-volume-d2") {
+        const d = this.program[1];
+        d.exercises.forEach((x, i) => {
+          if (i < 3)
+            x.sets = String(Math.max(2, (parseInt(x.sets, 10) || 3) - 1));
+        });
+        msg = {
+          text: "Trimmed Day 2 — dropped a set on the three main upper-body lifts. Keeps weekly pressing volume in check while her shoulder settles, without touching the accessory work.",
+          change: {
+            title: "Day 2 volume − 1 set",
+            detail: "Applied to the 3 primary lifts",
+          },
+        };
+      } else if (intent === "progress") {
+        this.program.forEach((d) => {
+          d.exercises.forEach((x) => {
+            const n = parseFloat(x.load);
+            if (!isNaN(n) && this.numeric(x.load) && x.rpe !== "—") {
+              x.load = String(this.round25(n + 2.5));
+            }
+          });
+        });
+        msg = {
+          text: "Progressed the main lifts by ~2.5 kg across the week, anchored to last block's logged loads and RPEs. Accessories held steady so the added stimulus stays on the big patterns.",
+          change: {
+            title: "+2.5 kg on primary lifts",
+            detail: "Driven by logged session data",
+          },
+        };
+      } else if (intent === "deload") {
+        this.view = "block";
+        const w = this.weeks[3];
+        Object.assign(w, { vol: 50, inten: 70, deload: true, phase: "Deload" });
+        msg = {
+          text: "Set Week 4 as a deload — volume drops ~45% while intensity holds near 70%. That clears accumulated fatigue and sets up a clean hand-off into the strength block.",
+          change: {
+            title: "Week 4 → Deload",
+            detail: "Volume −45% · intensity held",
+          },
+        };
+      } else {
+        msg = {
+          text: "Got it — I've noted that against Maya's profile and coaching rules. Want me to apply it to this week, or carry it into the next block's plan?",
+        };
+      }
+
+      this.messages.push({
+        id: Date.now() + 1,
+        role: "agent",
+        text: msg.text,
+        change: msg.change,
+      });
+      this.agentTyping = false;
+      this.scrollThread();
+    },
+  }));
+});

--- a/app/store_project/templates/meso/designer.html
+++ b/app/store_project/templates/meso/designer.html
@@ -1,0 +1,466 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Meso — Program Designer | Mastering Fitness</title>
+    <link rel="shortcut icon" href="{% static 'png/favicon-black.png' %}" />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="{% static 'css/meso.css' %}" />
+    <script defer src="{% static 'js/meso.js' %}"></script>
+    <script defer src="{% static 'js/alpine.min.js' %}"></script>
+  </head>
+
+  <body class="meso">
+    <div
+      class="meso meso-root"
+      x-data="meso()"
+      x-ref="root"
+      style="--bg:#f5f6f7;--surface:#ffffff;--rail:#fbfbfc;--ink:#16181c;--dim:#71777e;--line:#e7e9ec;--line-2:#f1f3f5;--radius:8px;--pad:14px;--accent:oklch(0.56 0.14 258);--accent-ink:#ffffff;--soft:color-mix(in srgb,var(--accent) 9%,#fff);--soft-line:color-mix(in srgb,var(--accent) 26%,#fff);--accent-deep:color-mix(in srgb,var(--accent) 82%,#1a1a1a);--warn:#b4541f;--warn-soft:#fbefe8;--ok:#2f8f56;display:flex;flex-direction:column;height:100vh;min-width:1240px;overflow:hidden;background:var(--bg);color:var(--ink);font-family:'Hanken Grotesk',system-ui,-apple-system,sans-serif;font-size:14px;line-height:1.45;-webkit-font-smoothing:antialiased;"
+    >
+      <!-- Delivered toast -->
+      <template x-if="delivered">
+        <div style="position:fixed;top:16px;left:50%;transform:translateX(-50%);z-index:80;display:flex;align-items:center;gap:9px;background:var(--ink);color:#fff;padding:10px 16px;border-radius:10px;box-shadow:0 8px 28px rgba(16,18,22,0.24);font-size:13px;font-weight:600;animation:toastIn .22s ease;">
+          <div style="width:16px;height:16px;border-radius:50%;background:var(--ok);display:flex;align-items:center;justify-content:center;color:#fff;font-size:11px;">&#10003;</div>
+          Delivered to Maya&#8217;s app &#183; she&#8217;ll see Day 1 on her phone
+        </div>
+      </template>
+
+      <!-- ===================== TOP BAR ===================== -->
+      <div style="height:55px;flex:0 0 auto;display:flex;align-items:center;gap:15px;padding:0 17px;background:var(--surface);border-bottom:1px solid var(--line);z-index:20;">
+        <div style="display:flex;align-items:center;gap:9px;">
+          <div style="width:23px;height:23px;border-radius:6px;background:var(--accent);display:flex;align-items:center;justify-content:center;">
+            <div style="width:8px;height:8px;background:var(--accent-ink);border-radius:2px;transform:rotate(45deg);"></div>
+          </div>
+          <span style="font-weight:800;font-size:16px;letter-spacing:-0.025em;">Meso</span>
+        </div>
+        <div style="width:1px;height:22px;background:var(--line);"></div>
+
+        <!-- Individual / Group identity -->
+        <div style="display:inline-flex;align-items:center;gap:10px;">
+          <template x-if="isIndividual">
+            <div style="display:flex;align-items:center;gap:9px;">
+              <div style="width:28px;height:28px;border-radius:50%;background:var(--soft);border:1px solid var(--soft-line);display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:700;color:var(--accent-deep);">MO</div>
+              <div style="line-height:1.15;">
+                <div style="font-size:13px;font-weight:700;letter-spacing:-0.01em;">Maya Okonkwo</div>
+                <div style="font-size:11px;color:var(--dim);">Intermediate &#183; Hypertrophy block</div>
+              </div>
+            </div>
+          </template>
+          <template x-if="isGroup">
+            <div style="display:flex;align-items:center;gap:9px;">
+              <div style="display:flex;">
+                <div style="width:28px;height:28px;border-radius:50%;background:var(--soft);border:2px solid var(--surface);display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;color:var(--accent-deep);">MO</div>
+                <div style="width:28px;height:28px;border-radius:50%;background:#eef0f2;border:2px solid var(--surface);display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;color:var(--dim);margin-left:-9px;">DR</div>
+                <div style="width:28px;height:28px;border-radius:50%;background:#eef0f2;border:2px solid var(--surface);display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;color:var(--dim);margin-left:-9px;">+3</div>
+              </div>
+              <div style="line-height:1.15;">
+                <div style="font-size:13px;font-weight:700;letter-spacing:-0.01em;">Hypertrophy Group</div>
+                <div style="font-size:11px;color:var(--dim);">5 participants</div>
+              </div>
+            </div>
+          </template>
+        </div>
+
+        <div class="meso-seg" style="margin-left:4px;">
+          <button class="meso-seg-btn" :class="{ 'is-on': isIndividual }" @click="mode = 'individual'">Individual</button>
+          <button class="meso-seg-btn" :class="{ 'is-on': isGroup }" @click="mode = 'group'">Group</button>
+        </div>
+
+        <div style="flex:1;"></div>
+
+        <div style="display:flex;align-items:center;gap:6px;padding:5px 11px;border-radius:7px;background:var(--soft);border:1px solid var(--soft-line);font-size:11.5px;font-weight:600;color:var(--accent-deep);">
+          <div style="width:6px;height:6px;border-radius:50%;background:var(--accent);"></div>
+          Hypertrophy &#183; Wk 2 / 4
+        </div>
+        <button data-hover="rail" @click="view = 'athlete'" style="appearance:none;cursor:pointer;font:inherit;font-size:12.5px;font-weight:600;color:var(--ink);background:var(--surface);border:1px solid var(--line);border-radius:8px;padding:7px 13px;">Preview as athlete</button>
+        <button data-hover="brighten" @click="onDeliver()" style="appearance:none;cursor:pointer;font:inherit;font-size:12.5px;font-weight:650;color:var(--accent-ink);background:var(--accent);border:0;border-radius:8px;padding:8px 15px;box-shadow:0 1px 2px rgba(16,18,22,0.12);">Deliver</button>
+      </div>
+
+      <!-- ===================== BODY ===================== -->
+      <div style="flex:1;display:flex;min-height:0;">
+
+        <!-- ---------- LEFT RAIL ---------- -->
+        <div style="width:266px;flex:0 0 auto;background:var(--rail);border-right:1px solid var(--line);overflow-y:auto;padding:16px 15px 24px;">
+
+          <template x-if="isIndividual">
+            <div>
+              <div style="display:flex;align-items:center;gap:11px;margin-bottom:14px;">
+                <div style="width:42px;height:42px;border-radius:11px;background:var(--soft);border:1px solid var(--soft-line);display:flex;align-items:center;justify-content:center;font-size:15px;font-weight:700;color:var(--accent-deep);">MO</div>
+                <div style="line-height:1.2;">
+                  <div style="font-size:15px;font-weight:700;letter-spacing:-0.015em;">Maya Okonkwo</div>
+                  <div style="font-size:11.5px;color:var(--dim);">34 &#183; Intermediate &#183; 14 mo trained</div>
+                </div>
+              </div>
+              <div style="margin-bottom:16px;">
+                <p style="font-size:10.5px;font-weight:700;letter-spacing:0.07em;text-transform:uppercase;color:var(--dim);margin:0 0 8px;">Goals</p>
+                <div style="display:flex;flex-wrap:wrap;gap:6px;">
+                  <span style="display:inline-flex;padding:4px 9px;border-radius:6px;background:var(--soft);border:1px solid var(--soft-line);font-size:11.5px;color:var(--accent-deep);font-weight:600;white-space:nowrap;">Hypertrophy</span>
+                  <span style="display:inline-flex;padding:4px 9px;border-radius:6px;background:var(--soft);border:1px solid var(--soft-line);font-size:11.5px;color:var(--accent-deep);font-weight:600;white-space:nowrap;">Return to lifting</span>
+                </div>
+              </div>
+              <div style="margin-bottom:16px;">
+                <p style="font-size:10.5px;font-weight:700;letter-spacing:0.07em;text-transform:uppercase;color:var(--dim);margin:0 0 8px;">Contraindications</p>
+                <div style="display:flex;flex-direction:column;gap:6px;">
+                  <div style="display:flex;gap:8px;align-items:flex-start;padding:7px 9px;border-radius:7px;background:var(--warn-soft);border:1px solid color-mix(in srgb,var(--warn) 22%,#fff);">
+                    <div style="width:5px;height:5px;border-radius:50%;background:var(--warn);margin-top:6px;flex:0 0 auto;"></div>
+                    <div style="font-size:12px;color:var(--warn);font-weight:600;line-height:1.3;">L knee &#8212; avoid deep knee flexion under load</div>
+                  </div>
+                  <div style="display:flex;gap:8px;align-items:flex-start;padding:7px 9px;border-radius:7px;background:var(--warn-soft);border:1px solid color-mix(in srgb,var(--warn) 22%,#fff);">
+                    <div style="width:5px;height:5px;border-radius:50%;background:var(--warn);margin-top:6px;flex:0 0 auto;"></div>
+                    <div style="font-size:12px;color:var(--warn);font-weight:600;line-height:1.3;">No max-effort jumping / impact</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </template>
+
+          <template x-if="isGroup">
+            <div>
+              <div style="display:flex;align-items:center;gap:11px;margin-bottom:14px;">
+                <div style="width:42px;height:42px;border-radius:11px;background:var(--soft);border:1px solid var(--soft-line);display:flex;align-items:center;justify-content:center;color:var(--accent-deep);">
+                  <div style="width:14px;height:14px;border:2px solid var(--accent-deep);border-radius:4px;"></div>
+                </div>
+                <div style="line-height:1.2;">
+                  <div style="font-size:15px;font-weight:700;letter-spacing:-0.015em;">Hypertrophy Group</div>
+                  <div style="font-size:11.5px;color:var(--dim);">5 participants &#183; General fitness</div>
+                </div>
+              </div>
+              <div style="margin-bottom:16px;">
+                <p style="font-size:10.5px;font-weight:700;letter-spacing:0.07em;text-transform:uppercase;color:var(--dim);margin:0 0 8px;">Participants</p>
+                <div style="display:flex;flex-direction:column;gap:4px;">
+                  <div style="display:flex;align-items:center;gap:8px;font-size:12.5px;font-weight:500;"><div style="width:22px;height:22px;border-radius:50%;background:var(--soft);font-size:9px;font-weight:700;color:var(--accent-deep);display:flex;align-items:center;justify-content:center;">MO</div>Maya Okonkwo</div>
+                  <div style="display:flex;align-items:center;gap:8px;font-size:12.5px;font-weight:500;"><div style="width:22px;height:22px;border-radius:50%;background:#eef0f2;font-size:9px;font-weight:700;color:var(--dim);display:flex;align-items:center;justify-content:center;">DR</div>Devon Reyes</div>
+                  <div style="display:flex;align-items:center;gap:8px;font-size:12.5px;font-weight:500;"><div style="width:22px;height:22px;border-radius:50%;background:#eef0f2;font-size:9px;font-weight:700;color:var(--dim);display:flex;align-items:center;justify-content:center;">PN</div>Priya Nair</div>
+                  <div style="display:flex;align-items:center;gap:8px;font-size:12.5px;font-weight:500;"><div style="width:22px;height:22px;border-radius:50%;background:#eef0f2;font-size:9px;font-weight:700;color:var(--dim);display:flex;align-items:center;justify-content:center;">MT</div>Marcus Tan</div>
+                  <div style="display:flex;align-items:center;gap:8px;font-size:12.5px;font-weight:500;"><div style="width:22px;height:22px;border-radius:50%;background:#eef0f2;font-size:9px;font-weight:700;color:var(--dim);display:flex;align-items:center;justify-content:center;">LK</div>Lena Kovic</div>
+                </div>
+              </div>
+              <div style="margin-bottom:16px;">
+                <p style="font-size:10.5px;font-weight:700;letter-spacing:0.07em;text-transform:uppercase;color:var(--dim);margin:0 0 8px;">Flags across group</p>
+                <div style="display:flex;gap:8px;align-items:flex-start;padding:7px 9px;border-radius:7px;background:var(--warn-soft);border:1px solid color-mix(in srgb,var(--warn) 22%,#fff);">
+                  <div style="width:5px;height:5px;border-radius:50%;background:var(--warn);margin-top:6px;flex:0 0 auto;"></div>
+                  <div style="font-size:12px;color:var(--warn);font-weight:600;line-height:1.3;">3 of 5 carry a knee or shoulder flag &#8212; auto-regressions applied per athlete</div>
+                </div>
+              </div>
+            </div>
+          </template>
+
+          <div style="height:1px;background:var(--line);margin:4px 0 16px;"></div>
+
+          <div style="margin-bottom:18px;">
+            <p style="font-size:10.5px;font-weight:700;letter-spacing:0.07em;text-transform:uppercase;color:var(--dim);margin:0 0 8px;">Coach&#8217;s programming style</p>
+            <div style="display:flex;flex-wrap:wrap;gap:6px;margin-bottom:9px;">
+              <span style="display:inline-flex;padding:4px 9px;border-radius:6px;background:var(--surface);border:1px solid var(--line);font-size:11.5px;font-weight:500;white-space:nowrap;">Compound-first</span>
+              <span style="display:inline-flex;padding:4px 9px;border-radius:6px;background:var(--surface);border:1px solid var(--line);font-size:11.5px;font-weight:500;white-space:nowrap;">RPE-based load</span>
+              <span style="display:inline-flex;padding:4px 9px;border-radius:6px;background:var(--surface);border:1px solid var(--line);font-size:11.5px;font-weight:500;white-space:nowrap;">Free-weight bias</span>
+              <span style="display:inline-flex;padding:4px 9px;border-radius:6px;background:var(--surface);border:1px solid var(--line);font-size:11.5px;font-weight:500;white-space:nowrap;">2-min rest cap</span>
+              <span style="display:inline-flex;padding:4px 9px;border-radius:6px;background:var(--surface);border:1px solid var(--line);font-size:11.5px;font-weight:500;white-space:nowrap;">Unilateral work</span>
+            </div>
+            <div style="font-size:11.5px;color:var(--dim);line-height:1.4;"><span style="font-weight:700;color:var(--warn);">Avoid:</span> machine-only days, untracked progressions, &gt;3 exercises to failure / session.</div>
+          </div>
+
+          <div style="height:1px;background:var(--line);margin:0 0 16px;"></div>
+
+          <div>
+            <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:9px;">
+              <p style="font-size:10.5px;font-weight:700;letter-spacing:0.07em;text-transform:uppercase;color:var(--dim);margin:0;">Macrocycle</p>
+              <button @click="view = 'block'" style="appearance:none;border:0;background:none;cursor:pointer;font:inherit;font-size:11px;font-weight:650;color:var(--accent);padding:0;">Open plan &#8594;</button>
+            </div>
+            <div style="display:flex;flex-direction:column;gap:5px;">
+              <div style="display:flex;align-items:center;gap:9px;padding:8px 10px;border-radius:7px;background:var(--surface);border:1px solid var(--line);opacity:0.62;">
+                <div style="width:7px;height:7px;border-radius:2px;background:var(--dim);"></div>
+                <div style="flex:1;font-size:12px;font-weight:600;">Base / GPP</div>
+                <div style="font-size:10.5px;color:var(--dim);white-space:nowrap;">4 wk &#183; done</div>
+              </div>
+              <div style="display:flex;align-items:center;gap:9px;padding:9px 10px;border-radius:7px;background:var(--soft);border:1px solid var(--soft-line);">
+                <div style="width:7px;height:7px;border-radius:2px;background:var(--accent);"></div>
+                <div style="flex:1;font-size:12px;font-weight:700;color:var(--accent-deep);">Hypertrophy</div>
+                <div style="font-size:10.5px;color:var(--accent-deep);font-weight:600;white-space:nowrap;">wk 2 / 4</div>
+              </div>
+              <div style="display:flex;align-items:center;gap:9px;padding:8px 10px;border-radius:7px;background:var(--surface);border:1px solid var(--line);">
+                <div style="width:7px;height:7px;border-radius:2px;background:var(--line);border:1px solid var(--dim);"></div>
+                <div style="flex:1;font-size:12px;font-weight:600;color:var(--dim);">Strength</div>
+                <div style="font-size:10.5px;color:var(--dim);white-space:nowrap;">4 wk &#183; next</div>
+              </div>
+              <div style="display:flex;align-items:center;gap:9px;padding:8px 10px;border-radius:7px;background:var(--surface);border:1px solid var(--line);">
+                <div style="width:7px;height:7px;border-radius:2px;background:var(--line);border:1px solid var(--dim);"></div>
+                <div style="flex:1;font-size:12px;font-weight:600;color:var(--dim);">Peak / Test</div>
+                <div style="font-size:10.5px;color:var(--dim);white-space:nowrap;">2 wk</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- ---------- AGENT CHAT ---------- -->
+        <div style="width:356px;flex:0 0 auto;background:var(--surface);border-right:1px solid var(--line);display:flex;flex-direction:column;min-height:0;">
+          <div style="height:48px;flex:0 0 auto;display:flex;align-items:center;gap:9px;padding:0 16px;border-bottom:1px solid var(--line-2);">
+            <div style="width:21px;height:21px;border-radius:6px;background:var(--accent);display:flex;align-items:center;justify-content:center;"><div style="width:7px;height:7px;background:var(--accent-ink);border-radius:1px;transform:rotate(45deg);"></div></div>
+            <div style="font-size:13.5px;font-weight:700;letter-spacing:-0.01em;">Agent</div>
+            <div x-show="agentTyping" class="meso-flex" style="align-items:center;gap:5px;font-size:11px;color:var(--dim);"><div style="width:6px;height:6px;border-radius:50%;background:var(--accent);"></div>drafting&#8230;</div>
+            <div x-show="!agentTyping" class="meso-flex" style="align-items:center;gap:5px;font-size:11px;color:var(--dim);"><div style="width:6px;height:6px;border-radius:50%;background:var(--ok);"></div>ready</div>
+            <div style="flex:1;"></div>
+            <div style="font-size:11px;color:var(--dim);">grounded on profile + logs</div>
+          </div>
+
+          <div x-ref="thread" style="flex:1;overflow-y:auto;padding:16px;display:flex;flex-direction:column;gap:13px;">
+            <template x-for="m in messages" :key="m.id">
+              <div>
+                <template x-if="m.role === 'agent'">
+                  <div style="display:flex;flex-direction:column;gap:8px;align-items:flex-start;max-width:90%;">
+                    <div style="background:var(--surface);border:1px solid var(--line);border-radius:4px 13px 13px 13px;padding:10px 13px;font-size:13px;line-height:1.5;color:var(--ink);box-shadow:0 1px 2px rgba(16,18,22,0.03);" x-text="m.text"></div>
+                    <template x-if="m.change">
+                      <div style="display:flex;gap:9px;align-items:flex-start;background:var(--soft);border:1px solid var(--soft-line);border-radius:9px;padding:9px 11px;width:100%;">
+                        <div style="width:17px;height:17px;border-radius:5px;background:var(--accent);display:flex;align-items:center;justify-content:center;color:var(--accent-ink);font-size:10px;flex:0 0 auto;margin-top:1px;">&#10003;</div>
+                        <div style="line-height:1.3;">
+                          <div style="font-size:12.5px;font-weight:700;color:var(--accent-deep);" x-text="m.change.title"></div>
+                          <div style="font-size:11.5px;color:var(--accent-deep);opacity:0.8;" x-text="m.change.detail"></div>
+                        </div>
+                      </div>
+                    </template>
+                  </div>
+                </template>
+                <template x-if="m.role === 'coach'">
+                  <div style="align-self:flex-end;margin-left:auto;max-width:84%;width:fit-content;background:var(--ink);color:#fff;border-radius:13px 13px 4px 13px;padding:9px 13px;font-size:13px;line-height:1.45;" x-text="m.text"></div>
+                </template>
+              </div>
+            </template>
+            <template x-if="agentTyping">
+              <div style="display:flex;gap:4px;align-items:center;background:var(--surface);border:1px solid var(--line);border-radius:4px 13px 13px 13px;padding:11px 14px;align-self:flex-start;">
+                <div style="width:6px;height:6px;border-radius:50%;background:var(--dim);animation:blink 1.2s infinite;"></div>
+                <div style="width:6px;height:6px;border-radius:50%;background:var(--dim);animation:blink 1.2s infinite 0.18s;"></div>
+                <div style="width:6px;height:6px;border-radius:50%;background:var(--dim);animation:blink 1.2s infinite 0.36s;"></div>
+              </div>
+            </template>
+          </div>
+
+          <div style="flex:0 0 auto;border-top:1px solid var(--line-2);padding:11px 14px 13px;">
+            <div style="display:flex;gap:6px;overflow-x:auto;padding-bottom:9px;">
+              <template x-for="c in chips" :key="c.intent">
+                <button data-hover="chip" @click="onChip(c.intent, c.label)" x-text="c.label" style="appearance:none;cursor:pointer;font:inherit;white-space:nowrap;font-size:11.5px;font-weight:550;color:var(--ink);background:var(--surface);border:1px solid var(--line);border-radius:999px;padding:6px 11px;flex:0 0 auto;"></button>
+              </template>
+            </div>
+            <div class="meso-composer" style="display:flex;align-items:flex-end;gap:8px;background:var(--rail);border:1px solid var(--line);border-radius:11px;padding:7px 7px 7px 12px;">
+              <input x-model="inputText" @keydown="onInputKey($event)" placeholder="Ask the agent to adjust the program&#8230;" style="flex:1;appearance:none;border:0;background:transparent;outline:none;font:inherit;font-size:13px;color:var(--ink);padding:5px 0;" />
+              <button data-hover="brighten" @click="onSend()" style="appearance:none;cursor:pointer;border:0;width:32px;height:32px;border-radius:8px;background:var(--accent);color:var(--accent-ink);display:flex;align-items:center;justify-content:center;flex:0 0 auto;font-size:15px;">&#8593;</button>
+            </div>
+          </div>
+        </div>
+
+        <!-- ---------- CANVAS ---------- -->
+        <div style="flex:1;display:flex;flex-direction:column;min-width:0;background:var(--bg);">
+          <div style="height:49px;flex:0 0 auto;display:flex;align-items:center;gap:14px;padding:0 18px;border-bottom:1px solid var(--line);background:var(--surface);">
+            <div class="meso-seg">
+              <button class="meso-seg-btn meso-seg-btn--v" :class="{ 'is-on': view === 'week' }" @click="view = 'week'">This week</button>
+              <button class="meso-seg-btn meso-seg-btn--v" :class="{ 'is-on': view === 'block' }" @click="view = 'block'">Periodization</button>
+              <button class="meso-seg-btn meso-seg-btn--v" :class="{ 'is-on': view === 'athlete' }" @click="view = 'athlete'">Athlete view</button>
+            </div>
+            <div style="flex:1;"></div>
+            <div x-show="view === 'week'" class="meso-flex" style="font-size:11.5px;color:var(--dim);align-items:center;gap:6px;"><div style="width:6px;height:6px;border-radius:50%;background:var(--ok);"></div>Autosaved &#183; last edit just now</div>
+            <div x-show="view === 'block'" class="meso-seg">
+              <button class="meso-seg-btn meso-seg-btn--p" :class="{ 'is-on': periodStyle === 'timeline' }" @click="periodStyle = 'timeline'">Timeline</button>
+              <button class="meso-seg-btn meso-seg-btn--p" :class="{ 'is-on': periodStyle === 'ladder' }" @click="periodStyle = 'ladder'">Phase ladder</button>
+              <button class="meso-seg-btn meso-seg-btn--p" :class="{ 'is-on': periodStyle === 'calendar' }" @click="periodStyle = 'calendar'">Calendar</button>
+            </div>
+          </div>
+
+          <div style="flex:1;overflow-y:auto;min-height:0;">
+
+            <!-- ===== WEEK VIEW ===== -->
+            <div x-show="view === 'week'" style="padding:18px 20px 40px;max-width:1080px;">
+              <div style="display:flex;align-items:flex-end;justify-content:space-between;margin-bottom:16px;">
+                <div>
+                  <h1 style="margin:0 0 3px;font-size:21px;font-weight:800;letter-spacing:-0.025em;">Week 2 &#8212; Accumulation</h1>
+                  <p style="margin:0;font-size:12.5px;color:var(--dim);">3 sessions &#183; hypertrophy emphasis &#183; tap any cell to edit</p>
+                </div>
+              </div>
+
+              <template x-if="isGroup">
+                <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:16px;padding:10px 13px;background:var(--soft);border:1px solid var(--soft-line);border-radius:9px;">
+                  <span style="font-size:11.5px;font-weight:700;color:var(--accent-deep);">Shared program &#183; per-athlete auto-adjusts:</span>
+                  <span style="font-size:11.5px;color:var(--accent-deep);opacity:0.85;">Devon &#8594; neutral-grip press</span><span style="color:var(--soft-line);">&#183;</span>
+                  <span style="font-size:11.5px;color:var(--accent-deep);opacity:0.85;">Lena &#8594; RDL for trap-bar</span><span style="color:var(--soft-line);">&#183;</span>
+                  <span style="font-size:11.5px;color:var(--accent-deep);opacity:0.85;">Maya &#8594; box squat</span>
+                </div>
+              </template>
+
+              <template x-for="(day, di) in program" :key="day.id">
+                <div style="background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);overflow:hidden;margin-bottom:15px;box-shadow:0 1px 2px rgba(16,18,22,0.03);">
+                  <div style="display:flex;align-items:center;gap:11px;padding:12px 15px;border-bottom:1px solid var(--line-2);">
+                    <div style="width:25px;height:25px;border-radius:7px;background:var(--ink);color:#fff;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;" x-text="day.n"></div>
+                    <div style="font-size:14.5px;font-weight:700;letter-spacing:-0.01em;" x-text="day.name"></div>
+                    <div style="font-size:11.5px;color:var(--dim);background:var(--rail);border:1px solid var(--line);padding:2px 8px;border-radius:5px;" x-text="day.bias"></div>
+                    <div style="flex:1;"></div>
+                    <div style="font-size:11.5px;color:var(--dim);" x-text="day.exercises.length + ' exercises'"></div>
+                  </div>
+                  <div style="display:grid;grid-template-columns:minmax(0,1.75fr) 84px 76px 44px minmax(0,0.92fr);gap:10px;padding:7px 16px;background:var(--rail);border-bottom:1px solid var(--line-2);font-size:10px;font-weight:700;letter-spacing:0.06em;text-transform:uppercase;color:var(--dim);">
+                    <div>Exercise</div><div style="text-align:center;">Sets &#215; Reps</div><div style="text-align:center;">Load</div><div style="text-align:center;">RPE</div><div>Notes</div>
+                  </div>
+                  <template x-for="(ex, xi) in day.exercises" :key="ex.id">
+                    <div style="display:grid;grid-template-columns:minmax(0,1.75fr) 84px 76px 44px minmax(0,0.92fr);gap:10px;padding:8px 16px;border-bottom:1px solid var(--line-2);align-items:center;">
+                      <div style="min-width:0;">
+                        <input class="meso-cell" x-model="ex.name" style="width:100%;appearance:none;border:0;background:transparent;font:inherit;font-size:13.5px;font-weight:600;color:var(--ink);padding:3px 6px;border-radius:5px;outline:none;letter-spacing:-0.01em;" />
+                        <div style="display:flex;flex-wrap:wrap;gap:5px;align-items:center;padding:1px 6px;margin-top:1px;min-height:15px;">
+                          <template x-if="ex.tag"><span style="display:inline-flex;align-items:center;gap:3px;font-size:10px;font-weight:700;color:var(--accent-deep);background:var(--soft);border:1px solid var(--soft-line);padding:0 5px;border-radius:4px;" x-text="ex.tag"></span></template>
+                          <template x-if="ex.last"><span style="font-size:10.5px;color:var(--dim);font-family:'IBM Plex Mono',monospace;" x-text="'last: ' + ex.last"></span></template>
+                          <template x-if="isGroup && ex.adj"><span style="font-size:10px;font-weight:600;color:var(--accent-deep);background:var(--soft);padding:0 5px;border-radius:4px;" x-text="ex.adj"></span></template>
+                        </div>
+                      </div>
+                      <div style="display:flex;align-items:center;justify-content:center;gap:2px;">
+                        <input class="meso-cell" x-model="ex.sets" style="width:30px;text-align:center;appearance:none;border:0;background:transparent;font-family:'IBM Plex Mono',monospace;font-size:13px;color:var(--ink);padding:4px 2px;border-radius:5px;outline:none;" />
+                        <span style="color:var(--dim);font-size:11px;">&#215;</span>
+                        <input class="meso-cell" x-model="ex.reps" style="width:34px;text-align:center;appearance:none;border:0;background:transparent;font-family:'IBM Plex Mono',monospace;font-size:13px;color:var(--ink);padding:4px 2px;border-radius:5px;outline:none;" />
+                      </div>
+                      <div style="display:flex;align-items:center;justify-content:center;gap:3px;">
+                        <input class="meso-cell" x-model="ex.load" style="width:42px;text-align:right;appearance:none;border:0;background:transparent;font-family:'IBM Plex Mono',monospace;font-size:13px;color:var(--ink);padding:4px 2px;border-radius:5px;outline:none;" />
+                        <span style="font-size:10.5px;color:var(--dim);min-width:14px;" x-text="loadSuffix(ex.load)"></span>
+                      </div>
+                      <div style="display:flex;justify-content:center;">
+                        <input class="meso-cell" x-model="ex.rpe" style="width:38px;text-align:center;appearance:none;border:0;background:transparent;font-family:'IBM Plex Mono',monospace;font-size:13px;color:var(--ink);padding:4px 2px;border-radius:5px;outline:none;" />
+                      </div>
+                      <div style="min-width:0;">
+                        <input class="meso-note" x-model="ex.note" placeholder="&#8212;" style="width:100%;appearance:none;border:0;background:transparent;font:inherit;font-size:12px;color:var(--dim);padding:4px 6px;border-radius:5px;outline:none;" />
+                      </div>
+                    </div>
+                  </template>
+                  <button data-hover="add" @click="addExercise(di)" style="appearance:none;border:0;cursor:pointer;width:100%;text-align:left;padding:9px 15px;background:transparent;font:inherit;font-size:12px;font-weight:600;color:var(--dim);">+ Add exercise</button>
+                </div>
+              </template>
+            </div>
+
+            <!-- ===== BLOCK / PERIODIZATION VIEW ===== -->
+            <div x-show="view === 'block'" style="padding:20px 22px 40px;max-width:1000px;">
+              <div style="margin-bottom:8px;">
+                <h1 style="margin:0 0 3px;font-size:21px;font-weight:800;letter-spacing:-0.025em;">Hypertrophy block &#8212; 4-week mesocycle</h1>
+                <p style="margin:0;font-size:12.5px;color:var(--dim);">Mesocycle 2 of 4 in the macrocycle &#183; accumulation into a planned deload</p>
+              </div>
+
+              <!-- macro strip -->
+              <div style="margin:18px 0 22px;display:flex;align-items:stretch;gap:8px;">
+                <template x-for="p in phases" :key="p.name">
+                  <div :style="`flex:${p.weeks === '2 wk' ? '0.5' : '1'};border-radius:9px;padding:11px 13px;background:${p.state === 'current' ? 'var(--accent)' : 'var(--surface)'};border:1px solid ${p.state === 'current' ? 'var(--accent)' : 'var(--line)'};opacity:${(p.state === 'next' || p.state === 'future') ? '0.72' : '1'}`">
+                    <div :style="`font-size:12.5px;font-weight:700;letter-spacing:-0.01em;color:${p.state === 'current' ? 'var(--accent-ink)' : (p.state === 'done' ? 'var(--accent-deep)' : 'var(--ink)')}`" x-text="p.name"></div>
+                    <div :style="`font-size:10.5px;margin-top:2px;color:${p.state === 'current' ? 'var(--accent-ink)' : 'var(--dim)'};opacity:${p.state === 'current' ? '0.85' : '1'}`" x-text="p.weeks + (p.state === 'current' ? ' · now' : (p.state === 'done' ? ' · done' : ''))"></div>
+                  </div>
+                </template>
+              </div>
+
+              <div style="background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);padding:18px 20px;box-shadow:0 1px 2px rgba(16,18,22,0.03);">
+                <div style="display:flex;align-items:center;gap:16px;margin-bottom:6px;">
+                  <div style="font-size:13px;font-weight:700;">This mesocycle</div>
+                  <div style="display:flex;align-items:center;gap:6px;font-size:11px;color:var(--dim);"><div style="width:11px;height:11px;border-radius:3px;background:var(--accent);"></div>Volume</div>
+                  <div style="display:flex;align-items:center;gap:6px;font-size:11px;color:var(--dim);"><div style="width:11px;height:11px;border-radius:3px;background:var(--surface);border:1.5px solid var(--accent);"></div>Intensity</div>
+                </div>
+
+                <!-- timeline -->
+                <div x-show="periodStyle === 'timeline'" class="meso-flex" style="gap:16px;align-items:flex-end;padding:12px 6px 4px;">
+                  <template x-for="w in weeks" :key="w.label">
+                    <div style="flex:1;display:flex;flex-direction:column;align-items:center;gap:9px;">
+                      <div style="height:156px;width:100%;display:flex;align-items:flex-end;justify-content:center;gap:7px;">
+                        <div :style="`width:20px;height:${barH(w.vol, 156)};border-radius:5px 5px 0 0;background:${w.current ? 'var(--accent)' : (w.deload ? 'color-mix(in srgb,var(--accent) 28%,#fff)' : 'var(--soft-line)')}`"></div>
+                        <div :style="`width:20px;height:${barH(w.inten, 156)};border-radius:5px 5px 0 0;background:var(--surface);border:1.5px solid var(--accent)`"></div>
+                      </div>
+                      <div :style="`font-size:12.5px;font-weight:700;color:${w.current ? 'var(--ink)' : 'var(--dim)'}`" x-text="w.label"></div>
+                      <div :style="`font-size:10.5px;font-weight:600;padding:2px 8px;border-radius:5px;color:${w.deload ? 'var(--warn)' : (w.current ? 'var(--accent-deep)' : 'var(--dim)')};background:${w.deload ? 'var(--warn-soft)' : (w.current ? 'var(--soft)' : 'transparent')}`" x-text="w.phase"></div>
+                    </div>
+                  </template>
+                </div>
+
+                <!-- phase ladder -->
+                <div x-show="periodStyle === 'ladder'" class="meso-flex" style="align-items:flex-end;gap:14px;padding:12px 6px 4px;">
+                  <template x-for="(p, i) in phases" :key="p.name">
+                    <div style="flex:1;display:flex;flex-direction:column;gap:9px;">
+                      <div :style="`height:${66 + i * 32}px;border-radius:9px;background:${p.state === 'current' ? 'var(--accent)' : (p.state === 'done' ? 'var(--soft)' : 'var(--surface)')};border:1.5px solid ${p.state === 'current' ? 'var(--accent)' : 'var(--line)'};display:flex;align-items:flex-end;padding:11px;color:${p.state === 'current' ? 'var(--accent-ink)' : (p.state === 'done' ? 'var(--accent-deep)' : 'var(--ink)')};font-weight:700;font-size:13px;letter-spacing:-0.01em`" x-text="p.name"></div>
+                      <div style="font-size:11px;color:var(--dim);text-align:center;font-weight:600;" x-text="p.weeks"></div>
+                    </div>
+                  </template>
+                </div>
+
+                <!-- calendar -->
+                <div x-show="periodStyle === 'calendar'" style="padding:14px 6px 4px;">
+                  <div style="display:grid;grid-template-columns:50px repeat(7,1fr);gap:7px;margin-bottom:8px;">
+                    <div></div>
+                    <template x-for="(d, i) in calDays" :key="i"><div style="text-align:center;font-size:11px;color:var(--dim);font-weight:700;" x-text="d"></div></template>
+                  </div>
+                  <template x-for="(w, ri) in weeks" :key="ri">
+                    <div style="display:grid;grid-template-columns:50px repeat(7,1fr);gap:7px;margin-bottom:7px;align-items:center;">
+                      <div :style="`font-size:11.5px;color:${w.current ? 'var(--ink)' : 'var(--dim)'};font-weight:700`" x-text="w.label"></div>
+                      <template x-for="(d, ci) in calDays" :key="ci">
+                        <div :style="cellStyle(w, ci)">
+                          <template x-if="cellOn(w, ci)"><div :style="`width:7px;height:7px;border-radius:50%;background:${w.current ? 'var(--accent-ink)' : 'var(--accent)'}`"></div></template>
+                        </div>
+                      </template>
+                    </div>
+                  </template>
+                </div>
+              </div>
+            </div>
+
+            <!-- ===== ATHLETE VIEW ===== -->
+            <div x-show="view === 'athlete'" class="meso-flex" style="padding:24px;gap:30px;align-items:flex-start;justify-content:center;flex-wrap:wrap;">
+              <div style="flex:0 0 auto;width:336px;height:680px;border-radius:42px;background:#0e0f12;padding:11px;box-shadow:0 24px 60px rgba(16,18,22,0.28);position:relative;">
+                <div style="width:100%;height:100%;border-radius:32px;background:var(--surface);overflow:hidden;display:flex;flex-direction:column;position:relative;">
+                  <div style="height:40px;flex:0 0 auto;display:flex;align-items:center;justify-content:space-between;padding:0 22px;font-size:12px;font-weight:600;color:var(--ink);">
+                    <span style="font-family:'IBM Plex Mono',monospace;">6:14</span>
+                    <div style="position:absolute;left:50%;top:9px;transform:translateX(-50%);width:88px;height:21px;background:#0e0f12;border-radius:0 0 14px 14px;"></div>
+                    <span style="font-size:11px;letter-spacing:0.05em;">&#9679;&#9679;&#9679; &#9673;</span>
+                  </div>
+                  <div style="flex:0 0 auto;padding:6px 18px 14px;border-bottom:1px solid var(--line-2);">
+                    <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:11px;">
+                      <button @click="view = 'week'" style="appearance:none;border:0;background:none;cursor:pointer;font:inherit;font-size:12px;font-weight:600;color:var(--accent);padding:0;">&#8592; Coach</button>
+                      <div style="font-size:11px;color:var(--dim);">Wed &#183; Day 1</div>
+                    </div>
+                    <h2 style="margin:0 0 2px;font-size:20px;font-weight:800;letter-spacing:-0.02em;">Lower &#183; Quad bias</h2>
+                    <div style="font-size:12px;color:var(--dim);margin-bottom:12px;">Box squat focus &#183; knee-safe</div>
+                    <div style="display:flex;align-items:center;gap:9px;">
+                      <div style="font-size:12px;font-weight:700;color:var(--ink);font-family:'IBM Plex Mono',monospace;"><span x-text="aDone"></span>/<span x-text="aTotal"></span></div>
+                      <div style="flex:1;display:flex;gap:3px;">
+                        <template x-for="e in athleteDay" :key="e.id">
+                          <template x-for="r in e.rows" :key="r.k">
+                            <div :style="`flex:1;height:5px;border-radius:3px;background:${r.done ? 'var(--accent)' : 'var(--line)'}`"></div>
+                          </template>
+                        </template>
+                      </div>
+                      <div style="font-size:11px;color:var(--dim);">sets</div>
+                    </div>
+                  </div>
+                  <div style="flex:1;overflow-y:auto;padding:14px;display:flex;flex-direction:column;gap:12px;">
+                    <template x-for="ae in athleteDay" :key="ae.id">
+                      <div style="border:1px solid var(--line);border-radius:13px;overflow:hidden;">
+                        <div style="padding:11px 13px 9px;border-bottom:1px solid var(--line-2);">
+                          <div style="font-size:14px;font-weight:700;letter-spacing:-0.01em;" x-text="ae.name"></div>
+                          <div style="font-size:11.5px;color:var(--dim);font-family:'IBM Plex Mono',monospace;" x-text="'target ' + ae.target"></div>
+                        </div>
+                        <template x-for="r in ae.rows" :key="r.k">
+                          <div style="display:flex;align-items:center;gap:9px;padding:8px 13px;border-bottom:1px solid var(--line-2);">
+                            <div style="width:18px;font-size:11px;font-weight:700;color:var(--dim);font-family:'IBM Plex Mono',monospace;" x-text="r.n"></div>
+                            <input class="meso-phone-input" placeholder="reps" style="width:46px;text-align:center;appearance:none;border:1px solid var(--line);border-radius:7px;background:var(--rail);font:inherit;font-family:'IBM Plex Mono',monospace;font-size:13px;padding:6px 4px;outline:none;color:var(--ink);" />
+                            <span style="font-size:11px;color:var(--dim);">&#215;</span>
+                            <input class="meso-phone-input" :placeholder="unit" style="width:54px;text-align:center;appearance:none;border:1px solid var(--line);border-radius:7px;background:var(--rail);font:inherit;font-family:'IBM Plex Mono',monospace;font-size:13px;padding:6px 4px;outline:none;color:var(--ink);" />
+                            <div style="flex:1;font-size:10.5px;color:var(--dim);text-align:right;" x-text="r.target"></div>
+                            <button @click="toggleCheck(r.k)" style="appearance:none;border:0;background:none;cursor:pointer;padding:0;flex:0 0 auto;">
+                              <template x-if="r.done"><div style="width:26px;height:26px;border-radius:50%;background:var(--accent);display:flex;align-items:center;justify-content:center;color:var(--accent-ink);font-size:13px;">&#10003;</div></template>
+                              <template x-if="!r.done"><div style="width:26px;height:26px;border-radius:50%;border:1.5px solid var(--line);background:var(--surface);"></div></template>
+                            </button>
+                          </div>
+                        </template>
+                      </div>
+                    </template>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Claude Design prototype — Meso program designer

Imports the **"Meso"** AI strength-training program designer from a
[Claude Design](https://claude.ai/design) prototype (`Meso.dc.html`) and ports it to
the project's existing stack (**Alpine.js + CSS custom properties** — no new
dependencies). Lives at **`/meso/`**, gated behind login.

### ⚠️ This is a mock, not a feature

Everything is **client-side and canned** — this is a clickable prototype to pressure-test
the product, not a working tool:

- **Data** (Maya, the group, every exercise/load/RPE, the macrocycle) is hardcoded fixture
  state in `meso.js`. No DB, no link to `users`/`exercises`.
- **The "Agent"** is a keyword intent engine (`detectIntent` → swap-knee / lower-volume /
  progress / deload), **not an LLM**. "grounded on profile + logs" is a label.
- **Nothing persists** across a refresh. **"Deliver"** just shows a toast; the phone's
  rep/weight inputs are cosmetic.

### What's included

A faithful port of the full prototype:

- **Coach designer** with three canvas views: editable **week grid**, **periodization**
  (timeline / phase ladder / calendar charts), and an **athlete phone preview** with set-logging.
- **Agent chat** — suggestion chips + free text drive intents that mutate the live program.
- **Individual / Group** modes with per-athlete auto-adjustments.

### Files

- New `meso` app — `TemplateView` (`LoginRequiredMixin`) + URL at `/meso/`
- `templates/meso/designer.html` — standalone full-screen UI
- `static/js/meso.js` — Alpine component (state, intent engine, charts)
- `static/css/meso.css` — resets, keyframes, segmented-control styles
- Registered in `INSTALLED_APPS` and `config/urls.py`

### Verification

Driven in a headless browser (Playwright + Chrome): all views, all three charts, the agent
applying edits to the grid, and group mode render with **zero console errors**. `ruff`,
Biome, and `manage.py check` are clean; all pre-commit hooks pass.

### Next

This is the **core designer screen**. Planned follow-up prototypes (still mocked) round out
the coaching loop: roster/dashboard, athlete profile, agent change-review, deliver/publish,
and session-results review.
