### PR TITLE
Meso — mark agent Phase 1 merged (PR #280) in planning docs

### DIFF
--- a/docs/meso/agent-plan.md
+++ b/docs/meso/agent-plan.md
@@ -1,6 +1,7 @@
 # Meso — agent slice plan
 
-**Status:** Phase 1 in progress · created 2026-06-27
+**Status:** Phase 1 done & merged (PR #280, squash `953d9d4`; deployed) · created 2026-06-27 ·
+**next = agent Phase 2 (approve/apply)**
 **Companion to:** [`decisions.md`](./decisions.md) (B6) · [`persistence-plan.md`](./persistence-plan.md)
 **Goal of this slice:** replace the designer's canned agent-chat engine
 (`detectIntent`/`applyIntent` in `meso.js`) and the review screen
@@ -109,7 +110,7 @@ clean ones, so a hallucinated or unsafe edit never reaches the review screen.
 
 ## Phasing (one PR each)
 
-**Phase 1 — Proposal engine. ← this PR.**
+**Phase 1 — Proposal engine. ✅ Done & merged (2026-06-27, PR #280).**
 Models (`AgentProposalBatch`, `ProposedChange`) + migration + admin + factories;
 the `agent/` package (client, validation, service); settings; the `POST .../agent/`
 endpoint; read-only `review/<batch_id>/` wiring. Tests: validation unit tests,
@@ -118,6 +119,19 @@ rejection), endpoint tests (ownership / login / method / missing-key guard /
 persists), review-render test.
 *Done when:* a coach instruction produces validated, contraindication-safe
 `ProposedChange` rows the review screen can render. **No real apply, no chat UI.**
+
+*Shipped* (branch `meso-agent-phase1`, **PR #280**, squash `953d9d4`; Django CI green, deployed
+to Hetzner — migration `meso.0004` applied): models + `meso/agent/` (`client`/`validation`/
+`service`) + `POST api/plan/<id>/agent/` (sync; 503 without an API key) + read-only
+`GET review/<batch_id>/`. The validation guardrail enforces, server-side: valid kind, targets
+resolving to the plan's **current week**, consistent session/prescription, a required target per
+kind (swap/progress→prescription, volume→session, deload→none), and a **contraindication backstop**
+that screens only swaps (plural-folded). Model pinned to `claude-opus-4-8`; **adaptive thinking
+omitted** (incompatible with a forced `tool_choice`). Built red→green: 47 new tests (146 meso / 286
+project-wide). **Local Codex review: clean (8 rounds)** — it caught two real bugs (a contraindication
+bypass when `introduces_exercise` was omitted; `rationale` dropped on persist) plus a series of
+guardrail-scoping refinements. **Deferred:** approve/apply, the chat rebuild, background job +
+streaming, eval cases.
 
 **Phase 2 — Review gate: approve/reject + apply.**
 Persist per-change approve/reject on the real review screen; apply approved

--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -91,8 +91,13 @@ Provider is **Claude** (project standing guidance). Real decisions:
 - **Eval:** golden cases so quality doesn't silently regress.
 - **Model tier + prompt caching:** pin against the `claude-api` reference at build time — not
   guessed here.
-- **Status:** 🟡 Proposed (detailed design after B1–B3).
-- **Decision:** _tbd_
+- **Status:** ✅ Decided & building (Phase 1 merged 2026-06-27, PR #280).
+- **Decision:** **Tool-calling + a server-side validation layer + the human review gate.** Provider =
+  Claude (`claude-opus-4-8`), forced `propose_program_changes` tool, prompt caching; adaptive thinking
+  omitted (incompatible with a forced `tool_choice`). Contraindications enforced deterministically in
+  `meso/agent/validation.py` (not just the prompt); the coach still approves. Execution is sync for
+  now (background job + streamed status deferred); eval golden cases deferred. Full phasing in
+  [`agent-plan.md`](./agent-plan.md).
 
 ---
 
@@ -213,3 +218,14 @@ _(Append dated entries here as decisions land.)_
   left-rail/agent/phone chrome stays static prototype HTML by design — it rebuilds with the agent +
   athlete slices. **Persistence slice complete.** Resume point → the **agent** slice (B6: proposal
   engine behind the review gate).
+- 2026-06-27 — **Agent Phase 1 built & merged** (PR #280, squash `953d9d4`; Django CI green, deployed
+  to Hetzner — migration `meso.0004` applied): the **B6 proposal engine behind the review gate** is
+  live. `AgentProposalBatch` + `ProposedChange` + the `meso/agent/` package (`client`/`validation`/
+  `service`); `POST api/plan/<id>/agent/` runs Claude (`claude-opus-4-8`, forced `propose_program_changes`
+  tool + prompt caching; **adaptive thinking omitted** — incompatible with a forced `tool_choice`),
+  validates server-side, and persists a reviewable batch; read-only `GET review/<batch_id>/` renders
+  it. **Contraindications enforced in a deterministic validation layer** (current-week scoping,
+  target consistency, swap-only contraindication backstop, plural-folded), not just the prompt;
+  human approval gate unchanged. 47 new tests (146 meso / 286 project-wide); local Codex review clean
+  (8 rounds). Build plan + phasing in [`agent-plan.md`](./agent-plan.md). Resume point → agent Phase 2
+  (per-change approve/reject + **apply** back into the program).


### PR DESCRIPTION
Doc-only follow-up to PR #280 (the meso agent slice Phase 1). Marks Phase 1
done/merged/deployed in `docs/meso/agent-plan.md`, adds the decision-log entry,
and settles **B6** in build form in `docs/meso/decisions.md`. No code changes.

https://claude.ai/code/session_015G62Gs7papVMJAfYqeExrN