### PR TITLE
Meso — athlete slice Phase 1: athlete read surface (home + session)

### DIFF
--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -8,9 +8,14 @@ activity fields are Phase 2/3 concepts; we pass honest neutral values
 without inventing numbers.
 """
 
+from django.urls import reverse
 from django.utils import timezone
 
+from .models import Plan
+from .models import SessionLog
 from .serializers import current_week
+from .serializers import latest_delivered_week
+from .serializers import serialize_prescription
 from .serializers import serialize_proposed_change
 
 
@@ -135,3 +140,102 @@ def coach_style(coach):
     if profile is None:
         return {"tags": [], "avoid": ""}
     return {"tags": profile.programming_style or [], "avoid": profile.avoid_rules}
+
+
+# -- athlete surface (athlete slice Phase 1) -------------------------------
+#
+# The athlete's *own* read view (distinct from the coach's view of an athlete).
+# Scoped to delivered weeks across the athlete's active coaches; an undelivered
+# week never reaches these presenters (the view filters first). Log status comes
+# only from the athlete's *own* ``SessionLog`` rows.
+
+
+def _done_session_ids(session_ids, athlete):
+    """Which of ``session_ids`` the athlete has a *done* log for (one query)."""
+    return set(
+        SessionLog.objects.filter(
+            session_id__in=session_ids,
+            athlete=athlete,
+            status=SessionLog.Status.DONE,
+        ).values_list("session_id", flat=True)
+    )
+
+
+def _athlete_session_row(session, *, done):
+    """One session in the athlete's week — a tappable row on the home screen."""
+    status = "done" if done else "pending"
+    return {
+        "id": session.pk,
+        "n": session.day_number,
+        "name": session.name,
+        "bias": session.bias,
+        # ``prescriptions`` is prefetched on the home query — no per-row query.
+        "exercise_count": len(session.prescriptions.all()),
+        "status": status,
+        "status_label": "Logged" if done else "To do",
+        "url": reverse("meso:athlete_session", kwargs={"pk": session.pk}),
+    }
+
+
+def athlete_home(user):
+    """The athlete's active programs, each with its latest delivered week.
+
+    One card per non-archived plan across the athlete's *active* coaches (D-a).
+    A plan with no delivered week is shown as awaiting; otherwise its delivered
+    sessions render with the athlete's own done/pending status.
+    """
+    plans = (
+        Plan.objects.for_athlete(user)
+        .exclude(status=Plan.Status.ARCHIVED)
+        .select_related("relationship__coach")
+        .order_by("-modified")
+    )
+    cards = []
+    for plan in plans:
+        week = latest_delivered_week(plan)
+        sessions = []
+        if week is not None:
+            session_objs = list(week.sessions.prefetch_related("prescriptions"))
+            done = _done_session_ids([s.pk for s in session_objs], user)
+            sessions = [
+                _athlete_session_row(s, done=s.pk in done) for s in session_objs
+            ]
+        cards.append(
+            {
+                "id": plan.pk,
+                "title": plan.title,
+                "goal": plan.goal,
+                "coach": plan.coach.display_name(),
+                "block": week.mesocycle.name if week else "",
+                "week": f"Wk {week.index}" if week else "",
+                "delivered_at": week.delivered_at if week else None,
+                "sessions": sessions,
+                "awaiting": week is None,
+            }
+        )
+    return cards
+
+
+def athlete_session(session, athlete):
+    """One delivered session's prescribed grid, for the athlete's read view.
+
+    ``session`` is already athlete-scoped + delivered by the view; this only
+    formats it (and reads the athlete's own done status). Prescriptions are
+    prefetched on the view query.
+    """
+    done = SessionLog.objects.filter(
+        session=session, athlete=athlete, status=SessionLog.Status.DONE
+    ).exists()
+    week = session.week
+    return {
+        "id": session.pk,
+        "n": session.day_number,
+        "name": session.name,
+        "bias": session.bias,
+        "status": "done" if done else "pending",
+        "status_label": "Logged" if done else "To do",
+        "block": week.mesocycle.name,
+        "week": f"Wk {week.index}",
+        "plan_title": week.mesocycle.plan.title,
+        "exercises": [serialize_prescription(p) for p in session.prescriptions.all()],
+    }

--- a/app/store_project/meso/serializers.py
+++ b/app/store_project/meso/serializers.py
@@ -173,6 +173,21 @@ def serialize_recent_logs(plan, *, limit=5, sets_cap=24):
     return summary
 
 
+def latest_delivered_week(plan):
+    """The most recently delivered week of ``plan``, or None.
+
+    Delivery is the athlete's publish gate (``Week.delivered_at`` is stamped by
+    ``plan_deliver``); an undelivered week is invisible on the athlete surface.
+    Newest delivery wins so the athlete lands on the week their coach just sent.
+    """
+    return (
+        models.Week.objects.filter(mesocycle__plan=plan, delivered_at__isnull=False)
+        .select_related("mesocycle")
+        .order_by("-delivered_at")
+        .first()
+    )
+
+
 def current_week(plan, week=None):
     """The week the designer opens to.
 

--- a/app/store_project/meso/serializers.py
+++ b/app/store_project/meso/serializers.py
@@ -176,9 +176,14 @@ def serialize_recent_logs(plan, *, limit=5, sets_cap=24):
 def latest_delivered_week(plan):
     """The most recently delivered week of ``plan``, or None.
 
-    Delivery is the athlete's publish gate (``Week.delivered_at`` is stamped by
-    ``plan_deliver``); an undelivered week is invisible on the athlete surface.
-    Newest delivery wins so the athlete lands on the week their coach just sent.
+    Delivery gates *visibility*: a week the coach has delivered
+    (``Week.delivered_at`` stamped by ``plan_deliver``) becomes visible to the
+    athlete; an undelivered week is not. The athlete then sees that week's
+    **current** (live) contents — a coach correcting an already-delivered week
+    is reflected, by design; the frozen ``WeekDelivery`` snapshot is the
+    historical record for the (deferred) "changes since last delivery" diff, not
+    a separate athlete-facing view. Newest delivery wins so the athlete lands on
+    the week their coach just sent. See ``docs/meso/athlete-plan.md``.
     """
     return (
         models.Week.objects.filter(mesocycle__plan=plan, delivered_at__isnull=False)

--- a/app/store_project/meso/tests/test_athlete_surface.py
+++ b/app/store_project/meso/tests/test_athlete_surface.py
@@ -1,0 +1,250 @@
+"""Athlete slice Phase 1 — the athlete's read surface.
+
+The first logged-in surface for an *athlete* (distinct from the coach's view of
+an athlete at ``/meso/athlete/<uuid>/``):
+
+- ``/meso/me/`` lists the athlete's active-coach plans, each with its latest
+  delivered week and that week's sessions (marked done/pending from the
+  athlete's own ``SessionLog``);
+- ``/meso/me/session/<id>/`` shows one delivered session's prescribed exercises,
+  read-only.
+
+These tests pin the **scoping contract** (see ``docs/meso/athlete-plan.md``):
+an athlete sees only plans across their *active* coaches, only **delivered**
+weeks, and never another athlete's data. Delivery — not plan status — is the
+publish gate; an undelivered week is invisible even to its own athlete.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+
+from store_project.meso.factories import CoachAthleteFactory
+from store_project.meso.factories import CoachProfileFactory
+from store_project.meso.factories import ExercisePrescriptionFactory
+from store_project.meso.factories import MesocycleFactory
+from store_project.meso.factories import PlanFactory
+from store_project.meso.factories import SessionFactory
+from store_project.meso.factories import SessionLogFactory
+from store_project.meso.factories import WeekFactory
+from store_project.meso.models import CoachAthlete
+from store_project.meso.models import Plan
+from store_project.meso.models import SessionLog
+from store_project.users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def seed(
+    *,
+    coach=None,
+    athlete=None,
+    delivered=True,
+    link_status=CoachAthlete.Status.ACTIVE,
+    plan_status=Plan.Status.ACTIVE,
+    session_name="Lower",
+):
+    """A minimal plan → (optionally delivered) week → session → prescription."""
+    coach = coach or UserFactory()
+    athlete = athlete or UserFactory()
+    rel = CoachAthleteFactory(coach=coach, athlete=athlete, status=link_status)
+    plan = PlanFactory(relationship=rel, title="Hypertrophy Block", status=plan_status)
+    meso = MesocycleFactory(plan=plan, name="Hypertrophy", order=0)
+    week = WeekFactory(
+        mesocycle=meso,
+        index=2,
+        is_current=True,
+        delivered_at=timezone.now() if delivered else None,
+    )
+    session = SessionFactory(week=week, day_number=1, name=session_name, bias="Quad")
+    presc = ExercisePrescriptionFactory(
+        session=session, name="Box Squat", sets="4", reps="6", load="70", rpe="7"
+    )
+    return SimpleNamespace(
+        coach=coach,
+        athlete=athlete,
+        rel=rel,
+        plan=plan,
+        meso=meso,
+        week=week,
+        session=session,
+        presc=presc,
+    )
+
+
+HOME = reverse("meso:athlete_home")
+
+
+def session_url(session):
+    return reverse("meso:athlete_session", kwargs={"pk": session.pk})
+
+
+# -- athlete home ----------------------------------------------------------
+
+
+class TestAthleteHome:
+    def test_requires_login(self, client):
+        resp = client.get(HOME)
+        assert resp.status_code == 302
+        assert "/accounts/login/" in resp.url
+
+    def test_lists_delivered_session(self, client):
+        s = seed(session_name="Lower")
+        client.force_login(s.athlete)
+        resp = client.get(HOME)
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert "Hypertrophy Block" in body
+        assert "Lower" in body
+        # The session links through to its detail page.
+        assert session_url(s.session) in body
+
+    def test_shows_coach_name(self, client):
+        s = seed()
+        s.coach.name = "Coach Lance"
+        s.coach.save(update_fields=["name"])
+        client.force_login(s.athlete)
+        body = client.get(HOME).content.decode()
+        assert "Coach Lance" in body
+
+    def test_hides_undelivered_week(self, client):
+        s = seed(delivered=False, session_name="SecretLower")
+        client.force_login(s.athlete)
+        body = client.get(HOME).content.decode()
+        # The plan card may show (awaiting delivery) but its sessions must not.
+        assert "SecretLower" not in body
+        assert session_url(s.session) not in body
+
+    def test_excludes_other_athletes_plan(self, client):
+        mine = seed(session_name="MyLower")
+        theirs = seed(session_name="TheirLower")
+        client.force_login(mine.athlete)
+        body = client.get(HOME).content.decode()
+        assert "MyLower" in body
+        assert "TheirLower" not in body
+        assert session_url(theirs.session) not in body
+
+    def test_excludes_inactive_link(self, client):
+        s = seed(
+            link_status=CoachAthlete.Status.PENDING_COACH_INVITE,
+            session_name="PendingLower",
+        )
+        client.force_login(s.athlete)
+        body = client.get(HOME).content.decode()
+        assert "PendingLower" not in body
+
+    def test_excludes_archived_plan(self, client):
+        s = seed(plan_status=Plan.Status.ARCHIVED, session_name="ArchivedLower")
+        client.force_login(s.athlete)
+        body = client.get(HOME).content.decode()
+        assert "ArchivedLower" not in body
+
+    def test_session_status_reflects_log(self, client):
+        s = seed()
+        SessionLogFactory(
+            session=s.session, athlete=s.athlete, status=SessionLog.Status.DONE
+        )
+        client.force_login(s.athlete)
+        body = client.get(HOME).content.decode()
+        assert "Logged" in body
+
+    def test_session_status_pending_without_log(self, client):
+        s = seed()
+        client.force_login(s.athlete)
+        body = client.get(HOME).content.decode()
+        assert "To do" in body
+
+    def test_another_athletes_log_does_not_mark_done(self, client):
+        """A log belonging to a *different* athlete must not flip my session done."""
+        s = seed()
+        other = UserFactory()
+        SessionLogFactory(
+            session=s.session, athlete=other, status=SessionLog.Status.DONE
+        )
+        client.force_login(s.athlete)
+        body = client.get(HOME).content.decode()
+        assert "To do" in body
+
+
+# -- athlete session detail ------------------------------------------------
+
+
+class TestAthleteSession:
+    def test_requires_login(self, client):
+        s = seed()
+        resp = client.get(session_url(s.session))
+        assert resp.status_code == 302
+        assert "/accounts/login/" in resp.url
+
+    def test_shows_prescribed_exercises(self, client):
+        s = seed()
+        client.force_login(s.athlete)
+        resp = client.get(session_url(s.session))
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert "Box Squat" in body
+        assert "Lower" in body
+        # The prescribed target is visible.
+        assert "6" in body
+
+    def test_404_for_other_athlete(self, client):
+        s = seed()
+        intruder = seed().athlete
+        client.force_login(intruder)
+        assert client.get(session_url(s.session)).status_code == 404
+
+    def test_404_when_undelivered(self, client):
+        s = seed(delivered=False)
+        client.force_login(s.athlete)
+        assert client.get(session_url(s.session)).status_code == 404
+
+    def test_404_inactive_link(self, client):
+        s = seed(link_status=CoachAthlete.Status.ENDED)
+        client.force_login(s.athlete)
+        assert client.get(session_url(s.session)).status_code == 404
+
+    def test_404_archived_plan(self, client):
+        s = seed(plan_status=Plan.Status.ARCHIVED)
+        client.force_login(s.athlete)
+        assert client.get(session_url(s.session)).status_code == 404
+
+    def test_404_unknown_session(self, client):
+        s = seed()
+        client.force_login(s.athlete)
+        assert (
+            client.get(
+                reverse("meso:athlete_session", kwargs={"pk": 999999})
+            ).status_code
+            == 404
+        )
+
+
+# -- roster routing for pure athletes --------------------------------------
+
+
+class TestRosterRedirect:
+    def test_pure_athlete_redirected_to_home(self, client):
+        s = seed()
+        # ``s.athlete`` has an active coach link but no CoachProfile.
+        client.force_login(s.athlete)
+        resp = client.get(reverse("meso:roster"))
+        assert resp.status_code == 302
+        assert resp.url == HOME
+
+    def test_coach_stays_on_roster(self, client):
+        s = seed()
+        CoachProfileFactory(user=s.coach)
+        client.force_login(s.coach)
+        resp = client.get(reverse("meso:roster"))
+        assert resp.status_code == 200
+
+    def test_coach_who_is_also_athlete_stays_on_roster(self, client):
+        s = seed()
+        # The coach also trains under someone else *and* coaches — stays on roster.
+        CoachProfileFactory(user=s.coach)
+        seed(athlete=s.coach)
+        client.force_login(s.coach)
+        resp = client.get(reverse("meso:roster"))
+        assert resp.status_code == 200

--- a/app/store_project/meso/urls.py
+++ b/app/store_project/meso/urls.py
@@ -1,7 +1,9 @@
 from django.urls import path
 
 from . import views
+from .views import AthleteHomeView
 from .views import AthleteProfileView
+from .views import AthleteSessionView
 from .views import ChangeReviewView
 from .views import DeliverView
 from .views import MesoDesignerView
@@ -22,6 +24,14 @@ urlpatterns = [
     path("deliver/", DeliverView.as_view(), name="deliver"),
     path("deliver/<int:plan_id>/", DeliverView.as_view(), name="deliver_plan"),
     path("results/", ResultsView.as_view(), name="results"),
+    # Athlete surface (athlete slice Phase 1) — the athlete's own training view,
+    # distinct from the coach's ``athlete/<uuid>/`` record.
+    path("me/", AthleteHomeView.as_view(), name="athlete_home"),
+    path(
+        "me/session/<int:pk>/",
+        AthleteSessionView.as_view(),
+        name="athlete_session",
+    ),
     path("athlete/<uuid:pk>/", AthleteProfileView.as_view(), name="athlete"),
     path("invite/<uuid:token>/accept/", views.invite_accept, name="invite_accept"),
     path("invite/<uuid:token>/decline/", views.invite_decline, name="invite_decline"),

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -155,8 +155,10 @@ class AthleteProfileView(LoginRequiredMixin, TemplateView):
 # The athlete's own logged-in surface, distinct from the coach's view of an
 # athlete (``/meso/athlete/<uuid>/``). Read-only here; logging lands in Phase 2.
 # Everything is scoped to the athlete's *active* coaches (``for_athlete``), to
-# **delivered** weeks (delivery is the publish gate), and to non-archived plans.
-# An out-of-scope session is a flat 404 — never a silent empty render.
+# **delivered** weeks (delivery gates *visibility* — an undelivered week is
+# hidden; a delivered week's *current* contents are shown, see
+# ``latest_delivered_week``), and to non-archived plans. An out-of-scope session
+# is a flat 404 — never a silent empty render.
 
 
 def _athlete_plans(user):

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -24,6 +24,7 @@ from .agent import jobs as agent_jobs
 from .agent import service as agent_service
 from .models import AgentProposalBatch
 from .models import CoachAthlete
+from .models import CoachProfile
 from .models import ExercisePrescription
 from .models import Plan
 from .models import ProposedChange
@@ -86,9 +87,21 @@ class MesoDesignerView(LoginRequiredMixin, TemplateView):
 
 
 class RosterView(LoginRequiredMixin, TemplateView):
-    """Front door: the coach's athletes (scoped to active relationships)."""
+    """Front door: the coach's athletes (scoped to active relationships).
+
+    A *pure* athlete — someone with an active coach link but no ``CoachProfile``
+    — has no roster of their own, so they're sent to their training surface
+    instead. A coach (or a coach who also trains) keeps the roster.
+    """
 
     template_name = "meso/roster.html"
+
+    def get(self, request, *args, **kwargs):
+        is_coach = CoachProfile.objects.filter(user=request.user).exists()
+        is_athlete = CoachAthlete.objects.for_athlete(request.user).active().exists()
+        if not is_coach and is_athlete:
+            return redirect("meso:athlete_home")
+        return super().get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
@@ -134,6 +147,71 @@ class AthleteProfileView(LoginRequiredMixin, TemplateView):
         # schema (Phase 2) and logging (Phase 3).
         ctx["macrocycle"] = []
         ctx["results_summary"] = None
+        return ctx
+
+
+# -- athlete surface (athlete slice Phase 1) -------------------------------
+#
+# The athlete's own logged-in surface, distinct from the coach's view of an
+# athlete (``/meso/athlete/<uuid>/``). Read-only here; logging lands in Phase 2.
+# Everything is scoped to the athlete's *active* coaches (``for_athlete``), to
+# **delivered** weeks (delivery is the publish gate), and to non-archived plans.
+# An out-of-scope session is a flat 404 — never a silent empty render.
+
+
+def _athlete_plans(user):
+    """Plans the athlete may see: active-coach, non-archived (D-a)."""
+    return Plan.objects.for_athlete(user).exclude(status=Plan.Status.ARCHIVED)
+
+
+def _athlete_session_or_404(user, pk):
+    """A delivered session the athlete owns, or ``Http404``.
+
+    404 unless the session's week is delivered *and* its plan is one the athlete
+    reaches through an active coach link — a foreign athlete, an undelivered
+    week, an archived plan, or an unknown id are indistinguishable (no leak).
+    """
+    session = (
+        Session.objects.filter(
+            pk=pk,
+            week__delivered_at__isnull=False,
+            week__mesocycle__plan__in=_athlete_plans(user),
+        )
+        .select_related("week__mesocycle__plan__relationship")
+        .prefetch_related("prescriptions")
+        .first()
+    )
+    if session is None:
+        raise Http404("Unknown session")
+    return session
+
+
+class AthleteHomeView(LoginRequiredMixin, TemplateView):
+    """The athlete's training home: their delivered programs, this week."""
+
+    template_name = "meso/athlete_home.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx["active"] = "training"
+        ctx["plans"] = presenters.athlete_home(self.request.user)
+        ctx["athlete_name"] = self.request.user.display_name()
+        ctx["athlete_initials"] = presenters.initials(ctx["athlete_name"])
+        return ctx
+
+
+class AthleteSessionView(LoginRequiredMixin, TemplateView):
+    """One delivered session's prescribed plan, read-only (logging in Phase 2)."""
+
+    template_name = "meso/athlete_session.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        session = _athlete_session_or_404(self.request.user, kwargs["pk"])
+        ctx["active"] = "training"
+        ctx["session"] = presenters.athlete_session(session, self.request.user)
+        ctx["athlete_name"] = self.request.user.display_name()
+        ctx["athlete_initials"] = presenters.initials(ctx["athlete_name"])
         return ctx
 
 

--- a/app/store_project/templates/meso/_meso_base.html
+++ b/app/store_project/templates/meso/_meso_base.html
@@ -23,12 +23,14 @@
           <b>Meso</b>
         </a>
         <div class="meso-navlinks">
-          <a class="meso-navlink {% if active == 'roster' %}is-active{% endif %}" href="{% url 'meso:roster' %}">Roster</a>
-          <a class="meso-navlink {% if active == 'designer' %}is-active{% endif %}" href="{% url 'meso:designer' %}">Designer</a>
+          {% block navlinks %}
+            <a class="meso-navlink {% if active == 'roster' %}is-active{% endif %}" href="{% url 'meso:roster' %}">Roster</a>
+            <a class="meso-navlink {% if active == 'designer' %}is-active{% endif %}" href="{% url 'meso:designer' %}">Designer</a>
+          {% endblock %}
         </div>
         <div class="meso-spacer"></div>
         {% block topnav_actions %}{% endblock %}
-        <div class="meso-avatar meso-avatar--sm meso-avatar--accent" title="Coach">LG</div>
+        {% block topnav_avatar %}<div class="meso-avatar meso-avatar--sm meso-avatar--accent" title="Coach">LG</div>{% endblock %}
       </nav>
 
       {% block content %}{% endblock %}

--- a/app/store_project/templates/meso/athlete_home.html
+++ b/app/store_project/templates/meso/athlete_home.html
@@ -1,0 +1,58 @@
+{% extends "meso/_meso_base.html" %}
+
+{% block title %}Training · Meso{% endblock %}
+
+{% block navlinks %}
+  <a class="meso-navlink {% if active == 'training' %}is-active{% endif %}" href="{% url 'meso:athlete_home' %}">Training</a>
+{% endblock %}
+
+{% block topnav_avatar %}
+  <div class="meso-avatar meso-avatar--sm meso-avatar--accent" title="{{ athlete_name }}">{{ athlete_initials }}</div>
+{% endblock %}
+
+{% block content %}
+  <div class="meso-page">
+    <div class="meso-pagehead">
+      <div>
+        <p class="meso-eyebrow">Your training</p>
+        <h1 class="meso-h1">This week</h1>
+        <p class="meso-sub">What your coach delivered — tap a session to see the plan.</p>
+      </div>
+    </div>
+
+    {% for plan in plans %}
+      <div class="meso-card meso-card--pad" style="margin-bottom:14px;">
+        <div style="display:flex;align-items:baseline;gap:10px;margin-bottom:4px;flex-wrap:wrap;">
+          <span style="font-size:17px;font-weight:800;letter-spacing:-0.02em;">{{ plan.title }}</span>
+          {% if plan.block %}<span class="meso-row-meta">{{ plan.block }} · {{ plan.week }}</span>{% endif %}
+        </div>
+        <p class="meso-row-meta" style="margin-bottom:12px;">Coach {{ plan.coach }}{% if plan.goal %} · {{ plan.goal }}{% endif %}</p>
+
+        {% if plan.sessions %}
+          <div class="meso-flex" style="flex-direction:column;gap:8px;">
+            {% for s in plan.sessions %}
+              <a class="meso-row" href="{{ s.url }}" style="display:flex;align-items:center;gap:12px;padding:12px 14px;border:1px solid var(--line);border-radius:11px;text-decoration:none;color:inherit;">
+                <div class="meso-mono" style="font-size:12px;font-weight:700;color:var(--dim);">D{{ s.n }}</div>
+                <div style="flex:1;min-width:0;">
+                  <div style="font-size:14px;font-weight:700;letter-spacing:-0.01em;">{{ s.name }}{% if s.bias %} · {{ s.bias }}{% endif %}</div>
+                  <div class="meso-row-meta">{{ s.exercise_count }} exercise{{ s.exercise_count|pluralize }}</div>
+                </div>
+                {% if s.status == 'done' %}
+                  <span class="meso-badge meso-badge--ok">{{ s.status_label }}</span>
+                {% else %}
+                  <span class="meso-badge">{{ s.status_label }}</span>
+                {% endif %}
+              </a>
+            {% endfor %}
+          </div>
+        {% else %}
+          <p class="meso-row-meta">Nothing delivered yet — your coach is still building this week.</p>
+        {% endif %}
+      </div>
+    {% empty %}
+      <div class="meso-card meso-card--pad">
+        <p class="meso-row-meta">No active programs yet. Once a coach delivers a week, it shows up here.</p>
+      </div>
+    {% endfor %}
+  </div>
+{% endblock %}

--- a/app/store_project/templates/meso/athlete_session.html
+++ b/app/store_project/templates/meso/athlete_session.html
@@ -1,0 +1,59 @@
+{% extends "meso/_meso_base.html" %}
+
+{% block title %}{{ session.name }} · Meso{% endblock %}
+
+{% block navlinks %}
+  <a class="meso-navlink {% if active == 'training' %}is-active{% endif %}" href="{% url 'meso:athlete_home' %}">Training</a>
+{% endblock %}
+
+{% block topnav_avatar %}
+  <div class="meso-avatar meso-avatar--sm meso-avatar--accent" title="{{ athlete_name }}">{{ athlete_initials }}</div>
+{% endblock %}
+
+{% block content %}
+  <div class="meso-page">
+    <div class="meso-crumbs">
+      <a href="{% url 'meso:athlete_home' %}">Training</a> <span>/</span>
+      <span>{{ session.block }} · {{ session.week }}</span> <span>/</span> <span>{{ session.name }}</span>
+    </div>
+
+    <div class="meso-pagehead">
+      <div>
+        <p class="meso-eyebrow">Day {{ session.n }}{% if session.bias %} · {{ session.bias }}{% endif %}</p>
+        <h1 class="meso-h1">{{ session.name }}</h1>
+        <p class="meso-sub">{{ session.plan_title }}</p>
+      </div>
+      <div class="meso-spacer"></div>
+      {% if session.status == 'done' %}
+        <span class="meso-badge meso-badge--ok">{{ session.status_label }}</span>
+      {% else %}
+        <span class="meso-badge">{{ session.status_label }}</span>
+      {% endif %}
+    </div>
+
+    <div class="meso-card">
+      <div style="display:grid;grid-template-columns:minmax(0,2fr) 48px 64px minmax(0,1fr) 48px;gap:10px;padding:9px 18px;background:var(--rail);border-bottom:1px solid var(--line-2);font-size:10px;font-weight:700;letter-spacing:0.06em;text-transform:uppercase;color:var(--dim);">
+        <div>Exercise</div><div style="text-align:center;">Sets</div><div style="text-align:center;">Reps</div><div>Load</div><div style="text-align:center;">RPE</div>
+      </div>
+      {% for e in session.exercises %}
+        <div style="display:grid;grid-template-columns:minmax(0,2fr) 48px 64px minmax(0,1fr) 48px;gap:10px;padding:11px 18px;border-bottom:1px solid var(--line-2);align-items:center;">
+          <div style="font-size:13.5px;font-weight:600;letter-spacing:-0.01em;min-width:0;">
+            {{ e.name }}
+            {% if e.tag %}<span class="meso-badge meso-badge--ok" style="margin-left:6px;">{{ e.tag }}</span>{% endif %}
+            {% if e.note %}<div class="meso-row-meta">{{ e.note }}</div>{% endif %}
+          </div>
+          <div class="meso-mono" style="text-align:center;font-size:12px;">{{ e.sets|default:"—" }}</div>
+          <div class="meso-mono" style="text-align:center;font-size:12px;">{{ e.reps|default:"—" }}</div>
+          <div class="meso-mono" style="font-size:12px;">{{ e.load|default:"—" }}</div>
+          <div class="meso-mono" style="text-align:center;font-size:12px;">{{ e.rpe|default:"—" }}</div>
+        </div>
+      {% endfor %}
+    </div>
+
+    <div style="display:flex;align-items:center;gap:12px;margin-top:16px;">
+      <a class="meso-btn" href="{% url 'meso:athlete_home' %}">← Back to training</a>
+      <div class="meso-spacer"></div>
+      <span class="meso-row-meta">Logging arrives next — for now this is your delivered plan.</span>
+    </div>
+  </div>
+{% endblock %}

--- a/docs/meso/athlete-plan.md
+++ b/docs/meso/athlete-plan.md
@@ -1,6 +1,7 @@
 # Meso — athlete-facing slice plan
 
-**Status:** Phase 1 in progress · created 2026-06-27
+**Status:** Phase 1 built (branch `meso-athlete-phase1`; +20 tests, 239 meso /
+379 project-wide; ruff clean; local Codex review clean, 1 round) · created 2026-06-27
 **Companion to:** [`decisions.md`](./decisions.md) (B2, S3, S7, N1/D-a/D-b) ·
 [`persistence-plan.md`](./persistence-plan.md) · [`agent-plan.md`](./agent-plan.md)
 **Goal of this slice:** give the **athlete** a real, logged-in surface — see the
@@ -93,7 +94,7 @@ coach-who-is-also-an-athlete — keeps the roster.
 
 ## Phasing (one PR each)
 
-**Phase 1 — Athlete home + session (the read surface). ⏳ In progress.**
+**Phase 1 — Athlete home + session (the read surface). ✅ Built.**
 The athlete's own logged-in surface, read-only: `/meso/me/` lists their active
 plans with each plan's latest delivered week and its sessions (each marked
 done/pending from the athlete's `SessionLog`); `/meso/me/session/<id>/` shows one
@@ -103,6 +104,28 @@ no migration** (the logging models already exist).
 *Done when:* an athlete logs in, sees only the weeks their coach delivered (never
 another athlete's, never an undelivered week), and opens a session to read its
 prescription. The write path + results-feedback are later phases.
+
+*Built* (branch `meso-athlete-phase1`): `AthleteHomeView` (`/meso/me/`) and
+`AthleteSessionView` (`/meso/me/session/<id>/`), both `LoginRequired`, with the
+athlete-side scoping helpers `_athlete_plans` (active-coach + non-archived) and
+`_athlete_session_or_404` (delivered week + owned plan, else a flat 404).
+`serializers.latest_delivered_week` + `presenters.athlete_home`/`athlete_session`
+format the read shape (reusing `serialize_prescription`); log status reads only
+the athlete's own `SessionLog`. `_meso_base.html` gains overridable `navlinks` +
+`topnav_avatar` blocks so the athlete templates (`athlete_home.html`,
+`athlete_session.html`) carry their own nav while coach screens render
+identically; `RosterView` redirects a pure athlete (active link, no
+`CoachProfile`) to `/meso/me/`. Built red→green: +20 tests
+(`test_athlete_surface.py` — scoping, delivered-only, non-owner/undelivered/
+archived 404s, login guards, log-status, roster redirect); 239 meso / 379
+project-wide pass, no migration. **Local Codex review clean (1 round):** it
+flagged that "delivery is the publish gate" over-claimed (live rows are rendered,
+so post-delivery coach edits show through) — resolved by making the contract
+precise (delivery gates *visibility*; contents are live; the `WeekDelivery`
+snapshot is the deferred-diff record) rather than splitting live vs. snapshot,
+which would fight Phase 2 logging. See the **Design note** above. **Deferred:**
+the logging write path (Phase 2), results-feedback (Phase 3), PWA + notifications
+(Phase 4).
 
 **Phase 2 — Session logging (the write path).**
 The session screen becomes the interactive logger (the phone-style set rows):

--- a/docs/meso/athlete-plan.md
+++ b/docs/meso/athlete-plan.md
@@ -1,0 +1,131 @@
+# Meso — athlete-facing slice plan
+
+**Status:** Phase 1 in progress · created 2026-06-27
+**Companion to:** [`decisions.md`](./decisions.md) (B2, S3, S7, N1/D-a/D-b) ·
+[`persistence-plan.md`](./persistence-plan.md) · [`agent-plan.md`](./agent-plan.md)
+**Goal of this slice:** give the **athlete** a real, logged-in surface — see the
+plan their coach delivered, log the sessions they train — and feed those logs
+back into the coach's results screen and the agent's grounding. This is item 3
+in the [decisions.md suggested sequence](./decisions.md#suggested-sequence):
+*"Athlete delivery + logging — the athlete PWA surface, notifications, then
+results feeding back to the agent."*
+
+The coach side (persistence slice) and the agent (agent slice) are complete; the
+logging models (`SessionLog`/`LoggedSet`) and the delivery snapshot
+(`WeekDelivery`) already exist, and the agent already grounds on
+`serialize_recent_logs`. **There is no athlete-facing data yet** — every
+`SessionLog` is fabricated in tests. This slice produces the first real ones.
+
+### Decisions this rests on (see `decisions.md`)
+- **B2** — athletes are `User`s who log in; the surface is responsive web / an
+  installable PWA (native deferred). The coach can edit their plan; the athlete
+  gets **read + logging only**.
+- **N1 / D-a / D-b** — an athlete may have several coaches; plans are owned per
+  `CoachAthlete` relationship; contraindications are global to the athlete.
+  `Plan.objects.for_athlete(user)` already scopes to all the athlete's *active*
+  coaches.
+- **S3** — delivery & notifications (email via `django-ses` + `notifications`;
+  push needs the PWA). **S7** — offline logging (gym wifi is bad) wants a PWA.
+  Both land in the PWA phase.
+
+### What the athlete may see (the scoping contract)
+- Plans via `Plan.objects.for_athlete(user)` — i.e. across every **active**
+  coach link. A declined/ended/pending link shows nothing.
+- Within a plan, only **delivered** weeks (`Week.delivered_at` is set). A coach's
+  in-progress, undelivered week is invisible — delivery is the publish gate.
+- Logging writes only the athlete's own `SessionLog`/`LoggedSet` rows; an athlete
+  can never read or write another athlete's logs, nor any coach surface.
+
+---
+
+## Architecture
+
+The athlete surface lives at its own URL prefix, **`/meso/me/`**, distinct from
+the coach's view of an athlete (`/meso/athlete/<uuid>/`). It is server-rendered
+(htmx + Alpine, matching the rest of Meso); the logging interaction reuses the
+prototype's "phone" styling already inline in `designer.html`. The write path is
+a small JSON endpoint, mirroring the designer's autosave seam (no DRF).
+
+```
+/meso/me/                     AthleteHomeView   — the athlete's active plans, each
+                                                  with its latest delivered week +
+                                                  that week's sessions (done/pending)
+/meso/me/session/<id>/        AthleteSessionView — one delivered session, its
+                                                  prescribed exercises (Phase 1 read-only;
+                                                  Phase 2 logs sets)
+/meso/api/me/session/<id>/log/  athlete log endpoint (Phase 2)
+```
+
+Scoping helpers (athlete-side analogues of `_coach_plan_or_forbidden`):
+
+- `Plan.objects.for_athlete(user)` (exists) — the athlete's active-coach plans.
+- `_athlete_session_or_404(request, pk)` (new) — a `Session` whose
+  `week.mesocycle.plan` is in `for_athlete(user)` **and** whose week is
+  delivered; anything else (foreign athlete, undelivered week, unknown id) is a
+  flat 404. Never a silent empty render.
+
+Serializers/presenters reuse the coach-side ones where the shape matches
+(`serialize_session` already emits the prescribed grid) and add athlete-only
+read helpers (delivered weeks, per-session log status) rather than leaking coach
+fields (volume/intensity bars, agent adjustments) to the athlete.
+
+### Role-aware navigation
+`_meso_base.html`'s top nav is coach-only today (Roster / Designer, a hardcoded
+"LG" coach avatar). Phase 1 wraps the nav links + avatar in overridable blocks so
+the athlete templates supply their own ("Training" + the athlete's initials)
+while **coach screens render byte-identical** (the default block content is the
+existing markup). A *pure* athlete (no `CoachProfile`, but an active coach link)
+who lands on the coach roster is redirected to `/meso/me/`; a coach — or a
+coach-who-is-also-an-athlete — keeps the roster.
+
+---
+
+## Phasing (one PR each)
+
+**Phase 1 — Athlete home + session (the read surface). ⏳ In progress.**
+The athlete's own logged-in surface, read-only: `/meso/me/` lists their active
+plans with each plan's latest delivered week and its sessions (each marked
+done/pending from the athlete's `SessionLog`); `/meso/me/session/<id>/` shows one
+delivered session's prescribed exercises. Athlete-scoped serializers/presenters,
+role-aware nav, the roster→home redirect for pure athletes. **No logging writes,
+no migration** (the logging models already exist).
+*Done when:* an athlete logs in, sees only the weeks their coach delivered (never
+another athlete's, never an undelivered week), and opens a session to read its
+prescription. The write path + results-feedback are later phases.
+
+**Phase 2 — Session logging (the write path).**
+The session screen becomes the interactive logger (the phone-style set rows):
+`POST /meso/api/me/session/<id>/log/` upserts the athlete's `SessionLog` and its
+`LoggedSet` rows (reps/load/rpe per set), flips the session done, and stamps the
+date. Athlete-scoped (only the logged-in athlete's own logs; only delivered
+sessions). This produces the first real rows `serialize_recent_logs` grounds the
+agent on. *Done when:* an athlete logs a session and it survives reload — and the
+agent's grounding sees it.
+
+**Phase 3 — Results feed back (close the loop).**
+Retire `mockdata.RESULTS_*`: the coach's results screen reads real
+`SessionLog`/`LoggedSet` against the prescribed targets (completion, RPE vs
+target, flags), and the designer's `last`/`adj` fields light up from logs. The
+agent already consumes `recent_logs`; this surfaces the same truth to the coach.
+*Done when:* a logged session drives a real results screen and the designer's
+"last time" column, with no fixtures left on the coach side.
+
+**Phase 4 — PWA + delivery notifications (S3 / S7).**
+A web-app manifest + service worker (installable, offline-tolerant logging), and
+delivery notifications (email via `django-ses` + the `notifications` app; web
+push deferred). The coach's "Deliver to her app" becomes literally true.
+*Done when:* the athlete can install Meso, log with flaky wifi, and gets notified
+when a week is delivered.
+
+## Out of scope (later)
+Groups (S1, shared program + per-athlete override) · cross-coach scheduling
+collisions in the athlete app · native apps · the full "changes since last
+delivery" diff UI (the `WeekDelivery` snapshot is captured; the diff renders
+here or with the coach review surface).
+
+## Testing
+pytest + factory_boy. Priorities, mirroring the coach-side discipline:
+**scoping** (athlete A cannot see athlete B's sessions; a pending/ended coach
+link shows nothing; an undelivered week is invisible), **access control**
+(non-owned session → 404, login required), and (Phase 2) **log ownership**
+(an athlete writes only their own `SessionLog`).

--- a/docs/meso/athlete-plan.md
+++ b/docs/meso/athlete-plan.md
@@ -32,9 +32,20 @@ logging models (`SessionLog`/`LoggedSet`) and the delivery snapshot
 - Plans via `Plan.objects.for_athlete(user)` — i.e. across every **active**
   coach link. A declined/ended/pending link shows nothing.
 - Within a plan, only **delivered** weeks (`Week.delivered_at` is set). A coach's
-  in-progress, undelivered week is invisible — delivery is the publish gate.
+  in-progress, undelivered week is invisible — delivery is the *visibility* gate.
 - Logging writes only the athlete's own `SessionLog`/`LoggedSet` rows; an athlete
   can never read or write another athlete's logs, nor any coach surface.
+
+**Design note — live contents vs. the delivery snapshot.** Delivery gates whether
+a week is *visible* to the athlete, not whether its contents are *frozen*. Once a
+week is delivered, the athlete sees its **current (live)** sessions/prescriptions,
+so a coach correcting an already-delivered week is reflected immediately — the
+intended behaviour for a fix-in-place. The frozen `WeekDelivery.payload` snapshot
+is the historical record that powers the (deferred) "changes since last delivery"
+diff, *not* a second athlete-facing render. This deliberately avoids a live/snapshot
+split that would also fight Phase 2 logging (which targets live prescription rows).
+A stricter "re-deliver to publish edits" gate (e.g. flag a delivered week dirty on
+edit) is a later-slice option if coaches want edits staged rather than live.
 
 ---
 

--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -271,3 +271,19 @@ _(Append dated entries here as decisions land.)_
   clean, 1 round; +40 tests, 219 meso / 359 project-wide). **The B6 agent slice is complete.** Resume point
   → either a **persisted chat thread** (saving the designer conversation, deferred since Phase 3) or the
   **athlete-facing slice** (delivery + logging PWA, then results feeding back to the agent — decisions S3/S7).
+- 2026-06-27 — **Athlete-facing slice started** (decision: build item 3 of the suggested sequence — the
+  athlete surface — over the persisted chat thread). Plan + phasing in [`athlete-plan.md`](./athlete-plan.md)
+  (Phase 1 read surface · Phase 2 logging · Phase 3 results-feedback · Phase 4 PWA + notifications, S3/S7).
+  **Phase 1 built** (branch `meso-athlete-phase1`): the athlete's own read surface — `AthleteHomeView`
+  (`/meso/me/`) lists their active-coach, non-archived plans with each plan's latest **delivered** week +
+  sessions (done/pending from the athlete's own `SessionLog`); `AthleteSessionView` (`/meso/me/session/<id>/`)
+  renders one delivered session's prescribed grid read-only. Athlete-side scoping (`_athlete_plans` /
+  `_athlete_session_or_404`) mirrors the coach's `_coach_plan_or_forbidden`: out-of-scope (foreign athlete /
+  undelivered week / archived plan / unknown id) is a flat 404. Role-aware nav (overridable `navlinks` /
+  `topnav_avatar` blocks; pure athletes redirected off the coach roster). **No model change / no migration**
+  (`SessionLog`/`LoggedSet` already exist; B2 confirms athletes are Users who log in). Settles the **delivery
+  contract**: delivery gates a week's *visibility*, contents stay live, the `WeekDelivery` snapshot is the
+  deferred-diff record (Codex-review nit resolved this way — see `athlete-plan.md` design note). Built
+  red→green: +20 tests (239 meso / 379 project-wide); local Codex review clean (1 round). Resume point →
+  athlete Phase 2 (session logging — the write path that produces the rows `serialize_recent_logs` grounds
+  the agent on).


### PR DESCRIPTION
Starts the **athlete-facing slice** (item 3 of the [decisions.md suggested sequence](../blob/main/docs/meso/decisions.md#suggested-sequence) — chosen over the persisted chat thread). The coach side (persistence) and the agent (proposal engine + review gate + execution/eval) are complete; this gives the **athlete** their first real, logged-in surface.

## What this adds
- **`GET /meso/me/` — `AthleteHomeView`**: lists the athlete's non-archived, active-coach plans, each with its latest **delivered** week and that week's sessions, marked done/pending from the athlete's *own* `SessionLog`.
- **`GET /meso/me/session/<id>/` — `AthleteSessionView`**: one delivered session's prescribed grid, read-only.

## Scoping contract (athlete-side analogue of `_coach_plan_or_forbidden`)
- Plans via `Plan.objects.for_athlete` (active coaches only) + non-archived (`_athlete_plans`).
- Only **delivered** weeks are visible (`_athlete_session_or_404`); an out-of-scope session — foreign athlete, undelivered week, archived plan, unknown id — is a flat **404**, never a silent empty render.
- Log status reads only the athlete's own rows (another athlete's `done` log never flips your session).

## Chrome
`_meso_base.html` nav links + avatar move into overridable blocks so the athlete templates supply "Training" + the athlete's initials while **coach screens render byte-identical**. A *pure* athlete (active link, no `CoachProfile`) landing on the coach roster is redirected to `/meso/me/`; a coach (or coach-who-also-trains) keeps the roster.

## Delivery contract (resolved a Codex-review nit)
Delivery gates a week's **visibility**, not the immutability of its contents: the athlete sees the delivered week's *current* (live) sessions, so a coach's fix-in-place is reflected by design. The `WeekDelivery` snapshot stays the historical record for the deferred "changes since last delivery" diff — deliberately avoiding a live/snapshot split that would fight Phase 2 logging (which targets live prescription rows). See the design note in `docs/meso/athlete-plan.md`.

## Notes
- **No model changes / no migration** (`SessionLog`/`LoggedSet` already exist).
- Built **red→green**: +20 tests (`test_athlete_surface.py`) — 239 meso / 379 project-wide pass; `ruff` clean.
- **Local Codex review: clean** (1 round — the only finding, the delivery-gate wording, is resolved above).

## Out of scope (later phases — see `docs/meso/athlete-plan.md`)
Phase 2 session logging (the write path) · Phase 3 results feeding back to the coach + agent · Phase 4 PWA + delivery notifications (S3/S7).

https://claude.ai/code/session_015G62Gs7papVMJAfYqeExrN