### PR TITLE
Meso — agent slice Phase 3: designer agent-chat goes live

### DIFF
--- a/app/store_project/meso/tests/test_designer_agent_chat.py
+++ b/app/store_project/meso/tests/test_designer_agent_chat.py
@@ -1,0 +1,91 @@
+"""Agent slice Phase 3 — the designer's agent-chat column goes live.
+
+The designer's left/agent column was a canned keyword intent engine
+(``detectIntent``/``applyIntent`` in ``static/js/meso.js``): it matched the
+coach's text to one of four scripted edits and mutated the in-memory grid
+directly, with no backend, DB, or LLM call. Phase 3 retires that engine and
+wires the chat to the real proposal endpoint (``POST api/plan/<id>/agent/``,
+shipped in Phase 1): the coach's message is POSTed, the returned batch is
+rendered inline, and a link sends the coach to the review gate. Proposed changes
+stay inert until applied there — the chat never mutates the program grid.
+
+There is no JS test runner in this project, so these guard the refactor at the
+source level (the canned engine is gone, the real wiring is present) alongside a
+behavioral check that the designer renders a real plan's chat column. The
+endpoint itself is covered end-to-end in ``test_agent_endpoint.py``.
+"""
+
+from pathlib import Path
+
+import pytest
+from django.contrib.staticfiles import finders
+from django.urls import reverse
+
+from store_project.meso.tests.test_designer_save import seed_plan
+
+pytestmark = pytest.mark.django_db
+
+
+def read_meso_js():
+    path = finders.find("js/meso.js")
+    assert path, "static js/meso.js must resolve"
+    return Path(path).read_text()
+
+
+def read_designer_template():
+    path = Path(__file__).resolve().parents[2] / "templates" / "meso" / "designer.html"
+    return path.read_text()
+
+
+class TestCannedEngineRetired:
+    def test_meso_js_drops_the_intent_engine(self):
+        js = read_meso_js()
+        for symbol in ("detectIntent", "applyIntent", "dispatch("):
+            assert symbol not in js, f"{symbol} should be retired in Phase 3"
+
+    def test_meso_js_drops_the_fabricated_seed_thread(self):
+        # The canned seed messages invented logged loads ("92.5 kg" off a
+        # trap-bar deadlift) that were never persisted — retired with the engine.
+        js = read_meso_js()
+        assert "92.5 kg" not in js
+
+    def test_designer_template_drops_intent_chip_wiring(self):
+        html = read_designer_template()
+        assert "c.intent" not in html
+        assert "applyIntent" not in html
+
+
+class TestRealAgentWiring:
+    def test_meso_js_posts_instructions_to_the_agent_endpoint(self):
+        js = read_meso_js()
+        assert "sendInstruction" in js
+        # The chat hits the real Phase 1 endpoint rather than a local matcher.
+        assert "/agent/" in js
+
+    def test_meso_js_renders_the_returned_batch_and_review_link(self):
+        js = read_meso_js()
+        # The inline render reads the endpoint's batch shape.
+        assert "review_url" in js
+        assert "summary" in js
+
+    def test_designer_template_wires_chips_as_instructions(self):
+        html = read_designer_template()
+        assert "onChip(c.label)" in html
+
+    def test_designer_template_renders_inline_changes_and_review_link(self):
+        html = read_designer_template()
+        # Inline batch render: the per-change list + a link to the review gate.
+        assert "m.changes" in html
+        assert "reviewUrl" in html
+
+
+class TestDesignerStillRendersChatColumn:
+    def test_designer_page_renders_the_agent_column(self, client):
+        plan, _, _ = seed_plan()
+        client.force_login(plan.relationship.coach)
+        resp = client.get(reverse("meso:designer_plan", kwargs={"plan_id": plan.pk}))
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        # The agent column header + composer survive the rebuild.
+        assert "Agent" in body
+        assert "Ask the agent to adjust the program" in body

--- a/app/store_project/static/js/meso.js
+++ b/app/store_project/static/js/meso.js
@@ -4,9 +4,12 @@
  * view injects a serialized plan and init() hydrates the grid (program / weeks /
  * phases) from it, then edits autosave to the JSON API. The client-side fixtures
  * were retired in Phase 5 — the page always renders a real, DB-backed plan now
- * (the bare URL redirects to one). The "agent" column is still a canned intent
- * engine (swap-knee / lower-volume / progress / deload) — replacing dispatch()/
- * applyIntent() with a real backend call is the next seam to make live.
+ * (the bare URL redirects to one). The agent column is live as of agent Phase 3:
+ * the coach's message POSTs to the real proposal endpoint (api/plan/<id>/agent/),
+ * the returned batch renders inline, and a link sends the coach to the review
+ * gate. The agent only *proposes* — changes stay inert until applied at review,
+ * so the chat never mutates the grid here. (The canned keyword intent engine it
+ * replaced — a client-side matcher that edited the grid in place — is gone.)
  */
 document.addEventListener("alpine:init", () => {
   Alpine.data("meso", () => ({
@@ -33,31 +36,14 @@ document.addEventListener("alpine:init", () => {
     planId: null,
     csrf: "",
 
-    // The agent column is still a canned intent engine (its own slice); these
-    // seed messages stay until the real agent backend replaces dispatch().
+    // The thread starts with a single orienting greeting. Real agent turns are
+    // appended as the coach sends instructions; the thread is not persisted yet
+    // (a later slice adds the background job + saved conversation).
     messages: [
       {
         id: 1,
         role: "agent",
-        text: "Here's Week 2 of Maya's hypertrophy block — 3 sessions, all knee-safe. I used box squats to parallel instead of back squats and kept deep knee flexion out of the loaded work.",
-        change: {
-          title: "Drafted Week 2 · 3 sessions",
-          detail: "Honors: avoid deep knee flexion under load",
-        },
-      },
-      {
-        id: 2,
-        role: "coach",
-        text: "Nice. Bump her trap-bar pull — she sat at RPE 6 last block.",
-      },
-      {
-        id: 3,
-        role: "agent",
-        text: "Done. Progressed the trap-bar deadlift to 92.5 kg. She logged 4×6 @ 90 / RPE 6 last session, so this lands around RPE 7 — right in the hypertrophy window.",
-        change: {
-          title: "Trap-Bar Deadlift → 92.5 kg",
-          detail: "From logged 4×6 @ 90 kg · RPE 6",
-        },
+        text: "Tell me how you'd like to adjust this plan — swap a lift, change a day's volume, progress loads, or add a deload. I'll propose changes for you to review before anything touches the program.",
       },
     ],
 
@@ -67,11 +53,12 @@ document.addEventListener("alpine:init", () => {
     weeks: [],
     phases: [],
 
+    // Each chip's label is sent verbatim as the agent instruction.
     chips: [
-      { label: "Lower Day 2 volume", intent: "lower-volume-d2" },
-      { label: "Swap a knee-sensitive lift", intent: "swap-knee" },
-      { label: "Progress from last block", intent: "progress" },
-      { label: "Add a deload week", intent: "deload" },
+      { label: "Lower Day 2 volume" },
+      { label: "Swap a knee-sensitive lift" },
+      { label: "Progress from last block" },
+      { label: "Add a deload week" },
     ],
 
     calDays: ["M", "T", "W", "T", "F", "S", "S"],
@@ -241,8 +228,16 @@ document.addEventListener("alpine:init", () => {
     },
 
     // ---- agent chat ----
+    //
+    // Each coach turn POSTs to the real proposal endpoint and renders the
+    // returned batch inline. The agent only proposes — the program grid is not
+    // mutated here; the coach applies (or discards) the batch at the review gate.
     pushCoach(text) {
       this.messages.push({ id: Date.now(), role: "coach", text });
+      this.scrollThread();
+    },
+    pushAgent(msg) {
+      this.messages.push({ id: Date.now() + 1, role: "agent", ...msg });
       this.scrollThread();
     },
     onInputKey(e) {
@@ -253,107 +248,83 @@ document.addEventListener("alpine:init", () => {
     },
     onSend() {
       const t = (this.inputText || "").trim();
-      if (!t) return;
-      this.pushCoach(t);
+      if (!t || this.agentTyping) return;
       this.inputText = "";
-      this.dispatch(this.detectIntent(t));
+      this.send(t);
     },
-    onChip(intent, label) {
-      this.pushCoach(label);
-      this.dispatch(intent);
-    },
-
-    detectIntent(t) {
-      const s = t.toLowerCase();
-      if (/knee|meniscus|swap|substitut|replace/.test(s)) return "swap-knee";
-      if (/deload|recover|fatigue|back off/.test(s)) return "deload";
-      if (/volume|lighter|reduce|less|trim|drop a set/.test(s))
-        return "lower-volume-d2";
-      if (/progress|heavier|bump|increase|overload|add (weight|load)/.test(s))
-        return "progress";
-      return "generic";
+    onChip(label) {
+      if (this.agentTyping) return;
+      this.send(label);
     },
 
-    dispatch(intent) {
+    send(instruction) {
+      this.pushCoach(instruction);
+      this.sendInstruction(instruction);
+    },
+
+    // POST the instruction to the agent, then render the batch (or an error).
+    async sendInstruction(instruction) {
+      if (!this.live) {
+        this.pushAgent({
+          text: "Load an athlete's plan first — there's nothing for me to edit yet.",
+          error: true,
+        });
+        return;
+      }
       this.agentTyping = true;
       this.scrollThread();
-      setTimeout(() => this.applyIntent(intent), 780);
+      try {
+        const res = await fetch(`/meso/api/plan/${this.planId}/agent/`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-CSRFToken": this.csrf,
+          },
+          body: JSON.stringify({ instruction }),
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) {
+          this.pushAgent({ text: this.agentErrorText(res.status, data), error: true });
+          return;
+        }
+        this.pushAgent(this.batchMessage(data));
+      } catch (err) {
+        console.error("Agent request failed", err);
+        this.pushAgent({
+          text: "Something went wrong reaching the agent. Please try again.",
+          error: true,
+        });
+      } finally {
+        this.agentTyping = false;
+        this.scrollThread();
+      }
     },
 
-    applyIntent(intent) {
-      let msg;
-
-      if (intent === "swap-knee") {
-        const d = this.program[0];
-        const ix = d.exercises.findIndex((x) => /bulgarian/i.test(x.name));
-        const tgt = ix >= 0 ? ix : 1;
-        Object.assign(d.exercises[tgt], {
-          name: "Box Step-Down (low)",
-          load: "14",
-          tag: "knee-safe",
-          note: "pain-free ROM, slow eccentric",
-        });
-        msg = {
-          text: "Swapped the Bulgarian split squat for a low box step-down. Same single-leg quad stimulus, but the knee tracks through a shorter, controlled range — a better fit for the meniscus history.",
-          change: {
-            title: "Bulgarian Split Squat → Box Step-Down",
-            detail: "Single-leg quad work · controlled ROM",
-          },
-        };
-      } else if (intent === "lower-volume-d2") {
-        const d = this.program[1];
-        d.exercises.forEach((x, i) => {
-          if (i < 3)
-            x.sets = String(Math.max(2, (parseInt(x.sets, 10) || 3) - 1));
-        });
-        msg = {
-          text: "Trimmed Day 2 — dropped a set on the three main upper-body lifts. Keeps weekly pressing volume in check while her shoulder settles, without touching the accessory work.",
-          change: {
-            title: "Day 2 volume − 1 set",
-            detail: "Applied to the 3 primary lifts",
-          },
-        };
-      } else if (intent === "progress") {
-        this.program.forEach((d) => {
-          d.exercises.forEach((x) => {
-            const n = parseFloat(x.load);
-            if (!isNaN(n) && this.numeric(x.load) && x.rpe !== "—") {
-              x.load = String(this.round25(n + 2.5));
-            }
-          });
-        });
-        msg = {
-          text: "Progressed the main lifts by ~2.5 kg across the week, anchored to last block's logged loads and RPEs. Accessories held steady so the added stimulus stays on the big patterns.",
-          change: {
-            title: "+2.5 kg on primary lifts",
-            detail: "Driven by logged session data",
-          },
-        };
-      } else if (intent === "deload") {
-        this.view = "block";
-        const w = this.weeks[3];
-        Object.assign(w, { vol: 50, inten: 70, deload: true, phase: "Deload" });
-        msg = {
-          text: "Set Week 4 as a deload — volume drops ~45% while intensity holds near 70%. That clears accumulated fatigue and sets up a clean hand-off into the strength block.",
-          change: {
-            title: "Week 4 → Deload",
-            detail: "Volume −45% · intensity held",
-          },
-        };
-      } else {
-        msg = {
-          text: "Got it — I've noted that against Maya's profile and coaching rules. Want me to apply it to this week, or carry it into the next block's plan?",
-        };
+    // Shape the endpoint's batch response into an agent chat message. Changes
+    // are inert here; the review link is the only way to act on them.
+    batchMessage(data) {
+      const changes = data.changes || [];
+      let text = data.summary || "";
+      if (!changes.length) {
+        text =
+          text ||
+          "I couldn't find any safe changes to propose for that. Try rephrasing or adjusting the plan directly.";
       }
+      return {
+        text,
+        changes,
+        reviewUrl: changes.length ? data.review_url : null,
+      };
+    },
 
-      this.messages.push({
-        id: Date.now() + 1,
-        role: "agent",
-        text: msg.text,
-        change: msg.change,
-      });
-      this.agentTyping = false;
-      this.scrollThread();
+    agentErrorText(status, data) {
+      if (status === 503)
+        return "The agent isn't configured in this environment yet.";
+      if (status === 502)
+        return "The agent had trouble responding. Give it another try.";
+      if (status === 400)
+        return "That message couldn't be sent — try a shorter instruction.";
+      return (data && data.error) || "The agent couldn't process that request.";
     },
   }));
 });

--- a/app/store_project/templates/meso/designer.html
+++ b/app/store_project/templates/meso/designer.html
@@ -220,14 +220,26 @@
               <div>
                 <template x-if="m.role === 'agent'">
                   <div style="display:flex;flex-direction:column;gap:8px;align-items:flex-start;max-width:90%;">
-                    <div style="background:var(--surface);border:1px solid var(--line);border-radius:4px 13px 13px 13px;padding:10px 13px;font-size:13px;line-height:1.5;color:var(--ink);box-shadow:0 1px 2px rgba(16,18,22,0.03);" x-text="m.text"></div>
-                    <template x-if="m.change">
-                      <div style="display:flex;gap:9px;align-items:flex-start;background:var(--soft);border:1px solid var(--soft-line);border-radius:9px;padding:9px 11px;width:100%;">
-                        <div style="width:17px;height:17px;border-radius:5px;background:var(--accent);display:flex;align-items:center;justify-content:center;color:var(--accent-ink);font-size:10px;flex:0 0 auto;margin-top:1px;">&#10003;</div>
-                        <div style="line-height:1.3;">
-                          <div style="font-size:12.5px;font-weight:700;color:var(--accent-deep);" x-text="m.change.title"></div>
-                          <div style="font-size:11.5px;color:var(--accent-deep);opacity:0.8;" x-text="m.change.detail"></div>
-                        </div>
+                    <div :style="`background:var(--surface);border:1px solid ${m.error ? 'color-mix(in srgb,var(--warn) 36%,#fff)' : 'var(--line)'};border-radius:4px 13px 13px 13px;padding:10px 13px;font-size:13px;line-height:1.5;color:${m.error ? 'var(--warn)' : 'var(--ink)'};box-shadow:0 1px 2px rgba(16,18,22,0.03);`" x-text="m.text"></div>
+                    <!-- Proposed changes returned by the agent, rendered inline (inert until applied at the review gate). -->
+                    <template x-if="m.changes && m.changes.length">
+                      <div style="display:flex;flex-direction:column;gap:7px;width:100%;">
+                        <template x-for="ch in m.changes" :key="ch.id">
+                          <div style="display:flex;gap:9px;align-items:flex-start;background:var(--soft);border:1px solid var(--soft-line);border-radius:9px;padding:9px 11px;width:100%;">
+                            <div style="width:17px;height:17px;border-radius:5px;background:var(--accent);display:flex;align-items:center;justify-content:center;color:var(--accent-ink);font-size:10px;flex:0 0 auto;margin-top:1px;">&#10003;</div>
+                            <div style="line-height:1.3;min-width:0;">
+                              <div style="font-size:12.5px;font-weight:700;color:var(--accent-deep);" x-text="ch.title"></div>
+                              <div style="font-size:11.5px;color:var(--accent-deep);opacity:0.8;">
+                                <span x-show="ch.before" style="text-decoration:line-through;" x-text="ch.before"></span>
+                                <span x-show="ch.before && ch.after"> &#8594; </span>
+                                <span x-text="ch.after"></span>
+                              </div>
+                            </div>
+                          </div>
+                        </template>
+                        <a :href="m.reviewUrl" data-hover="brighten" style="align-self:flex-start;text-decoration:none;font-size:12px;font-weight:650;color:var(--accent-ink);background:var(--accent);border-radius:8px;padding:7px 12px;">
+                          Review <span x-text="m.changes.length"></span> <span x-text="m.changes.length === 1 ? 'change' : 'changes'"></span> &#8594;
+                        </a>
                       </div>
                     </template>
                   </div>
@@ -248,13 +260,13 @@
 
           <div style="flex:0 0 auto;border-top:1px solid var(--line-2);padding:11px 14px 13px;">
             <div style="display:flex;gap:6px;overflow-x:auto;padding-bottom:9px;">
-              <template x-for="c in chips" :key="c.intent">
-                <button data-hover="chip" @click="onChip(c.intent, c.label)" x-text="c.label" style="appearance:none;cursor:pointer;font:inherit;white-space:nowrap;font-size:11.5px;font-weight:550;color:var(--ink);background:var(--surface);border:1px solid var(--line);border-radius:999px;padding:6px 11px;flex:0 0 auto;"></button>
+              <template x-for="c in chips" :key="c.label">
+                <button data-hover="chip" @click="onChip(c.label)" :disabled="agentTyping" x-text="c.label" style="appearance:none;cursor:pointer;font:inherit;white-space:nowrap;font-size:11.5px;font-weight:550;color:var(--ink);background:var(--surface);border:1px solid var(--line);border-radius:999px;padding:6px 11px;flex:0 0 auto;"></button>
               </template>
             </div>
             <div class="meso-composer" style="display:flex;align-items:flex-end;gap:8px;background:var(--rail);border:1px solid var(--line);border-radius:11px;padding:7px 7px 7px 12px;">
               <input x-model="inputText" @keydown="onInputKey($event)" placeholder="Ask the agent to adjust the program&#8230;" style="flex:1;appearance:none;border:0;background:transparent;outline:none;font:inherit;font-size:13px;color:var(--ink);padding:5px 0;" />
-              <button data-hover="brighten" @click="onSend()" style="appearance:none;cursor:pointer;border:0;width:32px;height:32px;border-radius:8px;background:var(--accent);color:var(--accent-ink);display:flex;align-items:center;justify-content:center;flex:0 0 auto;font-size:15px;">&#8593;</button>
+              <button data-hover="brighten" @click="onSend()" :disabled="agentTyping" :style="agentTyping ? 'opacity:0.55;cursor:default;' : ''" style="appearance:none;cursor:pointer;border:0;width:32px;height:32px;border-radius:8px;background:var(--accent);color:var(--accent-ink);display:flex;align-items:center;justify-content:center;flex:0 0 auto;font-size:15px;">&#8593;</button>
             </div>
           </div>
         </div>

--- a/docs/meso/agent-plan.md
+++ b/docs/meso/agent-plan.md
@@ -1,7 +1,8 @@
 # Meso — agent slice plan
 
 **Status:** Phase 1 done & merged (PR #280, squash `953d9d4`; deployed) · Phase 2 done & merged
-(PR #282, squash `ee7d456`; deployed) · created 2026-06-27 · **next = agent Phase 3 (designer chat column)**
+(PR #282, squash `ee7d456`; deployed) · Phase 3 built (branch `meso-agent-phase3`) · created 2026-06-27 ·
+**next = agent Phase 4 (execution + eval)**
 **Companion to:** [`decisions.md`](./decisions.md) (B6) · [`persistence-plan.md`](./persistence-plan.md)
 **Goal of this slice:** replace the designer's canned agent-chat engine
 (`detectIntent`/`applyIntent` in `meso.js`) and the review screen
@@ -151,11 +152,30 @@ coach's latest pending batch (fixtures retired). No migration (status/payload al
 red→green: +33 tests (179 meso / 319 project-wide). *Done when:* a coach can approve/reject and
 apply a real batch into the program. **No chat UI yet (Phase 3).**
 
-**Phase 3 — Designer agent-chat column.**
+**Phase 3 — Designer agent-chat column. ✅ Built (branch `meso-agent-phase3`).**
 Rebuild the designer's left/agent column (`meso.js` `detectIntent`/`applyIntent`,
 currently canned: swap-knee / lower-volume-d2 / progress / deload) to POST the
 coach's message to `.../agent/` and render the returned batch inline, linking to
 the review screen. Retire the canned intent engine.
+
+*Built:* the canned keyword engine (`detectIntent`/`applyIntent`/`dispatch` in
+`meso.js`, which matched the coach's text to one of four scripted edits and
+mutated the in-memory grid in place) is gone. A coach turn — typed or via a chip
+(chips now send their label verbatim as the instruction) — POSTs to
+`api/plan/<id>/agent/` (the Phase 1 endpoint), and the returned batch renders
+inline: a per-change list (`title` + `before`→`after`) under the agent's summary,
+plus a **"Review N changes →"** link to the review gate. The agent only
+*proposes* — the chat never mutates `program`/`weeks`/`phases`; changes stay inert
+until the coach applies them at review. Friendly fallbacks for 503 (no key) / 502
+(provider) / 400 / network errors; the composer + chips disable while the agent is
+drafting (`agentTyping`). The fabricated seed thread is dropped for one orienting
+greeting; the thread is **not persisted yet** (a later slice). Tests
+(`test_designer_agent_chat.py`, red→green): no JS runner in-project, so they guard
+the engine's retirement + the real endpoint wiring at the source level, plus a
+render check. 192 meso / 332 project-wide pass; `ruff` + pre-commit clean. **Local
+Codex review: clean (1 round, no findings).** *Done when:* a coach can chat the
+agent into a real proposal batch and jump to review. **Deferred:** persisted chat
+thread, background job + streamed "drafting…" status (Phase 4).
 
 **Phase 4 — Execution + eval.**
 Background job + streamed "drafting…" status (Redis); golden eval cases; logged

--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -240,3 +240,15 @@ _(Append dated entries here as decisions land.)_
   and wires Apply/Discard; bare `review/` redirects to the latest pending batch and `mockdata.PROPOSED_CHANGES`
   is retired. No migration (status/payload already existed). +33 tests (179 meso / 319 project-wide).
   Resume point → agent Phase 3 (designer agent-chat column).
+- 2026-06-27 — **Agent Phase 3 built** (branch `meso-agent-phase3`): the designer's agent-chat column
+  goes **live**. The canned keyword intent engine (`detectIntent`/`applyIntent`/`dispatch` in `meso.js`,
+  which matched the coach's text to one of four scripted edits and mutated the grid in place) is retired;
+  a coach turn — typed or via a chip — now POSTs to `api/plan/<id>/agent/` (the Phase 1 endpoint) and the
+  returned batch renders inline (per-change `title`/`before`→`after` under the summary) with a
+  **"Review N changes →"** link to the review gate. The agent only **proposes** — the chat never mutates
+  the program grid; changes stay inert until applied at review. Friendly fallbacks for 503/502/400/network
+  errors; composer + chips disable while drafting. No backend change (the endpoint already existed); chat
+  is **not persisted yet**. Tests (`test_designer_agent_chat.py`): no JS runner in-project, so they guard
+  the retirement + real wiring at the source level + a render check. +8 tests (192 meso / 332 project-wide);
+  local Codex review clean (1 round). Resume point → agent Phase 4 (background job + streamed status +
+  golden eval cases).


### PR DESCRIPTION
## What

Agent slice **Phase 3** — the designer's left/agent column goes **live**. Phases 1–2
landed the proposal engine and the review gate; this slice retires the designer's
canned chat and wires it to the real agent so a coach can chat the agent into a
proposal batch and jump straight to review.

Resumes from `docs/meso/agent-plan.md` (next was "agent Phase 3 (designer chat column)").

## How

- **Retire the canned engine.** `detectIntent`/`applyIntent`/`dispatch` in
  `meso.js` — a client-side keyword matcher that mapped the coach's text to one of
  four scripted edits and mutated the in-memory grid in place — are gone, along
  with the fabricated seed thread (invented logged loads that were never persisted).
- **Real wiring.** A coach turn (typed, or via a chip — chips now send their label
  verbatim as the instruction) POSTs to `api/plan/<id>/agent/` (the Phase 1
  endpoint) and the returned batch renders **inline**: a per-change list
  (`title` + `before`→`after`) under the agent's summary, plus a
  **"Review N changes →"** link to the review gate.
- **Proposes, never applies.** The chat does not touch `program`/`weeks`/`phases`;
  proposed changes stay inert until the coach applies them at review. This keeps the
  human gate the only path that writes back.
- **Degrades cleanly.** Friendly fallbacks for 503 (no API key) / 502 (provider) /
  400 / network errors; the composer + chips disable while the agent is drafting
  (`agentTyping`), so no overlapping batches. The thread opens with one orienting
  greeting and is **not persisted yet** (a later slice).
- **No backend change** — the endpoint and serializer already return everything the
  inline render needs.

## Testing

Built red→green. **192 meso / 332 project-wide** tests pass; `ruff` + pre-commit
clean. There's no JS test runner in-project, so `test_designer_agent_chat.py` guards
the refactor at the source level (the canned engine is retired; the real endpoint
wiring + inline render are present) alongside a behavioral check that the designer
still renders a real plan's chat column. The endpoint itself stays covered
end-to-end by `test_agent_endpoint.py`.

**Local Codex review: clean** (1 round, no findings).

Deferred to Phase 4: persisted chat thread, background job + streamed "drafting…"
status, golden eval cases.

https://claude.ai/code/session_015G62Gs7papVMJAfYqeExrN