### PR TITLE
Meso — planning docs (decisions + persistence-slice plan)

### DIFF
--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -1,0 +1,167 @@
+# Meso — decisions to make before building real
+
+**Status:** living document · started 2026-06-26
+**Context:** The Meso program designer + coaching-loop screens exist today as a
+**fully client-side mock** (PRs #267, #268). There is no database, no real agent,
+no athlete app — every screen reads canned fixtures from `app/store_project/meso/mockdata.py`.
+This doc tracks the decisions that gate turning those mocks into real code, so we
+don't write schema or architecture on top of unsettled product questions.
+
+How to read the status field:
+- **⏳ Awaiting decision** — genuinely your call; blocks real work until answered.
+- **🟡 Proposed** — architect's recommendation; will proceed on the rec unless overridden.
+- **✅ Decided** — locked, with the choice recorded.
+
+---
+
+## Blockers (foundation — schema & architecture depend on these)
+
+### B1 · Product shape & tenancy — single-coach or multi-coach?
+Is Meso *you* programming for your own clients (single-tenant), or a tool other
+coaches log into (multi-tenant SaaS)? Decides whether "coach" is a model, whether
+every query is tenant-scoped, and the entire permissions layer. The store today is
+B2C (sells programs to individuals); Meso is a different B2B-ish shape.
+
+- Options: (a) single-coach, you only; (b) multi-coach SaaS now; (c) single-coach now but keep a `coach` FK so multi-coach is a clean retrofit.
+- **Rec:** (c).
+- **Status:** ✅ Decided (2026-06-26).
+- **Decision:** **(b) Multi-coach SaaS from day one.** Tenant-scope everything: coaches are
+  accounts, data is isolated per coach, athletes belong to a coach via a relationship. This
+  promotes a tenancy + roles + permissions spine into even the first (persistence) slice —
+  see N1–N4 below.
+
+### B2 · What is an "athlete," and do they log in?
+(a) Reuse the existing `User` model (UUID PKs, allauth) for athletes, or a lightweight
+`Client` record with no login? (b) Do athletes get an **app** at all, or does the coach
+log everything? The phone view, "Deliver to her app," and push notifications all imply an
+authenticated athlete surface. (c) If yes — native, PWA, or responsive web?
+
+- **Rec:** athletes = `User`s; athlete surface = responsive web/PWA first (no native).
+- **Status:** ✅ Decided (2026-06-26).
+- **Decision:** **Athletes are `User`s who log in** (responsive web / installable PWA; native
+  deferred) **and** their coach can edit their program. So we need a coach↔athlete relationship
+  that grants the coach edit rights on the athlete's plan (see N1). A single `User` may act as
+  both coach and athlete.
+
+### B3 · Domain schema & relationship to the existing `Program` product.
+The store already has a sellable `Program` product; a Meso plan is a different thing
+(personalized, periodized, mutable). Decide: distinct entities, and the granularity —
+`Plan → Mesocycle → Week → Session/Day → ExercisePrescription → SetPrescription`, plus
+`SessionLog → LoggedSet`. And: do we need **draft vs delivered versions** + a
+`ProposedChange` diff record? (The review screen and "changes since last delivery" only
+exist if programs are versioned.)
+
+- **Rec:** distinct from store `Program`; full hierarchy; yes to draft/published versioning + a `ProposedChange` entity (load-bearing for the agent + review gate).
+- **Status:** 🟡 Proposed (architect's call once B1/B2 land).
+- **Decision:** _tbd_
+
+### B4 · Exercise source — catalog FK, free text, or hybrid?
+There's an `exercises` app with videos + alternatives. The prototype lets a coach type any
+exercise name AND shows "knee-safe" tags + per-athlete swaps. Decide whether a prescription
+FKs to a catalog `Exercise` (enables the picker, alternatives, contraindication matching,
+agent grounding) or stays free text.
+
+- Options: (a) hybrid — catalog when matched, free-text fallback; (b) catalog only; (c) free text only.
+- **Rec:** (a) hybrid — the agent and auto-adjust need the catalog to be useful.
+- **Status:** ✅ Decided (2026-06-26).
+- **Decision:** **(a) Hybrid.** A prescription FKs to a catalog `Exercise` when one matches
+  (nullable), with a free-text name as fallback. Picker/alternatives/contraindication-matching
+  light up for catalog-linked exercises; coaches can still type a one-off.
+
+### B5 · Front-end data flow — htmx server-rendered, or JSON API + client state?
+Every interactive screen is ephemeral client state today. To persist, pick a fork: lean on
+**htmx** (server-rendered partials, Django owns state — matches the rest of the app) vs. a
+**JSON API (DRF) + Alpine/JS** owning richer client state (better for the spreadsheet-like
+designer grid). Shapes how all five screens get wired; hard to reverse.
+
+- **Rec:** htmx for roster/profile/review/deliver/results; a small JSON-autosave endpoint for the designer grid specifically. Don't adopt DRF wholesale unless the athlete app forces it.
+- **Status:** 🟡 Proposed (architect's call; depends on B2).
+- **Decision:** _tbd_
+
+### B6 · The agent — architecture, grounding, guardrails, execution.
+Provider is **Claude** (project standing guidance). Real decisions:
+- **Shape:** structured tool-calling — the model emits a validated batch of program edits
+  (swap / load / volume / deload) applied server-side — vs. free text. **Rec: tool-calling.**
+- **Grounding:** profile, contraindications, coaching rules, recent logged sessions, exercise
+  catalog; how logs get summarized into context.
+- **Guardrails:** contraindications enforced in a **validation layer**, not just the prompt;
+  keep **human-in-the-loop approval** (the review screen is that gate). **Rec: both.**
+- **Execution:** sync / streamed ("drafting…") / background job (Redis is already in the stack).
+  **Rec: background job + streamed status.**
+- **Eval:** golden cases so quality doesn't silently regress.
+- **Model tier + prompt caching:** pin against the `claude-api` reference at build time — not
+  guessed here.
+- **Status:** 🟡 Proposed (detailed design after B1–B3).
+- **Decision:** _tbd_
+
+---
+
+## Promoted decisions (now in scope because of B1 multi-coach + B2 athlete login)
+
+Choosing multi-coach SaaS pulls these out of "later" and into the **persistence slice** —
+you can't write ownership/scoping-correct models without settling them.
+
+### N1 · Coach↔athlete relationship & cardinality ⏳
+The load-bearing new model. Decide: one **active** coach per athlete (simple, recommended for
+v1) vs. many concurrent coaches. How an athlete links to a coach (invite — see N4). A `User`
+acting as both coach and athlete (decided: allowed). Edit rights: the coach edits the athlete's
+plan; what can the athlete edit (log sessions only, or also tweak)?
+- **Rec:** `CoachAthlete(coach=User, athlete=User, status)` with one active coach per athlete;
+  coach has plan-edit rights, athlete has log + read. _Confirm cardinality before schema._
+
+### N2 · Tenancy scoping enforcement 🟡
+How isolation is guaranteed so coach A never sees coach B's athletes/plans. Manager-level
+scoping by `coach`, object-level permissions, or a tenancy middleware. **Rec:** explicit
+`coach` FK on tenant-owned models + a scoped base manager/queryset mixin + view-level checks.
+
+### N3 · User roles (coach vs athlete) 🟡
+The store `User` is currently a customer. Now a `User` may be coach, athlete, both, or neither.
+Mark via a `CoachProfile`/`AthleteProfile`, Django groups, or boolean flags. **Rec:** a thin
+`CoachProfile` (presence = is-a-coach) + the `CoachAthlete` link (presence = is-an-athlete);
+avoids overloading the User model.
+
+### N4 · Athlete onboarding / invites 🟡
+How an athlete joins a coach: coach invites by email → athlete signs up (allauth) → link
+created; or coach creates a stub athlete and sends a claim link. **Rec:** email invite +
+claim, reusing allauth. Detailed design when we build the relationship.
+
+---
+
+## Secondary decisions (resolve per-slice; not blocking the foundation)
+
+| # | Decision | Note |
+|---|----------|------|
+| S1 | **Groups** — "shared program + per-athlete auto-adjust" modeling (template + override diffs) | Defer until individuals work |
+| S2 | **Units & RPE vs %1RM** | Per-athlete/coach setting; needs a home |
+| S3 | **Delivery & notifications** | Push needs PWA + push infra; email via existing `django-ses` + `notifications` app |
+| S4 | **Results ↔ `challenges`/records** | Results screen shows a PR — reuse the records model or keep separate? |
+| S5 | **Real-time transport** | HTMX polling vs SSE/websockets for chat/drafting |
+| S6 | **Billing** | Paid/sub feature (Stripe is here) or internal-only? Tied to B1 |
+| S7 | **Offline logging** | Gym wifi is bad — does the athlete logger need offline/PWA? |
+
+---
+
+## Suggested sequence (decisions unblock work, not the reverse)
+
+Chosen first slice: **persistence first.** Note multi-coach (B1) makes this slice bigger than
+plain CRUD — it carries the tenancy/roles/relationship spine (N1–N3).
+
+0. **Confirm N1 cardinality** (one active coach per athlete?) — the one product fork still open before schema.
+1. **Tenancy + persistence slice** — `CoachProfile` / `CoachAthlete`, the program schema (B3),
+   hybrid exercises (B4), scoped managers (N2), and designer/roster/profile reading & writing
+   real data over htmx (B5). *No agent.* Replaces the most mock-y part; unblocks everything else.
+2. **Agent as proposal engine** behind the existing review gate (B6). Writes `ProposedChange`s;
+   coach still approves. Safe — the human gate already exists.
+3. **Athlete delivery + logging** — the athlete PWA surface, notifications, then results feeding
+   back to the agent.
+
+---
+
+## Decision log
+
+_(Append dated entries here as decisions land.)_
+
+- 2026-06-26 — Doc created; B1, B2, B4 and the build-order question raised for decision.
+- 2026-06-26 — **Decided:** B1 = multi-coach SaaS from day one · B2 = athletes are Users who
+  log in (web/PWA), coach can edit their plan · B4 = hybrid exercise source · first slice =
+  persistence. Multi-coach promoted N1–N4 into scope. **Open before schema:** N1 cardinality.

--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -101,13 +101,24 @@ Provider is **Claude** (project standing guidance). Real decisions:
 Choosing multi-coach SaaS pulls these out of "later" and into the **persistence slice** —
 you can't write ownership/scoping-correct models without settling them.
 
-### N1 · Coach↔athlete relationship & cardinality ⏳
-The load-bearing new model. Decide: one **active** coach per athlete (simple, recommended for
-v1) vs. many concurrent coaches. How an athlete links to a coach (invite — see N4). A `User`
-acting as both coach and athlete (decided: allowed). Edit rights: the coach edits the athlete's
-plan; what can the athlete edit (log sessions only, or also tweak)?
-- **Rec:** `CoachAthlete(coach=User, athlete=User, status)` with one active coach per athlete;
-  coach has plan-edit rights, athlete has log + read. _Confirm cardinality before schema._
+### N1 · Coach↔athlete relationship & cardinality ✅
+The load-bearing new model.
+- **Status:** ✅ Decided (2026-06-26).
+- **Decision:** **Many-to-many, athlete-consented.** An athlete may work with multiple coaches
+  concurrently (and a coach has many athletes). The link is
+  `CoachAthlete(coach, athlete, status, invited_by)`; relationships require the other party's
+  acceptance and the **athlete can decline or end** any coach link ("if they so choose"). A
+  `User` may be both coach and athlete.
+- **Consequences (now load-bearing for the schema):**
+  - **D-a · Plans owned per relationship** — each coach programs independently for the athlete; a
+    `Plan` FKs its `CoachAthlete`. _(rec)_
+  - **D-b · Athlete profile vs plan attributes** — contraindications/injuries + training history
+    are **global** to the athlete (every coach sees them); goals/focus live **per plan**. _(rec)_
+  - **D-c · Bidirectional invites** — coach invites athlete, or athlete requests coach; both need
+    acceptance; either side can end it (archives that coach's plans, never deletes). _(rec)_
+  - **Scoping** — a coach sees only athletes they have an active link to and edits only their own
+    plans; an athlete sees plans from all their coaches. Cross-coach scheduling collisions in the
+    athlete app are a later UX concern.
 
 ### N2 · Tenancy scoping enforcement 🟡
 How isolation is guaranteed so coach A never sees coach B's athletes/plans. Manager-level
@@ -146,7 +157,7 @@ claim, reusing allauth. Detailed design when we build the relationship.
 Chosen first slice: **persistence first.** Note multi-coach (B1) makes this slice bigger than
 plain CRUD — it carries the tenancy/roles/relationship spine (N1–N3).
 
-0. **Confirm N1 cardinality** (one active coach per athlete?) — the one product fork still open before schema.
+0. ~~Confirm N1 cardinality~~ — **done: many-to-many, athlete-consented.**
 1. **Tenancy + persistence slice** — `CoachProfile` / `CoachAthlete`, the program schema (B3),
    hybrid exercises (B4), scoped managers (N2), and designer/roster/profile reading & writing
    real data over htmx (B5). *No agent.* Replaces the most mock-y part; unblocks everything else.
@@ -165,3 +176,7 @@ _(Append dated entries here as decisions land.)_
 - 2026-06-26 — **Decided:** B1 = multi-coach SaaS from day one · B2 = athletes are Users who
   log in (web/PWA), coach can edit their plan · B4 = hybrid exercise source · first slice =
   persistence. Multi-coach promoted N1–N4 into scope. **Open before schema:** N1 cardinality.
+- 2026-06-26 — **Decided:** N1 = many-to-many, athlete-consented (an athlete may work with
+  multiple coaches; either party can end it). Plans owned per coach↔athlete relationship (D-a);
+  contraindications global, goals per-plan (D-b); bidirectional invites (D-c). Schema is now
+  unblocked.

--- a/docs/meso/persistence-plan.md
+++ b/docs/meso/persistence-plan.md
@@ -1,0 +1,158 @@
+# Meso — persistence slice plan
+
+**Status:** proposed · 2026-06-26
+**Companion to:** [`decisions.md`](./decisions.md)
+**Goal of this slice:** turn the **coach-side** screens (designer, roster, athlete profile)
+from client-side mocks into real, DB-backed, **tenant-scoped** data. No agent, no athlete app
+yet — the review and results screens keep running on seeded data until their own slices.
+
+This slice is bigger than plain CRUD: because Meso is multi-coach (B1) with a many-to-many,
+athlete-consented relationship (N1), it has to carry the tenancy + roles + relationship spine.
+
+### Decisions this rests on (see `decisions.md`)
+- **B1** multi-coach SaaS · **B2** athletes are Users who log in, coaches edit their plans ·
+  **B4** hybrid exercise source · **N1** many-to-many, athlete-consented.
+- **D-a** plans owned per coach↔athlete relationship · **D-b** contraindications global to the
+  athlete, goals per-plan · **D-c** bidirectional invites, either side can end.
+
+---
+
+## Architecture
+
+Models live in the **`meso`** app (`store_project/meso/models.py`) to keep the feature cohesive;
+they reference `settings.AUTH_USER_MODEL` (the existing UUID `User`) rather than subclassing it.
+No new third-party deps: htmx + Alpine (already bundled), allauth for accounts, `django-ses` +
+the `notifications` app for invite email. Front-end stays server-rendered (htmx) except the
+designer grid, which gets a small JSON autosave endpoint (plain `JsonResponse`, no DRF).
+
+### Entity sketch
+
+```
+User ──1:1── CoachProfile
+User ──1:1── AthleteProfile ──< Contraindication        (global to the athlete, D-b)
+
+CoachAthlete (coach=User, athlete=User, status, invited_by)   ← the M2M through table (N1)
+   └──< Plan (goal, status, unit)                              (owned per relationship, D-a)
+          └──< Mesocycle (phase, order, week_count)
+                 └──< Week (volume, intensity, is_deload, is_current, delivered_at)
+                        └──< Session (day_number, name, bias)
+                               └──< ExercisePrescription
+                                      (exercise→exercises.Exercise NULLABLE, name, sets,
+                                       reps, load, rpe, note, tags)            ← hybrid (B4)
+
+Session ──< SessionLog (athlete, date, status) ──< LoggedSet (prescription, reps, load, rpe)
+Week ──< WeekDelivery (delivered_at, payload JSON)            ← snapshot for "changes since…"
+```
+
+---
+
+## Data model (field-level)
+
+**Tenancy / roles / relationship**
+- `CoachProfile(user 1:1, display_name, programming_style JSON[list], avoid_rules text, default_unit[kg|lb])` — presence = is-a-coach.
+- `CoachAthlete(coach→User, athlete→User, status, invited_by, created_at, responded_at, ended_at, token UUID)`
+  - `status ∈ {pending_coach_invite, pending_athlete_request, active, declined, ended}`
+  - `invited_by ∈ {coach, athlete}`; `unique(coach, athlete)`; check `coach_id != athlete_id`.
+  - `token` backs the signed accept/decline URL.
+- `AthleteProfile(user 1:1, training_started date, notes)` — global athlete attrs (training age = derived).
+- `Contraindication(athlete→User, text, active, created_at)` — **global** to the athlete (D-b).
+
+**Program (per relationship — D-a)**
+- `Plan(relationship→CoachAthlete, title, goal, status[draft|active|archived], unit[kg|lb], created/updated)`; `coach`/`athlete` are properties off `relationship`.
+- `Mesocycle(plan, name, order, week_count)`.
+- `Week(mesocycle, index, phase, volume:int, intensity:int, is_deload, is_current, delivered_at:null)`.
+- `Session(week, day_number, name, bias, order)`.
+- `ExercisePrescription(session, exercise→exercises.Exercise null/blank, name, order, sets, reps, load, rpe, note, tags JSON[list])`
+  - `sets/reps/load/rpe` are **CharField** — the prototype grid is free-form (`load="BW"`, `rpe="—"`, rep ranges). Numeric coercion happens at read time, as the JS already does.
+  - `exercise` nullable = the hybrid (B4): linked → picker/alternatives/contraindication-matching; null → free text in `name`.
+
+**Logging (models now, UI in the athlete slice)**
+- `SessionLog(session, athlete→User, date, status[pending|done], notes)`.
+- `LoggedSet(session_log, prescription→ExercisePrescription null, set_number, reps, load, rpe)`.
+
+**Delivery / lightweight versioning**
+- `WeekDelivery(week, delivered_at, payload JSON)` — serialized snapshot of the week at delivery.
+  "Changes since last delivery" = diff(current serialization, latest `payload`). Full diff **UI**
+  is deferred to the agent/review slice; this just captures the data cheaply.
+
+---
+
+## Scoping & permissions (N2)
+
+- Scoped managers: `Plan.objects.for_coach(user)` → plans whose `relationship.coach == user` and
+  `relationship.status == active`; `Plan.objects.for_athlete(user)` → plans across all the
+  athlete's active coaches.
+- A coach's **roster** = athletes with an `active` `CoachAthlete` to them.
+- Edit a plan ⇒ `user == plan.relationship.coach` and active. Athletes get **read + logging only**.
+- View mixin `CoachOwnsPlanMixin` / `AthleteOwnsSessionMixin` enforce object-level access; every
+  list view goes through a scoped manager, never an unscoped `.all()`.
+
+## Invites / onboarding (N4, bidirectional — D-c)
+
+`CoachAthlete.status` state machine:
+
+```
+coach invites  → pending_coach_invite ─(athlete accepts)→ active ─(either ends)→ ended
+athlete asks   → pending_athlete_request ─(coach accepts)→ active
+any pending    ─(recipient declines)→ declined        (re-invite reopens a fresh row/status)
+```
+
+- Coach invites by email: find-or-stub a `User`, create `pending_coach_invite`, email a tokened
+  accept link (`notifications` + `django-ses`). New users complete signup via allauth, then accept.
+- Athlete requests a coach via a coach's share link → `pending_athlete_request`.
+- Ending a relationship sets `ended` and **archives** that coach's plans (never deletes); the
+  other coaches' plans are untouched.
+
+## Front-end (B5)
+
+- **Roster / profile / relationship management:** htmx, server-rendered from scoped querysets.
+- **Designer:** `meso.js` stops owning fixtures. The view serializes the plan to a JSON blob in
+  the page; `meso.js` **hydrates** from it, then **autosaves** edits to ownership-checked endpoints:
+  - `POST /meso/api/plan/<id>/prescription/<pid>/` — patch a cell (or a small batch).
+  - `POST /meso/api/plan/<id>/session/<sid>/exercise/` — add an exercise.
+  - `POST /meso/api/plan/<id>/deliver/` — stamp `delivered_at` + write a `WeekDelivery`.
+  - All return JSON; all check `request.user == plan.relationship.coach`.
+
+---
+
+## Phasing (one PR each)
+
+**Phase 1 — Roles + relationships.**
+Models: `CoachProfile`, `AthleteProfile`, `CoachAthlete`, `Contraindication`. Migrations, admin,
+scoped managers, the invite/accept state machine + email, and roster + athlete-profile reading
+**real** scoped data (replacing those mocks). Factories + tests for scoping and the invite flow.
+*Done when:* a coach sees only their athletes; an athlete can accept/decline/end; roster + profile
+render from the DB.
+
+**Phase 2 — Program schema.**
+Models: `Plan → Mesocycle → Week → Session → ExercisePrescription` + the hybrid `Exercise` FK.
+Admin, a plan→JSON serializer, factories. *Done when:* a seeded plan round-trips to the designer's
+expected JSON shape.
+
+**Phase 3 — Designer save/load.**
+Hydrate `meso.js` from the serialized plan; the JSON autosave endpoints above; ownership checks.
+*Done when:* editing a cell / adding an exercise persists and survives reload.
+
+**Phase 4 — Deliver (lightweight).**
+`delivered_at` + `WeekDelivery` snapshot; wire the deliver screen to a real action.
+*Done when:* delivering stamps the week and records a snapshot.
+
+**Phase 5 — Seed + retire mock.**
+`seed_meso_demo` management command (demo coach = you, the demo athletes, relationships, a sample
+plan); remove `mockdata.py` for coach-side screens. *Done when:* a fresh dev DB shows the same
+screens, now real. (Review/results stay seeded until their slices.)
+
+## Out of scope (later slices)
+Real agent + `ProposedChange` (agent slice) · athlete logging UI + PWA + notifications (athlete
+slice) · groups = shared program + per-athlete override (after individuals).
+
+## Testing
+pytest + factory_boy (already in use). Priorities: **scoping** (coach A cannot read/edit coach B's
+plans; athlete sees all their coaches'), the **invite state machine**, and **autosave ownership**
+(non-owner POST → 403).
+
+## Open assumptions (carried from the plan; flag to override)
+1. **D-a/D-b/D-c** as recorded in `decisions.md`.
+2. Roles live in the **`meso`** app (not `users`).
+3. "Changes since last delivery" = **snapshot-per-delivery now**, full diff UI deferred.
+4. **Logging models defined now**, UI later.


### PR DESCRIPTION
Living planning docs for turning the Meso prototype (#267, #268 — currently all mock) into real code, so we don't write schema/architecture on top of unsettled product questions.

## `docs/meso/decisions.md`
The decision record — foundational blockers (tenancy, athlete model, schema, exercise source, front-end data flow, the agent) each with options + a recommendation + status, plus a decision log.

**Decided so far:**
- Multi-coach SaaS from day one (tenant-scoped)
- Athletes are Users who log in (web/PWA; native deferred); coaches can edit their athletes' plans
- Hybrid exercise source (catalog FK + free-text fallback)
- **Coach↔athlete = many-to-many, athlete-consented** — an athlete may work with multiple coaches; either party can end it
- First slice: persistence (no agent yet)

## `docs/meso/persistence-plan.md`
Engineering plan for that first slice — coach-side designer/roster/profile on DB-backed, tenant-scoped data. Data model (tenancy/roles + the `CoachAthlete` M2M + `Plan→…→ExercisePrescription` with hybrid exercise FK + logging + delivery snapshots), scoping/permissions, the bidirectional invite state machine, the designer hydrate+autosave refactor, and a 5-phase rollout.

Both are living docs — edited in place as decisions land and the plan firms up.

https://claude.ai/code/session_01Viz5vr1SrLy8nm8fnC1qxJ