### PR TITLE
Meso — mark athlete Phase 1 merged (PR #288) in planning docs

### DIFF
--- a/docs/meso/athlete-plan.md
+++ b/docs/meso/athlete-plan.md
@@ -1,7 +1,8 @@
 # Meso — athlete-facing slice plan
 
-**Status:** Phase 1 built (branch `meso-athlete-phase1`; +20 tests, 239 meso /
-379 project-wide; ruff clean; local Codex review clean, 1 round) · created 2026-06-27
+**Status:** Phase 1 done & merged (PR #288, squash `42bb805`; Django CI green,
+deployed to Hetzner — no migration; +20 tests, 239 meso / 379 project-wide;
+ruff clean; local Codex review clean, 1 round) · created 2026-06-27
 **Companion to:** [`decisions.md`](./decisions.md) (B2, S3, S7, N1/D-a/D-b) ·
 [`persistence-plan.md`](./persistence-plan.md) · [`agent-plan.md`](./agent-plan.md)
 **Goal of this slice:** give the **athlete** a real, logged-in surface — see the
@@ -94,7 +95,7 @@ coach-who-is-also-an-athlete — keeps the roster.
 
 ## Phasing (one PR each)
 
-**Phase 1 — Athlete home + session (the read surface). ✅ Built.**
+**Phase 1 — Athlete home + session (the read surface). ✅ Done & merged (2026-06-27, PR #288, squash `42bb805`; Django CI green, deployed to Hetzner — no migration; `/meso/me/` live, login-gated).**
 The athlete's own logged-in surface, read-only: `/meso/me/` lists their active
 plans with each plan's latest delivered week and its sessions (each marked
 done/pending from the athlete's `SessionLog`); `/meso/me/session/<id>/` shows one

--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -287,3 +287,6 @@ _(Append dated entries here as decisions land.)_
   red→green: +20 tests (239 meso / 379 project-wide); local Codex review clean (1 round). Resume point →
   athlete Phase 2 (session logging — the write path that produces the rows `serialize_recent_logs` grounds
   the agent on).
+- 2026-06-27 — **Athlete Phase 1 merged & deployed** (PR #288, squash `42bb805`; Django CI green, deployed
+  to Hetzner — **no migration**; `/meso/me/` + `/meso/me/session/<id>/` live and login-gated in prod). The
+  athlete read surface is live. Resume point → **athlete Phase 2** (session logging — the write path).


### PR DESCRIPTION
Docs-only follow-up (matches the per-phase convention, e.g. #287): marks the athlete read surface **merged & deployed**.

- `athlete-plan.md`: Phase 1 status → done & merged (PR #288, squash `42bb805`; Django CI green, deployed to Hetzner, no migration; `/meso/me/` live and login-gated).
- `decisions.md`: log entry for the merge + deploy. Resume point → **athlete Phase 2** (session logging — the write path).

No code change; Django CI is skipped on docs-only diffs.

https://claude.ai/code/session_015G62Gs7papVMJAfYqeExrN