### PR TITLE
Meso — athlete slice Phase 4a: delivery notifications (email on deliver)

### DIFF
--- a/app/store_project/meso/tests/test_delivery_notifications.py
+++ b/app/store_project/meso/tests/test_delivery_notifications.py
@@ -1,0 +1,167 @@
+"""Athlete slice Phase 4a — delivery notifications (S3).
+
+When a coach delivers a week (``POST api/plan/<id>/deliver/``), the athlete is
+emailed that their next training week is ready, with a link to their own
+training surface (``/meso/me/``). Email is the channel that exists today
+(``django-ses`` + the ``notifications`` app); web push waits on the PWA (4b).
+
+The notification is **best-effort**: delivery has already succeeded by the time
+the email is attempted, so a mail failure must never roll it back. And it only
+reaches the athlete on a *successful* deliver — the 403/404/400 guard paths send
+nothing (they return before the week is stamped).
+
+These tests cover that seam:
+
+- a successful deliver emails the athlete exactly once, at their address;
+- the email names the coach, the plan, and the delivered week, and links home;
+- an athlete with no email on file is skipped (no crash, delivery still 201);
+- a mail backend failure does not break delivery (the week is still stamped);
+- only the athlete is emailed (never the coach);
+- re-delivering (a fix-in-place) notifies again;
+- the forbidden / unauthenticated guard paths send nothing.
+"""
+
+from unittest import mock
+
+import pytest
+from django.urls import reverse
+
+from store_project.meso.factories import CoachAthleteFactory
+from store_project.meso.factories import ExercisePrescriptionFactory
+from store_project.meso.factories import MesocycleFactory
+from store_project.meso.factories import PlanFactory
+from store_project.meso.factories import SessionFactory
+from store_project.meso.factories import WeekFactory
+from store_project.meso.models import Plan
+from store_project.meso.models import WeekDelivery
+from store_project.users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def seed_plan(coach=None, athlete=None):
+    """A minimal owned plan with one current week → session → prescription."""
+    rel = CoachAthleteFactory(
+        coach=coach or UserFactory(), athlete=athlete or UserFactory()
+    )
+    plan = PlanFactory(
+        relationship=rel, title="Hypertrophy Block", status=Plan.Status.ACTIVE
+    )
+    meso = MesocycleFactory(plan=plan, name="Hypertrophy", order=0)
+    week = WeekFactory(mesocycle=meso, index=1, is_current=True)
+    session = SessionFactory(week=week, day_number=1, name="Lower")
+    ExercisePrescriptionFactory(
+        session=session, name="Box Squat", sets="4", reps="6", load="70", rpe="7"
+    )
+    return plan, week
+
+
+def deliver_url(plan):
+    return reverse("meso:api_plan_deliver", kwargs={"plan_id": plan.pk})
+
+
+class TestDeliveryNotification:
+    def test_deliver_emails_the_athlete_once(self, client, mailoutbox):
+        coach = UserFactory(name="Coach Lance", email="coach@example.com")
+        athlete = UserFactory(name="Maya Okonkwo", email="maya@example.com")
+        plan, _ = seed_plan(coach=coach, athlete=athlete)
+        client.force_login(coach)
+
+        resp = client.post(deliver_url(plan))
+
+        assert resp.status_code == 201
+        assert len(mailoutbox) == 1
+        assert mailoutbox[0].to == ["maya@example.com"]
+
+    def test_email_names_coach_plan_and_week(self, client, mailoutbox):
+        coach = UserFactory(name="Coach Lance", email="coach@example.com")
+        athlete = UserFactory(name="Maya Okonkwo", email="maya@example.com")
+        plan, _ = seed_plan(coach=coach, athlete=athlete)
+        client.force_login(coach)
+
+        client.post(deliver_url(plan))
+
+        email = mailoutbox[0]
+        haystack = f"{email.subject}\n{email.body}"
+        assert "Coach Lance" in haystack
+        assert "Hypertrophy Block" in haystack
+        assert "Week 1" in haystack
+
+    def test_email_links_to_athlete_home(self, client, mailoutbox):
+        plan, _ = seed_plan()
+        client.force_login(plan.relationship.coach)
+
+        client.post(deliver_url(plan))
+
+        body = mailoutbox[0].body
+        assert reverse("meso:athlete_home") in body  # /meso/me/
+        # An absolute link the athlete can click from their inbox.
+        assert "http://testserver" in body
+
+    def test_no_email_when_athlete_has_no_address(self, client, mailoutbox):
+        coach = UserFactory(email="coach@example.com")
+        athlete = UserFactory(email="")
+        plan, week = seed_plan(coach=coach, athlete=athlete)
+        client.force_login(coach)
+
+        resp = client.post(deliver_url(plan))
+
+        # Delivery still succeeds; we simply skip the (impossible) email.
+        assert resp.status_code == 201
+        assert len(mailoutbox) == 0
+        week.refresh_from_db()
+        assert week.delivered_at is not None
+
+    def test_email_failure_does_not_break_delivery(self, client):
+        plan, week = seed_plan()
+        client.force_login(plan.relationship.coach)
+
+        with mock.patch(
+            "store_project.meso.views.send_week_delivered_email",
+            side_effect=RuntimeError("SES is down"),
+        ):
+            resp = client.post(deliver_url(plan))
+
+        # The mail blew up, but the deliver write committed.
+        assert resp.status_code == 201
+        week.refresh_from_db()
+        assert week.delivered_at is not None
+        assert WeekDelivery.objects.filter(week=week).count() == 1
+
+    def test_only_the_athlete_is_emailed(self, client, mailoutbox):
+        coach = UserFactory(name="Coach Lance", email="coach@example.com")
+        athlete = UserFactory(name="Maya Okonkwo", email="maya@example.com")
+        plan, _ = seed_plan(coach=coach, athlete=athlete)
+        client.force_login(coach)
+
+        client.post(deliver_url(plan))
+
+        recipients = [addr for email in mailoutbox for addr in email.to]
+        assert recipients == ["maya@example.com"]
+        assert "coach@example.com" not in recipients
+
+    def test_redelivering_notifies_again(self, client, mailoutbox):
+        plan, _ = seed_plan()
+        client.force_login(plan.relationship.coach)
+
+        client.post(deliver_url(plan))
+        client.post(deliver_url(plan))
+
+        assert len(mailoutbox) == 2
+
+    def test_forbidden_deliver_sends_no_email(self, client, mailoutbox):
+        plan, _ = seed_plan()
+        client.force_login(UserFactory())  # a stranger
+
+        resp = client.post(deliver_url(plan))
+
+        assert resp.status_code == 403
+        assert len(mailoutbox) == 0
+
+    def test_unauthenticated_deliver_sends_no_email(self, client, mailoutbox):
+        plan, _ = seed_plan()
+
+        resp = client.post(deliver_url(plan))
+
+        assert resp.status_code == 302
+        assert len(mailoutbox) == 0

--- a/app/store_project/meso/tests/test_delivery_notifications.py
+++ b/app/store_project/meso/tests/test_delivery_notifications.py
@@ -19,6 +19,12 @@ These tests cover that seam:
 - only the athlete is emailed (never the coach);
 - re-delivering (a fix-in-place) notifies again;
 - the forbidden / unauthenticated guard paths send nothing.
+
+The notification is deferred to ``transaction.on_commit`` (the view runs under
+``ATOMIC_REQUESTS``), so the tests that assert a send wrap the request in
+``django_capture_on_commit_callbacks(execute=True)`` to run those callbacks —
+the same idiom as ``test_agent_jobs``. The guard-path tests need no capture:
+they return before a callback is ever registered.
 """
 
 from unittest import mock
@@ -61,25 +67,31 @@ def deliver_url(plan):
 
 
 class TestDeliveryNotification:
-    def test_deliver_emails_the_athlete_once(self, client, mailoutbox):
+    def test_deliver_emails_the_athlete_once(
+        self, client, mailoutbox, django_capture_on_commit_callbacks
+    ):
         coach = UserFactory(name="Coach Lance", email="coach@example.com")
         athlete = UserFactory(name="Maya Okonkwo", email="maya@example.com")
         plan, _ = seed_plan(coach=coach, athlete=athlete)
         client.force_login(coach)
 
-        resp = client.post(deliver_url(plan))
+        with django_capture_on_commit_callbacks(execute=True):
+            resp = client.post(deliver_url(plan))
 
         assert resp.status_code == 201
         assert len(mailoutbox) == 1
         assert mailoutbox[0].to == ["maya@example.com"]
 
-    def test_email_names_coach_plan_and_week(self, client, mailoutbox):
+    def test_email_names_coach_plan_and_week(
+        self, client, mailoutbox, django_capture_on_commit_callbacks
+    ):
         coach = UserFactory(name="Coach Lance", email="coach@example.com")
         athlete = UserFactory(name="Maya Okonkwo", email="maya@example.com")
         plan, _ = seed_plan(coach=coach, athlete=athlete)
         client.force_login(coach)
 
-        client.post(deliver_url(plan))
+        with django_capture_on_commit_callbacks(execute=True):
+            client.post(deliver_url(plan))
 
         email = mailoutbox[0]
         haystack = f"{email.subject}\n{email.body}"
@@ -87,24 +99,30 @@ class TestDeliveryNotification:
         assert "Hypertrophy Block" in haystack
         assert "Week 1" in haystack
 
-    def test_email_links_to_athlete_home(self, client, mailoutbox):
+    def test_email_links_to_athlete_home(
+        self, client, mailoutbox, django_capture_on_commit_callbacks
+    ):
         plan, _ = seed_plan()
         client.force_login(plan.relationship.coach)
 
-        client.post(deliver_url(plan))
+        with django_capture_on_commit_callbacks(execute=True):
+            client.post(deliver_url(plan))
 
         body = mailoutbox[0].body
         assert reverse("meso:athlete_home") in body  # /meso/me/
         # An absolute link the athlete can click from their inbox.
         assert "http://testserver" in body
 
-    def test_no_email_when_athlete_has_no_address(self, client, mailoutbox):
+    def test_no_email_when_athlete_has_no_address(
+        self, client, mailoutbox, django_capture_on_commit_callbacks
+    ):
         coach = UserFactory(email="coach@example.com")
         athlete = UserFactory(email="")
         plan, week = seed_plan(coach=coach, athlete=athlete)
         client.force_login(coach)
 
-        resp = client.post(deliver_url(plan))
+        with django_capture_on_commit_callbacks(execute=True):
+            resp = client.post(deliver_url(plan))
 
         # Delivery still succeeds; we simply skip the (impossible) email.
         assert resp.status_code == 201
@@ -112,40 +130,53 @@ class TestDeliveryNotification:
         week.refresh_from_db()
         assert week.delivered_at is not None
 
-    def test_email_failure_does_not_break_delivery(self, client):
+    def test_email_failure_does_not_break_delivery(
+        self, client, django_capture_on_commit_callbacks
+    ):
         plan, week = seed_plan()
         client.force_login(plan.relationship.coach)
 
-        with mock.patch(
-            "store_project.meso.views.send_week_delivered_email",
-            side_effect=RuntimeError("SES is down"),
+        with (
+            mock.patch(
+                "store_project.meso.views.send_week_delivered_email",
+                side_effect=RuntimeError("SES is down"),
+            ),
+            django_capture_on_commit_callbacks(execute=True),
         ):
             resp = client.post(deliver_url(plan))
 
-        # The mail blew up, but the deliver write committed.
+        # The mail blew up inside the on_commit callback, but the deliver
+        # committed and the swallow kept it from surfacing as a 500.
         assert resp.status_code == 201
         week.refresh_from_db()
         assert week.delivered_at is not None
         assert WeekDelivery.objects.filter(week=week).count() == 1
 
-    def test_only_the_athlete_is_emailed(self, client, mailoutbox):
+    def test_only_the_athlete_is_emailed(
+        self, client, mailoutbox, django_capture_on_commit_callbacks
+    ):
         coach = UserFactory(name="Coach Lance", email="coach@example.com")
         athlete = UserFactory(name="Maya Okonkwo", email="maya@example.com")
         plan, _ = seed_plan(coach=coach, athlete=athlete)
         client.force_login(coach)
 
-        client.post(deliver_url(plan))
+        with django_capture_on_commit_callbacks(execute=True):
+            client.post(deliver_url(plan))
 
         recipients = [addr for email in mailoutbox for addr in email.to]
         assert recipients == ["maya@example.com"]
         assert "coach@example.com" not in recipients
 
-    def test_redelivering_notifies_again(self, client, mailoutbox):
+    def test_redelivering_notifies_again(
+        self, client, mailoutbox, django_capture_on_commit_callbacks
+    ):
         plan, _ = seed_plan()
         client.force_login(plan.relationship.coach)
 
-        client.post(deliver_url(plan))
-        client.post(deliver_url(plan))
+        with django_capture_on_commit_callbacks(execute=True):
+            client.post(deliver_url(plan))
+        with django_capture_on_commit_callbacks(execute=True):
+            client.post(deliver_url(plan))
 
         assert len(mailoutbox) == 2
 

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import logging
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -17,6 +18,8 @@ from django.utils import timezone
 from django.views.decorators.http import require_GET
 from django.views.decorators.http import require_POST
 from django.views.generic import TemplateView
+
+from store_project.notifications.emails import send_week_delivered_email
 
 from . import presenters
 from .agent import apply as agent_apply
@@ -39,6 +42,8 @@ from .serializers import serialize_prescription
 from .serializers import serialize_proposed_change
 from .serializers import serialize_session_log
 from .serializers import serialize_week_snapshot
+
+logger = logging.getLogger(__name__)
 
 
 def _coach_working_plan(user):
@@ -580,6 +585,7 @@ def plan_deliver(request, plan_id):
         week=week, delivered_at=now, payload=serialize_week_snapshot(week)
     )
     _touch_plan(plan)
+    _notify_athlete_delivered(request, plan, week)
     return JsonResponse(
         {
             "ok": True,
@@ -588,6 +594,30 @@ def plan_deliver(request, plan_id):
         },
         status=201,
     )
+
+
+def _notify_athlete_delivered(request, plan, week):
+    """Best-effort: email the athlete that ``week`` was delivered (S3).
+
+    Delivery has already committed by the time we get here, so a mail failure
+    must never surface as a 500 or roll the deliver back — swallow and log.
+    (Web push waits on the PWA, Phase 4b.)
+    """
+    home_url = request.build_absolute_uri(reverse("meso:athlete_home"))
+    try:
+        send_week_delivered_email(
+            athlete=plan.athlete,
+            coach=plan.coach,
+            plan=plan,
+            week=week,
+            home_url=home_url,
+        )
+    except Exception:  # mail is best-effort; never fail a delivery on it
+        logger.exception(
+            "Failed to send delivery notification for plan %s week %s",
+            plan.pk,
+            week.pk,
+        )
 
 
 # -- agent proposal engine (agent slice Phase 1 / Phase 4 — B6) -----------

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -599,25 +599,31 @@ def plan_deliver(request, plan_id):
 def _notify_athlete_delivered(request, plan, week):
     """Best-effort: email the athlete that ``week`` was delivered (S3).
 
-    Delivery has already committed by the time we get here, so a mail failure
-    must never surface as a 500 or roll the deliver back — swallow and log.
-    (Web push waits on the PWA, Phase 4b.)
+    Deferred to ``transaction.on_commit`` so it fires only after the delivery
+    actually commits — under ``ATOMIC_REQUESTS`` the view runs in a transaction,
+    and a rolled-back deliver must not email a false "your week is ready". The
+    send itself is best-effort: a mail failure is swallowed and logged, never a
+    500 or a rolled-back deliver. (Web push waits on the PWA, Phase 4b.)
     """
     home_url = request.build_absolute_uri(reverse("meso:athlete_home"))
-    try:
-        send_week_delivered_email(
-            athlete=plan.athlete,
-            coach=plan.coach,
-            plan=plan,
-            week=week,
-            home_url=home_url,
-        )
-    except Exception:  # mail is best-effort; never fail a delivery on it
-        logger.exception(
-            "Failed to send delivery notification for plan %s week %s",
-            plan.pk,
-            week.pk,
-        )
+
+    def _send():
+        try:
+            send_week_delivered_email(
+                athlete=plan.athlete,
+                coach=plan.coach,
+                plan=plan,
+                week=week,
+                home_url=home_url,
+            )
+        except Exception:  # mail is best-effort; never fail a delivery on it
+            logger.exception(
+                "Failed to send delivery notification for plan %s week %s",
+                plan.pk,
+                week.pk,
+            )
+
+    transaction.on_commit(_send)
 
 
 # -- agent proposal engine (agent slice Phase 1 / Phase 4 — B6) -----------

--- a/app/store_project/notifications/emails.py
+++ b/app/store_project/notifications/emails.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.core.mail import EmailMessage
+from django.core.mail import send_mail
 from django.template.loader import render_to_string
 
 
@@ -42,3 +43,49 @@ def send_contact_emails(message_subject: str, message: str, user_email: str) -> 
         ],
     )
     email_for_user.send()
+
+
+def send_week_delivered_email(*, athlete, coach, plan, week, home_url) -> bool:
+    """Email an athlete that their coach delivered a new training week.
+
+    Meso athlete slice Phase 4a (decision S3): when a coach delivers a week, the
+    athlete is notified through the channel that exists today — email via
+    ``django-ses``. Web push waits on the PWA (Phase 4b).
+
+    Args:
+        athlete: the ``User`` who trains the plan (the recipient).
+        coach: the ``User`` who delivered the week.
+        plan: the delivered week's ``Plan`` (for its title).
+        week: the delivered ``Week`` (for its index label).
+        home_url: absolute URL of the athlete's training surface (``/meso/me/``).
+
+    Returns:
+        ``True`` if a message was sent, ``False`` if skipped because the athlete
+        has no email address on file.
+
+    Raises a mail backend exception (``fail_silently=False``); callers that must
+    not let a delivery fail on a bounced email should treat this as best-effort.
+    """
+    if not athlete.email:
+        return False
+    context = {
+        "athlete_name": athlete.display_name(),
+        "coach_name": coach.display_name(),
+        "plan_title": plan.title,
+        "week_label": f"Week {week.index}",
+        "home_url": home_url,
+    }
+    subject = render_to_string(
+        "notifications/week_delivered_subject.txt", context
+    ).strip()
+    msg_plain = render_to_string("notifications/week_delivered.md", context)
+    msg_html = render_to_string("notifications/week_delivered.html", context)
+    send_mail(
+        subject=subject,
+        message=msg_plain,
+        html_message=msg_html,
+        from_email=None,  # defaults to settings.DEFAULT_FROM_EMAIL
+        recipient_list=[athlete.email],
+        fail_silently=False,
+    )
+    return True

--- a/app/store_project/templates/notifications/week_delivered.html
+++ b/app/store_project/templates/notifications/week_delivered.html
@@ -1,0 +1,9 @@
+<p>Hi {{ athlete_name }},</p>
+
+<p>{{ coach_name }} just delivered {{ week_label }} of
+  <strong>{{ plan_title }}</strong> to your training app.</p>
+
+<p><a href="{{ home_url }}">Open your training</a> to see your sessions and log
+  your work.</p>
+
+<p>Train hard,<br>Mastering Fitness</p>

--- a/app/store_project/templates/notifications/week_delivered.md
+++ b/app/store_project/templates/notifications/week_delivered.md
@@ -1,0 +1,10 @@
+Hi {{ athlete_name }},
+
+{{ coach_name }} just delivered {{ week_label }} of "{{ plan_title }}" to your training app.
+
+Open it to see your sessions and log your training:
+
+{{ home_url }}
+
+Train hard,
+Mastering Fitness

--- a/app/store_project/templates/notifications/week_delivered_subject.txt
+++ b/app/store_project/templates/notifications/week_delivered_subject.txt
@@ -1,0 +1,1 @@
+{{ coach_name }} delivered a new training week

--- a/docs/meso/athlete-plan.md
+++ b/docs/meso/athlete-plan.md
@@ -6,7 +6,9 @@ Hetzner — no migration). Phase 2 (session logging) done & merged (PR #290, squ
 squash `b8f0966`; 2026-06-28; Django CI green, deployed to Hetzner — no migration;
 +31 tests, 302 meso / 441 project-wide; ruff clean; `mockdata.py` deleted — every
 coach-side screen is DB-backed now; local Codex review 0 blocking across 3 rounds
-→ CLEAN, 4 nits fixed) · created 2026-06-27
+→ CLEAN, 4 nits fixed) · created 2026-06-27 · **Phase 4 split into 4a (delivery
+notifications — built, branch `meso-athlete-phase4a-delivery-notifications`,
++9 tests, no migration) + 4b (PWA — next).**
 **Companion to:** [`decisions.md`](./decisions.md) (B2, S3, S7, N1/D-a/D-b) ·
 [`persistence-plan.md`](./persistence-plan.md) · [`agent-plan.md`](./agent-plan.md)
 **Goal of this slice:** give the **athlete** a real, logged-in surface — see the
@@ -210,12 +212,36 @@ a **rep** shortfall (a 3×12 logged as 12,12,9), not just a missing-set one. Non
 declined. **Deferred:** the group-only `adj` overlay rides with groups (S1, out of
 scope); PWA + notifications (Phase 4).
 
-**Phase 4 — PWA + delivery notifications (S3 / S7).**
-A web-app manifest + service worker (installable, offline-tolerant logging), and
-delivery notifications (email via `django-ses` + the `notifications` app; web
-push deferred). The coach's "Deliver to her app" becomes literally true.
-*Done when:* the athlete can install Meso, log with flaky wifi, and gets notified
-when a week is delivered.
+**Phase 4 — PWA + delivery notifications (S3 / S7).** Split into two PRs — the
+notification half (4a) ships independently of the PWA half (4b), since email is
+backend-testable today while the service worker/offline queue is browser-side.
+
+**Phase 4a — Delivery notifications (S3). ✅ Built (2026-06-28, branch `meso-athlete-phase4a-delivery-notifications`; no migration).**
+When a coach delivers a week (`POST api/plan/<id>/deliver/`), the athlete is
+emailed that their next training week is ready, with an absolute link to their
+own surface (`/meso/me/`). Channel is the one that exists today — `send_mail`
+via `django-ses`, templated through the `notifications` app (plain + HTML).
+`notifications.emails.send_week_delivered_email` is pure/testable (takes the
+resolved athlete/coach/plan/week + an absolute `home_url`; returns `False` and
+sends nothing when the athlete has no address); the view's
+`_notify_athlete_delivered` builds the URL from the request and calls it
+**best-effort** — delivery has already committed, so a mail failure is swallowed
+and logged, never a 500 or a rolled-back deliver. Only fires on a *successful*
+deliver (the 403/404/400 guards return before the email) and only reaches the
+athlete (never the coach). Built red→green: **+9 tests**
+(`test_delivery_notifications.py` — emails the athlete once, names coach/plan/
+week + links home, skips a no-address athlete, survives a backend failure,
+athlete-only, re-deliver notifies again, forbidden/unauthenticated send nothing);
+311 meso / project-wide pass, ruff clean, **no migration**. *Done when:* a coach
+delivers and the athlete gets a "your week is ready" email linking to `/meso/me/`.
+**Deferred:** debouncing rapid re-delivers (each explicit deliver notifies);
+async send off the request thread (synchronous best-effort matches the existing
+`payments`/`notifications` pattern); web push (rides with the PWA, 4b).
+
+**Phase 4b — PWA (S7). ⏳ Next.**
+A web-app manifest + service worker (installable, offline-tolerant logging) so
+the athlete can install Meso and log through flaky gym wifi. *Done when:* the
+athlete can install Meso and log offline, syncing when wifi returns.
 
 ## Out of scope (later)
 Groups (S1, shared program + per-athlete override) · cross-coach scheduling


### PR DESCRIPTION
## What

When a coach delivers a week (`POST api/plan/<id>/deliver/`), email the athlete that their next training week is ready, with an absolute link to their own training surface (`/meso/me/`). This is the first half of athlete-slice **Phase 4** (S3), split out from the PWA half (4b) since email is backend-testable today while a service worker is browser-side.

The coach's "Deliver to her app" finally sends something.

## How

- **`notifications.emails.send_week_delivered_email`** — pure and testable: takes the resolved athlete/coach/plan/week plus an absolute `home_url`, renders the `notifications/week_delivered*` templates (plain + HTML), and sends via `send_mail` (`django-ses` in prod). Returns `False` and sends nothing when the athlete has no email on file.
- **`meso.views._notify_athlete_delivered`** — builds the absolute URL from the request and registers the send on **`transaction.on_commit`** (the deliver view runs under `ATOMIC_REQUESTS`, so a rolled-back deliver must not email a false "ready"). The send is **best-effort**: a mail failure is swallowed and logged, never a 500 or a rolled-back deliver. Matches the existing `agent/jobs.py` on_commit idiom.
- Fires only on a **successful** deliver (the 403/404/400 guards return before a callback is registered) and reaches **only the athlete**, never the coach.

## Tests

Red→green: **+9 tests** (`test_delivery_notifications.py`) — emails the athlete once at their address; names coach/plan/week and links home; skips a no-address athlete; survives a mail-backend failure (deliver still 201, week stamped); athlete-only; re-deliver notifies again; forbidden/unauthenticated send nothing. Email-asserting tests run the deferred `on_commit` callbacks via `django_capture_on_commit_callbacks`.

**311 meso tests pass, ruff clean, no migration.**

## Review

Local Codex review loop: 1 nit fixed (defer the email to `transaction.on_commit` — it was inline before, which could email on a rolled-back deliver under `ATOMIC_REQUESTS`), CLEAN on re-review.

## Deferred
- Debouncing rapid re-delivers (each explicit deliver notifies).
- Async send off the request thread (synchronous best-effort matches `payments`/`notifications`).
- Web push + the installable PWA / offline logging → **Phase 4b**.

https://claude.ai/code/session_015G62Gs7papVMJAfYqeExrN