### PR TITLE
Meso — mark agent Phase 2 merged (PR #282) in planning docs

### DIFF
--- a/docs/meso/agent-plan.md
+++ b/docs/meso/agent-plan.md
@@ -1,7 +1,7 @@
 # Meso — agent slice plan
 
-**Status:** Phase 1 done & merged (PR #280, squash `953d9d4`; deployed) · Phase 2 built
-(branch `meso-agent-phase2`) · created 2026-06-27 · **next = agent Phase 3 (designer chat column)**
+**Status:** Phase 1 done & merged (PR #280, squash `953d9d4`; deployed) · Phase 2 done & merged
+(PR #282, squash `ee7d456`; deployed) · created 2026-06-27 · **next = agent Phase 3 (designer chat column)**
 **Companion to:** [`decisions.md`](./decisions.md) (B6) · [`persistence-plan.md`](./persistence-plan.md)
 **Goal of this slice:** replace the designer's canned agent-chat engine
 (`detectIntent`/`applyIntent` in `meso.js`) and the review screen
@@ -133,7 +133,7 @@ bypass when `introduces_exercise` was omitted; `rationale` dropped on persist) p
 guardrail-scoping refinements. **Deferred:** approve/apply, the chat rebuild, background job +
 streaming, eval cases.
 
-**Phase 2 — Review gate: approve/reject + apply. ✅ Built (branch `meso-agent-phase2`).**
+**Phase 2 — Review gate: approve/reject + apply. ✅ Done & merged (2026-06-27, PR #282, squash `ee7d456`; deployed).**
 Persist per-change approve/reject on the real review screen; apply approved
 changes back into the program (swap → set prescription name; progress → set
 load; volume → set the prescription's set count; deload → flag the week); retire

--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -229,7 +229,8 @@ _(Append dated entries here as decisions land.)_
   human approval gate unchanged. 47 new tests (146 meso / 286 project-wide); local Codex review clean
   (8 rounds). Build plan + phasing in [`agent-plan.md`](./agent-plan.md). Resume point → agent Phase 2
   (per-change approve/reject + **apply** back into the program).
-- 2026-06-27 — **Agent Phase 2 built** (branch `meso-agent-phase2`): the review gate now **writes
+- 2026-06-27 — **Agent Phase 2 built & merged** (PR #282, squash `ee7d456`; Django CI green, deployed
+  to Hetzner — **no migration**, `status`/`payload` already existed): the review gate now **writes
   back**. `meso/agent/apply.py` applies each approved change's structured `payload` (swap → prescription
   name; progress → load; volume → set count; deload → flags the week), built deterministically by
   `agent.validation` from the tool's new `new_name`/`new_load`/`new_sets` fields. Endpoints (scoped to a


### PR DESCRIPTION
Docs-only: flip `docs/meso/agent-plan.md` + `decisions.md` from "Phase 2 built" to "done & merged (PR #282, squash `ee7d456`; deployed)". Keeps the planning docs' resume pointer accurate for the next session (→ agent Phase 3). No code changes.

https://claude.ai/code/session_015G62Gs7papVMJAfYqeExrN