### PR TITLE
Meso — groups slice (S1) Phase 2b: create-group-from-roster UI

### DIFF
--- a/app/store_project/meso/models.py
+++ b/app/store_project/meso/models.py
@@ -894,6 +894,25 @@ class MesoGroup(models.Model):
     def __str__(self):
         return self.name
 
+    @classmethod
+    def create_for_coach(cls, coach, *, name, focus="", athletes=()):
+        """Create a new group for ``coach`` and add the given athletes (S1 Phase 2b).
+
+        The create-group entry point from the roster. ``name`` is required by the
+        caller (the view rejects a blank one); ``focus`` is optional. Each athlete
+        is added via ``add_athlete``, so the same active-link tenancy guard
+        applies — one without an active link to this coach is skipped rather than
+        raising, since the create form only ever offers the coach's own athletes
+        and a stale/foreign pick shouldn't fail the whole create.
+        """
+        group = cls.objects.create(coach=coach, name=name, focus=focus)
+        for athlete in athletes:
+            try:
+                group.add_athlete(athlete)
+            except InvalidTransition:
+                continue
+        return group
+
     def add_athlete(self, athlete):
         """Add one of the coach's *active* athletes to the group (idempotent).
 

--- a/app/store_project/meso/tests/test_group_create.py
+++ b/app/store_project/meso/tests/test_group_create.py
@@ -1,0 +1,192 @@
+"""Groups slice (S1) Phase 2b — create a brand-new group from the roster.
+
+Phases 1–2a stood up the group + membership spine and a group's shared program,
+but a group could still only be born from the seed/admin. Phase 2b is the
+create-group entry point: a coach names a group, gives it a focus, and picks
+members from their roster.
+
+These tests pin the contract (see ``docs/meso/groups-plan.md``): ``name`` is
+required, members are scoped to the coach's *active* links (a foreign/stale pick
+is silently ignored, never a leak or a 500), and a successful create lands on
+the new group's detail page. The model helper (``create_for_coach``) carries the
+tenancy guard; the view is a thin form POST over it.
+"""
+
+import uuid
+
+import pytest
+from django.urls import reverse
+
+from store_project.meso.factories import CoachAthleteFactory
+from store_project.meso.factories import CoachProfileFactory
+from store_project.meso.models import CoachAthlete
+from store_project.meso.models import MesoGroup
+from store_project.users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def active_athlete(coach, *, name="Member One"):
+    """An athlete with an active link to ``coach`` (eligible for membership)."""
+    athlete = UserFactory(name=name)
+    CoachAthleteFactory(coach=coach, athlete=athlete, status=CoachAthlete.Status.ACTIVE)
+    return athlete
+
+
+# -- model helper -----------------------------------------------------------
+
+
+class TestCreateForCoach:
+    def test_creates_group_owned_by_coach(self):
+        coach = UserFactory()
+        group = MesoGroup.create_for_coach(
+            coach, name="Tue/Thu Squad", focus="Hypertrophy"
+        )
+        assert group.pk is not None
+        assert group.coach == coach
+        assert group.name == "Tue/Thu Squad"
+        assert group.focus == "Hypertrophy"
+        assert group.status == MesoGroup.Status.ACTIVE
+
+    def test_adds_given_athletes_off_active_links(self):
+        coach = UserFactory()
+        a = active_athlete(coach, name="Aaron Adams")
+        b = active_athlete(coach, name="Beth Brown")
+        group = MesoGroup.create_for_coach(coach, name="Squad", athletes=[a, b])
+        names = [u.name for u in group.active_member_users()]
+        assert names == ["Aaron Adams", "Beth Brown"]
+
+    def test_focus_defaults_blank_and_athletes_optional(self):
+        coach = UserFactory()
+        group = MesoGroup.create_for_coach(coach, name="Solo")
+        assert group.focus == ""
+        assert group.active_member_users() == []
+
+    def test_skips_athlete_without_active_link(self):
+        # A stranger (no active link) is skipped, not raised — the helper stays
+        # safe even if a caller passes an ineligible athlete.
+        coach = UserFactory()
+        good = active_athlete(coach, name="Good One")
+        stranger = UserFactory(name="No Link")
+        group = MesoGroup.create_for_coach(
+            coach, name="Squad", athletes=[good, stranger]
+        )
+        names = [u.name for u in group.active_member_users()]
+        assert names == ["Good One"]
+
+
+# -- view: create from the roster -------------------------------------------
+
+
+class TestGroupCreateView:
+    def test_post_creates_group_with_members_and_redirects_to_detail(self, client):
+        coach = UserFactory()
+        CoachProfileFactory(user=coach)
+        a = active_athlete(coach, name="Aaron Adams")
+        b = active_athlete(coach, name="Beth Brown")
+        client.force_login(coach)
+        resp = client.post(
+            reverse("meso:group_create"),
+            data={
+                "name": "Tue/Thu Squad",
+                "focus": "Strength",
+                "athletes": [str(a.pk), str(b.pk)],
+            },
+        )
+        group = MesoGroup.objects.for_coach(coach).get()
+        assert resp.status_code == 302
+        assert resp.url == reverse("meso:group", kwargs={"pk": group.pk})
+        assert group.name == "Tue/Thu Squad"
+        assert group.focus == "Strength"
+        assert {u.name for u in group.active_member_users()} == {
+            "Aaron Adams",
+            "Beth Brown",
+        }
+
+    def test_post_ignores_foreign_athlete(self, client):
+        # Picking another coach's athlete (a tampered/stale form) never adds them.
+        coach = UserFactory()
+        mine = active_athlete(coach, name="Mine")
+        other_coach = UserFactory()
+        foreign = active_athlete(other_coach, name="Theirs")
+        client.force_login(coach)
+        client.post(
+            reverse("meso:group_create"),
+            data={"name": "Squad", "athletes": [str(mine.pk), str(foreign.pk)]},
+        )
+        group = MesoGroup.objects.for_coach(coach).get()
+        assert [u.name for u in group.active_member_users()] == ["Mine"]
+
+    def test_post_ignores_pending_link_athlete(self, client):
+        coach = UserFactory()
+        pending = UserFactory(name="Pending")
+        CoachAthleteFactory(
+            coach=coach,
+            athlete=pending,
+            status=CoachAthlete.Status.PENDING_COACH_INVITE,
+        )
+        client.force_login(coach)
+        client.post(
+            reverse("meso:group_create"),
+            data={"name": "Squad", "athletes": [str(pending.pk)]},
+        )
+        group = MesoGroup.objects.for_coach(coach).get()
+        assert group.active_member_users() == []
+
+    def test_post_tolerates_malformed_athlete_id(self, client):
+        # A non-UUID value must never reach the ORM as a query error (500).
+        coach = UserFactory()
+        client.force_login(coach)
+        resp = client.post(
+            reverse("meso:group_create"),
+            data={"name": "Squad", "athletes": ["not-a-uuid", str(uuid.uuid4())]},
+        )
+        assert resp.status_code == 302
+        group = MesoGroup.objects.for_coach(coach).get()
+        assert group.active_member_users() == []
+
+    def test_blank_name_creates_nothing(self, client):
+        coach = UserFactory()
+        client.force_login(coach)
+        resp = client.post(
+            reverse("meso:group_create"), data={"name": "   ", "focus": "x"}
+        )
+        assert resp.status_code == 302
+        assert resp.url == reverse("meso:roster")
+        assert MesoGroup.objects.for_coach(coach).count() == 0
+
+    def test_get_not_allowed(self, client):
+        client.force_login(UserFactory())
+        resp = client.get(reverse("meso:group_create"))
+        assert resp.status_code == 405
+
+    def test_requires_login(self, client):
+        resp = client.post(reverse("meso:group_create"), data={"name": "Squad"})
+        assert resp.status_code == 302
+        assert MesoGroup.objects.count() == 0
+
+
+# -- roster: the create-group affordance ------------------------------------
+
+
+class TestRosterCreateForm:
+    def test_roster_offers_create_form_with_pickable_athletes(self, client):
+        coach = UserFactory()
+        CoachProfileFactory(user=coach)
+        athlete = active_athlete(coach, name="Aaron Adams")
+        client.force_login(coach)
+        body = client.get(reverse("meso:roster")).content.decode()
+        # The form posts to the create endpoint and offers the coach's athlete.
+        assert reverse("meso:group_create") in body
+        assert 'name="athletes"' in body
+        assert str(athlete.pk) in body
+        assert "Aaron Adams" in body
+
+    def test_roster_create_form_excludes_foreign_athlete(self, client):
+        coach = UserFactory()
+        CoachProfileFactory(user=coach)
+        other_coach = UserFactory()
+        active_athlete(other_coach, name="Foreign Athlete")
+        client.force_login(coach)
+        body = client.get(reverse("meso:roster")).content.decode()
+        assert "Foreign Athlete" not in body

--- a/app/store_project/meso/urls.py
+++ b/app/store_project/meso/urls.py
@@ -58,6 +58,7 @@ urlpatterns = [
         name="push_unsubscribe",
     ),
     path("athlete/<uuid:pk>/", AthleteProfileView.as_view(), name="athlete"),
+    path("group/new/", views.group_create, name="group_create"),
     path("group/<int:pk>/", GroupDetailView.as_view(), name="group"),
     path("group/<int:pk>/design/", views.group_design, name="group_design"),
     path("invite/<uuid:token>/accept/", views.invite_accept, name="invite_accept"),

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -2,6 +2,7 @@ import datetime
 import ipaddress
 import json
 import logging
+import uuid
 from urllib.parse import urlparse
 
 from django.conf import settings
@@ -252,6 +253,57 @@ class GroupDetailView(LoginRequiredMixin, TemplateView):
         ctx["active"] = "roster"
         ctx["group"] = presenters.group_detail(group)
         return ctx
+
+
+def _coach_active_athletes(coach, athlete_ids):
+    """Resolve posted athlete ids to this coach's *active*-link athletes.
+
+    Sanitizes each id to a UUID (a malformed value is skipped, never reaching the
+    ORM as a query error) and scopes to the coach's own active links, so only
+    their current athletes resolve — a foreign or stale pick simply drops out.
+    The order follows the posted ids' resolution, deduped by the link set.
+    """
+    valid_ids = []
+    for raw in athlete_ids:
+        try:
+            valid_ids.append(uuid.UUID(str(raw)))
+        except (ValueError, TypeError, AttributeError):
+            continue
+    if not valid_ids:
+        return []
+    links = (
+        CoachAthlete.objects.for_coach(coach)
+        .active()
+        .filter(athlete_id__in=valid_ids)
+        .select_related("athlete")
+    )
+    return [link.athlete for link in links]
+
+
+@login_required
+@require_POST
+def group_create(request):
+    """Create a new group from the roster: name + focus + picked members (Phase 2b).
+
+    A normal form POST (not JSON), the roster's "New group" disclosure. ``name``
+    is required; ``focus`` is optional; ``athletes`` is the multi-valued list of
+    picked athlete ids, each resolved against the coach's *active* links so only
+    their own current athletes can be added (a foreign/stale/malformed pick is
+    silently ignored — ``MesoGroup.create_for_coach`` carries the same tenancy
+    guard). Lands on the new group's detail page, where the coach designs its
+    shared program. A blank name creates nothing and returns to the roster (the
+    field is also ``required`` client-side).
+    """
+    name = (request.POST.get("name") or "").strip()
+    if not name:
+        messages.error(request, "A group needs a name.")
+        return redirect("meso:roster")
+    focus = (request.POST.get("focus") or "").strip()
+    athletes = _coach_active_athletes(request.user, request.POST.getlist("athletes"))
+    group = MesoGroup.create_for_coach(
+        request.user, name=name, focus=focus, athletes=athletes
+    )
+    return redirect("meso:group", pk=group.pk)
 
 
 @login_required

--- a/app/store_project/templates/meso/roster.html
+++ b/app/store_project/templates/meso/roster.html
@@ -59,32 +59,65 @@
           {% endfor %}
         </div>
 
-        {% if groups %}
-          <div class="meso-card">
-            <div style="display:flex;align-items:center;gap:10px;padding:13px 16px;border-bottom:1px solid var(--line-2);">
-              <p class="meso-eyebrow" style="margin:0;">Groups</p>
-            </div>
-            {% for g in groups %}
-              <a class="meso-row" href="{% url 'meso:group' g.id %}">
-                <div style="display:flex;">
-                  {% for m in g.member_objs|slice:":3" %}
-                    <div class="meso-avatar meso-avatar--sm {% if m.tone == 'accent' %}meso-avatar--accent{% endif %}" style="border:2px solid var(--surface);{% if not forloop.first %}margin-left:-9px;{% endif %}">{{ m.initials }}</div>
-                  {% endfor %}
-                  {% if g.member_objs|length > 3 %}
-                    <div class="meso-avatar meso-avatar--sm" style="border:2px solid var(--surface);margin-left:-9px;">+{{ g.member_objs|length|add:"-3" }}</div>
-                  {% endif %}
-                </div>
-                <div style="min-width:0;">
-                  <div class="meso-row-name">{{ g.name }}</div>
-                  <div class="meso-row-meta">{{ g.meta }}</div>
-                </div>
-                <div class="meso-spacer"></div>
-                <span class="meso-badge meso-badge--accent"><i></i>{{ g.status_label }}</span>
-                <span class="meso-muted" style="font-size:16px;">›</span>
-              </a>
-            {% endfor %}
+        <div class="meso-card">
+          <div style="display:flex;align-items:center;gap:10px;padding:13px 16px;border-bottom:1px solid var(--line-2);">
+            <p class="meso-eyebrow" style="margin:0;">Groups</p>
+            <div class="meso-spacer"></div>
+            <span class="meso-row-meta">{{ groups|length }} group{{ groups|length|pluralize }}</span>
           </div>
-        {% endif %}
+          {% for g in groups %}
+            <a class="meso-row" href="{% url 'meso:group' g.id %}">
+              <div style="display:flex;">
+                {% for m in g.member_objs|slice:":3" %}
+                  <div class="meso-avatar meso-avatar--sm {% if m.tone == 'accent' %}meso-avatar--accent{% endif %}" style="border:2px solid var(--surface);{% if not forloop.first %}margin-left:-9px;{% endif %}">{{ m.initials }}</div>
+                {% endfor %}
+                {% if g.member_objs|length > 3 %}
+                  <div class="meso-avatar meso-avatar--sm" style="border:2px solid var(--surface);margin-left:-9px;">+{{ g.member_objs|length|add:"-3" }}</div>
+                {% endif %}
+              </div>
+              <div style="min-width:0;">
+                <div class="meso-row-name">{{ g.name }}</div>
+                <div class="meso-row-meta">{{ g.meta }}</div>
+              </div>
+              <div class="meso-spacer"></div>
+              <span class="meso-badge meso-badge--accent"><i></i>{{ g.status_label }}</span>
+              <span class="meso-muted" style="font-size:16px;">›</span>
+            </a>
+          {% empty %}
+            <div class="meso-row" style="color:var(--dim);">
+              No groups yet. Create one to program several athletes together.
+            </div>
+          {% endfor %}
+
+          <!-- Create a brand-new group (Phase 2b): name + focus + pick members. -->
+          <details style="border-top:1px solid var(--line-2);">
+            <summary style="list-style:none;cursor:pointer;padding:11px 16px;font-size:12.5px;font-weight:650;color:var(--accent-ink);">+ New group</summary>
+            <form method="post" action="{% url 'meso:group_create' %}" style="display:flex;flex-direction:column;gap:11px;padding:4px 16px 16px;">
+              {% csrf_token %}
+              <input name="name" required maxlength="255" placeholder="Group name" style="appearance:none;border:1px solid var(--line);border-radius:8px;background:var(--rail);font:inherit;font-size:13px;color:var(--ink);padding:8px 10px;outline:none;" />
+              <input name="focus" maxlength="255" placeholder="Focus (optional) — e.g. Hypertrophy" style="appearance:none;border:1px solid var(--line);border-radius:8px;background:var(--rail);font:inherit;font-size:13px;color:var(--ink);padding:8px 10px;outline:none;" />
+              {% if athletes %}
+                <div>
+                  <p class="meso-eyebrow" style="margin:2px 0 7px;">Members</p>
+                  <div style="display:flex;flex-direction:column;gap:6px;max-height:220px;overflow:auto;">
+                    {% for a in athletes %}
+                      <label style="display:flex;align-items:center;gap:9px;font-size:13px;color:var(--ink);cursor:pointer;">
+                        <input type="checkbox" name="athletes" value="{{ a.id }}" />
+                        <span class="meso-avatar meso-avatar--sm {% if a.tone == 'accent' %}meso-avatar--accent{% endif %}">{{ a.initials }}</span>
+                        {{ a.name }}
+                      </label>
+                    {% endfor %}
+                  </div>
+                </div>
+              {% else %}
+                <p class="meso-sub" style="margin:0;">Invite an athlete first to add members.</p>
+              {% endif %}
+              <div>
+                <button type="submit" class="meso-btn meso-btn--primary">Create group</button>
+              </div>
+            </form>
+          </details>
+        </div>
       </div>
 
       <!-- activity column -->

--- a/docs/meso/groups-plan.md
+++ b/docs/meso/groups-plan.md
@@ -64,8 +64,8 @@ agent, and athlete slices.
     rows (`serialize_group_identity`); autosave edits its grid; **deliver + the agent reject
     group plans** (Phases 4/3). A `group_design` POST entry point + the group-detail
     "Design / Open shared program" card. The seeded demo group gets a shared program.
-  - **Phase 2b — create-group UI.** Create a brand-new group from the roster (name + focus +
-    pick members), so groups no longer come only from the seed/admin.
+  - **Phase 2b — create-group UI (built; this PR).** Create a brand-new group from the roster
+    (name + focus + pick members), so groups no longer come only from the seed/admin.
 - **Phase 3 — per-athlete overrides (the `adj` overlay) (built; this PR).**
   `PrescriptionOverride` per member (load %, swap, volume), effective-program resolution
   (`shared + overrides`), the designer's "Shared program · per-athlete auto-adjusts" row +
@@ -171,6 +171,48 @@ agent, and athlete slices.
   plan. The group-detail page shows Design vs Open by whether a shared plan exists.
 - Seed: the demo group gets a shared program (rooted at the group, with a scaffold), not
   duplicated on reseed.
+
+## Phase 2b — build notes
+
+- **A group can finally be born from the product, not just the seed/admin.**
+  `MesoGroup.create_for_coach(coach, *, name, focus="", athletes=())` is the model
+  entry point: it creates the coach's group, then adds each athlete through the
+  existing `add_athlete` so the same active-link tenancy guard applies — an
+  athlete without an active link to this coach is *skipped*, not raised, because
+  the create form only ever offers the coach's own athletes and a stale/foreign
+  pick shouldn't fail the whole create. No migration (no schema change — just a
+  helper + a view + a form).
+- **Endpoint:** `group_create` (POST `/meso/group/new/`) is a plain form POST (not
+  JSON), the roster's "New group" disclosure. `name` is required (a blank one
+  creates nothing and routes back to the roster — the field is also `required`
+  client-side); `focus` is optional; `athletes` is the multi-valued list of
+  picked ids. `_coach_active_athletes` resolves the posted ids: it sanitizes each
+  to a UUID (a malformed value is skipped, never reaching the ORM as a query
+  error → no 500) and scopes to the coach's own *active* links, so only their
+  current athletes resolve and a foreign/stale pick simply drops out. On success
+  it lands on the new group's **detail page**, where the coach designs the shared
+  program (Phase 2a) — the natural next step.
+- **Roster:** the *Groups* card now always renders (was gated on `{% if groups %}`),
+  with a group count, an empty state, and a `<details>` "New group" disclosure
+  holding the form — name + focus inputs and a checkbox per roster athlete (the
+  same `athletes` the *Individuals* card lists, already coach-scoped to active
+  links). JS-free (a native `<details>`), so it needs no Alpine on the roster.
+
+## Tests (Phase 2b)
+
+`meso/tests/test_group_create.py` — model helper + the view + the roster form:
+
+- `create_for_coach` creates a coach-owned group (name/focus/active status), adds
+  the given athletes off their active links, defaults `focus` blank with athletes
+  optional, and *skips* (doesn't raise on) an athlete with no active link.
+- `group_create`: a POST creates the group with its picked members and redirects
+  to the group detail; a foreign athlete / a pending-link athlete / a malformed
+  (non-UUID) id are each ignored (no member, no 500); a blank name creates nothing
+  and redirects to the roster; GET is 405; anonymous is redirected to login and
+  writes nothing.
+- The roster offers the create form (posts to `group_create`, a `name="athletes"`
+  checkbox per athlete carrying the athlete id) and excludes another coach's
+  athlete from the picker.
 
 ## Phase 3 — build notes
 


### PR DESCRIPTION
## What & why

Groups slice (S1) **Phase 2b** — the create-group entry point. Until now a
`MesoGroup` could only be born from the seed or the admin; this stands up the
product path: a coach names a group, gives it a focus, and picks members from
their roster. Next up is Phase 4 (deliver-to-all). Plan: `docs/meso/groups-plan.md`.

No migration — this is a model helper + a view + a form over the existing
group/membership spine.

## Changes

- **`MesoGroup.create_for_coach(coach, *, name, focus="", athletes=())`** — creates
  the coach's group, then adds each athlete via the existing `add_athlete`, so the
  same active-link tenancy guard applies. An athlete without an active link to this
  coach is **skipped, not raised** (the form only offers the coach's own athletes;
  a stale/foreign pick shouldn't fail the whole create).
- **`group_create` (POST `/meso/group/new/`)** — a plain form POST (the roster's
  "New group" disclosure). `name` required (blank → back to roster, nothing
  created; field is also `required` client-side); `focus` optional; `athletes` the
  multi-valued list of picked ids. `_coach_active_athletes` resolves them:
  UUID-sanitized (a malformed value is skipped, never an ORM query error → no 500)
  and scoped to the coach's **active** links, so a foreign/stale pick drops out.
  Lands on the new group's **detail page**, where the coach designs the shared
  program (Phase 2a).
- **Roster** — the *Groups* card always renders now (was gated on having groups):
  a group count, an empty state, and a JS-free `<details>` "New group" form with
  name + focus inputs and a checkbox per roster athlete (the same coach-scoped
  active athletes the *Individuals* card lists).

## Tests

`meso/tests/test_group_create.py` (red→green): the model helper (creates/adds/
skips-ineligible/optional-members), the view (creates + redirects to detail;
foreign / pending-link / malformed-UUID picks ignored with no 500; blank name
creates nothing; GET 405; anonymous redirected, writes nothing), and the roster
form (offers the create endpoint + a checkbox per athlete; excludes a foreign
coach's athlete). Full meso suite green (520 tests); ruff clean.

OpenAI Codex local review: **CLEAN** (0 blocking, 0 nits).

https://claude.ai/code/session_015G62Gs7papVMJAfYqeExrN