### PR TITLE
Meso — athlete slice Phase 2: session logging (the write path)

### DIFF
--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -228,17 +228,20 @@ def _prescribed_set_count(sets_text):
         return 0
 
 
-def _set_rows(prescription, logged, *, default=3, cap=12):
+def _set_rows(prescription, logged, *, default=3, cap=12, hard_cap=60):
     """Pre-filled set-input rows for one prescription (Phase 2 logger).
 
     ``logged`` maps ``(prescription_id, set_number)`` to the athlete's own
     ``LoggedSet``. The row count is the prescribed sets (capped, or ``default``
-    when the cell is free-form), always widened to show every set the athlete
-    already logged so a reload never hides logged data.
+    when the cell is free-form), widened to show every set the athlete already
+    logged so a reload never hides logged data — but ``hard_cap`` bounds the
+    render unconditionally so a stray large ``set_number`` can never balloon the
+    page (the log endpoint also rejects set numbers above its own ceiling).
     """
     prescribed = _prescribed_set_count(prescription.sets) or default
     logged_numbers = [n for (pid, n) in logged if pid == prescription.pk]
     count = max(min(prescribed, cap), max(logged_numbers, default=0), 1)
+    count = min(count, hard_cap)
     rows = []
     for n in range(1, count + 1):
         s = logged.get((prescription.pk, n))

--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -216,16 +216,67 @@ def athlete_home(user):
     return cards
 
 
-def athlete_session(session, athlete):
-    """One delivered session's prescribed grid, for the athlete's read view.
+def _prescribed_set_count(sets_text):
+    """How many set rows a prescription's ``sets`` cell asks for, or 0.
 
-    ``session`` is already athlete-scoped + delivered by the view; this only
-    formats it (and reads the athlete's own done status). Prescriptions are
+    ``sets`` is free text — "3" is a plain count, but "3-4"/"AMRAP" aren't. We
+    only expand a plain integer; the caller falls back to a default otherwise.
+    """
+    try:
+        return max(int(str(sets_text).strip()), 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _set_rows(prescription, logged, *, default=3, cap=12):
+    """Pre-filled set-input rows for one prescription (Phase 2 logger).
+
+    ``logged`` maps ``(prescription_id, set_number)`` to the athlete's own
+    ``LoggedSet``. The row count is the prescribed sets (capped, or ``default``
+    when the cell is free-form), always widened to show every set the athlete
+    already logged so a reload never hides logged data.
+    """
+    prescribed = _prescribed_set_count(prescription.sets) or default
+    logged_numbers = [n for (pid, n) in logged if pid == prescription.pk]
+    count = max(min(prescribed, cap), max(logged_numbers, default=0), 1)
+    rows = []
+    for n in range(1, count + 1):
+        s = logged.get((prescription.pk, n))
+        rows.append(
+            {
+                "set_number": n,
+                "reps": s.reps if s else "",
+                "load": s.load if s else "",
+                "rpe": s.rpe if s else "",
+                "done": s is not None,
+            }
+        )
+    return rows
+
+
+def _target_label(prescription):
+    """The prescribed target shown above a logger's set rows, e.g. "3 × 6"."""
+    return f"{prescription.sets or '—'} × {prescription.reps or '—'}"
+
+
+def athlete_session(session, athlete):
+    """One delivered session as the athlete's interactive logger (Phase 2).
+
+    ``session`` is already athlete-scoped + delivered by the view; this formats
+    the prescribed grid into set-input rows, pre-filled from the athlete's own
+    most-recent ``SessionLog``, and reports its done status. Prescriptions are
     prefetched on the view query.
     """
-    done = SessionLog.objects.filter(
-        session=session, athlete=athlete, status=SessionLog.Status.DONE
-    ).exists()
+    log = (
+        SessionLog.objects.filter(session=session, athlete=athlete)
+        .order_by("-created_at")
+        .prefetch_related("sets")
+        .first()
+    )
+    logged = (
+        {(s.prescription_id, s.set_number): s for s in log.sets.all()} if log else {}
+    )
+    done = log is not None and log.status == SessionLog.Status.DONE
     week = session.week
     return {
         "id": session.pk,
@@ -237,5 +288,39 @@ def athlete_session(session, athlete):
         "block": week.mesocycle.name,
         "week": f"Wk {week.index}",
         "plan_title": week.mesocycle.plan.title,
-        "exercises": [serialize_prescription(p) for p in session.prescriptions.all()],
+        "notes": log.notes if log else "",
+        "log_url": reverse("meso:athlete_log_session", kwargs={"pk": session.pk}),
+        "exercises": [
+            {
+                **serialize_prescription(p),
+                "target": _target_label(p),
+                "set_rows": _set_rows(p, logged),
+            }
+            for p in session.prescriptions.all()
+        ],
+    }
+
+
+def athlete_log_payload(session_ctx):
+    """The JSON the Alpine logger hydrates from (and POSTs back).
+
+    A trimmed view of ``athlete_session``: just what the client needs to render
+    the set rows and submit them — the log URL, current status, and per-exercise
+    rows. Kept separate from the display dict so the template's ``json_script``
+    payload stays small and intentional.
+    """
+    return {
+        "log_url": session_ctx["log_url"],
+        "status": session_ctx["status"],
+        "exercises": [
+            {
+                "id": e["id"],
+                "name": e["name"],
+                "target": e["target"],
+                "note": e.get("note", ""),
+                "tag": e.get("tag", ""),
+                "set_rows": e["set_rows"],
+            }
+            for e in session_ctx["exercises"]
+        ],
     }

--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -258,8 +258,18 @@ def _set_rows(prescription, logged, *, default=3, cap=12, hard_cap=60):
 
 
 def _target_label(prescription):
-    """The prescribed target shown above a logger's set rows, e.g. "3 × 6"."""
-    return f"{prescription.sets or '—'} × {prescription.reps or '—'}"
+    """The prescribed target shown above a logger's set rows.
+
+    Carries the coach's full prescription — sets×reps plus load and RPE when set
+    — so the athlete sees what to aim for before entering what they did, e.g.
+    "3 × 6 · 70 · RPE 7".
+    """
+    parts = [f"{prescription.sets or '—'} × {prescription.reps or '—'}"]
+    if prescription.load:
+        parts.append(prescription.load)
+    if prescription.rpe:
+        parts.append(f"RPE {prescription.rpe}")
+    return " · ".join(parts)
 
 
 def athlete_session(session, athlete):

--- a/app/store_project/meso/serializers.py
+++ b/app/store_project/meso/serializers.py
@@ -135,6 +135,31 @@ def serialize_week_snapshot(week):
     }
 
 
+def serialize_session_log(log):
+    """The athlete's saved log for a session, in the shape the log endpoint returns.
+
+    Echoes back what was persisted (status/date/notes + the logged sets) so the
+    athlete's logger can confirm the write and the page can re-hydrate on reload.
+    """
+    return {
+        "id": log.pk,
+        "status": log.status,
+        "date": log.date.isoformat() if log.date else None,
+        "notes": log.notes,
+        "sets": [
+            {
+                "id": s.pk,
+                "prescription": s.prescription_id,
+                "set_number": s.set_number,
+                "reps": s.reps,
+                "load": s.load,
+                "rpe": s.rpe,
+            }
+            for s in log.sets.order_by("set_number")
+        ],
+    }
+
+
 def serialize_recent_logs(plan, *, limit=5, sets_cap=24):
     """A compact summary of the athlete's most recent logged sessions on this plan.
 

--- a/app/store_project/meso/tests/test_athlete_logging.py
+++ b/app/store_project/meso/tests/test_athlete_logging.py
@@ -416,6 +416,24 @@ class TestLogValidation:
         assert resp.status_code == 400
         assert SessionLog.objects.count() == 0
 
+    def test_duplicate_set_key_rejected(self, client):
+        """Two sets with the same (prescription, set_number) are ambiguous — 400."""
+        s = seed()
+        client.force_login(s.athlete)
+        resp = post(
+            client,
+            s.session,
+            {
+                "sets": [
+                    {"prescription": s.squat.pk, "set_number": 1, "reps": "6"},
+                    {"prescription": s.squat.pk, "set_number": 1, "reps": "5"},
+                ]
+            },
+        )
+        assert resp.status_code == 400
+        assert SessionLog.objects.count() == 0
+        assert LoggedSet.objects.count() == 0
+
 
 # -- ownership isolation ---------------------------------------------------
 
@@ -450,6 +468,19 @@ class TestLogOwnership:
         )
         mine = SessionLog.objects.get(session=s.session, athlete=s.athlete)
         assert mine.status == SessionLog.Status.DONE
+
+
+# -- the logger surfaces the prescribed target -----------------------------
+
+
+class TestLogPage:
+    def test_shows_prescribed_load_and_rpe(self, client):
+        """The athlete sees the coach's prescribed load/RPE before logging."""
+        s = seed()  # Box Squat is prescribed 3 × 6 · load 70 · RPE 7
+        client.force_login(s.athlete)
+        body = client.get(session_url(s.session)).content.decode()
+        assert "70" in body
+        assert "RPE 7" in body
 
 
 # -- closes the loop: logged rows survive reload + reach the agent ---------

--- a/app/store_project/meso/tests/test_athlete_logging.py
+++ b/app/store_project/meso/tests/test_athlete_logging.py
@@ -276,6 +276,28 @@ class TestLogWrite:
         log = SessionLog.objects.get(session=s.session, athlete=s.athlete)
         assert log.date == datetime.date(2026, 6, 20)
 
+    def test_relog_without_date_keeps_original_date(self, client):
+        """Editing a set later (no date sent) must not move the workout to today."""
+        s = seed()
+        client.force_login(s.athlete)
+        # Logged as having trained on the 20th...
+        post(
+            client,
+            s.session,
+            {
+                "date": "2026-06-20",
+                "sets": [{"prescription": s.squat.pk, "set_number": 1, "reps": "6"}],
+            },
+        )
+        # ...then a later edit that omits the date entirely.
+        post(
+            client,
+            s.session,
+            {"sets": [{"prescription": s.squat.pk, "set_number": 1, "reps": "5"}]},
+        )
+        log = SessionLog.objects.get(session=s.session, athlete=s.athlete)
+        assert log.date == datetime.date(2026, 6, 20)  # not today
+
     def test_saves_notes(self, client):
         s = seed()
         client.force_login(s.athlete)

--- a/app/store_project/meso/tests/test_athlete_logging.py
+++ b/app/store_project/meso/tests/test_athlete_logging.py
@@ -1,0 +1,497 @@
+"""Athlete slice Phase 2 — session logging (the write path).
+
+The athlete's delivered session screen becomes the interactive logger:
+``POST /meso/api/me/session/<id>/log/`` upserts the athlete's own ``SessionLog``
+and its ``LoggedSet`` rows (reps/load/rpe per set), flips the session done, and
+stamps the date. These are the first *real* logged rows — the ones
+``serialize_recent_logs`` grounds the agent on (every log before this slice was
+fabricated in tests).
+
+The tests pin the same discipline as the read surface (see
+``docs/meso/athlete-plan.md``): the endpoint is athlete-scoped (only the
+logged-in athlete, only a **delivered** session they own), every out-of-scope
+target is a flat 404, bad input is a 400 that writes nothing, and the write is
+idempotent (re-logging updates the same ``SessionLog`` rather than piling up
+rows). A final pair of tests confirms a logged session survives reload and
+reaches the agent's grounding.
+"""
+
+import datetime
+import json
+from types import SimpleNamespace
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+
+from store_project.meso.agent import service
+from store_project.meso.factories import CoachAthleteFactory
+from store_project.meso.factories import ExercisePrescriptionFactory
+from store_project.meso.factories import MesocycleFactory
+from store_project.meso.factories import PlanFactory
+from store_project.meso.factories import SessionFactory
+from store_project.meso.factories import WeekFactory
+from store_project.meso.models import CoachAthlete
+from store_project.meso.models import LoggedSet
+from store_project.meso.models import Plan
+from store_project.meso.models import SessionLog
+from store_project.meso.serializers import serialize_recent_logs
+from store_project.users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def seed(
+    *,
+    coach=None,
+    athlete=None,
+    delivered=True,
+    link_status=CoachAthlete.Status.ACTIVE,
+    plan_status=Plan.Status.ACTIVE,
+):
+    """A minimal plan → (optionally delivered) week → session → two prescriptions."""
+    coach = coach or UserFactory()
+    athlete = athlete or UserFactory()
+    rel = CoachAthleteFactory(coach=coach, athlete=athlete, status=link_status)
+    plan = PlanFactory(relationship=rel, title="Hypertrophy Block", status=plan_status)
+    meso = MesocycleFactory(plan=plan, name="Hypertrophy", order=0)
+    week = WeekFactory(
+        mesocycle=meso,
+        index=2,
+        is_current=True,
+        delivered_at=timezone.now() if delivered else None,
+    )
+    session = SessionFactory(week=week, day_number=1, name="Lower", bias="Quad")
+    squat = ExercisePrescriptionFactory(
+        session=session,
+        name="Box Squat",
+        order=0,
+        sets="3",
+        reps="6",
+        load="70",
+        rpe="7",
+    )
+    rdl = ExercisePrescriptionFactory(
+        session=session, name="RDL", order=1, sets="3", reps="8", load="80", rpe="8"
+    )
+    return SimpleNamespace(
+        coach=coach,
+        athlete=athlete,
+        rel=rel,
+        plan=plan,
+        meso=meso,
+        week=week,
+        session=session,
+        squat=squat,
+        rdl=rdl,
+    )
+
+
+def log_url(session):
+    return reverse("meso:athlete_log_session", kwargs={"pk": session.pk})
+
+
+def session_url(session):
+    return reverse("meso:athlete_session", kwargs={"pk": session.pk})
+
+
+def post(client, session, payload):
+    return client.post(
+        log_url(session),
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+
+
+# -- access control --------------------------------------------------------
+
+
+class TestLogAccessControl:
+    def test_requires_login(self, client):
+        s = seed()
+        resp = post(client, s.session, {"sets": []})
+        assert resp.status_code == 302
+        assert "/accounts/login/" in resp.url
+        assert SessionLog.objects.count() == 0
+
+    def test_get_not_allowed(self, client):
+        s = seed()
+        client.force_login(s.athlete)
+        assert client.get(log_url(s.session)).status_code == 405
+
+    def test_404_for_other_athlete(self, client):
+        s = seed()
+        intruder = seed().athlete
+        client.force_login(intruder)
+        resp = post(client, s.session, {"sets": []})
+        assert resp.status_code == 404
+        assert SessionLog.objects.count() == 0
+
+    def test_404_when_undelivered(self, client):
+        s = seed(delivered=False)
+        client.force_login(s.athlete)
+        assert post(client, s.session, {"sets": []}).status_code == 404
+        assert SessionLog.objects.count() == 0
+
+    def test_404_inactive_link(self, client):
+        s = seed(link_status=CoachAthlete.Status.ENDED)
+        client.force_login(s.athlete)
+        assert post(client, s.session, {"sets": []}).status_code == 404
+
+    def test_404_archived_plan(self, client):
+        s = seed(plan_status=Plan.Status.ARCHIVED)
+        client.force_login(s.athlete)
+        assert post(client, s.session, {"sets": []}).status_code == 404
+
+    def test_404_unknown_session(self, client):
+        s = seed()
+        client.force_login(s.athlete)
+        resp = client.post(
+            reverse("meso:athlete_log_session", kwargs={"pk": 999999}),
+            data=json.dumps({"sets": []}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 404
+
+
+# -- write semantics -------------------------------------------------------
+
+
+class TestLogWrite:
+    def test_logs_sets_creates_done_log(self, client):
+        s = seed()
+        client.force_login(s.athlete)
+        resp = post(
+            client,
+            s.session,
+            {
+                "sets": [
+                    {
+                        "prescription": s.squat.pk,
+                        "set_number": 1,
+                        "reps": "6",
+                        "load": "72.5",
+                        "rpe": "8",
+                    },
+                    {
+                        "prescription": s.squat.pk,
+                        "set_number": 2,
+                        "reps": "6",
+                        "load": "72.5",
+                        "rpe": "8.5",
+                    },
+                ]
+            },
+        )
+        assert resp.status_code == 200
+        log = SessionLog.objects.get(session=s.session, athlete=s.athlete)
+        assert log.status == SessionLog.Status.DONE
+        # Logging stamps today's date when none is given.
+        assert log.date == timezone.localdate()
+        sets = list(log.sets.order_by("set_number"))
+        assert len(sets) == 2
+        assert sets[0].prescription_id == s.squat.pk
+        assert sets[0].reps == "6"
+        assert sets[0].load == "72.5"
+        assert sets[1].rpe == "8.5"
+
+    def test_response_echoes_saved_log(self, client):
+        s = seed()
+        client.force_login(s.athlete)
+        resp = post(
+            client,
+            s.session,
+            {
+                "sets": [
+                    {
+                        "prescription": s.squat.pk,
+                        "set_number": 1,
+                        "reps": "5",
+                        "load": "100",
+                        "rpe": "9",
+                    }
+                ]
+            },
+        )
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["log"]["status"] == "done"
+        assert data["log"]["sets"][0]["load"] == "100"
+        assert data["log"]["sets"][0]["prescription"] == s.squat.pk
+
+    def test_relog_updates_same_log(self, client):
+        """Re-logging the same session updates the one log — no duplicate rows."""
+        s = seed()
+        client.force_login(s.athlete)
+        post(
+            client,
+            s.session,
+            {
+                "sets": [
+                    {
+                        "prescription": s.squat.pk,
+                        "set_number": 1,
+                        "reps": "6",
+                        "load": "70",
+                        "rpe": "7",
+                    }
+                ]
+            },
+        )
+        post(
+            client,
+            s.session,
+            {
+                "sets": [
+                    {
+                        "prescription": s.squat.pk,
+                        "set_number": 1,
+                        "reps": "6",
+                        "load": "80",
+                        "rpe": "9",
+                    }
+                ]
+            },
+        )
+        assert (
+            SessionLog.objects.filter(session=s.session, athlete=s.athlete).count() == 1
+        )
+        log = SessionLog.objects.get(session=s.session, athlete=s.athlete)
+        sets = list(log.sets.all())
+        # The old set row is replaced, not appended.
+        assert len(sets) == 1
+        assert sets[0].load == "80"
+
+    def test_accepts_explicit_status_pending(self, client):
+        s = seed()
+        client.force_login(s.athlete)
+        post(client, s.session, {"status": "pending", "sets": []})
+        log = SessionLog.objects.get(session=s.session, athlete=s.athlete)
+        assert log.status == SessionLog.Status.PENDING
+
+    def test_accepts_explicit_date(self, client):
+        s = seed()
+        client.force_login(s.athlete)
+        post(client, s.session, {"date": "2026-06-20", "sets": []})
+        log = SessionLog.objects.get(session=s.session, athlete=s.athlete)
+        assert log.date == datetime.date(2026, 6, 20)
+
+    def test_saves_notes(self, client):
+        s = seed()
+        client.force_login(s.athlete)
+        post(client, s.session, {"notes": "Knee felt great.", "sets": []})
+        log = SessionLog.objects.get(session=s.session, athlete=s.athlete)
+        assert log.notes == "Knee felt great."
+
+    def test_empty_sets_marks_done(self, client):
+        """An athlete can mark a session done without logging every set."""
+        s = seed()
+        client.force_login(s.athlete)
+        resp = post(client, s.session, {"sets": []})
+        assert resp.status_code == 200
+        log = SessionLog.objects.get(session=s.session, athlete=s.athlete)
+        assert log.status == SessionLog.Status.DONE
+        assert log.sets.count() == 0
+
+
+# -- validation ------------------------------------------------------------
+
+
+class TestLogValidation:
+    def test_malformed_json(self, client):
+        s = seed()
+        client.force_login(s.athlete)
+        resp = client.post(
+            log_url(s.session), data="not json", content_type="application/json"
+        )
+        assert resp.status_code == 400
+        assert SessionLog.objects.count() == 0
+
+    def test_non_dict_body(self, client):
+        s = seed()
+        client.force_login(s.athlete)
+        resp = client.post(
+            log_url(s.session), data="[1,2,3]", content_type="application/json"
+        )
+        assert resp.status_code == 400
+
+    def test_sets_must_be_list(self, client):
+        s = seed()
+        client.force_login(s.athlete)
+        assert post(client, s.session, {"sets": {"nope": 1}}).status_code == 400
+
+    def test_set_must_be_object(self, client):
+        s = seed()
+        client.force_login(s.athlete)
+        assert post(client, s.session, {"sets": ["nope"]}).status_code == 400
+        assert SessionLog.objects.count() == 0
+
+    def test_bad_status(self, client):
+        s = seed()
+        client.force_login(s.athlete)
+        assert post(client, s.session, {"status": "wat", "sets": []}).status_code == 400
+
+    def test_bad_date(self, client):
+        s = seed()
+        client.force_login(s.athlete)
+        assert (
+            post(client, s.session, {"date": "not-a-date", "sets": []}).status_code
+            == 400
+        )
+
+    def test_foreign_prescription_rejected(self, client):
+        """A set pointing at a prescription from another session is a 400 — no write."""
+        s = seed()
+        other = seed()  # an unrelated plan/session/prescription
+        client.force_login(s.athlete)
+        resp = post(
+            client,
+            s.session,
+            {"sets": [{"prescription": other.squat.pk, "set_number": 1, "reps": "5"}]},
+        )
+        assert resp.status_code == 400
+        assert SessionLog.objects.count() == 0
+        assert LoggedSet.objects.count() == 0
+
+    def test_missing_prescription_rejected(self, client):
+        s = seed()
+        client.force_login(s.athlete)
+        assert (
+            post(
+                client, s.session, {"sets": [{"set_number": 1, "reps": "5"}]}
+            ).status_code
+            == 400
+        )
+
+    def test_non_int_prescription_rejected(self, client):
+        s = seed()
+        client.force_login(s.athlete)
+        resp = post(client, s.session, {"sets": [{"prescription": "x", "reps": "5"}]})
+        assert resp.status_code == 400
+
+    def test_non_string_field_rejected(self, client):
+        s = seed()
+        client.force_login(s.athlete)
+        resp = post(
+            client,
+            s.session,
+            {
+                "sets": [{"prescription": s.squat.pk, "reps": 5}]
+            },  # reps must be a string
+        )
+        assert resp.status_code == 400
+        assert SessionLog.objects.count() == 0
+
+    def test_overlong_field_rejected(self, client):
+        s = seed()
+        client.force_login(s.athlete)
+        resp = post(
+            client,
+            s.session,
+            {
+                "sets": [{"prescription": s.squat.pk, "load": "x" * 40}]
+            },  # load max_length 32
+        )
+        assert resp.status_code == 400
+
+    def test_bad_set_number_rejected(self, client):
+        s = seed()
+        client.force_login(s.athlete)
+        resp = post(
+            client,
+            s.session,
+            {"sets": [{"prescription": s.squat.pk, "set_number": 0, "reps": "5"}]},
+        )
+        assert resp.status_code == 400
+
+
+# -- ownership isolation ---------------------------------------------------
+
+
+class TestLogOwnership:
+    def test_logging_does_not_touch_another_athletes_log(self, client):
+        s = seed()
+        other = UserFactory()
+        # A pre-existing log on the *same* session belonging to a different athlete.
+        SessionLog.objects.create(
+            session=s.session, athlete=other, status=SessionLog.Status.PENDING
+        )
+        client.force_login(s.athlete)
+        post(
+            client,
+            s.session,
+            {
+                "sets": [
+                    {
+                        "prescription": s.squat.pk,
+                        "set_number": 1,
+                        "reps": "5",
+                        "load": "100",
+                    }
+                ]
+            },
+        )
+        # The other athlete's log is untouched; mine is separate and done.
+        assert SessionLog.objects.filter(session=s.session, athlete=other).count() == 1
+        assert SessionLog.objects.get(session=s.session, athlete=other).status == (
+            SessionLog.Status.PENDING
+        )
+        mine = SessionLog.objects.get(session=s.session, athlete=s.athlete)
+        assert mine.status == SessionLog.Status.DONE
+
+
+# -- closes the loop: logged rows survive reload + reach the agent ---------
+
+
+class TestLogFeedsBack:
+    def test_logged_session_survives_reload(self, client):
+        s = seed()
+        client.force_login(s.athlete)
+        post(
+            client,
+            s.session,
+            {
+                "sets": [
+                    {
+                        "prescription": s.squat.pk,
+                        "set_number": 1,
+                        "reps": "6",
+                        "load": "92.5",
+                        "rpe": "8",
+                    }
+                ]
+            },
+        )
+        # Reloading the session screen reflects what was logged.
+        body = client.get(session_url(s.session)).content.decode()
+        assert "92.5" in body
+        # And the session now reads as logged.
+        assert "Logged" in body
+
+    def test_logged_session_grounds_the_agent(self, client):
+        s = seed()
+        client.force_login(s.athlete)
+        post(
+            client,
+            s.session,
+            {
+                "sets": [
+                    {
+                        "prescription": s.squat.pk,
+                        "set_number": 1,
+                        "reps": "5",
+                        "load": "105",
+                        "rpe": "9",
+                    }
+                ]
+            },
+        )
+        # The very rows the agent's grounding reads (serialize_recent_logs).
+        recent = serialize_recent_logs(s.plan)
+        assert len(recent) == 1
+        assert recent[0]["status"] == "done"
+        assert recent[0]["sets"][0]["exercise"] == "Box Squat"
+        assert recent[0]["sets"][0]["load"] == "105"
+        # And through the agent's context builder.
+        context = service.build_context(s.plan)
+        assert context["recent_logs"][0]["sets"][0]["load"] == "105"

--- a/app/store_project/meso/tests/test_athlete_logging.py
+++ b/app/store_project/meso/tests/test_athlete_logging.py
@@ -404,6 +404,18 @@ class TestLogValidation:
         )
         assert resp.status_code == 400
 
+    def test_excessive_set_number_rejected(self, client):
+        """A wild set_number can't be stored — it would balloon the next render."""
+        s = seed()
+        client.force_login(s.athlete)
+        resp = post(
+            client,
+            s.session,
+            {"sets": [{"prescription": s.squat.pk, "set_number": 10_000, "reps": "5"}]},
+        )
+        assert resp.status_code == 400
+        assert SessionLog.objects.count() == 0
+
 
 # -- ownership isolation ---------------------------------------------------
 

--- a/app/store_project/meso/urls.py
+++ b/app/store_project/meso/urls.py
@@ -32,6 +32,11 @@ urlpatterns = [
         AthleteSessionView.as_view(),
         name="athlete_session",
     ),
+    path(
+        "api/me/session/<int:pk>/log/",
+        views.athlete_log_session,
+        name="athlete_log_session",
+    ),
     path("athlete/<uuid:pk>/", AthleteProfileView.as_view(), name="athlete"),
     path("invite/<uuid:token>/accept/", views.invite_accept, name="invite_accept"),
     path("invite/<uuid:token>/decline/", views.invite_decline, name="invite_decline"),

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -231,6 +231,10 @@ class AthleteSessionView(LoginRequiredMixin, TemplateView):
 
 # Free-form text cells per logged set, mapped to their model ``max_length``.
 LOG_SET_FIELDS = {"reps": 32, "load": 32, "rpe": 32}
+# A generous ceiling on a set's number — no real session has this many sets, and
+# bounding it here stops a malformed client from storing an enormous ``set_number``
+# that would later balloon the session page's set-row render (presenters._set_rows).
+MAX_LOGGED_SET_NUMBER = 50
 
 
 @login_required
@@ -337,10 +341,10 @@ def _clean_logged_sets(raw_sets, session):
         if (
             not isinstance(set_number, int)
             or isinstance(set_number, bool)
-            or set_number < 1
+            or not 1 <= set_number <= MAX_LOGGED_SET_NUMBER
         ):
             return None, HttpResponseBadRequest(
-                "set_number must be a positive integer."
+                f"set_number must be between 1 and {MAX_LOGGED_SET_NUMBER}."
             )
         fields = {}
         for field, max_length in LOG_SET_FIELDS.items():

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -324,6 +324,7 @@ def _clean_logged_sets(raw_sets, session):
         return None, HttpResponseBadRequest("sets must be a list.")
     allowed_ids = {p.pk for p in session.prescriptions.all()}
     cleaned = []
+    seen = set()
     for position, raw in enumerate(raw_sets, start=1):
         if not isinstance(raw, dict):
             return None, HttpResponseBadRequest("Each set must be an object.")
@@ -346,6 +347,15 @@ def _clean_logged_sets(raw_sets, session):
             return None, HttpResponseBadRequest(
                 f"set_number must be between 1 and {MAX_LOGGED_SET_NUMBER}."
             )
+        # Each (prescription, set_number) is logged at most once — duplicates
+        # would persist as two rows that the presenter collapses on reload but
+        # the agent's grounding still double-counts, breaking idempotency.
+        key = (presc_id, set_number)
+        if key in seen:
+            return None, HttpResponseBadRequest(
+                "Duplicate set for the same prescription and set number."
+            )
+        seen.add(key)
         fields = {}
         for field, max_length in LOG_SET_FIELDS.items():
             value = raw.get(field, "")

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -264,16 +264,20 @@ def athlete_log_session(request, pk):
     if status not in (SessionLog.Status.PENDING, SessionLog.Status.DONE):
         return HttpResponseBadRequest("status must be 'pending' or 'done'.")
 
+    # An explicit date is honored; a missing one defaults to today only when
+    # *creating* the log — re-saving an existing log without a date keeps its
+    # original date so editing a set days later doesn't move the workout (which
+    # would reorder recent-log grounding). ``explicit_date`` is None when none
+    # was sent.
     raw_date = payload.get("date")
-    if raw_date in (None, ""):
-        log_date = timezone.localdate()
-    elif isinstance(raw_date, str):
+    explicit_date = None
+    if raw_date not in (None, ""):
+        if not isinstance(raw_date, str):
+            return HttpResponseBadRequest("date must be an ISO date string.")
         try:
-            log_date = datetime.date.fromisoformat(raw_date)
+            explicit_date = datetime.date.fromisoformat(raw_date)
         except ValueError:
             return HttpResponseBadRequest("date must be an ISO date (YYYY-MM-DD).")
-    else:
-        return HttpResponseBadRequest("date must be an ISO date string.")
 
     notes = payload.get("notes", "")
     if not isinstance(notes, str):
@@ -292,7 +296,11 @@ def athlete_log_session(request, pk):
         if log is None:
             log = SessionLog(session=session, athlete=request.user)
         log.status = status
-        log.date = log_date
+        if explicit_date is not None:
+            log.date = explicit_date
+        elif log.date is None:  # first save (or a log never dated) → stamp today
+            log.date = timezone.localdate()
+        # else: a re-save with no date keeps the existing workout date.
         log.notes = notes
         log.save()
         log.sets.all().delete()

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -1,8 +1,10 @@
+import datetime
 import json
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.db import transaction
 from django.db.models import Max
 from django.http import Http404
 from django.http import HttpResponseBadRequest
@@ -26,14 +28,17 @@ from .models import AgentProposalBatch
 from .models import CoachAthlete
 from .models import CoachProfile
 from .models import ExercisePrescription
+from .models import LoggedSet
 from .models import Plan
 from .models import ProposedChange
 from .models import Session
+from .models import SessionLog
 from .models import WeekDelivery
 from .serializers import current_week
 from .serializers import serialize_plan
 from .serializers import serialize_prescription
 from .serializers import serialize_proposed_change
+from .serializers import serialize_session_log
 from .serializers import serialize_week_snapshot
 
 
@@ -203,18 +208,152 @@ class AthleteHomeView(LoginRequiredMixin, TemplateView):
 
 
 class AthleteSessionView(LoginRequiredMixin, TemplateView):
-    """One delivered session's prescribed plan, read-only (logging in Phase 2)."""
+    """One delivered session — the athlete's interactive logger (Phase 2).
+
+    Renders the prescribed grid as set-input rows pre-filled from the athlete's
+    own existing log, and injects ``log_data`` for the Alpine logger to hydrate
+    from and POST back to ``athlete_log_session``.
+    """
 
     template_name = "meso/athlete_session.html"
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         session = _athlete_session_or_404(self.request.user, kwargs["pk"])
+        sess = presenters.athlete_session(session, self.request.user)
         ctx["active"] = "training"
-        ctx["session"] = presenters.athlete_session(session, self.request.user)
+        ctx["session"] = sess
+        ctx["log_data"] = presenters.athlete_log_payload(sess)
         ctx["athlete_name"] = self.request.user.display_name()
         ctx["athlete_initials"] = presenters.initials(ctx["athlete_name"])
         return ctx
+
+
+# Free-form text cells per logged set, mapped to their model ``max_length``.
+LOG_SET_FIELDS = {"reps": 32, "load": 32, "rpe": 32}
+
+
+@login_required
+@require_POST
+def athlete_log_session(request, pk):
+    """Upsert the athlete's log for a delivered session they own (Phase 2).
+
+    Replaces the athlete's own ``SessionLog`` + ``LoggedSet`` rows for this
+    session with the posted state, flips the session done (unless an explicit
+    ``status`` says otherwise), and stamps the date (today when none is given).
+    Scoped by ``_athlete_session_or_404`` — a foreign, undelivered, archived, or
+    unknown session is a flat 404, never a silent write. The body is fully
+    validated *before* any write, so a bad request is a 400 that persists
+    nothing; the write itself is idempotent (re-logging updates the one log,
+    replacing its set rows rather than appending). These are the first real rows
+    ``serialize_recent_logs`` grounds the agent on.
+    """
+    session = _athlete_session_or_404(request.user, pk)
+    try:
+        payload = json.loads(request.body or "{}")
+    except json.JSONDecodeError:
+        return HttpResponseBadRequest("Malformed JSON.")
+    if not isinstance(payload, dict):
+        return HttpResponseBadRequest("Expected a JSON object.")
+
+    status = payload.get("status", SessionLog.Status.DONE)
+    if status not in (SessionLog.Status.PENDING, SessionLog.Status.DONE):
+        return HttpResponseBadRequest("status must be 'pending' or 'done'.")
+
+    raw_date = payload.get("date")
+    if raw_date in (None, ""):
+        log_date = timezone.localdate()
+    elif isinstance(raw_date, str):
+        try:
+            log_date = datetime.date.fromisoformat(raw_date)
+        except ValueError:
+            return HttpResponseBadRequest("date must be an ISO date (YYYY-MM-DD).")
+    else:
+        return HttpResponseBadRequest("date must be an ISO date string.")
+
+    notes = payload.get("notes", "")
+    if not isinstance(notes, str):
+        return HttpResponseBadRequest("notes must be a string.")
+
+    cleaned_sets, error = _clean_logged_sets(payload.get("sets", []), session)
+    if error is not None:
+        return error
+
+    with transaction.atomic():
+        log = (
+            SessionLog.objects.filter(session=session, athlete=request.user)
+            .order_by("-created_at")
+            .first()
+        )
+        if log is None:
+            log = SessionLog(session=session, athlete=request.user)
+        log.status = status
+        log.date = log_date
+        log.notes = notes
+        log.save()
+        log.sets.all().delete()
+        LoggedSet.objects.bulk_create(
+            [
+                LoggedSet(
+                    session_log=log,
+                    prescription_id=cs["prescription_id"],
+                    set_number=cs["set_number"],
+                    reps=cs["reps"],
+                    load=cs["load"],
+                    rpe=cs["rpe"],
+                )
+                for cs in cleaned_sets
+            ]
+        )
+    return JsonResponse({"ok": True, "log": serialize_session_log(log)})
+
+
+def _clean_logged_sets(raw_sets, session):
+    """Validate the posted ``sets`` against this session, or return a 400.
+
+    Returns ``(cleaned, None)`` on success or ``(None, HttpResponseBadRequest)``.
+    Every set must reference a prescription **in this session** (no foreign rows),
+    carry a positive integer ``set_number`` (defaulting to its position), and have
+    string reps/load/rpe within the model's ``max_length``.
+    """
+    if not isinstance(raw_sets, list):
+        return None, HttpResponseBadRequest("sets must be a list.")
+    allowed_ids = {p.pk for p in session.prescriptions.all()}
+    cleaned = []
+    for position, raw in enumerate(raw_sets, start=1):
+        if not isinstance(raw, dict):
+            return None, HttpResponseBadRequest("Each set must be an object.")
+        presc_id = raw.get("prescription")
+        # ``bool`` is an ``int`` subclass — reject it explicitly so ``true`` isn't an id.
+        if (
+            not isinstance(presc_id, int)
+            or isinstance(presc_id, bool)
+            or presc_id not in allowed_ids
+        ):
+            return None, HttpResponseBadRequest(
+                "Each set must reference a prescription in this session."
+            )
+        set_number = raw.get("set_number", position)
+        if (
+            not isinstance(set_number, int)
+            or isinstance(set_number, bool)
+            or set_number < 1
+        ):
+            return None, HttpResponseBadRequest(
+                "set_number must be a positive integer."
+            )
+        fields = {}
+        for field, max_length in LOG_SET_FIELDS.items():
+            value = raw.get(field, "")
+            if not isinstance(value, str):
+                return None, HttpResponseBadRequest(f"{field} must be a string.")
+            if len(value) > max_length:
+                return None, HttpResponseBadRequest(f"{field} is too long.")
+            fields[field] = value
+        cleaned.append(
+            {"prescription_id": presc_id, "set_number": set_number, **fields}
+        )
+    return cleaned, None
 
 
 # -- invite / relationship actions ----------------------------------------

--- a/app/store_project/static/css/meso.css
+++ b/app/store_project/static/css/meso.css
@@ -43,6 +43,11 @@ body.meso {
   --ok: #2f8f56;
 }
 
+/* Hide Alpine-managed elements until Alpine initializes (avoids a flash). */
+[x-cloak] {
+  display: none !important;
+}
+
 .meso input,
 .meso textarea {
   font-family: inherit;

--- a/app/store_project/static/js/meso_athlete.js
+++ b/app/store_project/static/js/meso_athlete.js
@@ -99,6 +99,7 @@ document.addEventListener("alpine:init", () => {
         if (!res.ok) throw new Error("Request failed: " + res.status);
         const data = await res.json();
         this.status = data.log.status;
+        this.syncFromLog(data.log);
         this.saved = true;
         setTimeout(() => {
           this.saved = false;
@@ -108,6 +109,21 @@ document.addEventListener("alpine:init", () => {
         this.error = true;
       } finally {
         this.saving = false;
+      }
+    },
+
+    // Reconcile the rows with what the server actually persisted so the check
+    // circles and counter match the saved log immediately — without this, rows
+    // that were sent because they carried data (but were never ticked) would
+    // stay un-checked until a reload. The returned log is the source of truth.
+    syncFromLog(log) {
+      const saved = new Set(
+        (log.sets || []).map((s) => `${s.prescription}:${s.set_number}`),
+      );
+      for (const e of this.exercises) {
+        for (const r of e.set_rows) {
+          r.done = saved.has(`${e.id}:${r.set_number}`);
+        }
       }
     },
   }));

--- a/app/store_project/static/js/meso_athlete.js
+++ b/app/store_project/static/js/meso_athlete.js
@@ -74,7 +74,10 @@ document.addEventListener("alpine:init", () => {
           });
         }
       }
-      return { status: markDone ? "done" : "pending", sets };
+      // "Log session" completes the session; "Save progress" keeps the current
+      // status, so saving edits to an already-logged session never downgrades it
+      // back to "To do".
+      return { status: markDone ? "done" : this.status, sets };
     },
 
     // POST the session. `markDone` flips it to "done" (Log session) vs "pending"

--- a/app/store_project/static/js/meso_athlete.js
+++ b/app/store_project/static/js/meso_athlete.js
@@ -1,0 +1,111 @@
+/* Meso — athlete session logger (athlete slice Phase 2).
+ *
+ * The athlete's delivered-session screen. init() hydrates the set rows from the
+ * injected `meso-log-data` (pre-filled from the athlete's own existing log), the
+ * athlete fills reps/load/rpe and checks sets off, and save() POSTs the whole
+ * session to the log endpoint (api/me/session/<id>/log/). The write is idempotent
+ * — re-saving updates the one log — so "Save progress" and "Log session" hit the
+ * same endpoint, differing only in the status they stamp (pending vs done).
+ */
+document.addEventListener("alpine:init", () => {
+  Alpine.data("logger", () => ({
+    logUrl: "",
+    csrf: "",
+    status: "pending",
+    exercises: [],
+    saving: false,
+    saved: false,
+    error: false,
+
+    init() {
+      const el = document.getElementById("meso-log-data");
+      if (!el) return; // nothing injected → inert (the page renders its fallback)
+      let data;
+      try {
+        data = JSON.parse(el.textContent);
+      } catch (e) {
+        console.error("Could not parse log data", e);
+        return;
+      }
+      this.logUrl = data.log_url;
+      this.status = data.status;
+      this.exercises = data.exercises || [];
+      const csrfEl = document.getElementById("meso-csrf");
+      this.csrf = csrfEl ? csrfEl.dataset.token : "";
+    },
+
+    // ---- derived progress ----
+    get totalSets() {
+      return this.exercises.reduce((acc, e) => acc + e.set_rows.length, 0);
+    },
+    get doneSets() {
+      return this.exercises.reduce(
+        (acc, e) => acc + e.set_rows.filter((r) => r.done).length,
+        0,
+      );
+    },
+
+    toggle(row) {
+      row.done = !row.done;
+    },
+
+    // A row is worth sending if it's checked or carries any entry.
+    rowFilled(r) {
+      return (
+        r.done ||
+        (r.reps || "") !== "" ||
+        (r.load || "") !== "" ||
+        (r.rpe || "") !== ""
+      );
+    },
+
+    // Collect the filled rows into the endpoint's payload shape.
+    buildPayload(markDone) {
+      const sets = [];
+      for (const e of this.exercises) {
+        for (const r of e.set_rows) {
+          if (!this.rowFilled(r)) continue;
+          sets.push({
+            prescription: e.id,
+            set_number: r.set_number,
+            reps: r.reps || "",
+            load: r.load || "",
+            rpe: r.rpe || "",
+          });
+        }
+      }
+      return { status: markDone ? "done" : "pending", sets };
+    },
+
+    // POST the session. `markDone` flips it to "done" (Log session) vs "pending"
+    // (Save progress); both upsert the same log.
+    async save(markDone) {
+      if (this.saving || !this.logUrl) return;
+      this.saving = true;
+      this.saved = false;
+      this.error = false;
+      try {
+        const res = await fetch(this.logUrl, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-CSRFToken": this.csrf,
+          },
+          body: JSON.stringify(this.buildPayload(markDone)),
+        });
+        if (!res.ok) throw new Error("Request failed: " + res.status);
+        const data = await res.json();
+        this.status = data.log.status;
+        this.saved = true;
+        setTimeout(() => {
+          this.saved = false;
+        }, 2400);
+      } catch (err) {
+        console.error("Log save failed", err);
+        this.error = true;
+      } finally {
+        this.saving = false;
+      }
+    },
+  }));
+});

--- a/app/store_project/templates/meso/athlete_session.html
+++ b/app/store_project/templates/meso/athlete_session.html
@@ -1,6 +1,12 @@
 {% extends "meso/_meso_base.html" %}
+{% load static %}
 
 {% block title %}{{ session.name }} · Meso{% endblock %}
+
+{% block head_extra %}
+  <script defer src="{% static 'js/meso_athlete.js' %}"></script>
+  <script defer src="{% static 'js/alpine.min.js' %}"></script>
+{% endblock %}
 
 {% block navlinks %}
   <a class="meso-navlink {% if active == 'training' %}is-active{% endif %}" href="{% url 'meso:athlete_home' %}">Training</a>
@@ -11,7 +17,9 @@
 {% endblock %}
 
 {% block content %}
-  <div class="meso-page">
+  {{ log_data|json_script:"meso-log-data" }}
+  <span id="meso-csrf" data-token="{{ csrf_token }}" hidden></span>
+  <div class="meso-page" x-data="logger()">
     <div class="meso-crumbs">
       <a href="{% url 'meso:athlete_home' %}">Training</a> <span>/</span>
       <span>{{ session.block }} · {{ session.week }}</span> <span>/</span> <span>{{ session.name }}</span>
@@ -24,36 +32,48 @@
         <p class="meso-sub">{{ session.plan_title }}</p>
       </div>
       <div class="meso-spacer"></div>
-      {% if session.status == 'done' %}
-        <span class="meso-badge meso-badge--ok">{{ session.status_label }}</span>
-      {% else %}
-        <span class="meso-badge">{{ session.status_label }}</span>
-      {% endif %}
+      <span class="meso-badge" :class="status === 'done' ? 'meso-badge--ok' : ''" x-text="status === 'done' ? 'Logged' : 'To do'">{{ session.status_label }}</span>
     </div>
 
-    <div class="meso-card">
-      <div style="display:grid;grid-template-columns:minmax(0,2fr) 48px 64px minmax(0,1fr) 48px;gap:10px;padding:9px 18px;background:var(--rail);border-bottom:1px solid var(--line-2);font-size:10px;font-weight:700;letter-spacing:0.06em;text-transform:uppercase;color:var(--dim);">
-        <div>Exercise</div><div style="text-align:center;">Sets</div><div style="text-align:center;">Reps</div><div>Load</div><div style="text-align:center;">RPE</div>
-      </div>
-      {% for e in session.exercises %}
-        <div style="display:grid;grid-template-columns:minmax(0,2fr) 48px 64px minmax(0,1fr) 48px;gap:10px;padding:11px 18px;border-bottom:1px solid var(--line-2);align-items:center;">
-          <div style="font-size:13.5px;font-weight:600;letter-spacing:-0.01em;min-width:0;">
-            {{ e.name }}
-            {% if e.tag %}<span class="meso-badge meso-badge--ok" style="margin-left:6px;">{{ e.tag }}</span>{% endif %}
-            {% if e.note %}<div class="meso-row-meta">{{ e.note }}</div>{% endif %}
-          </div>
-          <div class="meso-mono" style="text-align:center;font-size:12px;">{{ e.sets|default:"—" }}</div>
-          <div class="meso-mono" style="text-align:center;font-size:12px;">{{ e.reps|default:"—" }}</div>
-          <div class="meso-mono" style="font-size:12px;">{{ e.load|default:"—" }}</div>
-          <div class="meso-mono" style="text-align:center;font-size:12px;">{{ e.rpe|default:"—" }}</div>
+    <div style="display:flex;align-items:center;gap:10px;margin-bottom:14px;">
+      <span class="meso-mono" style="font-size:12px;font-weight:700;color:var(--ink);" x-text="doneSets + '/' + totalSets"></span>
+      <span class="meso-row-meta">sets logged — fill in what you did, then log the session.</span>
+    </div>
+
+    <template x-for="ex in exercises" :key="ex.id">
+      <div class="meso-card" style="margin-bottom:12px;overflow:hidden;">
+        <div style="padding:11px 16px 9px;border-bottom:1px solid var(--line-2);">
+          <div style="font-size:14px;font-weight:700;letter-spacing:-0.01em;" x-text="ex.name"></div>
+          <div class="meso-row-meta meso-mono">target <span x-text="ex.target"></span><template x-if="ex.note"><span> · <span x-text="ex.note"></span></span></template></div>
         </div>
-      {% endfor %}
-    </div>
+        <template x-for="r in ex.set_rows" :key="r.set_number">
+          <div style="display:flex;align-items:center;gap:9px;padding:9px 16px;border-bottom:1px solid var(--line-2);">
+            <div class="meso-mono" style="width:42px;font-size:11px;font-weight:700;color:var(--dim);">Set <span x-text="r.set_number"></span></div>
+            <input class="meso-phone-input" x-model="r.reps" placeholder="reps" inputmode="numeric"
+                   style="width:52px;text-align:center;appearance:none;border:1px solid var(--line);border-radius:7px;background:var(--rail);font:inherit;font-family:'IBM Plex Mono',monospace;font-size:13px;padding:6px 4px;outline:none;color:var(--ink);" />
+            <span style="font-size:11px;color:var(--dim);">&#215;</span>
+            <input class="meso-phone-input" x-model="r.load" placeholder="load" inputmode="decimal"
+                   style="width:60px;text-align:center;appearance:none;border:1px solid var(--line);border-radius:7px;background:var(--rail);font:inherit;font-family:'IBM Plex Mono',monospace;font-size:13px;padding:6px 4px;outline:none;color:var(--ink);" />
+            <input class="meso-phone-input" x-model="r.rpe" placeholder="rpe" inputmode="decimal"
+                   style="width:48px;text-align:center;appearance:none;border:1px solid var(--line);border-radius:7px;background:var(--rail);font:inherit;font-family:'IBM Plex Mono',monospace;font-size:13px;padding:6px 4px;outline:none;color:var(--ink);" />
+            <div class="meso-spacer"></div>
+            <button type="button" @click="toggle(r)" :aria-pressed="r.done" aria-label="Mark set done"
+                    style="appearance:none;border:0;background:none;cursor:pointer;padding:0;flex:0 0 auto;">
+              <template x-if="r.done"><div style="width:26px;height:26px;border-radius:50%;background:var(--accent);display:flex;align-items:center;justify-content:center;color:var(--accent-ink);font-size:13px;">&#10003;</div></template>
+              <template x-if="!r.done"><div style="width:26px;height:26px;border-radius:50%;border:1.5px solid var(--line);background:var(--surface);"></div></template>
+            </button>
+          </div>
+        </template>
+      </div>
+    </template>
 
-    <div style="display:flex;align-items:center;gap:12px;margin-top:16px;">
-      <a class="meso-btn" href="{% url 'meso:athlete_home' %}">← Back to training</a>
+    <div style="display:flex;align-items:center;gap:12px;margin-top:16px;flex-wrap:wrap;">
+      <a class="meso-btn" href="{% url 'meso:athlete_home' %}">&#8592; Back to training</a>
       <div class="meso-spacer"></div>
-      <span class="meso-row-meta">Logging arrives next — for now this is your delivered plan.</span>
+      <span class="meso-row-meta" style="color:var(--ok);" x-show="saved" x-cloak>Saved &#10003;</span>
+      <span class="meso-row-meta" style="color:var(--warn);" x-show="error" x-cloak>Couldn&#8217;t save — try again.</span>
+      <button type="button" class="meso-btn" @click="save(false)" :disabled="saving">Save progress</button>
+      <button type="button" class="meso-btn meso-btn--primary" @click="save(true)" :disabled="saving" x-text="saving ? 'Saving…' : 'Log session'">Log session</button>
     </div>
   </div>
 {% endblock %}

--- a/docs/meso/athlete-plan.md
+++ b/docs/meso/athlete-plan.md
@@ -1,8 +1,11 @@
 # Meso — athlete-facing slice plan
 
-**Status:** Phase 1 done & merged (PR #288, squash `42bb805`; Django CI green,
-deployed to Hetzner — no migration; +20 tests, 239 meso / 379 project-wide;
-ruff clean; local Codex review clean, 1 round) · created 2026-06-27
+**Status:** Phase 1 done & merged (PR #288, squash `42bb805`; deployed to
+Hetzner — no migration). **Phase 2 (session logging) built** on branch
+`meso-athlete-phase2` (+33 tests, 272 meso / 412 project-wide; ruff clean; no
+migration; local Codex review clean — 0 blocking across 5 rounds, one
+`unique(session, athlete)` nit declined by design, see Phase 2 note) ·
+created 2026-06-27
 **Companion to:** [`decisions.md`](./decisions.md) (B2, S3, S7, N1/D-a/D-b) ·
 [`persistence-plan.md`](./persistence-plan.md) · [`agent-plan.md`](./agent-plan.md)
 **Goal of this slice:** give the **athlete** a real, logged-in surface — see the
@@ -128,7 +131,7 @@ which would fight Phase 2 logging. See the **Design note** above. **Deferred:**
 the logging write path (Phase 2), results-feedback (Phase 3), PWA + notifications
 (Phase 4).
 
-**Phase 2 — Session logging (the write path).**
+**Phase 2 — Session logging (the write path). ✅ Built (2026-06-27, branch `meso-athlete-phase2`; no migration).**
 The session screen becomes the interactive logger (the phone-style set rows):
 `POST /meso/api/me/session/<id>/log/` upserts the athlete's `SessionLog` and its
 `LoggedSet` rows (reps/load/rpe per set), flips the session done, and stamps the
@@ -136,6 +139,36 @@ date. Athlete-scoped (only the logged-in athlete's own logs; only delivered
 sessions). This produces the first real rows `serialize_recent_logs` grounds the
 agent on. *Done when:* an athlete logs a session and it survives reload — and the
 agent's grounding sees it.
+
+*Built:* `athlete_log_session` (`POST /meso/api/me/session/<id>/log/`), scoped by
+the same `_athlete_session_or_404` as the read surface (foreign / undelivered /
+archived / unknown session → flat 404). The body is **validated before any
+write** (`_clean_logged_sets`) — bad input is a 400 that persists nothing — and
+the write is wrapped in a transaction: it upserts the athlete's own `SessionLog`
+(most-recent-wins, so re-logging updates the one log) and **replaces** its
+`LoggedSet` rows. `serialize_session_log` echoes the saved state back.
+`presenters.athlete_session` now formats the prescribed grid into set-input rows
+pre-filled from the athlete's existing log (carrying the coach's full target —
+sets×reps · load · RPE); `athlete_log_payload` trims that to the JSON the
+`athlete_session.html` + `meso_athlete.js` Alpine logger hydrates from and POSTs
+("Save progress" / "Log session" hit the same idempotent endpoint, differing
+only in the status they stamp). Built red→green: **+33 tests**
+(`test_athlete_logging.py` — access control, write semantics, validation,
+ownership isolation, survives-reload, agent grounding); 272 meso / 412
+project-wide pass, ruff clean, **no migration** (`SessionLog`/`LoggedSet` already
+exist). **Local Codex review: 0 blocking across 5 rounds.** Nits fixed: bound
+`set_number` (1–50) + hard-cap the render so a wild value can't balloon the page;
+reject duplicate `(prescription, set_number)` keys; show the prescribed load/RPE;
+"Save progress" preserves a done status (no downgrade); sync row check-state from
+the saved log; and **preserve the workout date on later edits** (a missing date
+defaults to today only on create — re-saving keeps the original date, so a later
+fix doesn't reorder grounding). **Declined by design:** a `unique(session,
+athlete)` constraint Codex raised twice — the model intentionally allows multiple
+logs per athlete/session (`serialize_recent_logs` + the capped-newest-first
+grounding test treat them as dated history), so the constraint would break
+grounding; the sequential re-save path stays idempotent and a concurrent
+double-submit at worst adds one history row, not corruption. **Deferred:**
+results-feedback (Phase 3), PWA + notifications (Phase 4).
 
 **Phase 3 — Results feed back (close the loop).**
 Retire `mockdata.RESULTS_*`: the coach's results screen reads real

--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -290,3 +290,21 @@ _(Append dated entries here as decisions land.)_
 - 2026-06-27 — **Athlete Phase 1 merged & deployed** (PR #288, squash `42bb805`; Django CI green, deployed
   to Hetzner — **no migration**; `/meso/me/` + `/meso/me/session/<id>/` live and login-gated in prod). The
   athlete read surface is live. Resume point → **athlete Phase 2** (session logging — the write path).
+- 2026-06-27 — **Athlete Phase 2 built** (branch `meso-athlete-phase2`): the **write path** —
+  `athlete_log_session` (`POST /meso/api/me/session/<id>/log/`) upserts the logged-in athlete's own
+  `SessionLog` + `LoggedSet` rows (most-recent-wins, idempotent), flips the session done, stamps the date.
+  Scoped by the read surface's `_athlete_session_or_404` (foreign/undelivered/archived/unknown → flat 404),
+  **validated before any write** (`_clean_logged_sets`; bad input is a 400 that persists nothing), wrapped in
+  a transaction (replace, not append, the set rows). The session screen becomes the interactive logger
+  (`presenters.athlete_session` pre-fills set rows from the existing log carrying the coach's full target;
+  `athlete_log_payload` + `athlete_session.html` + `meso_athlete.js`). **These are the first real rows
+  `serialize_recent_logs` grounds the agent on** — the agent slice already consumed `recent_logs`, this
+  produces them. **No model change / no migration** (`SessionLog`/`LoggedSet` already existed). Built
+  red→green: **+33 tests** (272 meso / 412 project-wide), ruff clean. **Local Codex review: 0 blocking
+  across 5 rounds**; nits fixed (set_number bound + render cap, duplicate-key reject, prescribed load/RPE
+  shown, Save-progress keeps done, row-state sync, **workout-date preserved on later edits**). **Declined by
+  design:** a `unique(session, athlete)` constraint — the model intentionally permits multiple logs per
+  athlete/session (dated history that `serialize_recent_logs` + `test_recent_logs_are_capped_and_newest_first`
+  rely on); the constraint would break grounding, and the re-save path is already idempotent. Resume point →
+  **athlete Phase 3** (results feed back: retire `mockdata.RESULTS_*`, light up the designer's `last`/`adj`
+  from real logs).


### PR DESCRIPTION
## What

The athlete's delivered-session screen becomes the **interactive logger**. `POST /meso/api/me/session/<id>/log/` upserts the logged-in athlete's own `SessionLog` + `LoggedSet` rows (reps/load/RPE per set), flips the session done, and stamps the date. These are the **first real rows** `serialize_recent_logs` grounds the agent on — every `SessionLog` before this slice was fabricated in tests.

Item 3 (logging) of the [athlete slice plan](https://github.com/lancegoyke/fitness-store/blob/meso-athlete-phase2/docs/meso/athlete-plan.md). Read surface (Phase 1, #288) shipped the read; this is the write path.

## How

- **`athlete_log_session`** — scoped by the read surface's `_athlete_session_or_404` (foreign / undelivered / archived / unknown session → flat **404**). The body is **validated before any write** (`_clean_logged_sets`; bad input is a **400** that persists nothing), and the write runs in a transaction: it upserts the athlete's own `SessionLog` (most-recent-wins → re-logging updates the one log, idempotent) and **replaces** its `LoggedSet` rows. `serialize_session_log` echoes the saved state back.
- **`presenters.athlete_session`** formats the prescribed grid into set-input rows **pre-filled** from the athlete's existing log, carrying the coach's full target (sets×reps · load · RPE). `athlete_log_payload` trims that to the JSON the **`athlete_session.html` + `meso_athlete.js`** Alpine logger hydrates from. "Save progress" / "Log session" hit the same idempotent endpoint, differing only in the status they stamp.
- **No model change / no migration** — `SessionLog`/`LoggedSet` already exist.

## Tests

Built **red→green**: **+33 tests** (`test_athlete_logging.py` — access control, write semantics, validation, ownership isolation, survives-reload, agent grounding). **272 meso / 412 project-wide pass**, ruff clean.

## Codex review

Local `codex review` loop: **0 blocking across 5 rounds.** Nits fixed: bound `set_number` (1–50) + hard-cap the render; reject duplicate `(prescription, set_number)` keys; show prescribed load/RPE; "Save progress" preserves a done status; sync row check-state from the saved log; **preserve the workout date on later edits**. **Declined by design:** a `unique(session, athlete)` constraint — the model intentionally permits multiple logs per athlete/session (dated history `serialize_recent_logs` + `test_recent_logs_are_capped_and_newest_first` rely on); it would break grounding, and the re-save path is already idempotent.

https://claude.ai/code/session_015G62Gs7papVMJAfYqeExrN