### PR TITLE
Meso — mark Phase 5 persistence merged (PR #278) in planning docs

### DIFF
--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -200,13 +200,16 @@ _(Append dated entries here as decisions land.)_
   Resume point → Phase 3 (designer save/load). Settles B3 in build form: distinct entities, full
   hierarchy; draft/active/archived status on `Plan` (no separate `ProposedChange` yet — that lands
   with the agent slice).
-- 2026-06-27 — **Phase 5 built** (branch `meso-persistence-phase5`): `seed_meso_demo` management
-  command (idempotent; `--delete` / `--coach-email`) stands up the coach + five athletes +
+- 2026-06-27 — **Phase 5 built & merged** (PR #278, squash `5babceb`; Django CI green, deployed to
+  Hetzner): `seed_meso_demo` management command (idempotent; `--delete` / `--coach-email`; created
+  coach gets a runtime-random password, no literal in source) stands up the coach + five athletes +
   active links + Maya's sample plan as real rows, reproducing the prototype roster/designer. The
   coach-side **mock is retired**: bare `/meso/designer/` + `/meso/deliver/` redirect to the coach's
   working plan (`_coach_working_plan`) or the roster, `DeliverView`'s `mockdata.DELIVER` fallback is
   gone, and `meso.js`'s `program`/`weeks`/`phases` fixtures are emptied (the grid always hydrates
   from an injected plan). `mockdata.py` now serves **only** the review + results screens (their own
-  slices). 16 new tests, 95 meso / 235 project-wide green. The designer's left-rail/agent/phone
-  chrome stays static prototype HTML by design — it rebuilds with the agent + athlete slices.
-  Resume point → the **agent** slice (B6: proposal engine behind the review gate).
+  slices). Built red→green then a 3-round local Codex review (reseed-reconcile + redirect ordering):
+  20 new tests, 99 meso / 239 project-wide green. No migration (no model changes). The designer's
+  left-rail/agent/phone chrome stays static prototype HTML by design — it rebuilds with the agent +
+  athlete slices. **Persistence slice complete.** Resume point → the **agent** slice (B6: proposal
+  engine behind the review gate).

--- a/docs/meso/persistence-plan.md
+++ b/docs/meso/persistence-plan.md
@@ -1,9 +1,9 @@
 # Meso — persistence slice plan
 
-**Status:** in progress — Phase 1 shipped & deployed 2026-06-27 (PR #270); Phase 2 merged
-2026-06-27 (PR #271); Phase 3 merged 2026-06-27 (PR #274); Phase 4 merged 2026-06-27
-(PR #276); Phase 5 built 2026-06-27 (`seed_meso_demo` + coach-side mock retired) · created
-2026-06-26
+**Status:** persistence slice complete — Phase 1 shipped & deployed 2026-06-27 (PR #270); Phase 2
+merged 2026-06-27 (PR #271); Phase 3 merged 2026-06-27 (PR #274); Phase 4 merged 2026-06-27
+(PR #276); Phase 5 merged & deployed 2026-06-27 (PR #278, `seed_meso_demo` + coach-side mock
+retired) · created 2026-06-26 · **next = the agent slice (B6)**
 **Companion to:** [`decisions.md`](./decisions.md)
 **Goal of this slice:** turn the **coach-side** screens (designer, roster, athlete profile)
 from client-side mocks into real, DB-backed, **tenant-scoped** data. No agent, no athlete app
@@ -193,7 +193,8 @@ delivery" diff UI (the snapshot is captured now; the diff renders with the agent
 plan); remove `mockdata.py` for coach-side screens. *Done when:* a fresh dev DB shows the same
 screens, now real. (Review/results stay seeded until their slices.)
 
-*Shipped* (branch `meso-persistence-phase5`): `meso/management/commands/seed_meso_demo.py` —
+*Shipped* (branch `meso-persistence-phase5`, **PR #278**, squash `5babceb`; Django CI green,
+deployed to Hetzner): `meso/management/commands/seed_meso_demo.py` —
 **idempotent** (`get_or_create`/`update_or_create` throughout; `--delete` tears the demo down;
 `--coach-email` overrides the default `lancegoyke@gmail.com`). It stands up the prototype's roster
 as real rows: the coach + `CoachProfile` (the COACH_STYLE voice), the five athletes


### PR DESCRIPTION
Docs-only follow-up bringing the Meso planning docs in line with the merged + deployed Phase 5 (PR #278, squash `5babceb`), matching the per-phase "mark merged" pattern (#272 / #275 / #277).

- `persistence-plan.md`: status → **persistence slice complete**; Phase 5 line → merged & deployed 2026-06-27 (PR #278); the *Shipped* block records PR #278 / squash `5babceb` / Django CI green / deployed to Hetzner.
- `decisions.md`: log entry → **built & merged** (PR #278, squash `5babceb`, deployed); corrected the final tallies to the post-Codex-review numbers (20 new tests, 99 meso / 239 project-wide); noted the slice is complete and the next slice is the agent (B6).

No code changes (Django CI is skipped on docs-only diffs).

https://claude.ai/code/session_015G62Gs7papVMJAfYqeExrN