### PR TITLE
Meso — mark Phase 2 persistence merged (PR #271) in planning docs

### DIFF
--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -189,12 +189,14 @@ _(Append dated entries here as decisions land.)_
 - 2026-06-27 — **Phase 1 merged & deployed:** PR #270 squash-merged to `main` (`ec06974`),
   Django CI green, deployed to Hetzner (migration applied in prod). Resume point → Phase 2
   (program schema).
-- 2026-06-27 — **Phase 2 built** (branch `meso-persistence-phase2`, not yet merged): the program
+- 2026-06-27 — **Phase 2 built & merged** (PR #271, squash `079b891`; Django CI green): the program
   schema `Plan → Mesocycle → Week → Session → ExercisePrescription` (hybrid catalog `Exercise` FK,
   nullable = B4) + `PlanQuerySet` scoping (D-a) + `SessionLog`/`LoggedSet` (models now, UI later)
   in `meso/models.py`; `CoachAthlete.end()` now archives the relationship's plans (D-c); a
   `serialize_plan` (`meso/serializers.py`) round-trips a seeded plan to the designer's
-  `program`/`weeks`/`phases` shape. Migration `meso.0002`; admin + factories; built red→green
-  (18 new tests, 46 meso / 186 project-wide). Resume point → Phase 3 (designer save/load).
-  Settles B3 in build form: distinct entities, full hierarchy; draft/active/archived status on
-  `Plan` (no separate `ProposedChange` yet — that lands with the agent slice).
+  `program`/`weeks`/`phases` shape (macrocycle phase state derived by sequence position, not
+  `order` arithmetic — robust to non-contiguous order). Migration `meso.0002`; admin + factories;
+  built red→green then a local Codex review pass (19 new tests, 47 meso / 187 project-wide).
+  Resume point → Phase 3 (designer save/load). Settles B3 in build form: distinct entities, full
+  hierarchy; draft/active/archived status on `Plan` (no separate `ProposedChange` yet — that lands
+  with the agent slice).

--- a/docs/meso/persistence-plan.md
+++ b/docs/meso/persistence-plan.md
@@ -1,7 +1,7 @@
 # Meso — persistence slice plan
 
-**Status:** in progress — Phase 1 shipped & deployed 2026-06-27 (PR #270); Phase 2 built
-2026-06-27 (branch `meso-persistence-phase2`, not yet merged); Phase 3 next · created 2026-06-26
+**Status:** in progress — Phase 1 shipped & deployed 2026-06-27 (PR #270); Phase 2 merged
+2026-06-27 (PR #271); Phase 3 next · created 2026-06-26
 **Companion to:** [`decisions.md`](./decisions.md)
 **Goal of this slice:** turn the **coach-side** screens (designer, roster, athlete profile)
 from client-side mocks into real, DB-backed, **tenant-scoped** data. No agent, no athlete app
@@ -150,7 +150,7 @@ plan→JSON serializer is `meso/serializers.py` (`serialize_plan` → the design
 `plan`/`program`/`weeks`/`phases` shape; `tags[]`→`tag`; `last`/`adj` deferred to the log/agent
 slices). Migration `meso.0002`; admin with nested inlines; factories for all seven models. Built
 test-first (red→green): 18 new tests (`test_program_models.py` + `test_serializers.py`, the Maya
-round-trip) on top of Phase 1's 28 — 46 meso tests, 186 project-wide, green. **Not yet merged.**
+round-trip) on top of Phase 1's 28 — 46 meso tests, 186 project-wide, green. **Merged as PR #271.**
 
 **Phase 3 — Designer save/load.**
 Hydrate `meso.js` from the serialized plan; the JSON autosave endpoints above; ownership checks.


### PR DESCRIPTION
## Summary

- Docs-only follow-up to #271: updates the Meso persistence-slice plan + decision log so the resume point is accurate — Phase 2 (program schema + plan→JSON serializer) is **merged to main** (PR #271); Phase 3 (designer save/load) is next.

## Changes

- `docs/meso/persistence-plan.md`: status line and Phase 2 section now read "merged (PR #271)" instead of "not yet merged".
- `docs/meso/decisions.md`: decision-log entry updated to "Phase 2 built & merged (PR #271, `079b891`)", noting the sequence-position phase-state refinement from the Codex review pass.

## Additional Notes

No code changes; no migration impact.

https://claude.ai/code/session_01Viz5vr1SrLy8nm8fnC1qxJ