### PR TITLE
Meso — agent slice Phase 2: review gate (approve/reject + apply)

### DIFF
--- a/app/store_project/meso/agent/apply.py
+++ b/app/store_project/meso/agent/apply.py
@@ -33,6 +33,35 @@ def _apply_prescription_field(change, field, value):
     return {"id": change.pk, "kind": change.kind, "field": field, "value": value}
 
 
+def _apply_volume(change):
+    """Set the new set count.
+
+    A volume change may target one exercise row (set that row) or a whole day
+    (set every row in the session) — the validation contract allows either. We
+    handle both so a valid session-scoped proposal is never a silent no-op.
+    """
+    sets = (change.payload or {}).get("sets")
+    if not sets:
+        return None
+    if change.prescription is not None:
+        return _apply_prescription_field(change, "sets", sets)
+    if change.session_id is None:
+        return None
+    prescriptions = list(change.session.prescriptions.all())
+    if not prescriptions:
+        return None
+    for presc in prescriptions:
+        presc.sets = sets
+        presc.save(update_fields=["sets"])
+    return {
+        "id": change.pk,
+        "kind": change.kind,
+        "field": "sets",
+        "value": sets,
+        "count": len(prescriptions),
+    }
+
+
 def _apply_deload(change):
     """Flag the change's week as a deload (its session's week, else current)."""
     week = change.session.week if change.session_id else current_week(change.batch.plan)
@@ -55,7 +84,7 @@ def apply_change(change):
     if change.kind == ProposedChange.Kind.PROGRESS:
         return _apply_prescription_field(change, "load", payload.get("load"))
     if change.kind == ProposedChange.Kind.VOLUME:
-        return _apply_prescription_field(change, "sets", payload.get("sets"))
+        return _apply_volume(change)
     if change.kind == ProposedChange.Kind.DELOAD:
         return _apply_deload(change)
     return None

--- a/app/store_project/meso/agent/apply.py
+++ b/app/store_project/meso/agent/apply.py
@@ -1,0 +1,97 @@
+"""Write approved agent proposals back into the program (agent slice Phase 2).
+
+The review screen is the human gate; once a coach approves changes, this module
+performs the structured edit each ``ProposedChange`` describes:
+
+- **swap**     → set the prescription's ``name`` to the introduced exercise;
+- **progress** → set the prescription's ``load``;
+- **volume**   → set the prescription's set count (``sets``);
+- **deload**   → flag the target week (``is_deload``).
+
+The edit value lives in ``ProposedChange.payload`` (built deterministically by
+``agent.validation``). ``apply_batch`` runs every non-rejected change in a single
+transaction, marks the batch applied, and bumps the plan's ``modified`` so it
+reads as the coach's working plan — mirroring the autosave endpoints. A change
+that lacks what it needs to apply (e.g. a swap with no target) is a safe no-op
+and is reported as skipped, never an error.
+"""
+
+from django.db import transaction
+
+from ..models import AgentProposalBatch
+from ..models import ProposedChange
+from ..serializers import current_week
+
+
+def _apply_prescription_field(change, field, value):
+    """Write ``value`` onto ``field`` of the change's prescription."""
+    presc = change.prescription
+    if presc is None or not value:
+        return None
+    setattr(presc, field, value)
+    presc.save(update_fields=[field])
+    return {"id": change.pk, "kind": change.kind, "field": field, "value": value}
+
+
+def _apply_deload(change):
+    """Flag the change's week as a deload (its session's week, else current)."""
+    week = change.session.week if change.session_id else current_week(change.batch.plan)
+    if week is None:
+        return None
+    if not week.is_deload:
+        week.is_deload = True
+        week.save(update_fields=["is_deload"])
+    return {"id": change.pk, "kind": change.kind, "field": "is_deload", "value": True}
+
+
+def apply_change(change):
+    """Apply one change to the program. Returns a describing dict, or None (no-op)."""
+    payload = change.payload or {}
+    if change.kind == ProposedChange.Kind.SWAP:
+        # A swap may carry its new name in the payload or only in the
+        # contraindication-checked introduces_exercise field.
+        name = payload.get("name") or change.introduces_exercise
+        return _apply_prescription_field(change, "name", name)
+    if change.kind == ProposedChange.Kind.PROGRESS:
+        return _apply_prescription_field(change, "load", payload.get("load"))
+    if change.kind == ProposedChange.Kind.VOLUME:
+        return _apply_prescription_field(change, "sets", payload.get("sets"))
+    if change.kind == ProposedChange.Kind.DELOAD:
+        return _apply_deload(change)
+    return None
+
+
+def apply_batch(batch):
+    """Apply every non-rejected change in ``batch`` and mark the batch applied.
+
+    Returns ``{"applied": <count>, "skipped": <count>}``. Rejected changes are
+    left untouched; applied changes are stamped ``approved`` for a clean audit
+    trail. Idempotency (only-when-pending) is enforced by the caller.
+    """
+    applied = []
+    skipped = 0
+    with transaction.atomic():
+        changes = batch.changes.exclude(
+            status=ProposedChange.Status.REJECTED
+        ).select_related("prescription", "session__week")
+        for change in changes:
+            result = apply_change(change)
+            if result is None:
+                skipped += 1
+                continue
+            if change.status != ProposedChange.Status.APPROVED:
+                change.status = ProposedChange.Status.APPROVED
+                change.save(update_fields=["status"])
+            applied.append(result)
+        batch.status = AgentProposalBatch.Status.APPLIED
+        batch.save(update_fields=["status"])
+        # Bump the plan so it reads as the coach's working plan (auto_now).
+        batch.plan.save(update_fields=["modified"])
+    return {"applied": len(applied), "skipped": skipped}
+
+
+def dismiss_batch(batch):
+    """Discard a batch without applying anything."""
+    batch.status = AgentProposalBatch.Status.DISMISSED
+    batch.save(update_fields=["status"])
+    return batch

--- a/app/store_project/meso/agent/client.py
+++ b/app/store_project/meso/agent/client.py
@@ -82,6 +82,23 @@ PROPOSE_TOOL = {
                                 "by the contraindication guardrail); else empty."
                             ),
                         },
+                        "new_name": {
+                            "type": "string",
+                            "description": (
+                                "swap only: the exercise name to set on the row "
+                                "(defaults to introduces_exercise if omitted)."
+                            ),
+                        },
+                        "new_load": {
+                            "type": "string",
+                            "description": (
+                                "progress only: the load to set, e.g. '92.5 kg'."
+                            ),
+                        },
+                        "new_sets": {
+                            "type": "string",
+                            "description": "volume only: the set count to set, e.g. '4'.",
+                        },
                     },
                     "required": ["kind", "title", "rationale"],
                 },
@@ -104,6 +121,8 @@ SYSTEM_PROMPT = (
     "alternative and name it in introduces_exercise.\n"
     "- Anchor load progressions to the values already in the plan; prefer small, "
     "defensible steps.\n"
+    "- Give the value to apply: new_name for a swap, new_load for a progress, "
+    "new_sets for a volume change. A deload needs no value.\n"
     "- Set 'honors' to the specific contraindication or coaching rule each change "
     "respects.\n"
     "- If the instruction needs no change, return an empty changes array and say "

--- a/app/store_project/meso/agent/validation.py
+++ b/app/store_project/meso/agent/validation.py
@@ -46,6 +46,15 @@ _TEXT_FIELDS = {
     "introduces_exercise": 255,
 }
 
+# The structured edit ``agent.apply`` performs per kind, as
+# (prescription/week field, the tool field that supplies it, model ``max_length``).
+# A deload has no value — it flags the week — so it is absent here.
+_APPLY_FIELD = {
+    "swap": ("name", "new_name", 255),
+    "progress": ("load", "new_load", 32),
+    "volume": ("sets", "new_sets", 32),
+}
+
 
 def _singular(word):
     """Cheap plural fold so 'squats' matches 'squat'. Keeps 'ss' (e.g. 'press').
@@ -201,6 +210,21 @@ def clean_change(raw, plan, *, forbidden=None):
                 "introduced movement violates a contraindication "
                 f"({', '.join(sorted(hit))})"
             )
+
+    # The structured edit the apply step (Phase 2) performs. A swap falls back to
+    # the (already contraindication-checked) introduced exercise when the model
+    # omits an explicit new name, so a Phase-1-shaped swap still applies.
+    payload = {}
+    spec = _APPLY_FIELD.get(kind)
+    if spec is not None:
+        field, raw_field, max_len = spec
+        value = raw.get(raw_field, "")
+        value = value.strip()[:max_len] if isinstance(value, str) else ""
+        if not value and kind == "swap":
+            value = cleaned["introduces_exercise"]
+        if value:
+            payload[field] = value
+    cleaned["payload"] = payload
 
     if errors:
         return None, errors

--- a/app/store_project/meso/agent/validation.py
+++ b/app/store_project/meso/agent/validation.py
@@ -193,27 +193,10 @@ def clean_change(raw, plan, *, forbidden=None):
     elif required == "session" and session is None:
         errors.append(f"a {kind} change must target a session")
 
-    # Contraindication backstop — only a SWAP introduces a new movement, so only
-    # swaps are screened (a volume/progress edit that *mentions* a flagged
-    # movement, e.g. "overhead pressing − 1 set", is safe and must pass). Check
-    # both ``introduces_exercise`` and ``after`` — a swap may omit the former, but
-    # ``after`` still names the new exercise. We deliberately do NOT check
-    # ``title``/``before``: those name the *removed* exercise, which is often the
-    # contraindicated one being swapped out (checking them would reject the fix).
-    if forbidden is None:
-        forbidden = forbidden_terms(plan)
-    if forbidden and kind == "swap":
-        introduced = f"{cleaned['introduces_exercise']} {cleaned['after']}"
-        hit = _name_words(introduced) & forbidden
-        if hit:
-            errors.append(
-                "introduced movement violates a contraindication "
-                f"({', '.join(sorted(hit))})"
-            )
-
-    # The structured edit the apply step (Phase 2) performs. A swap falls back to
-    # the (already contraindication-checked) introduced exercise when the model
-    # omits an explicit new name, so a Phase-1-shaped swap still applies.
+    # The structured edit the apply step (Phase 2) performs, built before the
+    # contraindication backstop so the swap's *apply value* is screened too. A
+    # swap falls back to the introduced exercise when the model omits an explicit
+    # new name, so a Phase-1-shaped swap still applies.
     payload = {}
     spec = _APPLY_FIELD.get(kind)
     if spec is not None:
@@ -225,6 +208,27 @@ def clean_change(raw, plan, *, forbidden=None):
         if value:
             payload[field] = value
     cleaned["payload"] = payload
+
+    # Contraindication backstop — only a SWAP introduces a new movement, so only
+    # swaps are screened (a volume/progress edit that *mentions* a flagged
+    # movement, e.g. "overhead pressing − 1 set", is safe and must pass). Check
+    # the name actually applied (``payload['name']``, which folds in ``new_name``)
+    # plus ``introduces_exercise`` and ``after`` — any of them can carry the new
+    # exercise. We deliberately do NOT check ``title``/``before``: those name the
+    # *removed* exercise, often the contraindicated one being swapped out.
+    if forbidden is None:
+        forbidden = forbidden_terms(plan)
+    if forbidden and kind == "swap":
+        introduced = (
+            f"{payload.get('name', '')} "
+            f"{cleaned['introduces_exercise']} {cleaned['after']}"
+        )
+        hit = _name_words(introduced) & forbidden
+        if hit:
+            errors.append(
+                "introduced movement violates a contraindication "
+                f"({', '.join(sorted(hit))})"
+            )
 
     # Progress/volume can only be applied with a concrete value, so an empty
     # payload means the change can't be applied — drop it rather than persist an

--- a/app/store_project/meso/agent/validation.py
+++ b/app/store_project/meso/agent/validation.py
@@ -226,6 +226,13 @@ def clean_change(raw, plan, *, forbidden=None):
             payload[field] = value
     cleaned["payload"] = payload
 
+    # Progress/volume can only be applied with a concrete value, so an empty
+    # payload means the change can't be applied — drop it rather than persist an
+    # "approved" edit the apply step would silently skip. A swap is exempt: it
+    # falls back to its (contraindication-checked) introduced exercise.
+    if kind in ("progress", "volume") and not payload:
+        errors.append(f"a {kind} change needs a value to apply ({spec[1]})")
+
     if errors:
         return None, errors
     return cleaned, []

--- a/app/store_project/meso/mockdata.py
+++ b/app/store_project/meso/mockdata.py
@@ -134,49 +134,9 @@ MACROCYCLE = [
     {"name": "Peak / Test", "weeks": "2 wk", "state": "future", "note": ""},
 ]
 
-# --- agent change review (proposed batch awaiting coach approval) ----------
-
-PROPOSED_CHANGES = [
-    {
-        "id": "swap-knee",
-        "kind": "Swap",
-        "day": "Day 1 · Lower",
-        "title": "Bulgarian Split Squat → Box Step-Down (low)",
-        "before": "Bulgarian Split Squat (DB) · 3×10 @ 18 kg",
-        "after": "Box Step-Down (low) · 3×10 @ 14 kg",
-        "rationale": (
-            "Same single-leg quad stimulus, but the knee tracks through a shorter, "
-            "controlled range — a better fit for the meniscus history."
-        ),
-        "honors": "L knee — avoid deep knee flexion under load",
-    },
-    {
-        "id": "progress",
-        "kind": "Progress",
-        "day": "Day 3 · Posterior",
-        "title": "Trap-Bar Deadlift → 92.5 kg",
-        "before": "4×6 @ 90 kg · logged RPE 6 last block",
-        "after": "4×6 @ 92.5 kg · projected RPE 7",
-        "rationale": (
-            "Anchored to last block's logged load and RPE — +2.5 kg lands in the "
-            "hypertrophy window without overshooting."
-        ),
-        "honors": "RPE-based load",
-    },
-    {
-        "id": "volume",
-        "kind": "Volume",
-        "day": "Day 2 · Upper",
-        "title": "Day 2 pressing volume − 1 set",
-        "before": "Incline DB Press, Chest-Supported Row, Lat Pulldown · 4 sets each",
-        "after": "Primary lifts · 3 sets each (accessories unchanged)",
-        "rationale": (
-            "Keeps weekly pressing volume in check while the shoulder settles, without "
-            "touching accessory work."
-        ),
-        "honors": "R shoulder — neutral-grip pressing only",
-    },
-]
+# --- agent change review --------------------------------------------------
+# Retired in agent slice Phase 2: the review screen now renders real
+# ``AgentProposalBatch`` rows (see ``meso/agent/`` + ``ChangeReviewView``).
 
 # --- session results (Maya, delivered Week 1 Day 1) -----------------------
 

--- a/app/store_project/meso/tests/test_agent_apply.py
+++ b/app/store_project/meso/tests/test_agent_apply.py
@@ -75,6 +75,27 @@ class TestApplyChange:
         presc.refresh_from_db()
         assert presc.sets == "4"
 
+    def test_volume_targeting_a_session_sets_all_rows(self):
+        # A volume change may target a whole day (session) rather than one row;
+        # apply it across every prescription so it is never a silent no-op.
+        from store_project.meso.factories import ExercisePrescriptionFactory
+
+        plan, session, presc = make_plan()  # one row at sets == "3"
+        presc2 = ExercisePrescriptionFactory(session=session, name="RDL", sets="3")
+        change = ProposedChangeFactory(
+            batch=_batch(plan),
+            kind=ProposedChange.Kind.VOLUME,
+            prescription=None,
+            session=session,
+            payload={"sets": "4"},
+        )
+        result = agent_apply.apply_change(change)
+        presc.refresh_from_db()
+        presc2.refresh_from_db()
+        assert presc.sets == "4"
+        assert presc2.sets == "4"
+        assert result["count"] == 2
+
     def test_deload_flags_the_current_week(self):
         plan, session, _ = make_plan()
         assert session.week.is_deload is False

--- a/app/store_project/meso/tests/test_agent_apply.py
+++ b/app/store_project/meso/tests/test_agent_apply.py
@@ -1,0 +1,172 @@
+"""Agent slice Phase 2 — applying an approved batch back into the program.
+
+``agent.apply`` is the write side of the review gate: once a coach approves
+changes, ``apply_batch`` performs the structured edit each ``ProposedChange``
+describes (swap → prescription name; progress → load; volume → sets; deload →
+flag the week), marks the batch applied, and leaves rejected changes untouched.
+Every write is deterministic and unit-tested here; the endpoint is the thin HTTP
+seam over this (see ``test_agent_apply_endpoint``).
+"""
+
+import pytest
+
+from store_project.meso.agent import apply as agent_apply
+from store_project.meso.factories import AgentProposalBatchFactory
+from store_project.meso.factories import ProposedChangeFactory
+from store_project.meso.models import AgentProposalBatch
+from store_project.meso.models import ProposedChange
+from store_project.meso.tests.test_agent_validation import make_plan
+
+pytestmark = pytest.mark.django_db
+
+
+def _batch(plan):
+    return AgentProposalBatchFactory(plan=plan, coach=plan.coach)
+
+
+class TestApplyChange:
+    def test_swap_sets_prescription_name_from_payload(self):
+        plan, _, presc = make_plan()
+        change = ProposedChangeFactory(
+            batch=_batch(plan),
+            kind=ProposedChange.Kind.SWAP,
+            prescription=presc,
+            payload={"name": "Box Squat"},
+        )
+        result = agent_apply.apply_change(change)
+        presc.refresh_from_db()
+        assert presc.name == "Box Squat"
+        assert result["field"] == "name"
+
+    def test_swap_falls_back_to_introduces_exercise(self):
+        plan, _, presc = make_plan()
+        change = ProposedChangeFactory(
+            batch=_batch(plan),
+            kind=ProposedChange.Kind.SWAP,
+            prescription=presc,
+            introduces_exercise="Goblet Squat",
+            payload={},
+        )
+        agent_apply.apply_change(change)
+        presc.refresh_from_db()
+        assert presc.name == "Goblet Squat"
+
+    def test_progress_sets_load(self):
+        plan, _, presc = make_plan()
+        change = ProposedChangeFactory(
+            batch=_batch(plan),
+            kind=ProposedChange.Kind.PROGRESS,
+            prescription=presc,
+            payload={"load": "92.5 kg"},
+        )
+        agent_apply.apply_change(change)
+        presc.refresh_from_db()
+        assert presc.load == "92.5 kg"
+
+    def test_volume_sets_set_count(self):
+        plan, _, presc = make_plan()  # factory default sets == "3"
+        change = ProposedChangeFactory(
+            batch=_batch(plan),
+            kind=ProposedChange.Kind.VOLUME,
+            prescription=presc,
+            payload={"sets": "4"},
+        )
+        agent_apply.apply_change(change)
+        presc.refresh_from_db()
+        assert presc.sets == "4"
+
+    def test_deload_flags_the_current_week(self):
+        plan, session, _ = make_plan()
+        assert session.week.is_deload is False
+        change = ProposedChangeFactory(
+            batch=_batch(plan),
+            kind=ProposedChange.Kind.DELOAD,
+            prescription=None,
+            session=None,
+        )
+        agent_apply.apply_change(change)
+        session.week.refresh_from_db()
+        assert session.week.is_deload is True
+
+    def test_swap_without_name_or_prescription_is_a_noop(self):
+        plan, _, _ = make_plan()
+        change = ProposedChangeFactory(
+            batch=_batch(plan),
+            kind=ProposedChange.Kind.SWAP,
+            prescription=None,
+            introduces_exercise="",
+            payload={},
+        )
+        assert agent_apply.apply_change(change) is None
+
+    def test_progress_without_load_is_a_noop(self):
+        plan, _, presc = make_plan()
+        change = ProposedChangeFactory(
+            batch=_batch(plan),
+            kind=ProposedChange.Kind.PROGRESS,
+            prescription=presc,
+            payload={},
+        )
+        before = presc.load
+        assert agent_apply.apply_change(change) is None
+        presc.refresh_from_db()
+        assert presc.load == before
+
+
+class TestApplyBatch:
+    def test_applies_non_rejected_and_marks_batch_applied(self):
+        plan, _, presc = make_plan()
+        batch = _batch(plan)
+        ProposedChangeFactory(
+            batch=batch,
+            kind=ProposedChange.Kind.SWAP,
+            prescription=presc,
+            payload={"name": "Box Squat"},
+            status=ProposedChange.Status.PENDING,
+        )
+        result = agent_apply.apply_batch(batch)
+
+        presc.refresh_from_db()
+        batch.refresh_from_db()
+        assert presc.name == "Box Squat"
+        assert result["applied"] == 1
+        assert batch.status == AgentProposalBatch.Status.APPLIED
+
+    def test_rejected_change_is_not_applied(self):
+        plan, _, presc = make_plan()
+        batch = _batch(plan)
+        ProposedChangeFactory(
+            batch=batch,
+            kind=ProposedChange.Kind.SWAP,
+            prescription=presc,
+            payload={"name": "Box Squat"},
+            status=ProposedChange.Status.REJECTED,
+        )
+        result = agent_apply.apply_batch(batch)
+
+        presc.refresh_from_db()
+        assert presc.name == "Back Squat"  # untouched
+        assert result["applied"] == 0
+
+    def test_bumps_plan_modified(self):
+        plan, _, presc = make_plan()
+        batch = _batch(plan)
+        ProposedChangeFactory(
+            batch=batch,
+            kind=ProposedChange.Kind.SWAP,
+            prescription=presc,
+            payload={"name": "Box Squat"},
+        )
+        before = plan.modified
+        agent_apply.apply_batch(batch)
+        plan.refresh_from_db()
+        assert plan.modified >= before
+
+
+class TestDismissBatch:
+    def test_marks_batch_dismissed(self):
+        plan, _, _ = make_plan()
+        batch = _batch(plan)
+        agent_apply.dismiss_batch(batch)
+        batch.refresh_from_db()
+        assert batch.status == AgentProposalBatch.Status.DISMISSED

--- a/app/store_project/meso/tests/test_agent_apply_endpoint.py
+++ b/app/store_project/meso/tests/test_agent_apply_endpoint.py
@@ -1,0 +1,174 @@
+"""Agent slice Phase 2 — the review-gate endpoints (approve/reject + apply).
+
+The HTTP seam over ``agent.apply``: per-change approve/reject persistence, the
+batch apply action (writes approved edits back into the program + marks the batch
+applied), and dismiss. Every endpoint is scoped to a batch the requester coaches
+over an active relationship — a foreign or unknown batch is a 404, never a silent
+write.
+"""
+
+import json
+
+import pytest
+from django.urls import reverse
+
+from store_project.meso.factories import AgentProposalBatchFactory
+from store_project.meso.factories import ProposedChangeFactory
+from store_project.meso.models import AgentProposalBatch
+from store_project.meso.models import ProposedChange
+from store_project.meso.tests.test_agent_validation import make_plan
+from store_project.users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def status_url(change):
+    return reverse("meso:api_change_status", kwargs={"pk": change.pk})
+
+
+def apply_url(batch):
+    return reverse("meso:api_batch_apply", kwargs={"batch_id": batch.pk})
+
+
+def dismiss_url(batch):
+    return reverse("meso:api_batch_dismiss", kwargs={"batch_id": batch.pk})
+
+
+def make_batch_with_swap():
+    plan, _, presc = make_plan()
+    batch = AgentProposalBatchFactory(plan=plan, coach=plan.coach)
+    change = ProposedChangeFactory(
+        batch=batch,
+        kind=ProposedChange.Kind.SWAP,
+        prescription=presc,
+        payload={"name": "Box Squat"},
+    )
+    return plan, presc, batch, change
+
+
+class TestChangeStatus:
+    def test_approve_persists(self, client):
+        plan, _, _, change = make_batch_with_swap()
+        client.force_login(plan.coach)
+        resp = client.post(
+            status_url(change),
+            data=json.dumps({"status": "rejected"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        change.refresh_from_db()
+        assert change.status == ProposedChange.Status.REJECTED
+
+    def test_invalid_status_400(self, client):
+        plan, _, _, change = make_batch_with_swap()
+        client.force_login(plan.coach)
+        resp = client.post(
+            status_url(change),
+            data=json.dumps({"status": "maybe"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+
+    def test_non_owner_404(self, client):
+        _, _, _, change = make_batch_with_swap()
+        client.force_login(UserFactory())
+        resp = client.post(
+            status_url(change),
+            data=json.dumps({"status": "approved"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 404
+
+    def test_status_on_resolved_batch_409(self, client):
+        plan, _, batch, change = make_batch_with_swap()
+        batch.status = AgentProposalBatch.Status.APPLIED
+        batch.save(update_fields=["status"])
+        client.force_login(plan.coach)
+        resp = client.post(
+            status_url(change),
+            data=json.dumps({"status": "rejected"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 409
+
+    def test_requires_login(self, client):
+        _, _, _, change = make_batch_with_swap()
+        resp = client.post(status_url(change))
+        assert resp.status_code == 302
+
+    def test_get_not_allowed(self, client):
+        plan, _, _, change = make_batch_with_swap()
+        client.force_login(plan.coach)
+        assert client.get(status_url(change)).status_code == 405
+
+
+class TestBatchApply:
+    def test_applies_approved_changes_and_marks_batch(self, client):
+        plan, presc, batch, _ = make_batch_with_swap()
+        client.force_login(plan.coach)
+        resp = client.post(apply_url(batch))
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["applied"] == 1
+        assert f"/meso/deliver/{plan.pk}/" in data["deliver_url"]
+        presc.refresh_from_db()
+        batch.refresh_from_db()
+        assert presc.name == "Box Squat"
+        assert batch.status == AgentProposalBatch.Status.APPLIED
+
+    def test_rejected_change_is_not_applied(self, client):
+        plan, presc, batch, change = make_batch_with_swap()
+        change.status = ProposedChange.Status.REJECTED
+        change.save(update_fields=["status"])
+        client.force_login(plan.coach)
+        client.post(apply_url(batch))
+        presc.refresh_from_db()
+        assert presc.name == "Back Squat"
+
+    def test_already_applied_409(self, client):
+        plan, _, batch, _ = make_batch_with_swap()
+        batch.status = AgentProposalBatch.Status.APPLIED
+        batch.save(update_fields=["status"])
+        client.force_login(plan.coach)
+        assert client.post(apply_url(batch)).status_code == 409
+
+    def test_non_owner_404(self, client):
+        _, _, batch, _ = make_batch_with_swap()
+        client.force_login(UserFactory())
+        assert client.post(apply_url(batch)).status_code == 404
+
+    def test_requires_login(self, client):
+        _, _, batch, _ = make_batch_with_swap()
+        assert client.post(apply_url(batch)).status_code == 302
+
+    def test_get_not_allowed(self, client):
+        plan, _, batch, _ = make_batch_with_swap()
+        client.force_login(plan.coach)
+        assert client.get(apply_url(batch)).status_code == 405
+
+
+class TestBatchDismiss:
+    def test_dismiss_marks_batch(self, client):
+        plan, presc, batch, _ = make_batch_with_swap()
+        client.force_login(plan.coach)
+        resp = client.post(dismiss_url(batch))
+
+        assert resp.status_code == 200
+        batch.refresh_from_db()
+        presc.refresh_from_db()
+        assert batch.status == AgentProposalBatch.Status.DISMISSED
+        assert presc.name == "Back Squat"  # nothing applied
+
+    def test_already_resolved_409(self, client):
+        plan, _, batch, _ = make_batch_with_swap()
+        batch.status = AgentProposalBatch.Status.DISMISSED
+        batch.save(update_fields=["status"])
+        client.force_login(plan.coach)
+        assert client.post(dismiss_url(batch)).status_code == 409
+
+    def test_non_owner_404(self, client):
+        _, _, batch, _ = make_batch_with_swap()
+        client.force_login(UserFactory())
+        assert client.post(dismiss_url(batch)).status_code == 404

--- a/app/store_project/meso/tests/test_agent_endpoint.py
+++ b/app/store_project/meso/tests/test_agent_endpoint.py
@@ -244,3 +244,19 @@ class TestReviewBatch:
         resp = client.get(reverse("meso:review"))
         assert resp.status_code == 302
         assert resp.url == reverse("meso:designer")
+
+    def test_bare_review_finds_a_batch_on_any_owned_plan(self, client):
+        # A pending batch on a non-working plan must still be reachable.
+        from store_project.meso.factories import CoachAthleteFactory
+        from store_project.meso.factories import PlanFactory
+
+        coach = UserFactory()
+        plan_a = PlanFactory(relationship=CoachAthleteFactory(coach=coach))
+        plan_b = PlanFactory(relationship=CoachAthleteFactory(coach=coach))
+        # plan_b is the more-recently-modified working plan, but the batch is on A.
+        plan_b.save()
+        batch = AgentProposalBatchFactory(plan=plan_a, coach=coach)
+        client.force_login(coach)
+
+        resp = client.get(reverse("meso:review"))
+        assert resp.url == reverse("meso:review_batch", kwargs={"batch_id": batch.pk})

--- a/app/store_project/meso/tests/test_agent_endpoint.py
+++ b/app/store_project/meso/tests/test_agent_endpoint.py
@@ -228,9 +228,19 @@ class TestReviewBatch:
         resp = client.get(reverse("meso:review_batch", kwargs={"batch_id": batch.pk}))
         assert resp.status_code == 404
 
-    def test_bare_review_still_renders_fixtures(self, client):
-        client.force_login(UserFactory())
+    def test_bare_review_redirects_to_latest_pending_batch(self, client):
+        # Fixtures are retired (Phase 2): the bare URL resolves to the coach's
+        # latest pending batch on their working plan.
+        plan, _, _ = make_plan()
+        batch = AgentProposalBatchFactory(plan=plan, coach=plan.coach)
+        client.force_login(plan.coach)
         resp = client.get(reverse("meso:review"))
-        assert resp.status_code == 200
-        # The prototype fixture athlete is Maya.
-        assert "Maya" in resp.content.decode()
+        assert resp.status_code == 302
+        assert resp.url == reverse("meso:review_batch", kwargs={"batch_id": batch.pk})
+
+    def test_bare_review_without_a_batch_redirects_to_designer(self, client):
+        plan, _, _ = make_plan()
+        client.force_login(plan.coach)
+        resp = client.get(reverse("meso:review"))
+        assert resp.status_code == 302
+        assert resp.url == reverse("meso:designer")

--- a/app/store_project/meso/tests/test_agent_service.py
+++ b/app/store_project/meso/tests/test_agent_service.py
@@ -58,6 +58,7 @@ def test_persists_valid_changes_into_a_batch():
                     "prescription_id": presc.pk,
                     "title": "Trap-Bar Deadlift → 92.5 kg",
                     "rationale": "Anchored to last block.",
+                    "new_load": "92.5 kg",
                 },
             ],
         }

--- a/app/store_project/meso/tests/test_agent_service.py
+++ b/app/store_project/meso/tests/test_agent_service.py
@@ -80,6 +80,38 @@ def test_persists_valid_changes_into_a_batch():
     assert changes[1].order == 1
 
 
+def test_persisted_changes_carry_an_apply_payload():
+    plan, _, presc = make_plan()
+    fake = FakeClient(
+        {
+            "summary": "",
+            "changes": [
+                {
+                    "kind": "swap",
+                    "prescription_id": presc.pk,
+                    "title": "Back Squat → Box Squat",
+                    "rationale": "Shorter range.",
+                    "introduces_exercise": "Box Squat",
+                },
+                {
+                    "kind": "progress",
+                    "prescription_id": presc.pk,
+                    "title": "Back Squat → 65 kg",
+                    "rationale": "Small step.",
+                    "new_load": "65 kg",
+                },
+            ],
+        }
+    )
+
+    batch, rejected = service.propose_changes(plan, "go", coach=plan.coach, client=fake)
+
+    assert rejected == []
+    changes = list(batch.changes.all())
+    assert changes[0].payload == {"name": "Box Squat"}
+    assert changes[1].payload == {"load": "65 kg"}
+
+
 def test_grounds_the_client_on_plan_and_contraindications():
     plan, _, _ = make_plan()
     ContraindicationFactory(

--- a/app/store_project/meso/tests/test_agent_validation.py
+++ b/app/store_project/meso/tests/test_agent_validation.py
@@ -269,3 +269,55 @@ class TestCleanChange:
         cleaned, errors = validation.clean_change("not a dict", plan)
         assert cleaned is None
         assert errors
+
+
+class TestApplyPayload:
+    """The structured edit ``agent.apply`` performs is built here (Phase 2)."""
+
+    def test_swap_payload_from_new_name(self):
+        plan, _, presc = make_plan()
+        cleaned, errors = validation.clean_change(
+            base_change(prescription_id=presc.pk, new_name="Box Squat"), plan
+        )
+        assert errors == []
+        assert cleaned["payload"] == {"name": "Box Squat"}
+
+    def test_swap_payload_falls_back_to_introduces_exercise(self):
+        plan, _, presc = make_plan()
+        cleaned, errors = validation.clean_change(
+            base_change(prescription_id=presc.pk, introduces_exercise="Goblet Squat"),
+            plan,
+        )
+        assert errors == []
+        assert cleaned["payload"] == {"name": "Goblet Squat"}
+
+    def test_progress_payload_carries_load(self):
+        plan, _, presc = make_plan()
+        cleaned, errors = validation.clean_change(
+            base_change(kind="progress", prescription_id=presc.pk, new_load="92.5 kg"),
+            plan,
+        )
+        assert errors == []
+        assert cleaned["payload"] == {"load": "92.5 kg"}
+
+    def test_volume_payload_carries_sets(self):
+        plan, session, presc = make_plan()
+        cleaned, errors = validation.clean_change(
+            base_change(kind="volume", session_id=session.pk, new_sets="4"), plan
+        )
+        assert errors == []
+        assert cleaned["payload"] == {"sets": "4"}
+
+    def test_deload_has_empty_payload(self):
+        plan, _, _ = make_plan()
+        cleaned, errors = validation.clean_change(base_change(kind="deload"), plan)
+        assert errors == []
+        assert cleaned["payload"] == {}
+
+    def test_payload_values_are_length_capped(self):
+        plan, _, presc = make_plan()
+        cleaned, _ = validation.clean_change(
+            base_change(kind="progress", prescription_id=presc.pk, new_load="x" * 99),
+            plan,
+        )
+        assert len(cleaned["payload"]["load"]) == 32

--- a/app/store_project/meso/tests/test_agent_validation.py
+++ b/app/store_project/meso/tests/test_agent_validation.py
@@ -165,7 +165,12 @@ class TestCleanChange:
     def test_volume_change_targets_a_session(self):
         plan, session, _ = make_plan()
         cleaned, errors = validation.clean_change(
-            base_change(kind="volume", session_id=session.pk, introduces_exercise=""),
+            base_change(
+                kind="volume",
+                session_id=session.pk,
+                introduces_exercise="",
+                new_sets="4",
+            ),
             plan,
         )
         assert errors == []
@@ -248,6 +253,7 @@ class TestCleanChange:
                 prescription_id=presc.pk,
                 after="Overhead Pressing − 1 set",
                 introduces_exercise="",
+                new_sets="3",
             ),
             plan,
         )
@@ -321,3 +327,21 @@ class TestApplyPayload:
             plan,
         )
         assert len(cleaned["payload"]["load"]) == 32
+
+    def test_progress_without_a_value_is_rejected(self):
+        # A progress change with no new_load can't be applied; persisting it would
+        # show an "approved" edit the apply step silently skips.
+        plan, _, presc = make_plan()
+        cleaned, errors = validation.clean_change(
+            base_change(kind="progress", prescription_id=presc.pk), plan
+        )
+        assert cleaned is None
+        assert any("value to apply" in e for e in errors)
+
+    def test_volume_without_a_value_is_rejected(self):
+        plan, session, _ = make_plan()
+        cleaned, errors = validation.clean_change(
+            base_change(kind="volume", session_id=session.pk), plan
+        )
+        assert cleaned is None
+        assert any("value to apply" in e for e in errors)

--- a/app/store_project/meso/tests/test_agent_validation.py
+++ b/app/store_project/meso/tests/test_agent_validation.py
@@ -224,6 +224,27 @@ class TestCleanChange:
         assert cleaned is None
         assert any("contraindication" in e for e in errors)
 
+    def test_contraindication_backstop_screens_the_apply_value(self):
+        # new_name is what apply writes to the prescription; a contraindicated
+        # movement hidden there (with innocuous after/introduces_exercise) must
+        # still be caught, not just the display fields.
+        athlete = UserFactory()
+        ContraindicationFactory(
+            athlete=athlete, text="L knee — avoid deep knee flexion under load"
+        )
+        plan, _, presc = make_plan(athlete=athlete)
+        cleaned, errors = validation.clean_change(
+            base_change(
+                prescription_id=presc.pk,
+                new_name="Deep Knee Flexion Drill",
+                after="Box Step-Down",
+                introduces_exercise="Box Step-Down",
+            ),
+            plan,
+        )
+        assert cleaned is None
+        assert any("contraindication" in e for e in errors)
+
     def test_contraindication_backstop_allows_safe_swap(self):
         athlete = UserFactory()
         ContraindicationFactory(

--- a/app/store_project/meso/tests/test_views.py
+++ b/app/store_project/meso/tests/test_views.py
@@ -129,12 +129,13 @@ class TestInviteActions:
 class TestScreensRender:
     """Every still-seeded Meso screen renders for a logged-in coach.
 
-    The coach-side designer/deliver no longer render on fixtures — their bare
-    URLs redirect (see ``TestBareDesignerDeliver``); only review/results (their
-    own slices) and the roster still render directly.
+    The coach-side designer/deliver/review no longer render on fixtures — their
+    bare URLs redirect (designer/deliver: ``TestBareDesignerDeliver``; review:
+    ``test_agent_endpoint``). Only results (its own slice) and the roster still
+    render directly.
     """
 
-    @pytest.mark.parametrize("name", ["roster", "review", "results"])
+    @pytest.mark.parametrize("name", ["roster", "results"])
     def test_renders(self, client, name):
         client.force_login(UserFactory())
         resp = client.get(reverse(f"meso:{name}"))

--- a/app/store_project/meso/urls.py
+++ b/app/store_project/meso/urls.py
@@ -52,4 +52,20 @@ urlpatterns = [
         views.agent_propose,
         name="api_plan_agent",
     ),
+    # Review gate: approve/reject + apply (agent slice Phase 2).
+    path(
+        "api/change/<int:pk>/status/",
+        views.change_set_status,
+        name="api_change_status",
+    ),
+    path(
+        "api/batch/<int:batch_id>/apply/",
+        views.batch_apply,
+        name="api_batch_apply",
+    ),
+    path(
+        "api/batch/<int:batch_id>/dismiss/",
+        views.batch_dismiss,
+        name="api_batch_dismiss",
+    ),
 ]

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -17,11 +17,13 @@ from django.views.generic import TemplateView
 
 from . import mockdata
 from . import presenters
+from .agent import apply as agent_apply
 from .agent import service as agent_service
 from .models import AgentProposalBatch
 from .models import CoachAthlete
 from .models import ExercisePrescription
 from .models import Plan
+from .models import ProposedChange
 from .models import Session
 from .models import WeekDelivery
 from .serializers import current_week
@@ -358,30 +360,142 @@ def agent_propose(request, plan_id):
     )
 
 
+# -- review gate: approve/reject + apply (agent slice Phase 2 — B6) --------
+#
+# The human gate is the review screen; these endpoints persist the coach's
+# per-change decisions and then write the approved edits back into the program.
+# Every action is scoped to a batch the requester coaches over an *active*
+# relationship (``Plan.objects.for_coach``) — a foreign/unknown batch is a 404,
+# never a silent write. Apply/dismiss only act on a still-``pending`` batch, so a
+# double-submit is a clean 409 rather than a re-apply.
+
+
+def _coach_batch_or_404(request, batch_id):
+    """The batch the requester coaches, or raise ``Http404``."""
+    batch = (
+        AgentProposalBatch.objects.filter(
+            pk=batch_id, plan__in=Plan.objects.for_coach(request.user)
+        )
+        .select_related("plan", "plan__relationship")
+        .first()
+    )
+    if batch is None:
+        raise Http404("Unknown proposal batch")
+    return batch
+
+
+@login_required
+@require_POST
+def change_set_status(request, pk):
+    """Persist a coach's approve/reject decision on one proposed change."""
+    change = (
+        ProposedChange.objects.filter(
+            pk=pk, batch__plan__in=Plan.objects.for_coach(request.user)
+        )
+        .select_related("batch")
+        .first()
+    )
+    if change is None:
+        raise Http404("Unknown proposed change")
+    if change.batch.status != AgentProposalBatch.Status.PENDING:
+        return JsonResponse(
+            {"ok": False, "error": "This batch has already been resolved."}, status=409
+        )
+    try:
+        payload = json.loads(request.body or "{}")
+    except json.JSONDecodeError:
+        return HttpResponseBadRequest("Malformed JSON.")
+    if not isinstance(payload, dict):
+        return HttpResponseBadRequest("Expected a JSON object.")
+    status = payload.get("status")
+    allowed = {ProposedChange.Status.APPROVED, ProposedChange.Status.REJECTED}
+    if status not in allowed:
+        return HttpResponseBadRequest("status must be 'approved' or 'rejected'.")
+    change.status = status
+    change.save(update_fields=["status"])
+    return JsonResponse({"ok": True, "id": change.pk, "status": change.status})
+
+
+@login_required
+@require_POST
+def batch_apply(request, batch_id):
+    """Apply the batch's approved changes back into the program."""
+    batch = _coach_batch_or_404(request, batch_id)
+    if batch.status != AgentProposalBatch.Status.PENDING:
+        return JsonResponse(
+            {"ok": False, "error": "This batch has already been resolved."}, status=409
+        )
+    result = agent_apply.apply_batch(batch)
+    return JsonResponse(
+        {
+            "ok": True,
+            "applied": result["applied"],
+            "skipped": result["skipped"],
+            "deliver_url": reverse(
+                "meso:deliver_plan", kwargs={"plan_id": batch.plan_id}
+            ),
+        }
+    )
+
+
+@login_required
+@require_POST
+def batch_dismiss(request, batch_id):
+    """Discard a batch without applying anything."""
+    batch = _coach_batch_or_404(request, batch_id)
+    if batch.status != AgentProposalBatch.Status.PENDING:
+        return JsonResponse(
+            {"ok": False, "error": "This batch has already been resolved."}, status=409
+        )
+    agent_apply.dismiss_batch(batch)
+    return JsonResponse(
+        {
+            "ok": True,
+            "designer_url": reverse(
+                "meso:designer_plan", kwargs={"plan_id": batch.plan_id}
+            ),
+        }
+    )
+
+
 # -- still on fixtures until their own slices ------------------------------
 
 
 class ChangeReviewView(LoginRequiredMixin, TemplateView):
     """Review the batch of edits the agent proposes before they hit the program.
 
-    ``review/<batch_id>/`` renders a real, owned ``AgentProposalBatch`` (agent
-    slice Phase 1). The bare ``review/`` stays on fixtures until per-change
-    approve/reject + apply land (Phase 2).
+    ``review/<batch_id>/`` renders a real, owned ``AgentProposalBatch``; the coach
+    approves/rejects per change and applies the batch (Phase 2). The bare
+    ``review/`` redirects to the coach's latest pending batch (fixtures retired).
     """
 
     template_name = "meso/review.html"
 
+    def get(self, request, *args, **kwargs):
+        if kwargs.get("batch_id") is None:
+            plan = _coach_working_plan(request.user)
+            batch = None
+            if plan is not None:
+                batch = (
+                    AgentProposalBatch.objects.filter(
+                        plan=plan, status=AgentProposalBatch.Status.PENDING
+                    )
+                    .order_by("-created_at")
+                    .first()
+                )
+            if batch is None:
+                messages.info(request, "No proposals to review yet.")
+                return redirect("meso:designer")
+            return redirect("meso:review_batch", batch_id=batch.pk)
+        return super().get(request, *args, **kwargs)
+
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         ctx["active"] = "designer"
-        batch_id = kwargs.get("batch_id")
-        if batch_id is None:
-            ctx["athlete"] = mockdata.athlete_by_slug("maya")
-            ctx["changes"] = mockdata.PROPOSED_CHANGES
-            return ctx
         batch = (
             AgentProposalBatch.objects.filter(
-                pk=batch_id, plan__in=Plan.objects.for_coach(self.request.user)
+                pk=kwargs["batch_id"],
+                plan__in=Plan.objects.for_coach(self.request.user),
             )
             .select_related("plan", "plan__relationship__athlete")
             .first()
@@ -389,6 +503,9 @@ class ChangeReviewView(LoginRequiredMixin, TemplateView):
         if batch is None:
             raise Http404("Unknown proposal batch")
         ctx.update(presenters.review_changes(batch))
+        ctx["batch_id"] = batch.pk
+        ctx["plan_id"] = batch.plan_id
+        ctx["is_pending"] = batch.status == AgentProposalBatch.Status.PENDING
         return ctx
 
 

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -473,16 +473,17 @@ class ChangeReviewView(LoginRequiredMixin, TemplateView):
 
     def get(self, request, *args, **kwargs):
         if kwargs.get("batch_id") is None:
-            plan = _coach_working_plan(request.user)
-            batch = None
-            if plan is not None:
-                batch = (
-                    AgentProposalBatch.objects.filter(
-                        plan=plan, status=AgentProposalBatch.Status.PENDING
-                    )
-                    .order_by("-created_at")
-                    .first()
+            # The latest pending batch across *any* plan the coach owns — a
+            # proposal on one athlete shouldn't be missed because another is the
+            # working plan.
+            batch = (
+                AgentProposalBatch.objects.filter(
+                    plan__in=Plan.objects.for_coach(request.user),
+                    status=AgentProposalBatch.Status.PENDING,
                 )
+                .order_by("-created_at")
+                .first()
+            )
             if batch is None:
                 messages.info(request, "No proposals to review yet.")
                 return redirect("meso:designer")

--- a/app/store_project/templates/meso/review.html
+++ b/app/store_project/templates/meso/review.html
@@ -90,6 +90,7 @@
         statuses: statuses,
         busy: false,
         inflight: [], // in-flight decision saves; Apply waits on these first
+        chains: {}, // id -> last save promise, to serialize per-change saves
         get approved() {
           return Object.values(this.statuses).filter((s) => s === "approved").length;
         },
@@ -105,8 +106,8 @@
         async setStatus(id, status) {
           if (!this.pending || this.busy) return;
           const prev = this.statuses[id];
-          this.statuses[id] = status; // optimistic
-          const save = (async () => {
+          this.statuses[id] = status; // optimistic; last click wins in the UI
+          const run = async () => {
             try {
               const res = await fetch(`/meso/api/change/${id}/status/`, {
                 method: "POST",
@@ -118,15 +119,22 @@
               });
               if (!res.ok) throw new Error("Request failed: " + res.status);
             } catch (e) {
-              this.statuses[id] = prev; // roll back on failure
+              // Only roll back if no newer click has superseded this one.
+              if (this.statuses[id] === status) this.statuses[id] = prev;
               console.error("Could not save decision", e);
             }
-          })();
-          this.inflight.push(save);
-          save.finally(() => {
-            this.inflight = this.inflight.filter((p) => p !== save);
+          };
+          // Chain per change id so saves hit the server in click order — the
+          // last click always wins server-side, even under rapid toggling.
+          const prevChain = this.chains[id] || Promise.resolve();
+          const next = prevChain.then(run, run);
+          this.chains[id] = next;
+          this.inflight.push(next);
+          next.finally(() => {
+            this.inflight = this.inflight.filter((p) => p !== next);
+            if (this.chains[id] === next) delete this.chains[id];
           });
-          return save;
+          return next;
         },
         // Don't resolve a batch until every pending decision save has landed —
         // otherwise a just-clicked Reject could be applied before it persists.

--- a/app/store_project/templates/meso/review.html
+++ b/app/store_project/templates/meso/review.html
@@ -9,8 +9,7 @@
 
 {% block content %}
   <div class="meso-page meso-page--narrow"
-       x-data="{ status: { {% for c in changes %}'{{ c.id }}': 'approved',{% endfor %} },
-               get approved() { return Object.values(this.status).filter(s => s === 'approved').length } }">
+       x-data="mesoReview({{ batch_id }}, '{{ csrf_token }}', {{ is_pending|yesno:'true,false' }}, { {% for c in changes %}'{{ c.id }}': '{% if c.status == 'rejected' %}rejected{% else %}approved{% endif %}',{% endfor %} })">
     <div class="meso-crumbs">
       <a href="{% url 'meso:roster' %}">Roster</a> <span>/</span>
       <span>{{ athlete.name }}</span> <span>/</span> <span>Review changes</span>
@@ -24,18 +23,24 @@
       </div>
     </div>
 
+    {% if not is_pending %}
+      <div class="meso-card meso-card--pad" style="margin-bottom:13px;">
+        <span class="meso-badge meso-badge--muted"><i></i>This batch has already been resolved — it can no longer be edited.</span>
+      </div>
+    {% endif %}
+
     <div style="display:flex;flex-direction:column;gap:13px;">
       {% for c in changes %}
         <div class="meso-card meso-card--pad"
-             :style="status['{{ c.id }}'] === 'rejected'
+             :style="statuses[{{ c.id }}] === 'rejected'
                      ? 'opacity:0.55;border-color:var(--line)'
                      : 'border-color:var(--soft-line);box-shadow:0 1px 2px rgba(16,18,22,0.05)'">
           <div style="display:flex;align-items:center;gap:9px;margin-bottom:9px;">
             <span class="meso-badge meso-badge--accent">{{ c.kind }}</span>
             <span class="meso-row-meta">{{ c.day }}</span>
             <div class="meso-spacer"></div>
-            <span class="meso-badge meso-badge--ok" x-show="status['{{ c.id }}'] === 'approved'"><i></i>Approved</span>
-            <span class="meso-badge meso-badge--muted" x-show="status['{{ c.id }}'] === 'rejected'"><i></i>Rejected</span>
+            <span class="meso-badge meso-badge--ok" x-show="statuses[{{ c.id }}] === 'approved'"><i></i>Approved</span>
+            <span class="meso-badge meso-badge--muted" x-show="statuses[{{ c.id }}] === 'rejected'"><i></i>Rejected</span>
           </div>
 
           <div style="font-size:15px;font-weight:700;letter-spacing:-0.01em;margin-bottom:8px;">{{ c.title }}</div>
@@ -49,13 +54,13 @@
           <p style="margin:0 0 10px;font-size:12.5px;color:var(--ink);line-height:1.45;">{{ c.rationale }}</p>
 
           <div style="display:flex;align-items:center;gap:10px;">
-            <span class="meso-badge meso-badge--warn" style="font-weight:600;">Honors: {{ c.honors }}</span>
+            {% if c.honors %}<span class="meso-badge meso-badge--warn" style="font-weight:600;">Honors: {{ c.honors }}</span>{% endif %}
             <div class="meso-spacer"></div>
             <div class="meso-seg">
-              <button class="meso-seg-btn" :class="{ 'is-on': status['{{ c.id }}'] === 'approved' }"
-                      @click="status['{{ c.id }}'] = 'approved'">Approve</button>
-              <button class="meso-seg-btn" :class="{ 'is-on': status['{{ c.id }}'] === 'rejected' }"
-                      @click="status['{{ c.id }}'] = 'rejected'">Reject</button>
+              <button class="meso-seg-btn" :class="{ 'is-on': statuses[{{ c.id }}] === 'approved' }"
+                      @click="setStatus({{ c.id }}, 'approved')" :disabled="!pending || busy">Approve</button>
+              <button class="meso-seg-btn" :class="{ 'is-on': statuses[{{ c.id }}] === 'rejected' }"
+                      @click="setStatus({{ c.id }}, 'rejected')" :disabled="!pending || busy">Reject</button>
             </div>
           </div>
         </div>
@@ -66,10 +71,75 @@
       <div style="font-size:13px;font-weight:700;"><span x-text="approved"></span> of {{ changes|length }} changes approved</div>
       <div class="meso-row-meta">Rejected edits are discarded — the program keeps its current values.</div>
       <div class="meso-spacer"></div>
-      <a class="meso-btn" href="{% url 'meso:designer' %}">Back to designer</a>
-      <a class="meso-btn meso-btn--primary" href="{% url 'meso:deliver' %}">
+      <button class="meso-btn" @click="dismiss()" :disabled="!pending || busy">Discard</button>
+      <button class="meso-btn meso-btn--primary" @click="apply()" :disabled="!pending || busy">
         Apply <span x-text="approved"></span> &amp; deliver →
-      </a>
+      </button>
     </div>
   </div>
+
+  <script>
+    // Review-gate state. Per-change Approve/Reject persists immediately; "Apply"
+    // writes every non-rejected change back into the program then sends the coach
+    // to deliver; "Discard" dismisses the batch without applying anything.
+    document.addEventListener("alpine:init", () => {
+      Alpine.data("mesoReview", (batchId, csrf, pending, statuses) => ({
+        batchId: batchId,
+        csrf: csrf,
+        pending: pending,
+        statuses: statuses,
+        busy: false,
+        get approved() {
+          return Object.values(this.statuses).filter((s) => s === "approved").length;
+        },
+        async post(url) {
+          const res = await fetch(url, {
+            method: "POST",
+            headers: { "Content-Type": "application/json", "X-CSRFToken": this.csrf },
+            body: JSON.stringify({}),
+          });
+          if (!res.ok) throw new Error("Request failed: " + res.status);
+          return res.json();
+        },
+        async setStatus(id, status) {
+          if (!this.pending || this.busy) return;
+          const prev = this.statuses[id];
+          this.statuses[id] = status; // optimistic
+          try {
+            const res = await fetch(`/meso/api/change/${id}/status/`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json", "X-CSRFToken": this.csrf },
+              body: JSON.stringify({ status: status }),
+            });
+            if (!res.ok) throw new Error("Request failed: " + res.status);
+          } catch (e) {
+            this.statuses[id] = prev; // roll back on failure
+            console.error("Could not save decision", e);
+          }
+        },
+        async apply() {
+          if (!this.pending || this.busy) return;
+          this.busy = true;
+          try {
+            const data = await this.post(`/meso/api/batch/${this.batchId}/apply/`);
+            window.location = data.deliver_url;
+          } catch (e) {
+            this.busy = false;
+            console.error("Apply failed", e);
+          }
+        },
+        async dismiss() {
+          if (!this.pending || this.busy) return;
+          this.busy = true;
+          try {
+            const data = await this.post(`/meso/api/batch/${this.batchId}/dismiss/`);
+            window.location = data.designer_url;
+          } catch (e) {
+            this.busy = false;
+            console.error("Dismiss failed", e);
+          }
+        },
+      }));
+    });
+  </script>
 {% endblock %}

--- a/app/store_project/templates/meso/review.html
+++ b/app/store_project/templates/meso/review.html
@@ -89,6 +89,7 @@
         pending: pending,
         statuses: statuses,
         busy: false,
+        inflight: [], // in-flight decision saves; Apply waits on these first
         get approved() {
           return Object.values(this.statuses).filter((s) => s === "approved").length;
         },
@@ -105,22 +106,38 @@
           if (!this.pending || this.busy) return;
           const prev = this.statuses[id];
           this.statuses[id] = status; // optimistic
-          try {
-            const res = await fetch(`/meso/api/change/${id}/status/`, {
-              method: "POST",
-              headers: { "Content-Type": "application/json", "X-CSRFToken": this.csrf },
-              body: JSON.stringify({ status: status }),
-            });
-            if (!res.ok) throw new Error("Request failed: " + res.status);
-          } catch (e) {
-            this.statuses[id] = prev; // roll back on failure
-            console.error("Could not save decision", e);
-          }
+          const save = (async () => {
+            try {
+              const res = await fetch(`/meso/api/change/${id}/status/`, {
+                method: "POST",
+                headers: {
+                  "Content-Type": "application/json",
+                  "X-CSRFToken": this.csrf,
+                },
+                body: JSON.stringify({ status: status }),
+              });
+              if (!res.ok) throw new Error("Request failed: " + res.status);
+            } catch (e) {
+              this.statuses[id] = prev; // roll back on failure
+              console.error("Could not save decision", e);
+            }
+          })();
+          this.inflight.push(save);
+          save.finally(() => {
+            this.inflight = this.inflight.filter((p) => p !== save);
+          });
+          return save;
+        },
+        // Don't resolve a batch until every pending decision save has landed —
+        // otherwise a just-clicked Reject could be applied before it persists.
+        async settle() {
+          await Promise.allSettled(this.inflight);
         },
         async apply() {
           if (!this.pending || this.busy) return;
           this.busy = true;
           try {
+            await this.settle();
             const data = await this.post(`/meso/api/batch/${this.batchId}/apply/`);
             window.location = data.deliver_url;
           } catch (e) {
@@ -132,6 +149,7 @@
           if (!this.pending || this.busy) return;
           this.busy = true;
           try {
+            await this.settle();
             const data = await this.post(`/meso/api/batch/${this.batchId}/dismiss/`);
             window.location = data.designer_url;
           } catch (e) {

--- a/docs/meso/agent-plan.md
+++ b/docs/meso/agent-plan.md
@@ -1,7 +1,7 @@
 # Meso — agent slice plan
 
-**Status:** Phase 1 done & merged (PR #280, squash `953d9d4`; deployed) · created 2026-06-27 ·
-**next = agent Phase 2 (approve/apply)**
+**Status:** Phase 1 done & merged (PR #280, squash `953d9d4`; deployed) · Phase 2 built
+(branch `meso-agent-phase2`) · created 2026-06-27 · **next = agent Phase 3 (designer chat column)**
 **Companion to:** [`decisions.md`](./decisions.md) (B6) · [`persistence-plan.md`](./persistence-plan.md)
 **Goal of this slice:** replace the designer's canned agent-chat engine
 (`detectIntent`/`applyIntent` in `meso.js`) and the review screen
@@ -133,11 +133,23 @@ bypass when `introduces_exercise` was omitted; `rationale` dropped on persist) p
 guardrail-scoping refinements. **Deferred:** approve/apply, the chat rebuild, background job +
 streaming, eval cases.
 
-**Phase 2 — Review gate: approve/reject + apply.**
+**Phase 2 — Review gate: approve/reject + apply. ✅ Built (branch `meso-agent-phase2`).**
 Persist per-change approve/reject on the real review screen; apply approved
 changes back into the program (swap → set prescription name; progress → set
-load; volume → add/remove a set; deload → flag the week); retire
+load; volume → set the prescription's set count; deload → flag the week); retire
 `mockdata.PROPOSED_CHANGES`. `AgentProposalBatch.status` → applied/dismissed.
+
+*Built:* `meso/agent/apply.py` (`apply_change`/`apply_batch`/`dismiss_batch`) applies a
+change's structured `payload` — built deterministically by `agent.validation` from the tool's
+`new_name`/`new_load`/`new_sets` fields (a swap falls back to the contraindication-checked
+`introduces_exercise`). Endpoints (all scoped to a coach-owned batch, 404 otherwise; apply/dismiss
+409 unless still pending): `POST api/change/<pk>/status/` (persist approve/reject),
+`POST api/batch/<id>/apply/` (writes every **non-rejected** change in one transaction → batch
+`applied`, bumps `Plan.modified`, returns the deliver URL), `POST api/batch/<id>/dismiss/`.
+`review.html` now persists each toggle and wires Apply/Discard; the bare `review/` redirects to the
+coach's latest pending batch (fixtures retired). No migration (status/payload already existed). Built
+red→green: +33 tests (179 meso / 319 project-wide). *Done when:* a coach can approve/reject and
+apply a real batch into the program. **No chat UI yet (Phase 3).**
 
 **Phase 3 — Designer agent-chat column.**
 Rebuild the designer's left/agent column (`meso.js` `detectIntent`/`applyIntent`,

--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -229,3 +229,13 @@ _(Append dated entries here as decisions land.)_
   human approval gate unchanged. 47 new tests (146 meso / 286 project-wide); local Codex review clean
   (8 rounds). Build plan + phasing in [`agent-plan.md`](./agent-plan.md). Resume point → agent Phase 2
   (per-change approve/reject + **apply** back into the program).
+- 2026-06-27 — **Agent Phase 2 built** (branch `meso-agent-phase2`): the review gate now **writes
+  back**. `meso/agent/apply.py` applies each approved change's structured `payload` (swap → prescription
+  name; progress → load; volume → set count; deload → flags the week), built deterministically by
+  `agent.validation` from the tool's new `new_name`/`new_load`/`new_sets` fields. Endpoints (scoped to a
+  coach-owned batch): `POST api/change/<pk>/status/` persists per-change approve/reject;
+  `POST api/batch/<id>/apply/` applies every non-rejected change in one transaction → batch `applied`,
+  bumps `Plan.modified`; `POST api/batch/<id>/dismiss/` → `dismissed`. `review.html` persists toggles
+  and wires Apply/Discard; bare `review/` redirects to the latest pending batch and `mockdata.PROPOSED_CHANGES`
+  is retired. No migration (status/payload already existed). +33 tests (179 meso / 319 project-wide).
+  Resume point → agent Phase 3 (designer agent-chat column).


### PR DESCRIPTION
## What

Agent slice **Phase 2** — the review gate now **writes back**. Phase 1 landed the proposal engine behind a read-only review screen; this slice lets a coach approve/reject each proposed change and **apply** the approved ones into the program.

Resumes from `docs/meso/agent-plan.md` (next was "agent Phase 2 (approve/apply)").

## How

- **`meso/agent/apply.py`** — `apply_change` / `apply_batch` / `dismiss_batch`. Applying a change performs its structured edit:
  - **swap** → set the prescription's `name`
  - **progress** → set `load`
  - **volume** → set the set count (`sets`) on the targeted row, or every row in the session if the change targets a whole day
  - **deload** → flag the target week (`is_deload`)
  - `apply_batch` runs every **non-rejected** change in one transaction, marks the batch `applied`, and bumps `Plan.modified`. Rejected changes are left untouched.
- **Apply payload** — the edit value lives in `ProposedChange.payload`, built deterministically by `agent.validation` from new tool fields `new_name` / `new_load` / `new_sets` (a swap falls back to the contraindication-checked `introduces_exercise`). A progress/volume change with no value is rejected at validation (it can't be applied), and the **contraindication backstop now screens the swap apply value** too, so an unsafe `new_name` can't slip through.
- **Endpoints** (scoped to a coach-owned batch; 404 otherwise; apply/dismiss 409 unless still pending):
  - `POST api/change/<pk>/status/` — persist per-change approve/reject
  - `POST api/batch/<id>/apply/` — apply, returns the deliver URL
  - `POST api/batch/<id>/dismiss/`
- **Review screen** — `review.html` persists each toggle (serialized per change, last-click-wins) and wires Apply/Discard; Apply waits on any in-flight decision saves first. The bare `review/` redirects to the coach's latest pending batch across any owned plan. `mockdata.PROPOSED_CHANGES` is retired.
- **No migration** — `status` and `payload` already existed on the Phase 1 models.

## Testing

Built red→green. 184 meso / 324 project-wide tests pass; `ruff` clean. New coverage: the apply engine (each kind + no-op guards), the three endpoints (ownership/409/login/method), payload validation incl. the unapplicable-edit and contraindicated-`new_name` rejections, and the bare-review redirect.

**Local Codex review: clean** (5 rounds) — caught a session-only volume no-op, an apply-before-save race, out-of-order decision saves, silently-unapplicable progress/volume edits, a review-lookup scope miss, and (P1) a contraindication-guard bypass via `new_name`. All fixed.

Deferred to Phase 3: the designer agent-chat column.

https://claude.ai/code/session_015G62Gs7papVMJAfYqeExrN