### PR TITLE
Meso coaching-loop screens — Claude Design prototype

### DIFF
--- a/app/store_project/meso/mockdata.py
+++ b/app/store_project/meso/mockdata.py
@@ -1,0 +1,294 @@
+"""Canonical mock data for the Meso program-designer prototype.
+
+Every Meso screen reads from this one module so the prototype stays internally
+consistent — the same athletes, program, and proposed changes appear across the
+roster, profile, review, deliver, and results screens. None of this is real:
+there is no database, no athlete records, no logged sessions. When the prototype
+graduates, these structures map onto real models (users / exercises / a future
+programs app) and this module goes away.
+"""
+
+# --- athletes -------------------------------------------------------------
+
+ATHLETES = [
+    {
+        "slug": "maya",
+        "name": "Maya Okonkwo",
+        "initials": "MO",
+        "age": 34,
+        "level": "Intermediate",
+        "trained": "14 mo trained",
+        "goals": ["Hypertrophy", "Return to lifting"],
+        "contraindications": [
+            "L knee — avoid deep knee flexion under load",
+            "No max-effort jumping / impact",
+        ],
+        "block": "Hypertrophy",
+        "week": "Wk 2 / 4",
+        "status": "needs_review",
+        "status_label": "Needs review",
+        "compliance": 92,
+        "flags": ["L knee"],
+        "tone": "accent",
+    },
+    {
+        "slug": "devon",
+        "name": "Devon Reyes",
+        "initials": "DR",
+        "age": 28,
+        "level": "Beginner",
+        "trained": "6 mo trained",
+        "goals": ["General fitness", "Strength"],
+        "contraindications": ["R shoulder — neutral-grip pressing only"],
+        "block": "Hypertrophy",
+        "week": "Wk 2 / 4",
+        "status": "delivered",
+        "status_label": "Delivered",
+        "compliance": 78,
+        "flags": ["R shoulder"],
+        "tone": "neutral",
+    },
+    {
+        "slug": "priya",
+        "name": "Priya Nair",
+        "initials": "PN",
+        "age": 41,
+        "level": "Advanced",
+        "trained": "6 yr trained",
+        "goals": ["Powerlifting peak"],
+        "contraindications": [],
+        "block": "Strength",
+        "week": "Wk 1 / 4",
+        "status": "active",
+        "status_label": "On track",
+        "compliance": 96,
+        "flags": [],
+        "tone": "neutral",
+    },
+    {
+        "slug": "marcus",
+        "name": "Marcus Tan",
+        "initials": "MT",
+        "age": 35,
+        "level": "Intermediate",
+        "trained": "3 yr trained",
+        "goals": ["Hypertrophy"],
+        "contraindications": [],
+        "block": "Hypertrophy",
+        "week": "Wk 2 / 4",
+        "status": "drafting",
+        "status_label": "Agent drafting",
+        "compliance": 84,
+        "flags": [],
+        "tone": "neutral",
+    },
+    {
+        "slug": "lena",
+        "name": "Lena Kovic",
+        "initials": "LK",
+        "age": 31,
+        "level": "Intermediate",
+        "trained": "2 yr trained",
+        "goals": ["General fitness"],
+        "contraindications": ["Lower back — trap-bar / RDL only, no conventional pull"],
+        "block": "Hypertrophy",
+        "week": "Wk 2 / 4",
+        "status": "delivered",
+        "status_label": "Delivered",
+        "compliance": 88,
+        "flags": ["Lower back"],
+        "tone": "neutral",
+    },
+]
+
+GROUPS = [
+    {
+        "slug": "hypertrophy-group",
+        "name": "Hypertrophy Group",
+        "focus": "General fitness",
+        "members": ["maya", "devon", "priya", "marcus", "lena"],
+        "week": "Wk 2 / 4",
+        "status": "needs_review",
+        "status_label": "Needs review",
+        "flag_note": "3 of 5 carry a knee or shoulder flag — auto-regressions applied per athlete",
+    },
+]
+
+# --- programming context (shared with the designer) -----------------------
+
+COACH_STYLE = {
+    "tags": [
+        "Compound-first",
+        "RPE-based load",
+        "Free-weight bias",
+        "2-min rest cap",
+        "Unilateral work",
+    ],
+    "avoid": "machine-only days, untracked progressions, >3 exercises to failure / session.",
+}
+
+MACROCYCLE = [
+    {"name": "Base / GPP", "weeks": "4 wk", "state": "done", "note": "done"},
+    {"name": "Hypertrophy", "weeks": "4 wk", "state": "current", "note": "wk 2 / 4"},
+    {"name": "Strength", "weeks": "4 wk", "state": "next", "note": "next"},
+    {"name": "Peak / Test", "weeks": "2 wk", "state": "future", "note": ""},
+]
+
+# --- agent change review (proposed batch awaiting coach approval) ----------
+
+PROPOSED_CHANGES = [
+    {
+        "id": "swap-knee",
+        "kind": "Swap",
+        "day": "Day 1 · Lower",
+        "title": "Bulgarian Split Squat → Box Step-Down (low)",
+        "before": "Bulgarian Split Squat (DB) · 3×10 @ 18 kg",
+        "after": "Box Step-Down (low) · 3×10 @ 14 kg",
+        "rationale": (
+            "Same single-leg quad stimulus, but the knee tracks through a shorter, "
+            "controlled range — a better fit for the meniscus history."
+        ),
+        "honors": "L knee — avoid deep knee flexion under load",
+    },
+    {
+        "id": "progress",
+        "kind": "Progress",
+        "day": "Day 3 · Posterior",
+        "title": "Trap-Bar Deadlift → 92.5 kg",
+        "before": "4×6 @ 90 kg · logged RPE 6 last block",
+        "after": "4×6 @ 92.5 kg · projected RPE 7",
+        "rationale": (
+            "Anchored to last block's logged load and RPE — +2.5 kg lands in the "
+            "hypertrophy window without overshooting."
+        ),
+        "honors": "RPE-based load",
+    },
+    {
+        "id": "volume",
+        "kind": "Volume",
+        "day": "Day 2 · Upper",
+        "title": "Day 2 pressing volume − 1 set",
+        "before": "Incline DB Press, Chest-Supported Row, Lat Pulldown · 4 sets each",
+        "after": "Primary lifts · 3 sets each (accessories unchanged)",
+        "rationale": (
+            "Keeps weekly pressing volume in check while the shoulder settles, without "
+            "touching accessory work."
+        ),
+        "honors": "R shoulder — neutral-grip pressing only",
+    },
+]
+
+# --- session results (Maya, delivered Week 1 Day 1) -----------------------
+
+RESULTS_SUMMARY = {
+    "athlete": "maya",
+    "session": "Week 1 · Day 1 — Lower",
+    "logged": "Wed, 6:42 pm",
+    "completion": 94,
+    "avg_rpe_delta": "+0.4",
+    "flag": "Box Squat ran 1.5 RPE over target on the top set — agent suggests holding load next session.",
+}
+
+RESULTS_ROWS = [
+    {
+        "name": "Box Squat (to parallel)",
+        "target": "4×6 @ 70 kg · RPE 7",
+        "logged": "4×6 @ 70 kg",
+        "rpe": "8.5",
+        "rpe_state": "over",
+        "note": "Top set felt heavy — bar speed dropped",
+    },
+    {
+        "name": "Bulgarian Split Squat (DB)",
+        "target": "3×10 @ 18 kg · RPE 7",
+        "logged": "3×10 @ 18 kg",
+        "rpe": "7",
+        "rpe_state": "on",
+        "note": "",
+    },
+    {
+        "name": "Leg Press (controlled ROM)",
+        "target": "3×12 @ 110 kg · RPE 8",
+        "logged": "3×12 @ 110 kg",
+        "rpe": "8",
+        "rpe_state": "on",
+        "note": "",
+    },
+    {
+        "name": "Seated Leg Curl",
+        "target": "3×12 @ 41 kg · RPE 8",
+        "logged": "2×12, 1×9 @ 41 kg",
+        "rpe": "9",
+        "rpe_state": "over",
+        "note": "Missed 3 reps on last set",
+    },
+    {
+        "name": "Standing Calf Raise",
+        "target": "4×15 @ 60 kg",
+        "logged": "4×15 @ 60 kg",
+        "rpe": "—",
+        "rpe_state": "on",
+        "note": "",
+    },
+]
+
+# --- roster activity feed -------------------------------------------------
+
+ACTIVITY = [
+    {
+        "who": "maya",
+        "text": "logged Week 1 · Day 1 — 94% complete",
+        "when": "2h ago",
+        "kind": "log",
+    },
+    {
+        "who": "devon",
+        "text": "flagged shoulder discomfort on Incline DB Press",
+        "when": "5h ago",
+        "kind": "flag",
+    },
+    {
+        "who": "priya",
+        "text": "hit a 3-rep PR on back squat — 142.5 kg",
+        "when": "Yesterday",
+        "kind": "pr",
+    },
+    {
+        "who": "marcus",
+        "text": "agent finished drafting Week 2 — awaiting your review",
+        "when": "Yesterday",
+        "kind": "draft",
+    },
+    {
+        "who": "lena",
+        "text": "completed Week 1 — 88% adherence",
+        "when": "2d ago",
+        "kind": "log",
+    },
+]
+
+# --- deliver payload ------------------------------------------------------
+
+DELIVER = {
+    "athlete": "maya",
+    "what": "Week 2 — Accumulation",
+    "sessions": 3,
+    "starts": "Wed, Jun 24",
+    "changes_since": [
+        "Box Step-Down swapped in for Bulgarian Split Squat (knee)",
+        "Trap-Bar Deadlift progressed to 92.5 kg",
+        "Day 2 pressing trimmed by 1 set",
+    ],
+    "channels": ["Push notification", "Email summary"],
+}
+
+
+def athlete_by_slug(slug):
+    for a in ATHLETES:
+        if a["slug"] == slug:
+            return a
+    return None
+
+
+def athletes_map():
+    return {a["slug"]: a for a in ATHLETES}

--- a/app/store_project/meso/urls.py
+++ b/app/store_project/meso/urls.py
@@ -1,8 +1,18 @@
 from django.urls import path
 
+from .views import AthleteProfileView
+from .views import ChangeReviewView
+from .views import DeliverView
 from .views import MesoDesignerView
+from .views import ResultsView
+from .views import RosterView
 
 app_name = "meso"
 urlpatterns = [
-    path("", MesoDesignerView.as_view(), name="designer"),
+    path("", RosterView.as_view(), name="roster"),
+    path("designer/", MesoDesignerView.as_view(), name="designer"),
+    path("review/", ChangeReviewView.as_view(), name="review"),
+    path("deliver/", DeliverView.as_view(), name="deliver"),
+    path("results/", ResultsView.as_view(), name="results"),
+    path("athlete/<slug:slug>/", AthleteProfileView.as_view(), name="athlete"),
 ]

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -1,5 +1,8 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.http import Http404
 from django.views.generic import TemplateView
+
+from . import mockdata
 
 
 class MesoDesignerView(LoginRequiredMixin, TemplateView):
@@ -11,3 +14,84 @@ class MesoDesignerView(LoginRequiredMixin, TemplateView):
     """
 
     template_name = "meso/designer.html"
+
+
+class RosterView(LoginRequiredMixin, TemplateView):
+    """Front door: the coach's athletes, groups, and recent activity."""
+
+    template_name = "meso/roster.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        amap = mockdata.athletes_map()
+        ctx["active"] = "roster"
+        ctx["athletes"] = mockdata.ATHLETES
+        ctx["groups"] = [
+            {**g, "member_objs": [amap[s] for s in g["members"] if s in amap]}
+            for g in mockdata.GROUPS
+        ]
+        ctx["activity"] = [
+            {**ev, "athlete": amap.get(ev["who"])} for ev in mockdata.ACTIVITY
+        ]
+        ctx["needs_review"] = sum(
+            1 for a in mockdata.ATHLETES if a["status"] == "needs_review"
+        )
+        return ctx
+
+
+class AthleteProfileView(LoginRequiredMixin, TemplateView):
+    """Full athlete record — the expanded version of the designer's left rail."""
+
+    template_name = "meso/athlete_profile.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        athlete = mockdata.athlete_by_slug(kwargs.get("slug"))
+        if athlete is None:
+            raise Http404("Unknown athlete")
+        ctx["active"] = "roster"
+        ctx["athlete"] = athlete
+        ctx["coach_style"] = mockdata.COACH_STYLE
+        ctx["macrocycle"] = mockdata.MACROCYCLE
+        ctx["results_summary"] = mockdata.RESULTS_SUMMARY
+        return ctx
+
+
+class ChangeReviewView(LoginRequiredMixin, TemplateView):
+    """Review the batch of edits the agent proposes before they hit the program."""
+
+    template_name = "meso/review.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx["active"] = "designer"
+        ctx["athlete"] = mockdata.athlete_by_slug("maya")
+        ctx["changes"] = mockdata.PROPOSED_CHANGES
+        return ctx
+
+
+class DeliverView(LoginRequiredMixin, TemplateView):
+    """Confirm what gets sent to the athlete, when, and how."""
+
+    template_name = "meso/deliver.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx["active"] = "designer"
+        ctx["deliver"] = mockdata.DELIVER
+        ctx["athlete"] = mockdata.athlete_by_slug(mockdata.DELIVER["athlete"])
+        return ctx
+
+
+class ResultsView(LoginRequiredMixin, TemplateView):
+    """Logged session results vs targets — closes the loop back to the agent."""
+
+    template_name = "meso/results.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx["active"] = "roster"
+        ctx["summary"] = mockdata.RESULTS_SUMMARY
+        ctx["rows"] = mockdata.RESULTS_ROWS
+        ctx["athlete"] = mockdata.athlete_by_slug(mockdata.RESULTS_SUMMARY["athlete"])
+        return ctx

--- a/app/store_project/static/css/meso.css
+++ b/app/store_project/static/css/meso.css
@@ -20,6 +20,29 @@ body.meso {
   font-family: "Hanken Grotesk", system-ui, -apple-system, sans-serif;
 }
 
+/* Default design tokens. The designer also sets these inline on its root (so it
+   stays self-contained); here they live on .meso so the standard pages inherit
+   them without repeating the block. */
+.meso {
+  --bg: #f5f6f7;
+  --surface: #ffffff;
+  --rail: #fbfbfc;
+  --ink: #16181c;
+  --dim: #71777e;
+  --line: #e7e9ec;
+  --line-2: #f1f3f5;
+  --radius: 8px;
+  --pad: 14px;
+  --accent: oklch(0.56 0.14 258);
+  --accent-ink: #ffffff;
+  --soft: color-mix(in srgb, var(--accent) 9%, #fff);
+  --soft-line: color-mix(in srgb, var(--accent) 26%, #fff);
+  --accent-deep: color-mix(in srgb, var(--accent) 82%, #1a1a1a);
+  --warn: #b4541f;
+  --warn-soft: #fbefe8;
+  --ok: #2f8f56;
+}
+
 .meso input,
 .meso textarea {
   font-family: inherit;
@@ -161,4 +184,348 @@ body.meso {
 .meso .meso-seg-btn--p {
   font-size: 12px;
   padding: 4px 11px;
+}
+
+/* ==========================================================================
+   Shared component layer for the spine screens (roster, profile, review,
+   deliver, results). The designer is a full-viewport tool with its own chrome;
+   these classes give the surrounding pages a consistent look built from the
+   same tokens. Standard pages set --bg/--ink/etc. on body.meso and scroll
+   normally (the designer locks the viewport instead).
+   ========================================================================== */
+
+.meso-app {
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: "Hanken Grotesk", system-ui, -apple-system, sans-serif;
+  font-size: 14px;
+  line-height: 1.45;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* --- top nav --- */
+.meso-topnav {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  height: 55px;
+  padding: 0 22px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--line);
+}
+.meso-brand {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  text-decoration: none;
+  color: var(--ink);
+}
+.meso-brand-mark {
+  width: 23px;
+  height: 23px;
+  border-radius: 6px;
+  background: var(--accent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.meso-brand-mark i {
+  width: 8px;
+  height: 8px;
+  background: var(--accent-ink);
+  border-radius: 2px;
+  transform: rotate(45deg);
+}
+.meso-brand b {
+  font-weight: 800;
+  font-size: 16px;
+  letter-spacing: -0.025em;
+}
+.meso-navlinks {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+.meso-navlink {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--dim);
+  text-decoration: none;
+  padding: 6px 11px;
+  border-radius: 7px;
+}
+.meso-navlink:hover {
+  background: var(--rail);
+  color: var(--ink);
+}
+.meso-navlink.is-active {
+  color: var(--ink);
+  background: var(--soft);
+}
+.meso-spacer {
+  flex: 1;
+}
+
+/* --- page scaffold --- */
+.meso-page {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 26px 24px 64px;
+}
+.meso-page--narrow {
+  max-width: 860px;
+}
+.meso-eyebrow {
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--dim);
+  margin: 0 0 8px;
+}
+.meso-h1 {
+  margin: 0 0 4px;
+  font-size: 24px;
+  font-weight: 800;
+  letter-spacing: -0.025em;
+}
+.meso-sub {
+  margin: 0;
+  font-size: 13px;
+  color: var(--dim);
+}
+.meso-pagehead {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 22px;
+}
+.meso-crumbs {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12.5px;
+  color: var(--dim);
+  margin-bottom: 14px;
+}
+.meso-crumbs a {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+/* --- cards --- */
+.meso-card {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: 0 1px 2px rgba(16, 18, 22, 0.03);
+}
+.meso-card--pad {
+  padding: 18px 20px;
+}
+.meso-grid {
+  display: grid;
+  gap: 14px;
+}
+.meso-grid--2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+.meso-grid--3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+.meso-grid--profile {
+  grid-template-columns: 320px minmax(0, 1fr);
+  align-items: start;
+}
+
+/* --- buttons --- */
+.meso-btn {
+  appearance: none;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 8px 14px;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  white-space: nowrap;
+}
+.meso-btn:hover {
+  background: var(--rail);
+}
+.meso-btn--primary {
+  color: var(--accent-ink);
+  background: var(--accent);
+  border-color: transparent;
+  font-weight: 650;
+  box-shadow: 0 1px 2px rgba(16, 18, 22, 0.12);
+}
+.meso-btn--primary:hover {
+  filter: brightness(1.06);
+  background: var(--accent);
+}
+.meso-btn--ghost {
+  background: transparent;
+  border-color: transparent;
+  color: var(--accent);
+  padding-left: 0;
+  padding-right: 0;
+}
+.meso-btn--ghost:hover {
+  background: transparent;
+  text-decoration: underline;
+}
+
+/* --- badges / status pills --- */
+.meso-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11.5px;
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+.meso-badge i {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+.meso-badge--accent {
+  color: var(--accent-deep);
+  background: var(--soft);
+  border: 1px solid var(--soft-line);
+}
+.meso-badge--warn {
+  color: var(--warn);
+  background: var(--warn-soft);
+  border: 1px solid color-mix(in srgb, var(--warn) 22%, #fff);
+}
+.meso-badge--ok {
+  color: var(--ok);
+  background: color-mix(in srgb, var(--ok) 12%, #fff);
+  border: 1px solid color-mix(in srgb, var(--ok) 26%, #fff);
+}
+.meso-badge--muted {
+  color: var(--dim);
+  background: var(--rail);
+  border: 1px solid var(--line);
+}
+.meso-tag {
+  display: inline-flex;
+  padding: 4px 9px;
+  border-radius: 6px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  font-size: 11.5px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+.meso-tag--accent {
+  background: var(--soft);
+  border-color: var(--soft-line);
+  color: var(--accent-deep);
+  font-weight: 600;
+}
+
+/* --- avatars --- */
+.meso-avatar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  font-weight: 700;
+  flex: 0 0 auto;
+  background: #eef0f2;
+  color: var(--dim);
+  width: 38px;
+  height: 38px;
+  font-size: 13px;
+}
+.meso-avatar--accent {
+  background: var(--soft);
+  border: 1px solid var(--soft-line);
+  color: var(--accent-deep);
+}
+.meso-avatar--sm {
+  width: 28px;
+  height: 28px;
+  font-size: 11px;
+}
+.meso-avatar--lg {
+  width: 48px;
+  height: 48px;
+  border-radius: 13px;
+  font-size: 16px;
+}
+
+/* --- athlete rows / list --- */
+.meso-row {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  padding: 13px 16px;
+  border-bottom: 1px solid var(--line-2);
+  text-decoration: none;
+  color: var(--ink);
+}
+.meso-row:last-child {
+  border-bottom: 0;
+}
+.meso-row:hover {
+  background: var(--rail);
+}
+.meso-row-name {
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.meso-row-meta {
+  font-size: 11.5px;
+  color: var(--dim);
+}
+
+/* --- progress bar --- */
+.meso-meter {
+  height: 6px;
+  border-radius: 4px;
+  background: var(--line);
+  overflow: hidden;
+  flex: 1;
+}
+.meso-meter > span {
+  display: block;
+  height: 100%;
+  border-radius: 4px;
+  background: var(--accent);
+}
+
+/* --- divider + misc --- */
+.meso-hr {
+  height: 1px;
+  background: var(--line);
+  border: 0;
+  margin: 16px 0;
+}
+.meso-muted {
+  color: var(--dim);
+}
+.meso-mono {
+  font-family: "IBM Plex Mono", monospace;
 }

--- a/app/store_project/templates/meso/_meso_base.html
+++ b/app/store_project/templates/meso/_meso_base.html
@@ -1,0 +1,38 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{% block title %}Meso{% endblock %} · Mastering Fitness</title>
+    <link rel="shortcut icon" href="{% static 'png/favicon-black.png' %}" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="{% static 'css/meso.css' %}" />
+    {% block head_extra %}{% endblock %}
+  </head>
+  <body class="meso">
+    <div class="meso-app">
+      <nav class="meso-topnav">
+        <a class="meso-brand" href="{% url 'meso:roster' %}">
+          <span class="meso-brand-mark"><i></i></span>
+          <b>Meso</b>
+        </a>
+        <div class="meso-navlinks">
+          <a class="meso-navlink {% if active == 'roster' %}is-active{% endif %}" href="{% url 'meso:roster' %}">Roster</a>
+          <a class="meso-navlink {% if active == 'designer' %}is-active{% endif %}" href="{% url 'meso:designer' %}">Designer</a>
+        </div>
+        <div class="meso-spacer"></div>
+        {% block topnav_actions %}{% endblock %}
+        <div class="meso-avatar meso-avatar--sm meso-avatar--accent" title="Coach">LG</div>
+      </nav>
+
+      {% block content %}{% endblock %}
+    </div>
+    {% block scripts %}{% endblock %}
+  </body>
+</html>

--- a/app/store_project/templates/meso/athlete_profile.html
+++ b/app/store_project/templates/meso/athlete_profile.html
@@ -1,0 +1,129 @@
+{% extends "meso/_meso_base.html" %}
+
+{% block title %}{{ athlete.name }} · Meso{% endblock %}
+
+{% block topnav_actions %}
+  <a class="meso-btn" href="{% url 'meso:results' %}">Latest results</a>
+  <a class="meso-btn meso-btn--primary" href="{% url 'meso:designer' %}">Open in designer</a>
+{% endblock %}
+
+{% block content %}
+  <div class="meso-page">
+    <div class="meso-crumbs">
+      <a href="{% url 'meso:roster' %}">Roster</a> <span>/</span> <span>{{ athlete.name }}</span>
+    </div>
+
+    <div class="meso-pagehead">
+      <div style="display:flex;align-items:center;gap:14px;">
+        <div class="meso-avatar meso-avatar--lg {% if athlete.tone == 'accent' %}meso-avatar--accent{% endif %}">{{ athlete.initials }}</div>
+        <div>
+          <h1 class="meso-h1">{{ athlete.name }}</h1>
+          <p class="meso-sub">{{ athlete.age }} · {{ athlete.level }} · {{ athlete.trained }}</p>
+        </div>
+      </div>
+      {% if athlete.status == 'needs_review' %}
+        <a class="meso-btn meso-btn--primary" href="{% url 'meso:review' %}">Review agent changes</a>
+      {% endif %}
+    </div>
+
+    <div class="meso-grid meso-grid--profile">
+      <!-- left rail -->
+      <div style="display:flex;flex-direction:column;gap:14px;">
+        <div class="meso-card meso-card--pad">
+          <p class="meso-eyebrow">Goals</p>
+          <div style="display:flex;flex-wrap:wrap;gap:6px;">
+            {% for goal in athlete.goals %}
+              <span class="meso-tag meso-tag--accent">{{ goal }}</span>
+            {% endfor %}
+          </div>
+        </div>
+
+        <div class="meso-card meso-card--pad">
+          <p class="meso-eyebrow">Contraindications</p>
+          {% if athlete.contraindications %}
+            <div style="display:flex;flex-direction:column;gap:6px;">
+              {% for c in athlete.contraindications %}
+                <div style="display:flex;gap:8px;align-items:flex-start;padding:7px 9px;border-radius:7px;background:var(--warn-soft);border:1px solid color-mix(in srgb,var(--warn) 22%,#fff);">
+                  <i style="width:5px;height:5px;border-radius:50%;background:var(--warn);margin-top:6px;flex:0 0 auto;"></i>
+                  <span style="font-size:12px;color:var(--warn);font-weight:600;line-height:1.3;">{{ c }}</span>
+                </div>
+              {% endfor %}
+            </div>
+          {% else %}
+            <p class="meso-sub">None on file.</p>
+          {% endif %}
+        </div>
+
+        <div class="meso-card meso-card--pad">
+          <p class="meso-eyebrow">Coach's programming style</p>
+          <div style="display:flex;flex-wrap:wrap;gap:6px;margin-bottom:9px;">
+            {% for tag in coach_style.tags %}
+              <span class="meso-tag">{{ tag }}</span>
+            {% endfor %}
+          </div>
+          <div style="font-size:11.5px;color:var(--dim);line-height:1.4;">
+            <span style="font-weight:700;color:var(--warn);">Avoid:</span> {{ coach_style.avoid }}
+          </div>
+        </div>
+      </div>
+
+      <!-- main -->
+      <div style="display:flex;flex-direction:column;gap:14px;">
+        <div class="meso-card meso-card--pad">
+          <div style="display:flex;align-items:center;gap:12px;margin-bottom:14px;">
+            <div>
+              <p class="meso-eyebrow" style="margin:0 0 3px;">Current block</p>
+              <div style="font-size:17px;font-weight:800;letter-spacing:-0.02em;">{{ athlete.block }} · {{ athlete.week }}</div>
+            </div>
+            <div class="meso-spacer"></div>
+            {% if athlete.status == 'needs_review' %}
+              <span class="meso-badge meso-badge--accent"><i></i>{{ athlete.status_label }}</span>
+            {% elif athlete.status == 'delivered' %}
+              <span class="meso-badge meso-badge--ok"><i></i>{{ athlete.status_label }}</span>
+            {% else %}
+              <span class="meso-badge meso-badge--muted"><i></i>{{ athlete.status_label }}</span>
+            {% endif %}
+          </div>
+          <div style="display:flex;align-items:center;gap:10px;">
+            <span class="meso-row-meta" style="width:78px;">Adherence</span>
+            <div class="meso-meter"><span style="width:{{ athlete.compliance }}%;"></span></div>
+            <span class="meso-row-meta meso-mono">{{ athlete.compliance }}%</span>
+          </div>
+          <hr class="meso-hr" />
+          <p class="meso-eyebrow">Macrocycle</p>
+          <div style="display:flex;flex-direction:column;gap:5px;">
+            {% for ph in macrocycle %}
+              <div style="display:flex;align-items:center;gap:9px;padding:8px 10px;border-radius:7px;background:{% if ph.state == 'current' %}var(--soft){% else %}var(--surface){% endif %};border:1px solid {% if ph.state == 'current' %}var(--soft-line){% else %}var(--line){% endif %};{% if ph.state == 'done' %}opacity:0.62;{% endif %}">
+                <i style="width:7px;height:7px;border-radius:2px;background:{% if ph.state == 'current' %}var(--accent){% elif ph.state == 'done' %}var(--dim){% else %}var(--line){% endif %};{% if ph.state == 'next' or ph.state == 'future' %}border:1px solid var(--dim);{% endif %}"></i>
+                <div style="flex:1;font-size:12px;font-weight:{% if ph.state == 'current' %}700{% else %}600{% endif %};color:{% if ph.state == 'current' %}var(--accent-deep){% elif ph.state == 'done' %}var(--ink){% else %}var(--dim){% endif %};">{{ ph.name }}</div>
+                <div class="meso-row-meta">{{ ph.weeks }}{% if ph.note %} · {{ ph.note }}{% endif %}</div>
+              </div>
+            {% endfor %}
+          </div>
+        </div>
+
+        <a class="meso-card meso-card--pad" href="{% url 'meso:results' %}" style="text-decoration:none;color:inherit;display:block;">
+          <div style="display:flex;align-items:center;gap:10px;margin-bottom:6px;">
+            <p class="meso-eyebrow" style="margin:0;">Latest session</p>
+            <div class="meso-spacer"></div>
+            <span class="meso-row-meta">{{ results_summary.session }}</span>
+          </div>
+          <div style="display:flex;align-items:center;gap:22px;">
+            <div>
+              <div style="font-size:22px;font-weight:800;letter-spacing:-0.02em;">{{ results_summary.completion }}%</div>
+              <div class="meso-row-meta">completed</div>
+            </div>
+            <div>
+              <div style="font-size:22px;font-weight:800;letter-spacing:-0.02em;" class="meso-mono">{{ results_summary.avg_rpe_delta }}</div>
+              <div class="meso-row-meta">avg RPE vs target</div>
+            </div>
+            <div style="flex:1;display:flex;gap:8px;align-items:flex-start;padding:9px 11px;border-radius:8px;background:var(--warn-soft);border:1px solid color-mix(in srgb,var(--warn) 22%,#fff);">
+              <i style="width:5px;height:5px;border-radius:50%;background:var(--warn);margin-top:6px;flex:0 0 auto;"></i>
+              <span style="font-size:12px;color:var(--warn);font-weight:600;line-height:1.3;">{{ results_summary.flag }}</span>
+            </div>
+          </div>
+        </a>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/app/store_project/templates/meso/deliver.html
+++ b/app/store_project/templates/meso/deliver.html
@@ -1,0 +1,97 @@
+{% extends "meso/_meso_base.html" %}
+{% load static %}
+
+{% block title %}Deliver · Meso{% endblock %}
+
+{% block head_extra %}
+  <script defer src="{% static 'js/alpine.min.js' %}"></script>
+{% endblock %}
+
+{% block content %}
+  <div class="meso-page meso-page--narrow"
+       x-data="{ delivered: false, channels: { push: true, email: true }, schedule: 'scheduled' }">
+    <div class="meso-crumbs">
+      <a href="{% url 'meso:roster' %}">Roster</a> <span>/</span>
+      <a href="{% url 'meso:athlete' athlete.slug %}">{{ athlete.name }}</a> <span>/</span> <span>Deliver</span>
+    </div>
+
+    <div class="meso-pagehead">
+      <div>
+        <p class="meso-eyebrow">Publish</p>
+        <h1 class="meso-h1">Deliver {{ deliver.what }}</h1>
+        <p class="meso-sub">{{ deliver.sessions }} sessions · to {{ athlete.name }} · once delivered she sees it in her app.</p>
+      </div>
+    </div>
+
+    <!-- pre-deliver -->
+    <div x-show="!delivered" style="display:flex;flex-direction:column;gap:14px;">
+      <div class="meso-card meso-card--pad">
+        <div style="display:flex;align-items:center;gap:13px;">
+          <div class="meso-avatar meso-avatar--lg {% if athlete.tone == 'accent' %}meso-avatar--accent{% endif %}">{{ athlete.initials }}</div>
+          <div>
+            <div class="meso-row-name" style="font-size:15px;">{{ athlete.name }}</div>
+            <div class="meso-row-meta">{{ athlete.block }} · {{ athlete.week }} · starts {{ deliver.starts }}</div>
+          </div>
+          <div class="meso-spacer"></div>
+          <span class="meso-badge meso-badge--accent"><i></i>{{ deliver.what }}</span>
+        </div>
+      </div>
+
+      <div class="meso-card meso-card--pad">
+        <p class="meso-eyebrow">Changes since last delivery</p>
+        <div style="display:flex;flex-direction:column;gap:7px;">
+          {% for ch in deliver.changes_since %}
+            <div style="display:flex;gap:9px;align-items:flex-start;">
+              <span style="width:17px;height:17px;border-radius:5px;background:var(--accent);display:flex;align-items:center;justify-content:center;color:var(--accent-ink);font-size:10px;flex:0 0 auto;margin-top:1px;">✓</span>
+              <span style="font-size:12.5px;line-height:1.35;">{{ ch }}</span>
+            </div>
+          {% endfor %}
+        </div>
+      </div>
+
+      <div class="meso-card meso-card--pad">
+        <p class="meso-eyebrow">Schedule</p>
+        <div class="meso-seg" style="margin-bottom:16px;">
+          <button class="meso-seg-btn meso-seg-btn--v" :class="{ 'is-on': schedule === 'now' }" @click="schedule = 'now'">Send now</button>
+          <button class="meso-seg-btn meso-seg-btn--v" :class="{ 'is-on': schedule === 'scheduled' }" @click="schedule = 'scheduled'">On start date ({{ deliver.starts }})</button>
+        </div>
+
+        <p class="meso-eyebrow">Notify via</p>
+        <div style="display:flex;gap:9px;">
+          <button @click="channels.push = !channels.push" class="meso-tag"
+                  :class="channels.push ? 'meso-tag--accent' : ''"
+                  :style="channels.push ? '' : 'opacity:0.6'"
+                  style="cursor:pointer;padding:7px 12px;">
+            <span x-text="channels.push ? '✓ ' : ''"></span>Push notification
+          </button>
+          <button @click="channels.email = !channels.email" class="meso-tag"
+                  :class="channels.email ? 'meso-tag--accent' : ''"
+                  :style="channels.email ? '' : 'opacity:0.6'"
+                  style="cursor:pointer;padding:7px 12px;">
+            <span x-text="channels.email ? '✓ ' : ''"></span>Email summary
+          </button>
+        </div>
+      </div>
+
+      <div style="display:flex;align-items:center;gap:12px;">
+        <a class="meso-btn" href="{% url 'meso:review' %}">← Back to changes</a>
+        <div class="meso-spacer"></div>
+        <button class="meso-btn meso-btn--primary" @click="delivered = true" style="font-size:13.5px;padding:10px 18px;">Deliver to {{ athlete.name }}</button>
+      </div>
+    </div>
+
+    <!-- post-deliver -->
+    <div x-show="delivered" x-cloak class="meso-card meso-card--pad" style="text-align:center;padding:36px 24px;">
+      <div style="width:46px;height:46px;border-radius:50%;background:var(--ok);display:flex;align-items:center;justify-content:center;color:#fff;font-size:22px;margin:0 auto 14px;">✓</div>
+      <h2 style="margin:0 0 4px;font-size:19px;font-weight:800;letter-spacing:-0.02em;">Delivered to {{ athlete.name }}</h2>
+      <p class="meso-sub" style="margin-bottom:20px;">{{ deliver.what }} is live — she'll see Day 1 on her phone<span x-show="schedule === 'scheduled'"> on {{ deliver.starts }}</span>.</p>
+      <div style="display:flex;gap:10px;justify-content:center;">
+        <a class="meso-btn" href="{% url 'meso:roster' %}">Back to roster</a>
+        <a class="meso-btn meso-btn--primary" href="{% url 'meso:results' %}">Track her sessions →</a>
+      </div>
+    </div>
+  </div>
+{% endblock %}
+{% block scripts %}
+  <style>[x-cloak]{display:none !important;}</style>
+{% endblock %}

--- a/app/store_project/templates/meso/designer.html
+++ b/app/store_project/templates/meso/designer.html
@@ -35,12 +35,12 @@
 
       <!-- ===================== TOP BAR ===================== -->
       <div style="height:55px;flex:0 0 auto;display:flex;align-items:center;gap:15px;padding:0 17px;background:var(--surface);border-bottom:1px solid var(--line);z-index:20;">
-        <div style="display:flex;align-items:center;gap:9px;">
+        <a href="{% url 'meso:roster' %}" title="Back to roster" style="display:flex;align-items:center;gap:9px;text-decoration:none;color:var(--ink);">
           <div style="width:23px;height:23px;border-radius:6px;background:var(--accent);display:flex;align-items:center;justify-content:center;">
             <div style="width:8px;height:8px;background:var(--accent-ink);border-radius:2px;transform:rotate(45deg);"></div>
           </div>
           <span style="font-weight:800;font-size:16px;letter-spacing:-0.025em;">Meso</span>
-        </div>
+        </a>
         <div style="width:1px;height:22px;background:var(--line);"></div>
 
         <!-- Individual / Group identity -->
@@ -81,7 +81,8 @@
           Hypertrophy &#183; Wk 2 / 4
         </div>
         <button data-hover="rail" @click="view = 'athlete'" style="appearance:none;cursor:pointer;font:inherit;font-size:12.5px;font-weight:600;color:var(--ink);background:var(--surface);border:1px solid var(--line);border-radius:8px;padding:7px 13px;">Preview as athlete</button>
-        <button data-hover="brighten" @click="onDeliver()" style="appearance:none;cursor:pointer;font:inherit;font-size:12.5px;font-weight:650;color:var(--accent-ink);background:var(--accent);border:0;border-radius:8px;padding:8px 15px;box-shadow:0 1px 2px rgba(16,18,22,0.12);">Deliver</button>
+        <a href="{% url 'meso:review' %}" data-hover="rail" style="text-decoration:none;font:inherit;font-size:12.5px;font-weight:600;color:var(--ink);background:var(--surface);border:1px solid var(--line);border-radius:8px;padding:7px 13px;">Review changes</a>
+        <a href="{% url 'meso:deliver' %}" data-hover="brighten" style="text-decoration:none;font:inherit;font-size:12.5px;font-weight:650;color:var(--accent-ink);background:var(--accent);border-radius:8px;padding:8px 15px;box-shadow:0 1px 2px rgba(16,18,22,0.12);">Deliver</a>
       </div>
 
       <!-- ===================== BODY ===================== -->

--- a/app/store_project/templates/meso/results.html
+++ b/app/store_project/templates/meso/results.html
@@ -1,0 +1,81 @@
+{% extends "meso/_meso_base.html" %}
+
+{% block title %}Session results · Meso{% endblock %}
+
+{% block topnav_actions %}
+  <a class="meso-btn meso-btn--primary" href="{% url 'meso:designer' %}">Adjust next week →</a>
+{% endblock %}
+
+{% block content %}
+  <div class="meso-page">
+    <div class="meso-crumbs">
+      <a href="{% url 'meso:roster' %}">Roster</a> <span>/</span>
+      <a href="{% url 'meso:athlete' athlete.slug %}">{{ athlete.name }}</a> <span>/</span> <span>Session results</span>
+    </div>
+
+    <div class="meso-pagehead">
+      <div>
+        <p class="meso-eyebrow">Logged session · {{ summary.logged }}</p>
+        <h1 class="meso-h1">{{ summary.session }}</h1>
+        <p class="meso-sub">{{ athlete.name }} · how the delivered targets actually went.</p>
+      </div>
+    </div>
+
+    <!-- summary stats -->
+    <div class="meso-grid meso-grid--3" style="margin-bottom:14px;">
+      <div class="meso-card meso-card--pad">
+        <div style="font-size:26px;font-weight:800;letter-spacing:-0.025em;">{{ summary.completion }}%</div>
+        <div class="meso-row-meta">sets completed</div>
+      </div>
+      <div class="meso-card meso-card--pad">
+        <div style="font-size:26px;font-weight:800;letter-spacing:-0.025em;" class="meso-mono">{{ summary.avg_rpe_delta }}</div>
+        <div class="meso-row-meta">avg RPE vs target</div>
+      </div>
+      <div class="meso-card meso-card--pad">
+        <div style="font-size:26px;font-weight:800;letter-spacing:-0.025em;color:var(--warn);">1</div>
+        <div class="meso-row-meta">flag to act on</div>
+      </div>
+    </div>
+
+    <!-- agent flag -->
+    <div class="meso-card meso-card--pad" style="margin-bottom:14px;display:flex;gap:11px;align-items:flex-start;background:var(--warn-soft);border-color:color-mix(in srgb,var(--warn) 22%,#fff);">
+      <span style="width:21px;height:21px;border-radius:6px;background:var(--warn);display:flex;align-items:center;justify-content:center;color:#fff;font-size:12px;flex:0 0 auto;">!</span>
+      <div style="line-height:1.4;">
+        <div style="font-size:13px;font-weight:700;color:var(--warn);">Agent caught a fatigue signal</div>
+        <div style="font-size:12.5px;color:var(--warn);">{{ summary.flag }}</div>
+      </div>
+      <div class="meso-spacer"></div>
+      <a class="meso-btn" href="{% url 'meso:review' %}" style="flex:0 0 auto;">Apply to next week</a>
+    </div>
+
+    <!-- per-exercise results -->
+    <div class="meso-card">
+      <div style="display:grid;grid-template-columns:minmax(0,1.5fr) minmax(0,1.3fr) minmax(0,1.1fr) 56px minmax(0,1.3fr);gap:10px;padding:9px 18px;background:var(--rail);border-bottom:1px solid var(--line-2);font-size:10px;font-weight:700;letter-spacing:0.06em;text-transform:uppercase;color:var(--dim);">
+        <div>Exercise</div><div>Target</div><div>Logged</div><div style="text-align:center;">RPE</div><div>Note</div>
+      </div>
+      {% for r in rows %}
+        <div style="display:grid;grid-template-columns:minmax(0,1.5fr) minmax(0,1.3fr) minmax(0,1.1fr) 56px minmax(0,1.3fr);gap:10px;padding:11px 18px;border-bottom:1px solid var(--line-2);align-items:center;">
+          <div style="font-size:13.5px;font-weight:600;letter-spacing:-0.01em;">{{ r.name }}</div>
+          <div class="meso-mono" style="font-size:11.5px;color:var(--dim);">{{ r.target }}</div>
+          <div class="meso-mono" style="font-size:12px;{% if r.rpe_state == 'over' %}color:var(--warn);font-weight:600;{% endif %}">{{ r.logged }}</div>
+          <div style="text-align:center;">
+            {% if r.rpe == '—' %}
+              <span class="meso-row-meta">—</span>
+            {% elif r.rpe_state == 'over' %}
+              <span class="meso-badge meso-badge--warn meso-mono" style="padding:2px 7px;">{{ r.rpe }}↑</span>
+            {% else %}
+              <span class="meso-badge meso-badge--ok meso-mono" style="padding:2px 7px;">{{ r.rpe }}</span>
+            {% endif %}
+          </div>
+          <div style="font-size:11.5px;color:{% if r.note %}var(--warn){% else %}var(--dim){% endif %};">{{ r.note|default:"—" }}</div>
+        </div>
+      {% endfor %}
+    </div>
+
+    <div style="display:flex;align-items:center;gap:12px;margin-top:16px;">
+      <a class="meso-btn" href="{% url 'meso:athlete' athlete.slug %}">← {{ athlete.name }}'s profile</a>
+      <div class="meso-spacer"></div>
+      <a class="meso-btn meso-btn--primary" href="{% url 'meso:designer' %}">Adjust next week with the agent →</a>
+    </div>
+  </div>
+{% endblock %}

--- a/app/store_project/templates/meso/review.html
+++ b/app/store_project/templates/meso/review.html
@@ -1,0 +1,75 @@
+{% extends "meso/_meso_base.html" %}
+{% load static %}
+
+{% block title %}Review changes · Meso{% endblock %}
+
+{% block head_extra %}
+  <script defer src="{% static 'js/alpine.min.js' %}"></script>
+{% endblock %}
+
+{% block content %}
+  <div class="meso-page meso-page--narrow"
+       x-data="{ status: { {% for c in changes %}'{{ c.id }}': 'approved',{% endfor %} },
+               get approved() { return Object.values(this.status).filter(s => s === 'approved').length } }">
+    <div class="meso-crumbs">
+      <a href="{% url 'meso:roster' %}">Roster</a> <span>/</span>
+      <a href="{% url 'meso:athlete' athlete.slug %}">{{ athlete.name }}</a> <span>/</span> <span>Review changes</span>
+    </div>
+
+    <div class="meso-pagehead">
+      <div>
+        <p class="meso-eyebrow">Agent · proposed edits</p>
+        <h1 class="meso-h1">{{ changes|length }} changes for {{ athlete.name }}</h1>
+        <p class="meso-sub">Grounded on her profile, contraindications, and last block's logged sessions.</p>
+      </div>
+    </div>
+
+    <div style="display:flex;flex-direction:column;gap:13px;">
+      {% for c in changes %}
+        <div class="meso-card meso-card--pad"
+             :style="status['{{ c.id }}'] === 'rejected'
+                     ? 'opacity:0.55;border-color:var(--line)'
+                     : 'border-color:var(--soft-line);box-shadow:0 1px 2px rgba(16,18,22,0.05)'">
+          <div style="display:flex;align-items:center;gap:9px;margin-bottom:9px;">
+            <span class="meso-badge meso-badge--accent">{{ c.kind }}</span>
+            <span class="meso-row-meta">{{ c.day }}</span>
+            <div class="meso-spacer"></div>
+            <span class="meso-badge meso-badge--ok" x-show="status['{{ c.id }}'] === 'approved'"><i></i>Approved</span>
+            <span class="meso-badge meso-badge--muted" x-show="status['{{ c.id }}'] === 'rejected'"><i></i>Rejected</span>
+          </div>
+
+          <div style="font-size:15px;font-weight:700;letter-spacing:-0.01em;margin-bottom:8px;">{{ c.title }}</div>
+
+          <div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:10px;">
+            <span class="meso-mono" style="font-size:12px;color:var(--dim);text-decoration:line-through;">{{ c.before }}</span>
+            <span style="color:var(--accent);">→</span>
+            <span class="meso-mono" style="font-size:12px;color:var(--accent-deep);font-weight:600;">{{ c.after }}</span>
+          </div>
+
+          <p style="margin:0 0 10px;font-size:12.5px;color:var(--ink);line-height:1.45;">{{ c.rationale }}</p>
+
+          <div style="display:flex;align-items:center;gap:10px;">
+            <span class="meso-badge meso-badge--warn" style="font-weight:600;">Honors: {{ c.honors }}</span>
+            <div class="meso-spacer"></div>
+            <div class="meso-seg">
+              <button class="meso-seg-btn" :class="{ 'is-on': status['{{ c.id }}'] === 'approved' }"
+                      @click="status['{{ c.id }}'] = 'approved'">Approve</button>
+              <button class="meso-seg-btn" :class="{ 'is-on': status['{{ c.id }}'] === 'rejected' }"
+                      @click="status['{{ c.id }}'] = 'rejected'">Reject</button>
+            </div>
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+
+    <div class="meso-card meso-card--pad" style="margin-top:16px;display:flex;align-items:center;gap:14px;position:sticky;bottom:16px;">
+      <div style="font-size:13px;font-weight:700;"><span x-text="approved"></span> of {{ changes|length }} changes approved</div>
+      <div class="meso-row-meta">Rejected edits are discarded — the program keeps its current values.</div>
+      <div class="meso-spacer"></div>
+      <a class="meso-btn" href="{% url 'meso:designer' %}">Back to designer</a>
+      <a class="meso-btn meso-btn--primary" href="{% url 'meso:deliver' %}">
+        Apply <span x-text="approved"></span> &amp; deliver →
+      </a>
+    </div>
+  </div>
+{% endblock %}

--- a/app/store_project/templates/meso/roster.html
+++ b/app/store_project/templates/meso/roster.html
@@ -1,0 +1,110 @@
+{% extends "meso/_meso_base.html" %}
+
+{% block title %}Roster · Meso{% endblock %}
+
+{% block topnav_actions %}
+  <a class="meso-btn meso-btn--primary" href="{% url 'meso:designer' %}">+ New program</a>
+{% endblock %}
+
+{% block content %}
+  <div class="meso-page">
+    <div class="meso-pagehead">
+      <div>
+        <p class="meso-eyebrow">Coach workspace</p>
+        <h1 class="meso-h1">Your athletes</h1>
+        <p class="meso-sub">{{ athletes|length }} athletes · {{ groups|length }} group · {{ needs_review }} needs review</p>
+      </div>
+    </div>
+
+    <div style="display:grid;grid-template-columns:minmax(0,1fr) 312px;gap:18px;align-items:start;">
+      <!-- main column -->
+      <div style="display:flex;flex-direction:column;gap:18px;">
+
+        <div class="meso-card">
+          <div style="display:flex;align-items:center;gap:10px;padding:13px 16px;border-bottom:1px solid var(--line-2);">
+            <p class="meso-eyebrow" style="margin:0;">Individuals</p>
+            <div class="meso-spacer"></div>
+            <span class="meso-row-meta">{{ athletes|length }} athletes</span>
+          </div>
+          {% for a in athletes %}
+            <a class="meso-row" href="{% url 'meso:athlete' a.slug %}">
+              <div class="meso-avatar {% if a.tone == 'accent' %}meso-avatar--accent{% endif %}">{{ a.initials }}</div>
+              <div style="min-width:0;">
+                <div class="meso-row-name">{{ a.name }}</div>
+                <div class="meso-row-meta">{{ a.level }} · {{ a.block }} · {{ a.week }}</div>
+              </div>
+              <div class="meso-spacer"></div>
+              {% for f in a.flags %}
+                <span class="meso-badge meso-badge--warn"><i></i>{{ f }}</span>
+              {% endfor %}
+              <div style="width:108px;display:flex;align-items:center;gap:8px;">
+                <div class="meso-meter"><span style="width:{{ a.compliance }}%;"></span></div>
+                <span class="meso-row-meta meso-mono">{{ a.compliance }}%</span>
+              </div>
+              {% if a.status == 'needs_review' %}
+                <span class="meso-badge meso-badge--accent"><i></i>{{ a.status_label }}</span>
+              {% elif a.status == 'delivered' %}
+                <span class="meso-badge meso-badge--ok"><i></i>{{ a.status_label }}</span>
+              {% elif a.status == 'drafting' %}
+                <span class="meso-badge meso-badge--accent"><i></i>{{ a.status_label }}</span>
+              {% else %}
+                <span class="meso-badge meso-badge--muted"><i></i>{{ a.status_label }}</span>
+              {% endif %}
+              <span class="meso-muted" style="font-size:16px;">›</span>
+            </a>
+          {% endfor %}
+        </div>
+
+        <div class="meso-card">
+          <div style="display:flex;align-items:center;gap:10px;padding:13px 16px;border-bottom:1px solid var(--line-2);">
+            <p class="meso-eyebrow" style="margin:0;">Groups</p>
+          </div>
+          {% for g in groups %}
+            <a class="meso-row" href="{% url 'meso:designer' %}">
+              <div style="display:flex;">
+                {% for m in g.member_objs|slice:":3" %}
+                  <div class="meso-avatar meso-avatar--sm {% if m.tone == 'accent' %}meso-avatar--accent{% endif %}" style="border:2px solid var(--surface);{% if not forloop.first %}margin-left:-9px;{% endif %}">{{ m.initials }}</div>
+                {% endfor %}
+                {% if g.member_objs|length > 3 %}
+                  <div class="meso-avatar meso-avatar--sm" style="border:2px solid var(--surface);margin-left:-9px;">+{{ g.member_objs|length|add:"-3" }}</div>
+                {% endif %}
+              </div>
+              <div style="min-width:0;">
+                <div class="meso-row-name">{{ g.name }}</div>
+                <div class="meso-row-meta">{{ g.member_objs|length }} participants · {{ g.focus }} · {{ g.week }}</div>
+              </div>
+              <div class="meso-spacer"></div>
+              <span class="meso-badge meso-badge--accent"><i></i>{{ g.status_label }}</span>
+              <span class="meso-muted" style="font-size:16px;">›</span>
+            </a>
+          {% endfor %}
+        </div>
+      </div>
+
+      <!-- activity column -->
+      <div class="meso-card meso-card--pad">
+        <p class="meso-eyebrow">Recent activity</p>
+        <div style="display:flex;flex-direction:column;gap:14px;margin-top:4px;">
+          {% for ev in activity %}
+            <div style="display:flex;gap:10px;align-items:flex-start;">
+              <div class="meso-avatar meso-avatar--sm {% if ev.athlete.tone == 'accent' %}meso-avatar--accent{% endif %}">{{ ev.athlete.initials }}</div>
+              <div style="min-width:0;line-height:1.35;">
+                <div style="font-size:12.5px;">
+                  <a href="{% url 'meso:athlete' ev.athlete.slug %}" style="font-weight:700;color:var(--ink);text-decoration:none;">{{ ev.athlete.name }}</a>
+                  {% if ev.kind == 'flag' %}
+                    <span style="color:var(--warn);"> {{ ev.text }}</span>
+                  {% else %}
+                    <span class="meso-muted"> {{ ev.text }}</span>
+                  {% endif %}
+                </div>
+                <div class="meso-row-meta" style="margin-top:2px;">{{ ev.when }}</div>
+              </div>
+            </div>
+          {% endfor %}
+        </div>
+        <hr class="meso-hr" />
+        <a class="meso-btn meso-btn--ghost" href="{% url 'meso:results' %}">View latest session results →</a>
+      </div>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Claude Design prototype — Meso coaching-loop screens

Builds the Meso prototype out from a single designer screen (shipped in #267) into a
**walkable, end-to-end coaching loop**. Same Claude Design visual language, same stack
(Django templates + Alpine.js, no new deps).

### ⚠️ Still a mock

No DB, no real agent. One canonical fixture set in **`meso/mockdata.py`** feeds every screen
so they stay internally consistent (same athletes, same program, same proposed changes).
All views are `LoginRequiredMixin` `TemplateView`s.

### New screens

| Route | Screen |
|---|---|
| `/meso/` | **Roster** — athletes, group, recent activity (the new front door) |
| `/meso/athlete/<slug>/` | **Athlete profile** — goals, contraindications, macrocycle, latest session |
| `/meso/review/` | **Agent change-review** — approve/reject each proposed edit (Alpine; live count) |
| `/meso/deliver/` | **Deliver / publish** — schedule, notify channels, delivered confirmation (Alpine) |
| `/meso/results/` | **Session results** — logged vs target, RPE-over flags, agent fatigue signal |

**The walk:** roster → athlete → designer → review → deliver → results → *adjust next week* → designer.

The designer moves to **`/meso/designer/`** (roster now owns `/meso/`); its top bar links back to
the roster and forward to **Review changes** / **Deliver**.

### Shared foundation

- `templates/meso/_meso_base.html` — common chrome (sticky top nav, fonts, tokens)
- `static/css/meso.css` — a reusable component layer (nav, cards, badges, avatars, buttons,
  meters) built on the existing tokens, plus the default token set on `.meso`
- `meso/mockdata.py` — athletes, program, proposed changes, results, activity feed

### Verification

Driven in a headless browser through the **entire flow** (roster → profile → review → deliver →
results) plus the designer: navigation resolves, the review approve/reject updates the live count,
the deliver flow reaches its confirmation state — **zero console errors**. `ruff`, Biome,
`DjHTML`, and `manage.py check` all pass.

### Note

The designer's in-app "Deliver" toast (`onDeliver`) is now superseded by the real deliver screen;
the handler remains in `meso.js` but is no longer wired to a button. Left in place intentionally —
trivial to remove or re-purpose.
