### PR TITLE
Meso — persisted designer chat thread (rebuilt from proposal batches)

### DIFF
--- a/app/store_project/meso/serializers.py
+++ b/app/store_project/meso/serializers.py
@@ -84,9 +84,13 @@ def _agent_reply_for_batch(batch):
         message["error"] = True
         return message
     if batch.status == Status.DRAFTING:
-        # A run that never finished before the reload — a neutral note, not an
-        # error and not a blank bubble.
+        # A run still in flight at render time. Carry the status URL so the
+        # front-end can resume polling and replace this placeholder when the
+        # batch lands; the note is the fallback if the run never resolves.
         message["text"] = _DRAFTING_NOTE
+        message["pollUrl"] = reverse(
+            "meso:api_batch_status", kwargs={"batch_id": batch.pk}
+        )
         return message
 
     changes = [serialize_proposed_change(c) for c in batch.changes.all()]

--- a/app/store_project/meso/serializers.py
+++ b/app/store_project/meso/serializers.py
@@ -17,6 +17,8 @@ groups slice (S1, out of scope) and is still not emitted.
 from collections import Counter
 from collections import defaultdict
 
+from django.urls import reverse
+
 from . import models
 
 
@@ -55,6 +57,66 @@ def serialize_proposed_change(change):
         "honors": change.honors,
         "status": change.status,
     }
+
+
+# A change-less, summary-less agent reply still says *something* so the bubble
+# never renders blank — mirrors ``meso.js``'s ``batchMessage`` fallback.
+_NO_CHANGES_NOTE = (
+    "I couldn't find any safe changes to propose for that. "
+    "Try rephrasing or adjusting the plan directly."
+)
+_DRAFTING_NOTE = "Still working on this proposal…"
+_FAILED_NOTE = "The agent had trouble responding. Give it another try."
+
+
+def _agent_reply_for_batch(batch):
+    """The agent's side of one batch, in the ``meso.js`` message shape.
+
+    The agent never sends free-form chat — its reply is exactly the batch's
+    outcome: a failure note, a still-drafting note, or a summary plus the inline
+    proposed changes (with a review link when there are any).
+    """
+    Status = models.AgentProposalBatch.Status
+    message = {"id": f"agent-{batch.pk}", "role": "agent"}
+
+    if batch.status == Status.FAILED:
+        message["text"] = batch.error or _FAILED_NOTE
+        message["error"] = True
+        return message
+    if batch.status == Status.DRAFTING:
+        # A run that never finished before the reload — a neutral note, not an
+        # error and not a blank bubble.
+        message["text"] = _DRAFTING_NOTE
+        return message
+
+    changes = [serialize_proposed_change(c) for c in batch.changes.all()]
+    message["text"] = batch.summary or (_NO_CHANGES_NOTE if not changes else "")
+    message["changes"] = changes
+    message["reviewUrl"] = (
+        reverse("meso:review_batch", kwargs={"batch_id": batch.pk}) if changes else None
+    )
+    return message
+
+
+def serialize_chat_thread(plan):
+    """The designer's persisted agent conversation, oldest message first.
+
+    Every coach turn is an ``AgentProposalBatch`` (``instruction`` = the coach's
+    message; ``summary`` + ``ProposedChange`` rows = the agent's reply), so the
+    plan's batches *are* the thread — no separate chat model. Each batch expands
+    to a coach message then an agent message, in the exact shape ``meso.js``'s
+    ``messages`` array renders, so the front-end hydrates without remapping.
+    """
+    batches = plan.proposal_batches.order_by("created_at", "pk").prefetch_related(
+        "changes"
+    )
+    thread = []
+    for batch in batches:
+        thread.append(
+            {"id": f"coach-{batch.pk}", "role": "coach", "text": batch.instruction}
+        )
+        thread.append(_agent_reply_for_batch(batch))
+    return thread
 
 
 def serialize_session(session):

--- a/app/store_project/meso/tests/test_chat_thread.py
+++ b/app/store_project/meso/tests/test_chat_thread.py
@@ -1,0 +1,213 @@
+"""Persisted designer chat thread — the conversation survives a reload.
+
+The designer's agent chat went live in agent Phase 3, but the thread itself was
+never persisted: ``meso.js`` re-seeds ``messages`` to a single greeting on every
+load. The proposals, though, *are* persisted — every coach turn is an
+``AgentProposalBatch`` (``instruction`` = the coach's message, ``summary`` + the
+``ProposedChange`` rows = the agent's reply, ``status``/``created_at`` = state and
+order). So this slice reconstructs the thread from those batches rather than
+adding a model: ``serialize_chat_thread(plan)`` expands the plan's batches into
+the message shape ``meso.js`` renders, the designer view injects it, and the JS
+hydrates ``messages`` from it (falling back to the greeting when empty).
+
+No JS runner in this project, so the JS wiring is guarded at the source level
+(mirroring ``test_designer_agent_chat.py``); the serializer + view seam is
+covered end-to-end here.
+"""
+
+from pathlib import Path
+
+import pytest
+from django.contrib.staticfiles import finders
+from django.urls import reverse
+
+from store_project.meso.factories import AgentProposalBatchFactory
+from store_project.meso.factories import ProposedChangeFactory
+from store_project.meso.models import AgentProposalBatch
+from store_project.meso.serializers import serialize_chat_thread
+from store_project.meso.tests.test_designer_save import seed_plan
+
+pytestmark = pytest.mark.django_db
+
+
+def read_meso_js():
+    path = finders.find("js/meso.js")
+    assert path, "static js/meso.js must resolve"
+    return Path(path).read_text()
+
+
+class TestSerializeChatThread:
+    def test_empty_plan_has_no_messages(self):
+        plan, _, _ = seed_plan()
+        assert serialize_chat_thread(plan) == []
+
+    def test_one_batch_yields_coach_then_agent(self):
+        plan, _, _ = seed_plan()
+        batch = AgentProposalBatchFactory(
+            plan=plan,
+            instruction="Lower Day 2 volume",
+            summary="Trimmed Day 2 back-off sets.",
+            status=AgentProposalBatch.Status.PENDING,
+        )
+        ProposedChangeFactory(batch=batch, title="Drop a back-off set")
+        ProposedChangeFactory(batch=batch, title="Reduce accessory volume")
+
+        thread = serialize_chat_thread(plan)
+
+        assert len(thread) == 2
+        coach, agent = thread
+        assert coach["role"] == "coach"
+        assert coach["text"] == "Lower Day 2 volume"
+        assert agent["role"] == "agent"
+        assert agent["text"] == "Trimmed Day 2 back-off sets."
+        assert len(agent["changes"]) == 2
+        assert agent["reviewUrl"] == reverse(
+            "meso:review_batch", kwargs={"batch_id": batch.pk}
+        )
+        # Distinct, stable keys so Alpine's x-for never collides a coach/agent pair.
+        assert coach["id"] != agent["id"]
+
+    def test_changes_use_the_proposed_change_shape(self):
+        plan, _, _ = seed_plan()
+        batch = AgentProposalBatchFactory(plan=plan)
+        ProposedChangeFactory(
+            batch=batch,
+            title="Swap to box squat",
+            before="Back squat",
+            after="Box squat",
+        )
+
+        agent = serialize_chat_thread(plan)[1]
+        change = agent["changes"][0]
+        # The inline render reads id/title/before/after — same shape the live
+        # status endpoint returns, so a hydrated change renders identically.
+        assert change["title"] == "Swap to box squat"
+        assert change["before"] == "Back squat"
+        assert change["after"] == "Box squat"
+        assert "id" in change
+
+    def test_thread_is_oldest_first(self):
+        plan, _, _ = seed_plan()
+        first = AgentProposalBatchFactory(plan=plan, instruction="First ask")
+        second = AgentProposalBatchFactory(plan=plan, instruction="Second ask")
+
+        thread = serialize_chat_thread(plan)
+
+        coach_texts = [m["text"] for m in thread if m["role"] == "coach"]
+        assert coach_texts == ["First ask", "Second ask"]
+        # Sanity: each batch contributes a coach + an agent message, interleaved.
+        assert [m["role"] for m in thread] == [
+            "coach",
+            "agent",
+            "coach",
+            "agent",
+        ]
+        assert first.created_at <= second.created_at
+
+    def test_failed_batch_is_an_error_message(self):
+        plan, _, _ = seed_plan()
+        AgentProposalBatchFactory(
+            plan=plan,
+            instruction="Do something impossible",
+            status=AgentProposalBatch.Status.FAILED,
+            error="The agent request failed: boom",
+        )
+
+        agent = serialize_chat_thread(plan)[1]
+        assert agent["role"] == "agent"
+        assert agent["error"] is True
+        assert agent["text"] == "The agent request failed: boom"
+        assert not agent.get("changes")
+        assert agent.get("reviewUrl") is None
+
+    def test_batch_without_changes_has_no_review_link(self):
+        plan, _, _ = seed_plan()
+        AgentProposalBatchFactory(
+            plan=plan,
+            summary="No safe changes to make here.",
+            status=AgentProposalBatch.Status.PENDING,
+        )
+
+        agent = serialize_chat_thread(plan)[1]
+        assert agent["text"] == "No safe changes to make here."
+        assert agent["changes"] == []
+        assert agent["reviewUrl"] is None
+
+    def test_batch_without_summary_or_changes_falls_back_to_a_note(self):
+        plan, _, _ = seed_plan()
+        AgentProposalBatchFactory(
+            plan=plan, summary="", status=AgentProposalBatch.Status.PENDING
+        )
+
+        agent = serialize_chat_thread(plan)[1]
+        assert agent["text"].strip(), (
+            "a summary-less, change-less reply still says something"
+        )
+        assert agent["changes"] == []
+
+    def test_drafting_batch_renders_a_neutral_note(self):
+        # A batch left ``drafting`` after a reload (the background job never
+        # finished) is surfaced as a neutral note, not an error or a blank.
+        plan, _, _ = seed_plan()
+        AgentProposalBatchFactory(plan=plan, status=AgentProposalBatch.Status.DRAFTING)
+
+        agent = serialize_chat_thread(plan)[1]
+        assert agent["role"] == "agent"
+        assert agent["text"].strip()
+        assert not agent.get("error")
+        assert not agent.get("changes")
+
+    def test_thread_is_plan_scoped(self):
+        plan, _, _ = seed_plan()
+        other_plan, _, _ = seed_plan()
+        AgentProposalBatchFactory(plan=other_plan, instruction="On the other plan")
+
+        assert serialize_chat_thread(plan) == []
+
+
+class TestDesignerInjectsThread:
+    def test_designer_injects_the_chat_thread(self, client):
+        plan, _, _ = seed_plan()
+        AgentProposalBatchFactory(plan=plan, instruction="Lower Day 2 volume")
+        client.force_login(plan.relationship.coach)
+
+        resp = client.get(reverse("meso:designer_plan", kwargs={"plan_id": plan.pk}))
+
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert 'id="meso-chat-thread"' in body
+        assert "Lower Day 2 volume" in body
+
+    def test_designer_injects_empty_thread_when_no_batches(self, client):
+        plan, _, _ = seed_plan()
+        client.force_login(plan.relationship.coach)
+
+        resp = client.get(reverse("meso:designer_plan", kwargs={"plan_id": plan.pk}))
+
+        body = resp.content.decode()
+        assert 'id="meso-chat-thread"' in body
+        # json_script renders an empty history as a literal empty array.
+        assert ">[]</script>" in body
+
+    def test_thread_only_carries_this_plans_batches(self, client):
+        plan, _, _ = seed_plan()
+        coach = plan.relationship.coach
+        other_plan, _, _ = seed_plan(coach=coach)
+        AgentProposalBatchFactory(plan=other_plan, instruction="Other plan ask")
+        client.force_login(coach)
+
+        resp = client.get(reverse("meso:designer_plan", kwargs={"plan_id": plan.pk}))
+
+        body = resp.content.decode()
+        assert "Other plan ask" not in body
+
+
+class TestMesoJsHydratesThread:
+    def test_meso_js_reads_the_injected_thread(self):
+        js = read_meso_js()
+        assert "meso-chat-thread" in js
+
+    def test_meso_js_keeps_the_greeting_fallback(self):
+        # An empty history still shows the orienting greeting.
+        js = read_meso_js()
+        assert "Tell me how you'd like to adjust this plan" in js

--- a/app/store_project/meso/tests/test_chat_thread.py
+++ b/app/store_project/meso/tests/test_chat_thread.py
@@ -146,8 +146,8 @@ class TestSerializeChatThread:
         assert agent["changes"] == []
 
     def test_drafting_batch_renders_a_neutral_note(self):
-        # A batch left ``drafting`` after a reload (the background job never
-        # finished) is surfaced as a neutral note, not an error or a blank.
+        # A batch still ``drafting`` at reload is surfaced as a neutral note, not
+        # an error or a blank bubble.
         plan, _, _ = seed_plan()
         AgentProposalBatchFactory(plan=plan, status=AgentProposalBatch.Status.DRAFTING)
 
@@ -156,6 +156,26 @@ class TestSerializeChatThread:
         assert agent["text"].strip()
         assert not agent.get("error")
         assert not agent.get("changes")
+
+    def test_drafting_batch_carries_a_poll_url_to_resume(self):
+        # A run still in flight at render time carries its status URL so the
+        # front-end can resume polling and replace the placeholder when it lands,
+        # rather than leaving the thread stuck on the note.
+        plan, _, _ = seed_plan()
+        batch = AgentProposalBatchFactory(
+            plan=plan, status=AgentProposalBatch.Status.DRAFTING
+        )
+
+        agent = serialize_chat_thread(plan)[1]
+        assert agent["pollUrl"] == reverse(
+            "meso:api_batch_status", kwargs={"batch_id": batch.pk}
+        )
+        # A resolved batch never carries a poll URL — nothing left to poll.
+        resolved_plan, _, _ = seed_plan()
+        AgentProposalBatchFactory(
+            plan=resolved_plan, status=AgentProposalBatch.Status.PENDING
+        )
+        assert "pollUrl" not in serialize_chat_thread(resolved_plan)[1]
 
     def test_thread_is_plan_scoped(self):
         plan, _, _ = seed_plan()
@@ -211,3 +231,10 @@ class TestMesoJsHydratesThread:
         # An empty history still shows the orienting greeting.
         js = read_meso_js()
         assert "Tell me how you'd like to adjust this plan" in js
+
+    def test_meso_js_resumes_polling_a_hydrated_drafting_run(self):
+        # A run still drafting at load resumes via its poll URL so a thread
+        # hydrated mid-run isn't left stuck on the placeholder.
+        js = read_meso_js()
+        assert "resumeDrafting" in js
+        assert "pollUrl" in js

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -45,6 +45,7 @@ from .models import Session
 from .models import SessionLog
 from .models import WeekDelivery
 from .serializers import current_week
+from .serializers import serialize_chat_thread
 from .serializers import serialize_plan
 from .serializers import serialize_prescription
 from .serializers import serialize_proposed_change
@@ -115,8 +116,9 @@ class MesoDesignerView(LoginRequiredMixin, TemplateView):
     A self-contained, full-screen coach tool. The view serializes a real, owned
     plan into the page and the Alpine front-end hydrates from it (then autosaves
     edits to the API endpoints below). The bare URL has no fixtures anymore — it
-    redirects to the coach's working plan (or the roster). The agent column
-    stays mock until its slice.
+    redirects to the coach's working plan (or the roster). The agent column is
+    live (agent slice) and its conversation is persisted: ``chat_thread``
+    rebuilds the thread from the plan's proposal batches so it survives a reload.
     """
 
     template_name = "meso/designer.html"
@@ -140,6 +142,10 @@ class MesoDesignerView(LoginRequiredMixin, TemplateView):
         if plan is None:
             raise Http404("Unknown plan")
         ctx["plan_data"] = serialize_plan(plan)
+        # The persisted agent conversation, rebuilt from this plan's proposal
+        # batches so the chat survives a reload (the JS hydrates ``messages``
+        # from it, falling back to the greeting when empty).
+        ctx["chat_thread"] = serialize_chat_thread(plan)
         return ctx
 
 

--- a/app/store_project/static/js/meso.js
+++ b/app/store_project/static/js/meso.js
@@ -116,7 +116,30 @@ document.addEventListener("alpine:init", () => {
         console.error("Could not parse chat thread", e);
         return;
       }
-      if (Array.isArray(thread) && thread.length) this.messages = thread;
+      if (!Array.isArray(thread) || !thread.length) return;
+      this.messages = thread;
+      // If the last turn was still drafting at render time, drop that
+      // placeholder and resume polling so a run that finishes after the page
+      // loads updates the thread instead of leaving it stuck on the note.
+      const last = thread[thread.length - 1];
+      if (last && last.pollUrl) {
+        this.messages.pop();
+        this.resumeDrafting(last.pollUrl);
+      }
+    },
+
+    // Resume polling a batch that was still drafting when the page loaded. The
+    // typing indicator shows while we wait; pollBatch appends the resolved reply
+    // (or an error / timeout note) when the batch lands.
+    async resumeDrafting(pollUrl) {
+      this.agentTyping = true;
+      this.scrollThread();
+      try {
+        await this.pollBatch(pollUrl);
+      } finally {
+        this.agentTyping = false;
+        this.scrollThread();
+      }
     },
 
     async apiPost(url, body) {

--- a/app/store_project/static/js/meso.js
+++ b/app/store_project/static/js/meso.js
@@ -118,6 +118,9 @@ document.addEventListener("alpine:init", () => {
       }
       if (!Array.isArray(thread) || !thread.length) return;
       this.messages = thread;
+      // Land a restored thread on its latest turn, not the oldest message — a
+      // long conversation would otherwise reload scrolled to the top.
+      this.scrollThread();
       // If the last turn was still drafting at render time, drop that
       // placeholder and resume polling so a run that finishes after the page
       // loads updates the thread instead of leaving it stuck on the note.

--- a/app/store_project/static/js/meso.js
+++ b/app/store_project/static/js/meso.js
@@ -42,9 +42,11 @@ document.addEventListener("alpine:init", () => {
     planId: null,
     csrf: "",
 
-    // The thread starts with a single orienting greeting. Real agent turns are
-    // appended as the coach sends instructions; the thread is not persisted yet
-    // (a later slice adds the background job + saved conversation).
+    // The thread starts with a single orienting greeting. On load, init()
+    // replaces it with the plan's persisted conversation (rebuilt server-side
+    // from the proposal batches and injected as `meso-chat-thread`) when there
+    // is one; an empty history keeps this greeting. Real agent turns are
+    // appended live as the coach sends instructions.
     messages: [
       {
         id: 1,
@@ -97,6 +99,24 @@ document.addEventListener("alpine:init", () => {
       this.phases = data.phases;
       const csrfEl = document.getElementById("meso-csrf");
       this.csrf = csrfEl ? csrfEl.dataset.token : "";
+      this.hydrateThread();
+    },
+
+    // Replace the greeting with the plan's persisted conversation when the view
+    // injects one. The thread is rebuilt server-side from the proposal batches
+    // (serialize_chat_thread) in the exact `messages` shape, so it drops in
+    // without remapping. An empty history (no batches) keeps the greeting.
+    hydrateThread() {
+      const el = document.getElementById("meso-chat-thread");
+      if (!el) return;
+      let thread;
+      try {
+        thread = JSON.parse(el.textContent);
+      } catch (e) {
+        console.error("Could not parse chat thread", e);
+        return;
+      }
+      if (Array.isArray(thread) && thread.length) this.messages = thread;
     },
 
     async apiPost(url, body) {

--- a/app/store_project/templates/meso/designer.html
+++ b/app/store_project/templates/meso/designer.html
@@ -21,6 +21,7 @@
   <body class="meso">
     {% if plan_data %}
       {{ plan_data|json_script:"meso-plan-data" }}
+      {{ chat_thread|json_script:"meso-chat-thread" }}
       <span id="meso-csrf" data-token="{{ csrf_token }}" hidden></span>
     {% endif %}
     <div

--- a/docs/meso/agent-plan.md
+++ b/docs/meso/agent-plan.md
@@ -217,4 +217,9 @@ reviewable batch — and a golden-eval command guards quality. **Agent slice
 complete.**
 
 ## Out of scope (later)
-Athlete-facing surfaces · groups · the full "changes since last delivery" diff UI.
+Athlete-facing surfaces (**done** — see [`athlete-plan.md`](./athlete-plan.md)) ·
+groups · the full "changes since last delivery" diff UI.
+
+**Follow-up shipped:** the persisted chat thread deferred from Phase 3/4 (the
+designer conversation now survives a reload, rebuilt from the proposal batches —
+no new model). See [`chat-thread-plan.md`](./chat-thread-plan.md).

--- a/docs/meso/chat-thread-plan.md
+++ b/docs/meso/chat-thread-plan.md
@@ -1,6 +1,14 @@
 # Meso — persisted designer chat thread plan
 
-**Status:** building (branch `meso-chat-thread`) · created 2026-06-28
+**Status:** **Built** (branch `meso-chat-thread`; 2026-06-28). Built red→green:
+**+16 tests** (`test_chat_thread.py` — serializer shape/ordering/scoping/states,
+the drafting resume-poll, view injection, JS wiring); 379 meso / 519 project-wide
+pass, ruff clean, **no migration** (the conversation is already in the
+`AgentProposalBatch` rows). **Local Codex review: 0 blocking across 3 rounds →
+CLEAN.** Two nits fixed: a thread hydrated while a run was still `drafting`
+resumes polling (carries `pollUrl`, `meso.js` `resumeDrafting`) instead of going
+stale; and a long restored thread scrolls to its latest turn on load. · created
+2026-06-28
 **Companion to:** [`agent-plan.md`](./agent-plan.md) (the chat went live in agent
 Phase 3, but the thread was never persisted) · [`decisions.md`](./decisions.md) (B6)
 **Goal of this slice:** the designer's agent-chat conversation **survives a page
@@ -43,9 +51,11 @@ two messages, in the exact shape `meso.js`'s `messages` array renders:
 - **coach** — `{id: "coach-<pk>", role: "coach", text: instruction}`.
 - **agent** — depends on the batch's terminal state:
   - `failed`   → `{role: "agent", text: error-or-fallback, error: true}` (no changes).
-  - `drafting` → `{role: "agent", text: "Still working on this proposal…"}` (a
-    stuck/in-flight run after a reload — rendered as a neutral note, never silently
-    dropped).
+  - `drafting` → `{role: "agent", text: "Still working on this proposal…",
+    pollUrl: <batch-status-url>}` (an in-flight run at render time — rendered as a
+    neutral note, and `meso.js` drops the placeholder and **resumes polling** that
+    URL so a run finishing after load updates the thread instead of going stale;
+    the note is the fallback if it never resolves).
   - `pending` / `applied` / `dismissed` → `{role: "agent", text: summary-or-fallback,
     changes: [serialize_proposed_change…], reviewUrl: review_batch-url-when-changes}`.
 
@@ -62,10 +72,12 @@ existing `{% if plan_data %}` block (the thread only matters when a plan loads).
 
 ### JS (`meso.js`)
 
-`init()` reads `#meso-chat-thread`; when present and non-empty it **replaces** the
-default greeting (`this.messages = thread`). An empty history (no batches) keeps
-the orienting greeting. Hydrated message ids are strings (`coach-<pk>`); runtime
-turns keep appending with `Date.now()` — no key collision.
+`init()` → `hydrateThread()` reads `#meso-chat-thread`; when present and non-empty
+it **replaces** the default greeting (`this.messages = thread`), scrolls to the
+latest turn, and — if the last message carries a `pollUrl` (a still-drafting run)
+— drops that placeholder and `resumeDrafting()`s the poll. An empty history (no
+batches) keeps the orienting greeting. Hydrated message ids are strings
+(`coach-<pk>`); runtime turns keep appending with `Date.now()` — no key collision.
 
 ## Out of scope (later)
 A `ChatMessage` model (only needed if the agent ever sends free-form text not
@@ -78,9 +90,11 @@ pytest + factory_boy, mirroring the slice discipline:
 - **serializer** — empty plan → `[]`; one pending batch → `[coach, agent]` with
   the instruction/summary text + changes + a review url; ordering (oldest first,
   interleaved); a `failed` batch → an error message, no changes/link; a
-  no-changes batch → no review link + a summary fallback; **plan-scoping** (a
-  batch on another plan never bleeds in).
+  no-changes batch → no review link + a summary fallback; a `drafting` batch → a
+  neutral note **carrying a `pollUrl`** (resolved batches carry none);
+  **plan-scoping** (a batch on another plan never bleeds in).
 - **view** — the designer page injects `meso-chat-thread` with the prior
   instruction; a plan with no batches injects an empty `[]`.
 - **wiring** (source-level, as the project has no JS runner) — `meso.js` reads
-  `meso-chat-thread` and hydrates `messages`, keeping the greeting fallback.
+  `meso-chat-thread` and hydrates `messages`, keeping the greeting fallback, and
+  resumes the poll for a hydrated drafting run.

--- a/docs/meso/chat-thread-plan.md
+++ b/docs/meso/chat-thread-plan.md
@@ -1,0 +1,86 @@
+# Meso — persisted designer chat thread plan
+
+**Status:** building (branch `meso-chat-thread`) · created 2026-06-28
+**Companion to:** [`agent-plan.md`](./agent-plan.md) (the chat went live in agent
+Phase 3, but the thread was never persisted) · [`decisions.md`](./decisions.md) (B6)
+**Goal of this slice:** the designer's agent-chat conversation **survives a page
+reload**. Today the chat is ephemeral — `meso.js` re-seeds `messages` to a single
+orienting greeting on every load, so a coach who proposes changes, navigates away,
+and comes back sees an empty thread even though the proposals themselves persisted.
+This was the last loose end from the agent slice (Phase 3/4 both noted "the thread
+is not persisted yet").
+
+## The key realization — no new model, no migration
+
+The conversation is **already persisted, losslessly**, in the
+`AgentProposalBatch` rows the agent slice writes. Every coach turn maps 1:1 to a
+batch:
+
+- `batch.instruction` — the coach's chat message, verbatim (the endpoint stores
+  `payload["instruction"].strip()`, which is exactly what `meso.js` sent).
+- `batch.summary` + the batch's `ProposedChange` rows — the agent's reply.
+- `batch.status` — `pending` / `applied` / `dismissed` / `failed` / `drafting`.
+- `batch.created_at` — thread order.
+
+The agent never emits free-form chit-chat: it only ever responds with a proposal
+batch (a summary + changes) or an error. So the batches **are** the thread. A
+dedicated `ChatMessage` table would store nothing the batch doesn't already hold;
+it would duplicate `instruction`/`summary` and add a write path on every turn for
+no new information. We therefore reconstruct the thread from the plan's batches
+rather than adding a model — the same "reuse what exists, defer new tables" taste
+the athlete slice followed (Phases 1–3 added no migration).
+
+## Architecture
+
+```
+serializers.serialize_chat_thread(plan)
+    → [ {coach msg}, {agent msg}, {coach msg}, {agent msg}, … ]   # oldest first
+```
+
+Each of the plan's `AgentProposalBatch` rows (ascending `created_at`) expands to
+two messages, in the exact shape `meso.js`'s `messages` array renders:
+
+- **coach** — `{id: "coach-<pk>", role: "coach", text: instruction}`.
+- **agent** — depends on the batch's terminal state:
+  - `failed`   → `{role: "agent", text: error-or-fallback, error: true}` (no changes).
+  - `drafting` → `{role: "agent", text: "Still working on this proposal…"}` (a
+    stuck/in-flight run after a reload — rendered as a neutral note, never silently
+    dropped).
+  - `pending` / `applied` / `dismissed` → `{role: "agent", text: summary-or-fallback,
+    changes: [serialize_proposed_change…], reviewUrl: review_batch-url-when-changes}`.
+
+`reviewUrl` is camelCase here (the serializer emits messages **ready to drop into
+`messages`**, unlike the live status endpoint, which emits snake-case `review_url`
+that `batchMessage` remaps). The change shape reuses `serialize_proposed_change`,
+so a hydrated proposal renders byte-identical to a freshly returned one.
+
+### View + template
+
+`MesoDesignerView.get_context_data` adds `ctx["chat_thread"]`. The template
+injects it with `{{ chat_thread|json_script:"meso-chat-thread" }}` inside the
+existing `{% if plan_data %}` block (the thread only matters when a plan loads).
+
+### JS (`meso.js`)
+
+`init()` reads `#meso-chat-thread`; when present and non-empty it **replaces** the
+default greeting (`this.messages = thread`). An empty history (no batches) keeps
+the orienting greeting. Hydrated message ids are strings (`coach-<pk>`); runtime
+turns keep appending with `Date.now()` — no key collision.
+
+## Out of scope (later)
+A `ChatMessage` model (only needed if the agent ever sends free-form text not
+tied to a batch) · editing/deleting past turns · pagination of a very long thread
+(every proposal batch is rendered; revisit only if a plan accumulates hundreds) ·
+real-time multi-tab sync.
+
+## Testing
+pytest + factory_boy, mirroring the slice discipline:
+- **serializer** — empty plan → `[]`; one pending batch → `[coach, agent]` with
+  the instruction/summary text + changes + a review url; ordering (oldest first,
+  interleaved); a `failed` batch → an error message, no changes/link; a
+  no-changes batch → no review link + a summary fallback; **plan-scoping** (a
+  batch on another plan never bleeds in).
+- **view** — the designer page injects `meso-chat-thread` with the prior
+  instruction; a plan with no batches injects an empty `[]`.
+- **wiring** (source-level, as the project has no JS runner) — `meso.js` reads
+  `meso-chat-thread` and hydrates `messages`, keeping the greeting fallback.

--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -333,3 +333,20 @@ _(Append dated entries here as decisions land.)_
   them (push just stays dormant). Resume point → **the athlete slice is feature-complete** (install + offline
   logging + delivery email/push + results feeding the coach & agent). Open follow-ups: Background Sync,
   re-deliver push debouncing, in-app notification settings.
+- 2026-06-28 — **Persisted designer chat thread built** (branch `meso-chat-thread`; the loose end deferred
+  since agent Phase 3/4). The designer's agent conversation now **survives a reload**. Key realization: the
+  thread is **already persisted, losslessly**, in the `AgentProposalBatch` rows — each coach turn is a batch
+  (`instruction` = the coach's message, `summary` + the `ProposedChange` rows = the agent's reply,
+  `status`/`created_at` = state + order), and the agent never sends free-form chat, so the batches **are** the
+  thread. So we rebuild it rather than adding a model: `serializers.serialize_chat_thread(plan)` expands the
+  plan's batches (oldest first) into the exact `meso.js` `messages` shape (failed → an error note; drafting →
+  a neutral note carrying a `pollUrl`; else the summary + inline changes + a review link), the designer view
+  injects it via `json_script`, and `meso.js` `hydrateThread()` replaces the lone greeting (kept only for an
+  empty history), scrolls to the latest turn, and **resumes polling** a still-drafting run so a reload mid-run
+  doesn't go stale. **No model, no migration** — same "reuse what exists, defer new tables" taste as the
+  athlete slice. Built red→green: **+16 tests** (`test_chat_thread.py`; 379 meso / 519 project-wide), ruff
+  clean. **Local Codex review: 0 blocking across 3 rounds → CLEAN** (two nits fixed: the drafting resume-poll
+  and the scroll-to-latest). Plan in [`chat-thread-plan.md`](./chat-thread-plan.md). **Deferred:** a dedicated
+  `ChatMessage` model (only if the agent ever sends text not tied to a batch) · editing past turns ·
+  pagination of a very long thread. Resume point → next-slice options: **groups (S1)** is the main remaining
+  Meso feature area.


### PR DESCRIPTION
## What

The designer's agent chat went live in the agent slice, but the **thread was ephemeral**: `meso.js` re-seeded `messages` to a single greeting on every load, so a coach who proposed changes, navigated away, and came back saw an empty thread — even though the proposals themselves persisted. This was the last loose end from the agent slice (Phase 3/4 both noted "the thread is not persisted yet").

## The key realization — no model, no migration

The conversation is **already persisted, losslessly**, in the `AgentProposalBatch` rows. Every coach turn is a batch:

- `batch.instruction` — the coach's message, verbatim
- `batch.summary` + the `ProposedChange` rows — the agent's reply
- `batch.status` / `batch.created_at` — state and order

The agent never sends free-form chat (only a proposal batch or an error), so the **batches *are* the thread**. A dedicated `ChatMessage` table would store nothing the batch doesn't already hold. So this slice reconstructs the thread rather than adding a model — the same "reuse what exists, defer new tables" taste the athlete slice followed.

## How

- **`serializers.serialize_chat_thread(plan)`** — the plan's batches (oldest first), each expanded to a coach message + an agent reply, in the exact `meso.js` `messages` shape (`failed` → an error note; `drafting` → a neutral note carrying a `pollUrl`; else the summary + inline changes + a review link when there are changes). Reuses `serialize_proposed_change`, so a hydrated change renders byte-identical to a freshly returned one.
- **`MesoDesignerView`** injects `chat_thread`; `designer.html` ships it via `json_script`.
- **`meso.js` `init()` → `hydrateThread()`** replaces the lone greeting (kept only for an empty history), scrolls to the latest turn, and **resumes polling** a still-drafting run (`resumeDrafting()`) so a reload mid-run updates the thread instead of going stale.

## Tests

Built red→green: **+16 tests** (`test_chat_thread.py` — serializer shape/ordering/scoping/states, the drafting resume-poll, view injection, JS wiring). **379 meso / 519 project-wide pass**, ruff clean, **no migration**.

**Local Codex review: 0 blocking across 3 rounds → CLEAN.** Two nits fixed: a thread hydrated while a run was still `drafting` resumes polling instead of going stale; and a long restored thread scrolls to its latest turn on load.

## Docs

`docs/meso/chat-thread-plan.md` (new), with status + log entries in `agent-plan.md` and `decisions.md`. Next-slice resume point: groups (S1).

https://claude.ai/code/session_015G62Gs7papVMJAfYqeExrN