### PR TITLE
Meso — mark agent Phase 4 merged (PR #286) in planning docs

### DIFF
--- a/docs/meso/agent-plan.md
+++ b/docs/meso/agent-plan.md
@@ -2,8 +2,8 @@
 
 **Status:** Phase 1 done & merged (PR #280, squash `953d9d4`; deployed) · Phase 2 done & merged
 (PR #282, squash `ee7d456`; deployed) · Phase 3 done & merged (PR #284, squash `5bfe754`; deployed) ·
-Phase 4 **built** (background job + streamed status + logs-in-grounding + golden evals) ·
-created 2026-06-27 · **agent slice complete after Phase 4**
+Phase 4 done & merged (PR #286, squash `82fd360`; Django CI green, deployed to Hetzner —
+migration `meso.0005` applied) · created 2026-06-27 · **agent slice complete**
 **Companion to:** [`decisions.md`](./decisions.md) (B6) · [`persistence-plan.md`](./persistence-plan.md)
 **Goal of this slice:** replace the designer's canned agent-chat engine
 (`detectIntent`/`applyIntent` in `meso.js`) and the review screen
@@ -178,7 +178,7 @@ Codex review: clean (1 round, no findings).** *Done when:* a coach can chat the
 agent into a real proposal batch and jump to review. **Deferred:** persisted chat
 thread, background job + streamed "drafting…" status (Phase 4).
 
-**Phase 4 — Execution + eval. ✅ Built (2026-06-27).**
+**Phase 4 — Execution + eval. ✅ Done & merged (2026-06-27, PR #286, squash `82fd360`; deployed to Hetzner — migration `meso.0005` applied; local Codex review clean, 1 round).**
 Background job + streamed "drafting…" status; golden eval cases; logged sessions
 fed into grounding.
 

--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -266,3 +266,8 @@ _(Append dated entries here as decisions land.)_
   (`agent/evals.py` model-agnostic invariants responsive/grounded/safe + `manage.py meso_agent_eval`,
   side-effect-free, `--dry-run` without a key). Built red→green (+40 tests). **Closes the B6 agent slice**
   (only persisted chat thread + athlete-facing surfaces remain, both later slices).
+- 2026-06-27 — **Agent Phase 4 merged & deployed** (PR #286, squash `82fd360`; Django CI green, deployed to
+  Hetzner — migration `meso.0005_agentproposalbatch_error_and_more` applied in prod; local Codex review
+  clean, 1 round; +40 tests, 219 meso / 359 project-wide). **The B6 agent slice is complete.** Resume point
+  → either a **persisted chat thread** (saving the designer conversation, deferred since Phase 3) or the
+  **athlete-facing slice** (delivery + logging PWA, then results feeding back to the agent — decisions S3/S7).


### PR DESCRIPTION
Docs-only follow-up: record the Phase 4 squash hash (`82fd360`), prod deploy (migration `meso.0005` applied), and the clean Codex review in `docs/meso/agent-plan.md` + `docs/meso/decisions.md`. The B6 agent slice is complete.

https://claude.ai/code/session_015G62Gs7papVMJAfYqeExrN