### PR TITLE
Meso — Phase 3 persistence: designer save/load (real plans + autosave API)

### DIFF
--- a/app/store_project/meso/tests/test_designer_save.py
+++ b/app/store_project/meso/tests/test_designer_save.py
@@ -1,0 +1,252 @@
+"""Phase 3 — designer save/load.
+
+The designer (``static/js/meso.js``) stops owning fixtures: the view serializes a
+real ``Plan`` into the page and the JS hydrates from it, then autosaves edits to
+ownership-checked JSON endpoints. These tests cover the server seam:
+
+- ``meso:designer_plan`` renders a real plan's serialized JSON into the page
+  (and 404s a plan the requester does not coach);
+- patching a prescription cell persists and survives a reload;
+- adding an exercise to a session persists;
+- every autosave endpoint enforces ``request.user == plan.relationship.coach``
+  over an *active* relationship (non-owner / inactive → 403).
+"""
+
+import json
+
+import pytest
+from django.urls import reverse
+
+from store_project.meso.factories import CoachAthleteFactory
+from store_project.meso.factories import ExercisePrescriptionFactory
+from store_project.meso.factories import MesocycleFactory
+from store_project.meso.factories import PlanFactory
+from store_project.meso.factories import SessionFactory
+from store_project.meso.factories import WeekFactory
+from store_project.meso.models import Plan
+from store_project.users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def seed_plan(coach=None, athlete=None):
+    """A minimal owned plan with one current week → session → prescription."""
+    rel = CoachAthleteFactory(
+        coach=coach or UserFactory(), athlete=athlete or UserFactory()
+    )
+    plan = PlanFactory(
+        relationship=rel, title="Hypertrophy Block", status=Plan.Status.ACTIVE
+    )
+    meso = MesocycleFactory(plan=plan, name="Hypertrophy", order=0)
+    week = WeekFactory(mesocycle=meso, index=1, is_current=True)
+    session = SessionFactory(week=week, day_number=1, name="Lower")
+    presc = ExercisePrescriptionFactory(
+        session=session, name="Box Squat", sets="4", reps="6", load="70", rpe="7"
+    )
+    return plan, session, presc
+
+
+class TestDesignerLoad:
+    def test_designer_plan_serializes_real_plan(self, client):
+        plan, _, _ = seed_plan()
+        client.force_login(plan.relationship.coach)
+        resp = client.get(reverse("meso:designer_plan", kwargs={"plan_id": plan.pk}))
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        # The serialized plan is injected for the JS to hydrate from.
+        assert 'id="meso-plan-data"' in body
+        assert "Hypertrophy Block" in body
+        assert "Box Squat" in body
+
+    def test_designer_plan_404_for_non_owned(self, client):
+        plan, _, _ = seed_plan()
+        client.force_login(UserFactory())  # not this plan's coach
+        resp = client.get(reverse("meso:designer_plan", kwargs={"plan_id": plan.pk}))
+        assert resp.status_code == 404
+
+    def test_designer_plan_404_for_inactive_relationship(self, client):
+        plan, _, _ = seed_plan()
+        coach = plan.relationship.coach
+        plan.relationship.end()  # relationship no longer active
+        client.force_login(coach)
+        resp = client.get(reverse("meso:designer_plan", kwargs={"plan_id": plan.pk}))
+        assert resp.status_code == 404
+
+    def test_bare_designer_renders_without_plan_data(self, client):
+        client.force_login(UserFactory())
+        resp = client.get(reverse("meso:designer"))
+        assert resp.status_code == 200
+        assert 'id="meso-plan-data"' not in resp.content.decode()
+
+
+class TestPrescriptionPatch:
+    def _url(self, plan, presc):
+        return reverse(
+            "meso:api_prescription_patch",
+            kwargs={"plan_id": plan.pk, "pk": presc.pk},
+        )
+
+    def test_patch_persists_and_survives_reload(self, client):
+        plan, _, presc = seed_plan()
+        client.force_login(plan.relationship.coach)
+        resp = client.post(
+            self._url(plan, presc),
+            data=json.dumps({"load": "75", "rpe": "8", "note": "felt easy"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        presc.refresh_from_db()
+        assert presc.load == "75"
+        assert presc.rpe == "8"
+        assert presc.note == "felt easy"
+        # Survives reload: the serialized designer reflects the saved value.
+        reload_body = client.get(
+            reverse("meso:designer_plan", kwargs={"plan_id": plan.pk})
+        ).content.decode()
+        assert "felt easy" in reload_body
+
+    def test_patch_only_touches_provided_fields(self, client):
+        plan, _, presc = seed_plan()
+        client.force_login(plan.relationship.coach)
+        client.post(
+            self._url(plan, presc),
+            data=json.dumps({"load": "80"}),
+            content_type="application/json",
+        )
+        presc.refresh_from_db()
+        assert presc.load == "80"
+        assert presc.sets == "4"  # untouched
+        assert presc.reps == "6"  # untouched
+
+    def test_non_owner_patch_forbidden(self, client):
+        plan, _, presc = seed_plan()
+        client.force_login(UserFactory())  # a stranger
+        resp = client.post(
+            self._url(plan, presc),
+            data=json.dumps({"load": "999"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 403
+        presc.refresh_from_db()
+        assert presc.load == "70"  # unchanged
+
+    def test_patch_inactive_relationship_forbidden(self, client):
+        plan, _, presc = seed_plan()
+        coach = plan.relationship.coach
+        plan.relationship.end()
+        client.force_login(coach)
+        resp = client.post(
+            self._url(plan, presc),
+            data=json.dumps({"load": "999"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 403
+        presc.refresh_from_db()
+        assert presc.load == "70"
+
+    def test_patch_rejects_foreign_prescription(self, client):
+        plan, _, _ = seed_plan()
+        # A prescription that belongs to a *different* plan.
+        _, _, other_presc = seed_plan()
+        client.force_login(plan.relationship.coach)
+        resp = client.post(
+            self._url(plan, other_presc),
+            data=json.dumps({"load": "5"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 404
+
+    def test_patch_rejects_overlong_value(self, client):
+        plan, _, presc = seed_plan()
+        client.force_login(plan.relationship.coach)
+        resp = client.post(
+            self._url(plan, presc),
+            data=json.dumps({"load": "x" * 40}),  # load max_length is 32
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        presc.refresh_from_db()
+        assert presc.load == "70"
+
+    def test_patch_rejects_non_string_value(self, client):
+        plan, _, presc = seed_plan()
+        client.force_login(plan.relationship.coach)
+        resp = client.post(
+            self._url(plan, presc),
+            data=json.dumps({"sets": 4}),  # must be a string
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+
+    def test_patch_rejects_malformed_json(self, client):
+        plan, _, presc = seed_plan()
+        client.force_login(plan.relationship.coach)
+        resp = client.post(
+            self._url(plan, presc), data="not json", content_type="application/json"
+        )
+        assert resp.status_code == 400
+
+    def test_patch_requires_login(self, client):
+        plan, _, presc = seed_plan()
+        resp = client.post(
+            self._url(plan, presc),
+            data=json.dumps({"load": "75"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 302
+        assert "/accounts/login/" in resp.url
+
+    def test_patch_get_not_allowed(self, client):
+        plan, _, presc = seed_plan()
+        client.force_login(plan.relationship.coach)
+        resp = client.get(self._url(plan, presc))
+        assert resp.status_code == 405
+
+
+class TestAddExercise:
+    def _url(self, plan, session):
+        return reverse(
+            "meso:api_session_add_exercise",
+            kwargs={"plan_id": plan.pk, "pk": session.pk},
+        )
+
+    def test_add_exercise_persists(self, client):
+        plan, session, presc = seed_plan()
+        client.force_login(plan.relationship.coach)
+        before = session.prescriptions.count()
+        resp = client.post(self._url(plan, session))
+        assert resp.status_code == 201
+        assert session.prescriptions.count() == before + 1
+        payload = resp.json()["prescription"]
+        assert isinstance(payload["id"], int)
+        assert payload["name"] == "New exercise"
+        # The new row lands after the existing ones (max order + 1).
+        added = session.prescriptions.order_by("order").last()
+        assert added.pk == payload["id"]
+        assert added.order == presc.order + 1
+
+    def test_non_owner_add_forbidden(self, client):
+        plan, session, _ = seed_plan()
+        client.force_login(UserFactory())
+        resp = client.post(self._url(plan, session))
+        assert resp.status_code == 403
+        assert session.prescriptions.count() == 1
+
+    def test_add_rejects_foreign_session(self, client):
+        plan, _, _ = seed_plan()
+        _, other_session, _ = seed_plan()
+        client.force_login(plan.relationship.coach)
+        resp = client.post(self._url(plan, other_session))
+        assert resp.status_code == 404
+
+    def test_add_requires_login(self, client):
+        plan, session, _ = seed_plan()
+        resp = client.post(self._url(plan, session))
+        assert resp.status_code == 302
+        assert "/accounts/login/" in resp.url
+
+    def test_add_get_not_allowed(self, client):
+        plan, session, _ = seed_plan()
+        client.force_login(plan.relationship.coach)
+        resp = client.get(self._url(plan, session))
+        assert resp.status_code == 405

--- a/app/store_project/meso/urls.py
+++ b/app/store_project/meso/urls.py
@@ -12,6 +12,7 @@ app_name = "meso"
 urlpatterns = [
     path("", RosterView.as_view(), name="roster"),
     path("designer/", MesoDesignerView.as_view(), name="designer"),
+    path("designer/<int:plan_id>/", MesoDesignerView.as_view(), name="designer_plan"),
     path("review/", ChangeReviewView.as_view(), name="review"),
     path("deliver/", DeliverView.as_view(), name="deliver"),
     path("results/", ResultsView.as_view(), name="results"),
@@ -22,5 +23,16 @@ urlpatterns = [
         "relationship/<uuid:token>/end/",
         views.relationship_end,
         name="relationship_end",
+    ),
+    # Designer autosave API (Phase 3).
+    path(
+        "api/plan/<int:plan_id>/prescription/<int:pk>/",
+        views.prescription_patch,
+        name="api_prescription_patch",
+    ),
+    path(
+        "api/plan/<int:plan_id>/session/<int:pk>/exercise/",
+        views.session_add_exercise,
+        name="api_session_add_exercise",
     ),
 ]

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -1,8 +1,13 @@
+import json
+
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.db.models import Max
 from django.http import Http404
+from django.http import HttpResponseBadRequest
 from django.http import HttpResponseForbidden
+from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
 from django.shortcuts import redirect
 from django.views.decorators.http import require_POST
@@ -11,17 +16,34 @@ from django.views.generic import TemplateView
 from . import mockdata
 from . import presenters
 from .models import CoachAthlete
+from .models import ExercisePrescription
+from .models import Plan
+from .models import Session
+from .serializers import serialize_plan
+from .serializers import serialize_prescription
 
 
 class MesoDesignerView(LoginRequiredMixin, TemplateView):
-    """The Meso AI strength-training program designer.
+    """The Meso strength-training program designer.
 
-    A self-contained, full-screen coach tool. All program/agent state lives
-    client-side (Alpine.js); the view only serves the shell. Wiring it to real
-    athlete profiles, logged sets, and a live agent is a future step (Phase 3).
+    A self-contained, full-screen coach tool. With a ``plan_id`` the view
+    serializes a real, owned plan into the page and the Alpine front-end
+    hydrates from it (then autosaves edits to the API endpoints below); without
+    one it falls back to the prototype's client-side fixtures until the seed
+    slice (Phase 5) retires them. The agent column stays mock until its slice.
     """
 
     template_name = "meso/designer.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        plan_id = kwargs.get("plan_id")
+        if plan_id is not None:
+            plan = Plan.objects.for_coach(self.request.user).filter(pk=plan_id).first()
+            if plan is None:
+                raise Http404("Unknown plan")
+            ctx["plan_data"] = serialize_plan(plan)
+        return ctx
 
 
 class RosterView(LoginRequiredMixin, TemplateView):
@@ -115,6 +137,98 @@ def relationship_end(request, token):
     link.end()
     messages.success(request, "Relationship ended.")
     return redirect("meso:roster")
+
+
+# -- designer autosave API (Phase 3) --------------------------------------
+#
+# Plain JSON endpoints (no DRF) the designer grid POSTs edits to. Every call is
+# scoped to a plan the requester coaches over an *active* relationship — an
+# existing-but-unowned plan is a 403, never a silent no-op (N2 / the plan's
+# "non-owner POST → 403"). Children (prescription, session) must belong to that
+# plan, or it's a 404.
+
+# Free-form text cells the grid edits, mapped to their model ``max_length``.
+PATCHABLE_FIELDS = {
+    "name": 255,
+    "sets": 32,
+    "reps": 32,
+    "load": 32,
+    "rpe": 32,
+    "note": 255,
+}
+
+
+def _coach_plan_or_forbidden(request, plan_id):
+    """The plan the requester coaches, or an ``HttpResponseForbidden``.
+
+    404 when the plan does not exist; 403 when it exists but the requester is
+    not its coach over an active relationship.
+    """
+    plan = get_object_or_404(Plan, pk=plan_id)
+    if plan.relationship.coach_id != request.user.id or not plan.relationship.is_active:
+        return None, HttpResponseForbidden("You do not own this plan.")
+    return plan, None
+
+
+@login_required
+@require_POST
+def prescription_patch(request, plan_id, pk):
+    """Patch one prescription cell (or a small batch of cells)."""
+    plan, forbidden = _coach_plan_or_forbidden(request, plan_id)
+    if forbidden is not None:
+        return forbidden
+    prescription = get_object_or_404(
+        ExercisePrescription, pk=pk, session__week__mesocycle__plan=plan
+    )
+    try:
+        payload = json.loads(request.body or "{}")
+    except json.JSONDecodeError:
+        return HttpResponseBadRequest("Malformed JSON.")
+    if not isinstance(payload, dict):
+        return HttpResponseBadRequest("Expected a JSON object.")
+
+    updates = {}
+    for field, max_length in PATCHABLE_FIELDS.items():
+        if field not in payload:
+            continue
+        value = payload[field]
+        if not isinstance(value, str):
+            return HttpResponseBadRequest(f"{field} must be a string.")
+        if len(value) > max_length:
+            return HttpResponseBadRequest(f"{field} is too long.")
+        updates[field] = value
+
+    if updates:
+        for field, value in updates.items():
+            setattr(prescription, field, value)
+        prescription.save(update_fields=list(updates))
+    return JsonResponse(
+        {"ok": True, "prescription": serialize_prescription(prescription)}
+    )
+
+
+@login_required
+@require_POST
+def session_add_exercise(request, plan_id, pk):
+    """Append a blank prescription row to a session."""
+    plan, forbidden = _coach_plan_or_forbidden(request, plan_id)
+    if forbidden is not None:
+        return forbidden
+    session = get_object_or_404(Session, pk=pk, week__mesocycle__plan=plan)
+    next_order = (session.prescriptions.aggregate(m=Max("order"))["m"] or 0) + 1
+    prescription = ExercisePrescription.objects.create(
+        session=session,
+        name="New exercise",
+        order=next_order,
+        sets="3",
+        reps="10",
+        load="",
+        rpe="7",
+        note="",
+    )
+    return JsonResponse(
+        {"ok": True, "prescription": serialize_prescription(prescription)}, status=201
+    )
 
 
 # -- still on fixtures until their own slices ------------------------------

--- a/app/store_project/static/js/meso.js
+++ b/app/store_project/static/js/meso.js
@@ -1,11 +1,12 @@
-/* Meso — AI strength-training program designer.
+/* Meso — strength-training program designer.
  *
- * A faithful port of the Meso.dc.html Claude Design prototype to Alpine.js.
- * All program/agent state is client-side; the "agent" is a canned intent
- * engine (swap-knee / lower-volume / progress / deload) that mutates the
- * in-memory program, exactly as the original prototype did. Replacing
- * dispatch()/applyIntent() with a real backend call is the seam to make this
- * live.
+ * A port of the Meso.dc.html Claude Design prototype to Alpine.js. When the
+ * designer view injects a serialized plan (Phase 3), init() hydrates the grid
+ * from it and edits autosave to the JSON API; without one, the program/weeks/
+ * phases below are fixtures and the page runs fully client-side, as the
+ * original prototype did. The "agent" column is still a canned intent engine
+ * (swap-knee / lower-volume / progress / deload) — replacing dispatch()/
+ * applyIntent() with a real backend call is the next seam to make live.
  */
 document.addEventListener("alpine:init", () => {
   Alpine.data("meso", () => ({
@@ -23,6 +24,13 @@ document.addEventListener("alpine:init", () => {
     delivered: false,
     checks: {},
     exSeq: 1,
+
+    // ---- backend hydration (Phase 3) ----
+    // init() flips these on when the view injects a real plan; otherwise the
+    // fixtures below stand and no network calls are made.
+    live: false,
+    planId: null,
+    csrf: "",
 
     messages: [
       {
@@ -280,6 +288,53 @@ document.addEventListener("alpine:init", () => {
       return this.mode !== "group";
     },
 
+    // ---- backend hydration + autosave (Phase 3) ----
+    init() {
+      const el = document.getElementById("meso-plan-data");
+      if (!el) return; // no plan injected → keep the prototype fixtures
+      let data;
+      try {
+        data = JSON.parse(el.textContent);
+      } catch (e) {
+        console.error("Could not parse plan data", e);
+        return;
+      }
+      this.live = true;
+      this.planId = data.plan.id;
+      if (data.plan.unit) this.unit = data.plan.unit;
+      this.program = data.program;
+      this.weeks = data.weeks;
+      this.phases = data.phases;
+      const csrfEl = document.getElementById("meso-csrf");
+      this.csrf = csrfEl ? csrfEl.dataset.token : "";
+    },
+
+    async apiPost(url, body) {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRFToken": this.csrf,
+        },
+        body: body == null ? null : JSON.stringify(body),
+      });
+      if (!res.ok) throw new Error("Request failed: " + res.status);
+      return res.json();
+    },
+
+    // Autosave one edited row to its prescription. No-op until a plan is loaded.
+    persistRow(ex) {
+      if (!this.live || !ex || ex.id == null) return;
+      this.apiPost(`/meso/api/plan/${this.planId}/prescription/${ex.id}/`, {
+        name: ex.name ?? "",
+        sets: ex.sets ?? "",
+        reps: ex.reps ?? "",
+        load: ex.load ?? "",
+        rpe: ex.rpe ?? "",
+        note: ex.note ?? "",
+      }).catch((err) => console.error("Autosave failed", err));
+    },
+
     // ---- helpers ----
     numeric(v) {
       const s = String(v == null ? "" : v).trim();
@@ -319,6 +374,7 @@ document.addEventListener("alpine:init", () => {
     // ---- athlete (phone) view: first day, first three lifts ----
     get athleteDay() {
       const day = this.program[0];
+      if (!day) return []; // a plan whose current week has no sessions yet
       return day.exercises.slice(0, 3).map((x, xi) => {
         const setN = parseInt(x.sets, 10) || 3;
         const rows = [];
@@ -362,8 +418,21 @@ document.addEventListener("alpine:init", () => {
       }, 2800);
     },
 
-    addExercise(di) {
-      this.program[di].exercises.push({
+    async addExercise(di) {
+      const day = this.program[di];
+      if (this.live) {
+        try {
+          const data = await this.apiPost(
+            `/meso/api/plan/${this.planId}/session/${day.id}/exercise/`,
+            null,
+          );
+          day.exercises.push(data.prescription);
+        } catch (err) {
+          console.error("Add exercise failed", err);
+        }
+        return;
+      }
+      day.exercises.push({
         id: "n" + this.exSeq++,
         name: "New exercise",
         sets: "3",

--- a/app/store_project/templates/meso/designer.html
+++ b/app/store_project/templates/meso/designer.html
@@ -19,6 +19,10 @@
   </head>
 
   <body class="meso">
+    {% if plan_data %}
+      {{ plan_data|json_script:"meso-plan-data" }}
+      <span id="meso-csrf" data-token="{{ csrf_token }}" hidden></span>
+    {% endif %}
     <div
       class="meso meso-root"
       x-data="meso()"
@@ -307,7 +311,7 @@
                   <template x-for="(ex, xi) in day.exercises" :key="ex.id">
                     <div style="display:grid;grid-template-columns:minmax(0,1.75fr) 84px 76px 44px minmax(0,0.92fr);gap:10px;padding:8px 16px;border-bottom:1px solid var(--line-2);align-items:center;">
                       <div style="min-width:0;">
-                        <input class="meso-cell" x-model="ex.name" style="width:100%;appearance:none;border:0;background:transparent;font:inherit;font-size:13.5px;font-weight:600;color:var(--ink);padding:3px 6px;border-radius:5px;outline:none;letter-spacing:-0.01em;" />
+                        <input class="meso-cell" x-model="ex.name" @change="persistRow(ex)" style="width:100%;appearance:none;border:0;background:transparent;font:inherit;font-size:13.5px;font-weight:600;color:var(--ink);padding:3px 6px;border-radius:5px;outline:none;letter-spacing:-0.01em;" />
                         <div style="display:flex;flex-wrap:wrap;gap:5px;align-items:center;padding:1px 6px;margin-top:1px;min-height:15px;">
                           <template x-if="ex.tag"><span style="display:inline-flex;align-items:center;gap:3px;font-size:10px;font-weight:700;color:var(--accent-deep);background:var(--soft);border:1px solid var(--soft-line);padding:0 5px;border-radius:4px;" x-text="ex.tag"></span></template>
                           <template x-if="ex.last"><span style="font-size:10.5px;color:var(--dim);font-family:'IBM Plex Mono',monospace;" x-text="'last: ' + ex.last"></span></template>
@@ -315,19 +319,19 @@
                         </div>
                       </div>
                       <div style="display:flex;align-items:center;justify-content:center;gap:2px;">
-                        <input class="meso-cell" x-model="ex.sets" style="width:30px;text-align:center;appearance:none;border:0;background:transparent;font-family:'IBM Plex Mono',monospace;font-size:13px;color:var(--ink);padding:4px 2px;border-radius:5px;outline:none;" />
+                        <input class="meso-cell" x-model="ex.sets" @change="persistRow(ex)" style="width:30px;text-align:center;appearance:none;border:0;background:transparent;font-family:'IBM Plex Mono',monospace;font-size:13px;color:var(--ink);padding:4px 2px;border-radius:5px;outline:none;" />
                         <span style="color:var(--dim);font-size:11px;">&#215;</span>
-                        <input class="meso-cell" x-model="ex.reps" style="width:34px;text-align:center;appearance:none;border:0;background:transparent;font-family:'IBM Plex Mono',monospace;font-size:13px;color:var(--ink);padding:4px 2px;border-radius:5px;outline:none;" />
+                        <input class="meso-cell" x-model="ex.reps" @change="persistRow(ex)" style="width:34px;text-align:center;appearance:none;border:0;background:transparent;font-family:'IBM Plex Mono',monospace;font-size:13px;color:var(--ink);padding:4px 2px;border-radius:5px;outline:none;" />
                       </div>
                       <div style="display:flex;align-items:center;justify-content:center;gap:3px;">
-                        <input class="meso-cell" x-model="ex.load" style="width:42px;text-align:right;appearance:none;border:0;background:transparent;font-family:'IBM Plex Mono',monospace;font-size:13px;color:var(--ink);padding:4px 2px;border-radius:5px;outline:none;" />
+                        <input class="meso-cell" x-model="ex.load" @change="persistRow(ex)" style="width:42px;text-align:right;appearance:none;border:0;background:transparent;font-family:'IBM Plex Mono',monospace;font-size:13px;color:var(--ink);padding:4px 2px;border-radius:5px;outline:none;" />
                         <span style="font-size:10.5px;color:var(--dim);min-width:14px;" x-text="loadSuffix(ex.load)"></span>
                       </div>
                       <div style="display:flex;justify-content:center;">
-                        <input class="meso-cell" x-model="ex.rpe" style="width:38px;text-align:center;appearance:none;border:0;background:transparent;font-family:'IBM Plex Mono',monospace;font-size:13px;color:var(--ink);padding:4px 2px;border-radius:5px;outline:none;" />
+                        <input class="meso-cell" x-model="ex.rpe" @change="persistRow(ex)" style="width:38px;text-align:center;appearance:none;border:0;background:transparent;font-family:'IBM Plex Mono',monospace;font-size:13px;color:var(--ink);padding:4px 2px;border-radius:5px;outline:none;" />
                       </div>
                       <div style="min-width:0;">
-                        <input class="meso-note" x-model="ex.note" placeholder="&#8212;" style="width:100%;appearance:none;border:0;background:transparent;font:inherit;font-size:12px;color:var(--dim);padding:4px 6px;border-radius:5px;outline:none;" />
+                        <input class="meso-note" x-model="ex.note" @change="persistRow(ex)" placeholder="&#8212;" style="width:100%;appearance:none;border:0;background:transparent;font:inherit;font-size:12px;color:var(--dim);padding:4px 6px;border-radius:5px;outline:none;" />
                       </div>
                     </div>
                   </template>


### PR DESCRIPTION
## What

Phase 3 of the Meso persistence slice: turn the designer grid from client-side
fixtures into a real, DB-backed, **tenant-scoped** surface. Resumes from Phase 2
(PR #271).

- **`/meso/designer/<plan_id>/`** serializes an owned `Plan` into the page
  (`serialize_plan`, built in Phase 2). `meso.js` `init()` hydrates
  `program`/`weeks`/`phases`/`unit`/`planId` from it. With **no** plan injected
  (the bare `/meso/designer/`), it falls back to the prototype fixtures — those
  are retired in Phase 5 (seed slice).
- **Cell edits autosave** on `@change`; **"+ Add exercise"** creates a real row
  and adopts the server-assigned id.

### Endpoints (plain `JsonResponse`, no DRF)
Each is scoped to a plan the requester coaches over an **active** relationship —
non-owner / inactive → **403**, child not in the plan → **404**:

- `POST /meso/api/plan/<id>/prescription/<pid>/` — patch grid cells. Values are
  type- and length-validated against the model's free-form `CharField`s (→ 400).
- `POST /meso/api/plan/<id>/session/<sid>/exercise/` — append a blank row
  (order = max + 1).

## Tests (red→green)

19 new tests in `test_designer_save.py`: load/serialize-into-page, ownership
(403), child-belongs-to-plan (404), validation (400), method/login guards, and
the headline **patch-survives-reload**. **66 meso / 206 project-wide pass.**

## Out of scope (next slices)

Deliver (`delivered_at` + `WeekDelivery` snapshot) is Phase 4; the agent column
stays mock until its slice.

## Review

Local Codex review (`/codex-review-loop`) against `main`: **CLEAN**, 0 blocking,
0 nits.

🤖 https://claude.ai/code/session_01Viz5vr1SrLy8nm8fnC1qxJ