### PR TITLE
Meso — mark agent Phase 3 merged (PR #284) in planning docs

### DIFF
--- a/docs/meso/agent-plan.md
+++ b/docs/meso/agent-plan.md
@@ -1,8 +1,8 @@
 # Meso — agent slice plan
 
 **Status:** Phase 1 done & merged (PR #280, squash `953d9d4`; deployed) · Phase 2 done & merged
-(PR #282, squash `ee7d456`; deployed) · Phase 3 built (branch `meso-agent-phase3`) · created 2026-06-27 ·
-**next = agent Phase 4 (execution + eval)**
+(PR #282, squash `ee7d456`; deployed) · Phase 3 done & merged (PR #284, squash `5bfe754`; deployed) ·
+created 2026-06-27 · **next = agent Phase 4 (execution + eval)**
 **Companion to:** [`decisions.md`](./decisions.md) (B6) · [`persistence-plan.md`](./persistence-plan.md)
 **Goal of this slice:** replace the designer's canned agent-chat engine
 (`detectIntent`/`applyIntent` in `meso.js`) and the review screen
@@ -152,7 +152,7 @@ coach's latest pending batch (fixtures retired). No migration (status/payload al
 red→green: +33 tests (179 meso / 319 project-wide). *Done when:* a coach can approve/reject and
 apply a real batch into the program. **No chat UI yet (Phase 3).**
 
-**Phase 3 — Designer agent-chat column. ✅ Built (branch `meso-agent-phase3`).**
+**Phase 3 — Designer agent-chat column. ✅ Done & merged (2026-06-27, PR #284, squash `5bfe754`; Django CI green, deployed to Hetzner — no migration).**
 Rebuild the designer's left/agent column (`meso.js` `detectIntent`/`applyIntent`,
 currently canned: swap-knee / lower-volume-d2 / progress / deload) to POST the
 coach's message to `.../agent/` and render the returned batch inline, linking to

--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -240,8 +240,9 @@ _(Append dated entries here as decisions land.)_
   and wires Apply/Discard; bare `review/` redirects to the latest pending batch and `mockdata.PROPOSED_CHANGES`
   is retired. No migration (status/payload already existed). +33 tests (179 meso / 319 project-wide).
   Resume point → agent Phase 3 (designer agent-chat column).
-- 2026-06-27 — **Agent Phase 3 built** (branch `meso-agent-phase3`): the designer's agent-chat column
-  goes **live**. The canned keyword intent engine (`detectIntent`/`applyIntent`/`dispatch` in `meso.js`,
+- 2026-06-27 — **Agent Phase 3 done & merged** (PR #284, squash `5bfe754`; Django CI green, deployed to
+  Hetzner — no migration; deployed `meso.js` serving the new chat confirmed live): the designer's
+  agent-chat column goes **live**. The canned keyword intent engine (`detectIntent`/`applyIntent`/`dispatch` in `meso.js`,
   which matched the coach's text to one of four scripted edits and mutated the grid in place) is retired;
   a coach turn — typed or via a chip — now POSTs to `api/plan/<id>/agent/` (the Phase 1 endpoint) and the
   returned batch renders inline (per-change `title`/`before`→`after` under the summary) with a


### PR DESCRIPTION
Records agent Phase 3 (designer agent-chat goes live) as **done & merged** in the
planning docs: squash SHA `5bfe754`, PR #284, Django CI green, deployed to Hetzner
(no migration; the deployed `meso.js` serving the live chat was confirmed in
production). Sets the resume point to **agent Phase 4 (execution + eval)**.

Docs-only — Django CI skips on `docs/**` / `**.md`.

https://claude.ai/code/session_015G62Gs7papVMJAfYqeExrN