### PR TITLE
Meso — groups slice (S1): in-grid per-athlete override editor

### DIFF
--- a/app/store_project/meso/serializers.py
+++ b/app/store_project/meso/serializers.py
@@ -529,7 +529,19 @@ def group_adjustments(plan, prescriptions):
             continue
         name = override.membership.relationship.athlete.display_name()
         by_presc[override.prescription_id].append(
-            {"name": name, "initials": initials(name), "label": label}
+            {
+                "id": str(override.membership.relationship.athlete_id),
+                "name": name,
+                "initials": initials(name),
+                "label": label,
+                # The raw stored diff, so the in-grid editor can pre-fill the
+                # member's existing adjust (the label is display-only).
+                "swap": override.swap_name,
+                "load_pct": override.load_pct,
+                "sets": override.sets,
+                "reps": override.reps,
+                "note": override.note,
+            }
         )
     result = {}
     for presc_id, adjusts in by_presc.items():

--- a/app/store_project/meso/tests/test_group_overrides.py
+++ b/app/store_project/meso/tests/test_group_overrides.py
@@ -307,6 +307,25 @@ class TestGroupAdjustments:
         presc = first_prescription(plan)
         assert serializers.group_adjustments(plan, [presc]) == {}
 
+    def test_adjust_carries_member_id_and_raw_diff(self):
+        # The in-grid override editor pre-fills a member's existing adjust, so
+        # each adjust must carry the athlete id + the raw stored diff (not just
+        # the rendered label).
+        group = MesoGroupFactory()
+        membership = make_member(group, name="Maya Okonkwo")
+        plan = group.create_shared_plan()
+        presc = first_prescription(plan)
+        membership.set_override(
+            presc, swap_name="Box Squat", load_pct=90, sets="4", reps="6", note="slow"
+        )
+        adjust = serializers.group_adjustments(plan, [presc])[presc.pk]["adjusts"][0]
+        assert adjust["id"] == str(membership.relationship.athlete.pk)
+        assert adjust["swap"] == "Box Squat"
+        assert adjust["load_pct"] == 90
+        assert adjust["sets"] == "4"
+        assert adjust["reps"] == "6"
+        assert adjust["note"] == "slow"
+
 
 # -- serializer: the adj overlay the designer renders -----------------------
 
@@ -382,6 +401,29 @@ class TestOverrideEndpoint:
         assert resp.status_code == 200
         assert membership.overrides.count() == 1
         assert resp.json()["adj"] == "MO -10%"
+
+    def test_reply_adjusts_carry_member_id_and_raw_diff(self, client):
+        # The reply repaints the badge *and* re-seeds the editor, so its adjusts
+        # carry the athlete id + raw diff like group_adjustments.
+        group = MesoGroupFactory()
+        membership = make_member(group, name="Maya Okonkwo")
+        plan = group.create_shared_plan()
+        presc = first_prescription(plan)
+        client.force_login(group.coach)
+        resp = client.post(
+            self._url(plan, presc),
+            data={
+                "athlete": str(membership.relationship.athlete.pk),
+                "swap": "Box Squat",
+                "load_pct": 90,
+            },
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        adjust = resp.json()["adjusts"][0]
+        assert adjust["id"] == str(membership.relationship.athlete.pk)
+        assert adjust["swap"] == "Box Squat"
+        assert adjust["load_pct"] == 90
 
     def test_partial_update_preserves_other_fields(self, client):
         # A later request updating only load_pct must not drop an earlier swap
@@ -522,3 +564,27 @@ class TestOverrideEndpoint:
         presc = first_prescription(plan)
         resp = client.post(self._url(plan, presc))
         assert resp.status_code == 302
+
+
+# -- view: the designer surfaces the in-grid override editor -----------------
+
+
+class TestDesignerOverrideEditor:
+    """The designer page wires the in-grid click-to-adjust editor.
+
+    Alpine gates it to Group mode at runtime; this guards the markup the editor
+    methods drive from regressing.
+    """
+
+    def test_group_designer_includes_the_override_editor(self, client):
+        group = MesoGroupFactory(name="Squad")
+        make_member(group, name="Maya Okonkwo")
+        plan = group.create_shared_plan()
+        client.force_login(group.coach)
+        resp = client.get(reverse("meso:designer_plan", kwargs={"plan_id": plan.pk}))
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        # The per-row affordance and the modal the editor methods drive.
+        assert "openOverride(ex)" in body
+        assert "saveOverride()" in body
+        assert 'x-if="override"' in body

--- a/app/store_project/static/js/meso.js
+++ b/app/store_project/static/js/meso.js
@@ -222,7 +222,14 @@ function createMeso() {
       if (!this.isGroup || !this.live) return;
       const members = (this.group && this.group.members) || [];
       if (!members.length) return;
-      const memberId = members[0].id;
+      // Land on a member who already adjusts this row (the badge the coach
+      // tapped) so a save edits the existing adjust rather than overwriting the
+      // wrong athlete; fall back to the first member for a fresh adjust. Guard
+      // against a stored adjust whose member has since left the roster.
+      const adjusted = (ex.adjusts || []).find((a) =>
+        members.some((m) => m.id === a.id),
+      );
+      const memberId = adjusted ? adjusted.id : members[0].id;
       this.override = {
         ex,
         members,

--- a/app/store_project/static/js/meso.js
+++ b/app/store_project/static/js/meso.js
@@ -32,6 +32,11 @@ function createMeso() {
     checks: {},
     exSeq: 1,
 
+    // Group mode only: the open per-athlete override editor (one shared row),
+    // or null when closed. Holds the targeted row (`ex`), the group's members,
+    // the selected member id, and an editable `draft` of their adjust.
+    override: null,
+
     // The agent runs as a background job (Phase 4): POST kicks it off, then we
     // poll the batch's status until it lands. `agentTyping` stays true (the
     // "drafting…" indicator) for the whole poll.
@@ -189,6 +194,120 @@ function createMeso() {
         rpe: ex.rpe ?? "",
         note: ex.note ?? "",
       }).catch((err) => console.error("Autosave failed", err));
+    },
+
+    // ---- per-athlete override editor (group mode) ----
+    //
+    // In Group mode every shared row can be adjusted per athlete. openOverride
+    // opens an editor for one prescription; the coach picks a member and edits
+    // their diff (swap / load% / volume / note), and saveOverride POSTs it to
+    // the override endpoint. The reply recomputes the row's `adj` badge, which
+    // we paint straight back onto the row. The editor pre-fills from the
+    // member's stored adjust (`ex.adjusts`), so editing and clearing both work
+    // off the real diffs the serializer injected.
+
+    // The member's stored diff on this row as editable strings (blank if unset).
+    overrideDraft(ex, memberId) {
+      const found = (ex.adjusts || []).find((a) => a.id === memberId);
+      return {
+        swap: (found && found.swap) || "",
+        load_pct: found && found.load_pct != null ? String(found.load_pct) : "",
+        sets: (found && found.sets) || "",
+        reps: (found && found.reps) || "",
+        note: (found && found.note) || "",
+      };
+    },
+
+    openOverride(ex) {
+      if (!this.isGroup || !this.live) return;
+      const members = (this.group && this.group.members) || [];
+      if (!members.length) return;
+      const memberId = members[0].id;
+      this.override = {
+        ex,
+        members,
+        memberId,
+        draft: this.overrideDraft(ex, memberId),
+        saving: false,
+        error: "",
+      };
+    },
+
+    selectOverrideMember(memberId) {
+      if (!this.override) return;
+      this.override.memberId = memberId;
+      this.override.draft = this.overrideDraft(this.override.ex, memberId);
+      this.override.error = "";
+    },
+
+    closeOverride() {
+      this.override = null;
+    },
+
+    // True when the selected member already has a stored adjust on the open row
+    // (so the editor can offer "Clear").
+    get overrideHasExisting() {
+      if (!this.override) return false;
+      return (this.override.ex.adjusts || []).some(
+        (a) => a.id === this.override.memberId,
+      );
+    },
+
+    // Parse the load% field to the endpoint's int | null. Blank → null (clear
+    // that part); anything but a whole number in the model's 1–200 band is
+    // rejected here so the badge never repaints off a server 400.
+    parseOverrideLoadPct() {
+      const raw = (this.override.draft.load_pct || "").trim();
+      if (raw === "") return { ok: true, value: null };
+      if (!/^[0-9]+$/.test(raw)) return { ok: false };
+      const n = parseInt(raw, 10);
+      if (n < 1 || n > 200) return { ok: false };
+      return { ok: true, value: n };
+    },
+
+    async saveOverride() {
+      if (!this.override || this.override.saving) return;
+      const parsed = this.parseOverrideLoadPct();
+      if (!parsed.ok) {
+        this.override.error = "Load % must be a whole number from 1 to 200.";
+        return;
+      }
+      const { ex, memberId, draft } = this.override;
+      await this.submitOverride(ex, {
+        athlete: memberId,
+        swap: draft.swap.trim(),
+        load_pct: parsed.value,
+        sets: draft.sets.trim(),
+        reps: draft.reps.trim(),
+        note: draft.note.trim(),
+      });
+    },
+
+    async clearOverride() {
+      if (!this.override || this.override.saving) return;
+      const { ex, memberId } = this.override;
+      await this.submitOverride(ex, { athlete: memberId, clear: true });
+    },
+
+    // POST the override change, repaint the row's adj badge from the reply, and
+    // close the editor. On failure the editor stays open with an error so the
+    // coach can retry without losing their edits.
+    async submitOverride(ex, body) {
+      this.override.saving = true;
+      this.override.error = "";
+      try {
+        const data = await this.apiPost(
+          `/meso/api/plan/${this.planId}/prescription/${ex.id}/override/`,
+          body,
+        );
+        ex.adj = data.adj || null;
+        ex.adjusts = data.adjusts || [];
+        this.closeOverride();
+      } catch (err) {
+        console.error("Override save failed", err);
+        this.override.error = "Couldn't save that adjust. Please try again.";
+        this.override.saving = false;
+      }
     },
 
     // ---- helpers ----

--- a/app/store_project/static/js/meso.js
+++ b/app/store_project/static/js/meso.js
@@ -241,6 +241,11 @@ function createMeso() {
     },
 
     closeOverride() {
+      // Don't dismiss mid-save: submitOverride keeps the editor open on failure
+      // to surface a retry, which relies on `this.override` staying non-null for
+      // the whole request. Escape / backdrop both route through here, so this is
+      // the one place that guard belongs (the footer buttons are also disabled).
+      if (this.override && this.override.saving) return;
       this.override = null;
     },
 
@@ -302,6 +307,7 @@ function createMeso() {
         );
         ex.adj = data.adj || null;
         ex.adjusts = data.adjusts || [];
+        this.override.saving = false; // clear before the guarded close
         this.closeOverride();
       } catch (err) {
         console.error("Override save failed", err);

--- a/app/store_project/templates/meso/designer.html
+++ b/app/store_project/templates/meso/designer.html
@@ -319,7 +319,7 @@
               <template x-if="isGroup">
                 <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:16px;padding:10px 13px;background:var(--soft);border:1px solid var(--soft-line);border-radius:9px;">
                   <span style="font-size:11.5px;font-weight:700;color:var(--accent-deep);">Shared program &#183; per-athlete auto-adjusts</span>
-                  <span style="font-size:11.5px;color:var(--accent-deep);opacity:0.85;">Every member trains off this program &#8212; a member's badge marks where their plan auto-adjusts.</span>
+                  <span style="font-size:11.5px;color:var(--accent-deep);opacity:0.85;">Every member trains off this program &#8212; tap a row's adjust to tune one athlete's load, swap, or volume.</span>
                 </div>
               </template>
 
@@ -342,7 +342,12 @@
                         <div style="display:flex;flex-wrap:wrap;gap:5px;align-items:center;padding:1px 6px;margin-top:1px;min-height:15px;">
                           <template x-if="ex.tag"><span style="display:inline-flex;align-items:center;gap:3px;font-size:10px;font-weight:700;color:var(--accent-deep);background:var(--soft);border:1px solid var(--soft-line);padding:0 5px;border-radius:4px;" x-text="ex.tag"></span></template>
                           <template x-if="ex.last"><span style="font-size:10.5px;color:var(--dim);font-family:'IBM Plex Mono',monospace;" x-text="'last: ' + ex.last"></span></template>
-                          <template x-if="isGroup && ex.adj"><span :title="(ex.adjusts || []).map(a => a.name + ': ' + a.label).join('\n')" style="font-size:10px;font-weight:600;color:var(--accent-deep);background:var(--soft);padding:0 5px;border-radius:4px;cursor:help;" x-text="ex.adj"></span></template>
+                          <template x-if="isGroup">
+                            <button @click="openOverride(ex)" data-hover="brighten" :title="ex.adj ? (ex.adjusts || []).map(a => a.name + ': ' + a.label).join('\n') : 'Set a per-athlete adjust'" style="appearance:none;cursor:pointer;font:inherit;font-size:10px;font-weight:600;line-height:1.6;border:1px solid var(--soft-line);border-radius:4px;padding:0 5px;color:var(--accent-deep);background:var(--soft);">
+                              <span x-show="ex.adj" x-text="ex.adj"></span>
+                              <span x-show="!ex.adj" style="color:var(--dim);">+ adjust</span>
+                            </button>
+                          </template>
                         </div>
                       </div>
                       <div style="display:flex;align-items:center;justify-content:center;gap:2px;">
@@ -493,6 +498,65 @@
           </div>
         </div>
       </div>
+
+      <!-- ===== PER-ATHLETE OVERRIDE EDITOR (group mode) ===== -->
+      <template x-if="override">
+        <div @click.self="closeOverride()" @keydown.escape.window="closeOverride()" style="position:fixed;inset:0;z-index:90;background:rgba(16,18,22,0.34);display:flex;align-items:center;justify-content:center;padding:24px;">
+          <div style="width:430px;max-width:100%;background:var(--surface);border:1px solid var(--line);border-radius:14px;box-shadow:0 24px 60px rgba(16,18,22,0.28);overflow:hidden;">
+            <!-- header -->
+            <div style="padding:15px 18px 13px;border-bottom:1px solid var(--line-2);">
+              <div style="font-size:10.5px;font-weight:700;letter-spacing:0.07em;text-transform:uppercase;color:var(--dim);margin-bottom:3px;">Per-athlete adjust</div>
+              <div style="font-size:15px;font-weight:700;letter-spacing:-0.015em;" x-text="override.ex.name"></div>
+              <div style="font-size:11.5px;color:var(--dim);font-family:'IBM Plex Mono',monospace;margin-top:1px;">shared <span x-text="override.ex.sets + '×' + override.ex.reps"></span><span x-show="numeric(override.ex.load)" x-text="' · ' + override.ex.load + ' ' + unit"></span></div>
+            </div>
+            <!-- member selector -->
+            <div style="padding:13px 18px 6px;">
+              <p style="font-size:10.5px;font-weight:700;letter-spacing:0.07em;text-transform:uppercase;color:var(--dim);margin:0 0 8px;">Athlete</p>
+              <div style="display:flex;flex-wrap:wrap;gap:6px;">
+                <template x-for="m in override.members" :key="m.id">
+                  <button @click="selectOverrideMember(m.id)" :style="`appearance:none;cursor:pointer;font:inherit;display:inline-flex;align-items:center;gap:6px;font-size:12px;font-weight:600;padding:5px 10px;border-radius:7px;border:1px solid ${m.id === override.memberId ? 'var(--accent)' : 'var(--line)'};background:${m.id === override.memberId ? 'var(--soft)' : 'var(--surface)'};color:${m.id === override.memberId ? 'var(--accent-deep)' : 'var(--ink)'};`">
+                    <span x-text="m.name"></span>
+                    <template x-if="(override.ex.adjusts || []).some(a => a.id === m.id)"><span style="width:6px;height:6px;border-radius:50%;background:var(--accent);"></span></template>
+                  </button>
+                </template>
+              </div>
+            </div>
+            <!-- fields -->
+            <div style="padding:10px 18px 4px;display:grid;grid-template-columns:1fr 1fr;gap:11px 12px;">
+              <div style="grid-column:1 / -1;">
+                <label style="display:block;font-size:11px;font-weight:600;color:var(--dim);margin-bottom:4px;">Swap exercise</label>
+                <input x-model="override.draft.swap" :placeholder="override.ex.name" style="width:100%;box-sizing:border-box;appearance:none;border:1px solid var(--line);border-radius:8px;background:var(--rail);font:inherit;font-size:13px;color:var(--ink);padding:7px 9px;outline:none;" />
+              </div>
+              <div>
+                <label style="display:block;font-size:11px;font-weight:600;color:var(--dim);margin-bottom:4px;">Load %</label>
+                <input x-model="override.draft.load_pct" inputmode="numeric" placeholder="100" style="width:100%;box-sizing:border-box;appearance:none;border:1px solid var(--line);border-radius:8px;background:var(--rail);font:inherit;font-family:'IBM Plex Mono',monospace;font-size:13px;color:var(--ink);padding:7px 9px;outline:none;" />
+              </div>
+              <div>
+                <label style="display:block;font-size:11px;font-weight:600;color:var(--dim);margin-bottom:4px;">Sets &#215; Reps</label>
+                <div style="display:flex;align-items:center;gap:6px;">
+                  <input x-model="override.draft.sets" :placeholder="override.ex.sets" style="width:100%;box-sizing:border-box;appearance:none;border:1px solid var(--line);border-radius:8px;background:var(--rail);font:inherit;font-family:'IBM Plex Mono',monospace;font-size:13px;color:var(--ink);padding:7px 9px;outline:none;text-align:center;" />
+                  <span style="color:var(--dim);">&#215;</span>
+                  <input x-model="override.draft.reps" :placeholder="override.ex.reps" style="width:100%;box-sizing:border-box;appearance:none;border:1px solid var(--line);border-radius:8px;background:var(--rail);font:inherit;font-family:'IBM Plex Mono',monospace;font-size:13px;color:var(--ink);padding:7px 9px;outline:none;text-align:center;" />
+                </div>
+              </div>
+              <div style="grid-column:1 / -1;">
+                <label style="display:block;font-size:11px;font-weight:600;color:var(--dim);margin-bottom:4px;">Note</label>
+                <input x-model="override.draft.note" placeholder="&#8212;" style="width:100%;box-sizing:border-box;appearance:none;border:1px solid var(--line);border-radius:8px;background:var(--rail);font:inherit;font-size:13px;color:var(--ink);padding:7px 9px;outline:none;" />
+              </div>
+            </div>
+            <div style="padding:2px 18px 0;min-height:18px;">
+              <div x-show="override.error" x-text="override.error" style="font-size:11.5px;color:var(--warn);font-weight:600;"></div>
+            </div>
+            <!-- footer -->
+            <div style="padding:12px 18px 15px;display:flex;align-items:center;gap:9px;">
+              <button x-show="overrideHasExisting" @click="clearOverride()" :disabled="override.saving" data-hover="rail" style="appearance:none;cursor:pointer;font:inherit;font-size:12.5px;font-weight:600;color:var(--warn);background:var(--surface);border:1px solid color-mix(in srgb,var(--warn) 30%,#fff);border-radius:8px;padding:8px 13px;">Clear adjust</button>
+              <div style="flex:1;"></div>
+              <button @click="closeOverride()" :disabled="override.saving" data-hover="rail" style="appearance:none;cursor:pointer;font:inherit;font-size:12.5px;font-weight:600;color:var(--ink);background:var(--surface);border:1px solid var(--line);border-radius:8px;padding:8px 13px;">Cancel</button>
+              <button @click="saveOverride()" :disabled="override.saving" :style="override.saving ? 'opacity:0.6;cursor:default;' : ''" data-hover="brighten" style="appearance:none;cursor:pointer;font:inherit;font-size:12.5px;font-weight:650;color:var(--accent-ink);background:var(--accent);border:0;border-radius:8px;padding:8px 15px;">Save adjust</button>
+            </div>
+          </div>
+        </div>
+      </template>
     </div>
   </body>
 </html>

--- a/frontend/meso.test.js
+++ b/frontend/meso.test.js
@@ -34,6 +34,55 @@ beforeEach(() => {
   vi.restoreAllMocks();
 });
 
+// A meso component in Group mode with two members and one shared row, wired
+// enough to drive the in-grid per-athlete override editor without Alpine/DOM.
+function makeGroupMeso(overrides = {}) {
+  const c = makeMeso();
+  c.mode = "group";
+  c.group = {
+    id: 3,
+    name: "Squad",
+    members: [
+      { id: "a1", name: "Maya Okonkwo", initials: "MO" },
+      { id: "a2", name: "Aaron Adams", initials: "AA" },
+    ],
+  };
+  return Object.assign(c, overrides);
+}
+
+// A shared-program row Maya already adjusts (load 90% of a 100kg base).
+function groupRow(overrides = {}) {
+  return Object.assign(
+    {
+      id: 11,
+      name: "Back Squat",
+      sets: "3",
+      reps: "10",
+      load: "100",
+      adj: "MO -10%",
+      adjusts: [
+        {
+          id: "a1",
+          name: "Maya Okonkwo",
+          initials: "MO",
+          label: "-10%",
+          swap: "",
+          load_pct: 90,
+          sets: "",
+          reps: "",
+          note: "",
+        },
+      ],
+    },
+    overrides,
+  );
+}
+
+// The body sent on the nth fetch call, parsed back from JSON.
+function sentBody(n = 0) {
+  return JSON.parse(global.fetch.mock.calls[n][1].body);
+}
+
 describe("agentErrorText", () => {
   const c = createMeso();
   it("maps known statuses to friendly copy", () => {
@@ -136,5 +185,125 @@ describe("pollBatch", () => {
     expect(global.fetch).toHaveBeenCalledTimes(3);
     expect(lastAgent(c).error).toBe(true);
     expect(lastAgent(c).text).toMatch(/taking longer than expected/);
+  });
+});
+
+describe("override editor", () => {
+  it("opens on a shared row, selecting the first member with their stored diff", () => {
+    const c = makeGroupMeso();
+    const ex = groupRow();
+    c.openOverride(ex);
+    expect(c.override).not.toBe(null);
+    expect(c.override.ex).toBe(ex);
+    expect(c.override.memberId).toBe("a1");
+    // Maya's stored 90% pre-fills the draft (as a string for the text input).
+    expect(c.override.draft.load_pct).toBe("90");
+    expect(c.override.draft.swap).toBe("");
+    expect(c.overrideHasExisting).toBe(true);
+  });
+
+  it("blanks the draft when switching to a member with no adjust", () => {
+    const c = makeGroupMeso();
+    c.openOverride(groupRow());
+    c.selectOverrideMember("a2");
+    expect(c.override.memberId).toBe("a2");
+    expect(c.override.draft.load_pct).toBe("");
+    expect(c.override.draft.swap).toBe("");
+    expect(c.overrideHasExisting).toBe(false);
+  });
+
+  it("is a no-op outside group mode or with no members", () => {
+    const indiv = makeMeso();
+    indiv.openOverride(groupRow());
+    expect(indiv.override == null).toBe(true);
+
+    const empty = makeGroupMeso({ group: { id: 3, name: "Squad", members: [] } });
+    empty.openOverride(groupRow());
+    expect(empty.override == null).toBe(true);
+  });
+
+  it("saves a member's adjust, posts the full diff, and repaints the row", async () => {
+    const c = makeGroupMeso();
+    const ex = groupRow();
+    global.fetch = vi.fn().mockResolvedValue(
+      res({
+        body: {
+          adj: "2 adjusts",
+          adjusts: [{ id: "a1" }, { id: "a2" }],
+        },
+      }),
+    );
+    c.openOverride(ex);
+    c.selectOverrideMember("a2");
+    c.override.draft.swap = "Box Squat";
+    c.override.draft.load_pct = "85";
+    await c.saveOverride();
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch.mock.calls[0][0]).toBe(
+      "/meso/api/plan/7/prescription/11/override/",
+    );
+    expect(sentBody()).toEqual({
+      athlete: "a2",
+      swap: "Box Squat",
+      load_pct: 85,
+      sets: "",
+      reps: "",
+      note: "",
+    });
+    // The reply repaints the badge and closes the editor.
+    expect(ex.adj).toBe("2 adjusts");
+    expect(ex.adjusts).toHaveLength(2);
+    expect(c.override).toBe(null);
+  });
+
+  it("sends load_pct null when the field is left blank", async () => {
+    const c = makeGroupMeso();
+    global.fetch = vi.fn().mockResolvedValue(res({ body: { adj: null, adjusts: [] } }));
+    c.openOverride(groupRow());
+    c.selectOverrideMember("a2");
+    c.override.draft.note = "tempo";
+    await c.saveOverride();
+    expect(sentBody().load_pct).toBe(null);
+    expect(sentBody().note).toBe("tempo");
+  });
+
+  it("rejects a non-numeric or out-of-band load% without posting", async () => {
+    const c = makeGroupMeso();
+    global.fetch = vi.fn();
+    c.openOverride(groupRow());
+    c.override.draft.load_pct = "abc";
+    await c.saveOverride();
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(c.override.error).toMatch(/Load %/);
+
+    c.override.draft.load_pct = "500";
+    await c.saveOverride();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("clears a member's adjust and repaints the row", async () => {
+    const c = makeGroupMeso();
+    const ex = groupRow();
+    global.fetch = vi.fn().mockResolvedValue(res({ body: { adj: null, adjusts: [] } }));
+    c.openOverride(ex);
+    await c.clearOverride();
+    expect(sentBody()).toEqual({ athlete: "a1", clear: true });
+    expect(ex.adj).toBe(null);
+    expect(ex.adjusts).toEqual([]);
+    expect(c.override).toBe(null);
+  });
+
+  it("keeps the editor open and surfaces an error when the save fails", async () => {
+    const c = makeGroupMeso();
+    const ex = groupRow();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    global.fetch = vi.fn().mockResolvedValue(res({ ok: false, status: 500 }));
+    c.openOverride(ex);
+    c.override.draft.load_pct = "80";
+    await c.saveOverride();
+    expect(c.override).not.toBe(null);
+    expect(c.override.error).toMatch(/Couldn't save/);
+    expect(ex.adj).toBe("MO -10%"); // unchanged
   });
 });

--- a/frontend/meso.test.js
+++ b/frontend/meso.test.js
@@ -294,6 +294,16 @@ describe("override editor", () => {
     expect(c.override).toBe(null);
   });
 
+  it("ignores a dismiss while a save is in flight", () => {
+    // Escape / backdrop both route through closeOverride; if it nulled the
+    // editor mid-save, a later save failure would throw setting override.error.
+    const c = makeGroupMeso();
+    c.openOverride(groupRow());
+    c.override.saving = true;
+    c.closeOverride();
+    expect(c.override).not.toBe(null);
+  });
+
   it("keeps the editor open and surfaces an error when the save fails", async () => {
     const c = makeGroupMeso();
     const ex = groupRow();

--- a/frontend/meso.test.js
+++ b/frontend/meso.test.js
@@ -202,6 +202,21 @@ describe("override editor", () => {
     expect(c.overrideHasExisting).toBe(true);
   });
 
+  it("preselects the adjusted member when the badge isn't the first member", () => {
+    const c = makeGroupMeso();
+    // Only Aaron (the second member) adjusts this row.
+    const ex = groupRow({
+      adj: "AA -10%",
+      adjusts: [
+        { id: "a2", name: "Aaron Adams", initials: "AA", label: "-10%", swap: "", load_pct: 90, sets: "", reps: "", note: "" },
+      ],
+    });
+    c.openOverride(ex);
+    expect(c.override.memberId).toBe("a2");
+    expect(c.override.draft.load_pct).toBe("90");
+    expect(c.overrideHasExisting).toBe(true);
+  });
+
   it("blanks the draft when switching to a member with no adjust", () => {
     const c = makeGroupMeso();
     c.openOverride(groupRow());


### PR DESCRIPTION
## Groups slice (S1) — the in-grid per-athlete override editor

Phase 3 landed the override **engine** (the `PrescriptionOverride` model, the
`prescription_override` endpoint, the `resolve_prescription`/`group_adjustments`
serializers, and the per-row `adj` badge), but a coach had **no way to set an
adjust from the designer** — only the seed, the admin, or a raw API call could.
This PR adds the missing coach-facing affordance: click a shared-program row in
Group mode → set or clear one member's swap / load % / volume / note.

### What changed

- **`serializers.group_adjustments`** — each adjust entry now also carries the
  athlete `id` and the **raw stored diff** (`swap`/`load_pct`/`sets`/`reps`/`note`),
  not just the rendered label, so the editor can pre-fill a member's existing
  adjust. This flows into `ex.adjusts` (the serialized grid row) and the override
  endpoint reply for free — both already build off `group_adjustments`.
- **`meso.js`** — the override editor component: `openOverride` (lands on the
  row's already-adjusted member when there is one, else the first member),
  `selectOverrideMember`, `saveOverride`/`clearOverride` (POST the full diff,
  repaint the row's `adj` badge from the reply), client-side load% validation,
  and a guard so an in-flight save can't be dismissed mid-request.
- **`designer.html`** — each group row's `adj` badge becomes an **adjust button**
  (shows the summary when set, `+ adjust` otherwise) that opens a modal editor:
  member selector + swap / load% / sets×reps / note fields + Clear.

### Testing

Built **red→green**. The override **API + badge already existed and are
unchanged in behavior** — this is the UI on top.

- **+4 backend tests** — enriched `group_adjustments` + endpoint-reply shape
  (athlete id + raw diff) and a designer-render guard for the editor wiring.
- **+9 Vitest tests** (`frontend/meso.test.js`) — open/pre-fill, member switch,
  save POST body + row repaint, clear, load% validation, no-op guards, the
  dismiss-mid-save guard, and adjusted-member preselect.

`494 meso / 40 JS` green; `ruff` clean.

### Codex review

Local `codex review` loop converged **CLEAN** (3 iterations) — fixed 2 P2 nits,
none declined:
1. Escape/backdrop could dismiss the modal mid-save, crashing the failure path.
2. Opening a row whose adjust belonged to a non-first member could overwrite the
   wrong athlete.

### Notes

No model change / no migration. The remaining groups work is Phase 2b
(create-group-from-roster UI) and Phase 4 (deliver-to-all). Plan in
`docs/meso/groups-plan.md`.

https://claude.ai/code/session_015G62Gs7papVMJAfYqeExrN
