### PR TITLE
CI — skip Django CI on docs-only changes; cancel superseded PR runs

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -3,12 +3,25 @@ name: Django CI
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
   pull_request:
     branches: ["main"]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+
+# Cancel superseded runs on the same PR branch, but let main runs finish
+# so every merge gets its CI + downstream deploy.
+concurrency:
+  group: django-ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
 
     env:
       SECRET_KEY: NotSecureForTesting


### PR DESCRIPTION
## What

Three optimizations to `.github/workflows/django.yml`:

1. **`paths-ignore` (`**.md`, `docs/**`)** on the push/PR triggers — docs-only commits skip the test suite. Because the deploy workflow chains off Django CI via `workflow_run`, this also skips the deploy on docs-only pushes to `main` (docs aren't served by the app, so there's nothing to redeploy).
2. **`concurrency` group** — cancels superseded runs on a PR branch, but lets `main` runs finish so every merge still gets its CI + downstream deploy.
3. **`timeout-minutes: 15`** — guards against a hung run burning the 6-hour default.

## Why it's safe

- `paths-ignore` skips only when **every** changed file matches — a commit touching both `.py` and `.md` still runs the full suite.
- The `main` ruleset requires PRs but has **no required status checks** (`required_checks: []`), so a docs-only PR can't get stuck on a "skipped" required check — the usual `paths` gotcha doesn't apply here.
- `.github/**` is deliberately *not* ignored, so workflow edits still trigger CI.

## Trade-off

On a docs-only push to `main`, the box's git tree lags one commit behind until the next code deploy's `git pull` catches it up — harmless, since the app doesn't serve `docs/` or markdown.

https://claude.ai/code/session_01Viz5vr1SrLy8nm8fnC1qxJ