### PR TITLE
Meso — units & RPE/%1RM slice (S2) Phase 2a: agent %1RM-awareness

### DIFF
--- a/app/store_project/meso/agent/client.py
+++ b/app/store_project/meso/agent/client.py
@@ -92,7 +92,10 @@ PROPOSE_TOOL = {
                         "new_load": {
                             "type": "string",
                             "description": (
-                                "progress only: the load to set, e.g. '92.5 kg'."
+                                "progress only: the load to set. For an "
+                                "absolute-load row (load_type 'abs') a weight in "
+                                "the plan's unit, e.g. '92.5 kg'; for a %1RM row "
+                                "(load_type 'pct') a percentage of 1RM, e.g. '82'."
                             ),
                         },
                         "new_sets": {
@@ -121,6 +124,11 @@ SYSTEM_PROMPT = (
     "alternative and name it in introduces_exercise.\n"
     "- Anchor load progressions to the values already in the plan; prefer small, "
     "defensible steps.\n"
+    "- Each exercise row carries a load_type: 'abs' means its load is an absolute "
+    "weight in the plan's unit (kg/lb); 'pct' means the load is a percentage of "
+    "1RM. When you progress a 'pct' lift, new_load is a percentage (keep it in a "
+    "sane range, typically at or below 100%) — never convert it into an absolute "
+    "weight, and never convert an absolute lift into a percentage.\n"
     "- Give the value to apply: new_name for a swap, new_load for a progress, "
     "new_sets for a volume change. A deload needs no value.\n"
     "- Set 'honors' to the specific contraindication or coaching rule each change "

--- a/app/store_project/meso/agent/validation.py
+++ b/app/store_project/meso/agent/validation.py
@@ -18,10 +18,17 @@ screen. Two layers:
 import re
 
 from ..models import ExercisePrescription
+from ..models import LoadType
 from ..models import Session
 from ..serializers import current_week
 
 VALID_KINDS = {"swap", "progress", "volume", "deload"}
+
+# A %1RM progression moves a PERCENT, so its value is bounded to a sane band. The
+# ceiling sits above legitimate supramaximal work (eccentrics / walkouts run a
+# little over 100%) but well below a number that is plainly an absolute load the
+# type-agnostic model mistyped (e.g. "180"). The floor is just above zero.
+MAX_PERCENT_1RM = 120
 
 # What an actionable change of each kind must resolve to within the plan. A swap
 # or progression edits a specific exercise row; a volume change edits a day; a
@@ -134,6 +141,25 @@ def _resolve(model, value, label, errors, **scope):
     return obj
 
 
+_NUMERIC_RE = re.compile(r"-?\d+(?:\.\d+)?")
+
+
+def _percent_value(text):
+    """The leading number in a load string ('82.5 %' → 82.5), or ``None``."""
+    match = _NUMERIC_RE.search(text or "")
+    if match is None:
+        return None
+    try:
+        return float(match.group())
+    except ValueError:
+        return None
+
+
+def _fmt_percent(value):
+    """A bare percent string ('82' / '82.5'); no '%' so the suffix isn't doubled."""
+    return str(int(value)) if value == int(value) else str(value)
+
+
 def clean_change(raw, plan, *, forbidden=None):
     """Validate and normalize one raw change dict.
 
@@ -220,6 +246,27 @@ def clean_change(raw, plan, *, forbidden=None):
         if value:
             payload[field] = value
     cleaned["payload"] = payload
+
+    # %1RM bound — a progress on a percent-typed lift moves a PERCENTAGE. The
+    # model treats ``load`` as an opaque string, so this keeps the new value a
+    # number in a sane band (stopping "75%" → an absolute "180") and normalizes
+    # it to a bare percent so the designer's ``%`` suffix isn't doubled. Keyed on
+    # the *target row's* type; an absolute lift is left unbounded as before.
+    load_value = payload.get("load")
+    if kind == "progress" and presc is not None and load_value:
+        if presc.load_type == LoadType.PERCENT:
+            pct = _percent_value(load_value)
+            if pct is None:
+                errors.append(
+                    f"a %1RM progression must be a number (got {load_value!r})"
+                )
+            elif not 0 < pct <= MAX_PERCENT_1RM:
+                errors.append(
+                    f"%1RM progression {pct:g}% is out of range "
+                    f"(expected 1–{MAX_PERCENT_1RM}%)"
+                )
+            else:
+                payload["load"] = _fmt_percent(pct)
 
     # Contraindication backstop — only a SWAP introduces a new movement, so only
     # swaps are screened (a volume/progress edit that *mentions* a flagged

--- a/app/store_project/meso/agent/validation.py
+++ b/app/store_project/meso/agent/validation.py
@@ -141,18 +141,21 @@ def _resolve(model, value, label, errors, **scope):
     return obj
 
 
-_NUMERIC_RE = re.compile(r"-?\d+(?:\.\d+)?")
+def _percent_load(text):
+    """A %1RM progression's value as a float, or ``None`` if it isn't a percent.
 
-
-def _percent_value(text):
-    """The leading number in a load string ('82.5 %' → 82.5), or ``None``."""
-    match = _NUMERIC_RE.search(text or "")
-    if match is None:
+    A %1RM load is a *bare* percentage — a number with an optional ``%`` sign
+    ("82", "82.5 %"). A unit-suffixed or otherwise non-numeric string ("82.5 kg",
+    "100 lb", "heavy") is the model converting the lift to an absolute weight,
+    which is NOT a percent and must be rejected rather than silently reinterpreted
+    (storing "100 lb" as "100%" would corrupt the prescribed intensity).
+    """
+    cleaned = (text or "").strip()
+    if cleaned.endswith("%"):
+        cleaned = cleaned[:-1].strip()
+    if not re.fullmatch(r"\d+(?:\.\d+)?", cleaned):
         return None
-    try:
-        return float(match.group())
-    except ValueError:
-        return None
+    return float(cleaned)
 
 
 def _fmt_percent(value):
@@ -248,17 +251,18 @@ def clean_change(raw, plan, *, forbidden=None):
     cleaned["payload"] = payload
 
     # %1RM bound — a progress on a percent-typed lift moves a PERCENTAGE. The
-    # model treats ``load`` as an opaque string, so this keeps the new value a
-    # number in a sane band (stopping "75%" → an absolute "180") and normalizes
-    # it to a bare percent so the designer's ``%`` suffix isn't doubled. Keyed on
-    # the *target row's* type; an absolute lift is left unbounded as before.
+    # model treats ``load`` as an opaque string, so this requires a clean percent
+    # in a sane band (rejecting both an absolute-looking "180" and a unit-suffixed
+    # "100 lb" the model wrongly converted) and normalizes a valid one to a bare
+    # number so the designer's ``%`` suffix isn't doubled. Keyed on the *target
+    # row's* type; an absolute lift is left unbounded as before.
     load_value = payload.get("load")
     if kind == "progress" and presc is not None and load_value:
         if presc.load_type == LoadType.PERCENT:
-            pct = _percent_value(load_value)
+            pct = _percent_load(load_value)
             if pct is None:
                 errors.append(
-                    f"a %1RM progression must be a number (got {load_value!r})"
+                    f"a %1RM progression must be a bare percent (got {load_value!r})"
                 )
             elif not 0 < pct <= MAX_PERCENT_1RM:
                 errors.append(

--- a/app/store_project/meso/tests/test_agent_validation.py
+++ b/app/store_project/meso/tests/test_agent_validation.py
@@ -398,9 +398,9 @@ class TestPercentProgressBound:
         assert errors == []
         assert cleaned["payload"] == {"load": "82"}
 
-    def test_strips_a_percent_sign_and_stray_unit(self):
-        # The model may echo the '%' (or wrongly append a unit); the stored load
-        # is normalized to a bare percent so the designer's suffix isn't doubled.
+    def test_strips_a_percent_sign(self):
+        # The model may echo the '%'; the stored load is normalized to a bare
+        # percent so the designer's suffix isn't doubled.
         plan, _, presc = make_percent_plan()
         cleaned, errors = validation.clean_change(
             base_change(kind="progress", prescription_id=presc.pk, new_load="82.5 %"),
@@ -408,6 +408,18 @@ class TestPercentProgressBound:
         )
         assert errors == []
         assert cleaned["payload"] == {"load": "82.5"}
+
+    def test_rejects_a_unit_suffixed_load(self):
+        # A unit on a %1RM lift is the model converting it to an absolute weight;
+        # reject it rather than silently storing "100 lb" as "100%" (which would
+        # corrupt the prescribed intensity), even though 100 is within the band.
+        plan, _, presc = make_percent_plan()
+        cleaned, errors = validation.clean_change(
+            base_change(kind="progress", prescription_id=presc.pk, new_load="100 lb"),
+            plan,
+        )
+        assert cleaned is None
+        assert any("percent" in e for e in errors)
 
     def test_rejects_an_absolute_looking_load(self):
         # 180 is a plausible kg/lb load but an absurd %1RM — the bound catches a
@@ -427,7 +439,7 @@ class TestPercentProgressBound:
             plan,
         )
         assert cleaned is None
-        assert any("number" in e for e in errors)
+        assert any("percent" in e for e in errors)
 
     def test_allows_legitimate_supramaximal_percent(self):
         # Eccentric/walkout work above 100% is real programming; the ceiling is

--- a/app/store_project/meso/tests/test_agent_validation.py
+++ b/app/store_project/meso/tests/test_agent_validation.py
@@ -9,6 +9,7 @@ the model returns through this before persisting anything.
 
 import pytest
 
+from store_project.meso.agent import client
 from store_project.meso.agent import validation
 from store_project.meso.factories import CoachAthleteFactory
 from store_project.meso.factories import ContraindicationFactory
@@ -17,6 +18,7 @@ from store_project.meso.factories import MesocycleFactory
 from store_project.meso.factories import PlanFactory
 from store_project.meso.factories import SessionFactory
 from store_project.meso.factories import WeekFactory
+from store_project.meso.models import LoadType
 from store_project.users.factories import UserFactory
 
 pytestmark = pytest.mark.django_db
@@ -366,3 +368,102 @@ class TestApplyPayload:
         )
         assert cleaned is None
         assert any("value to apply" in e for e in errors)
+
+
+def make_percent_plan():
+    """A plan whose single prescription is prescribed as a %1RM (S2 Phase 2a)."""
+    plan, session, presc = make_plan()
+    presc.load = "75"
+    presc.load_type = LoadType.PERCENT
+    presc.save(update_fields=["load", "load_type"])
+    return plan, session, presc
+
+
+class TestPercentProgressBound:
+    """A ``progress`` on a %1RM-typed lift moves a PERCENTAGE (S2 Phase 2a).
+
+    The agent is type-agnostic (it treats ``load`` as an opaque string), so this
+    deterministic backstop keeps a %1RM progression in a sane percent band —
+    stopping the model from turning "75%" into an absolute "180" — and normalizes
+    the stored value to a bare number so the ``%`` suffix isn't doubled. The
+    absolute path is deliberately left unbounded.
+    """
+
+    def test_accepts_a_sane_percent(self):
+        plan, _, presc = make_percent_plan()
+        cleaned, errors = validation.clean_change(
+            base_change(kind="progress", prescription_id=presc.pk, new_load="82"),
+            plan,
+        )
+        assert errors == []
+        assert cleaned["payload"] == {"load": "82"}
+
+    def test_strips_a_percent_sign_and_stray_unit(self):
+        # The model may echo the '%' (or wrongly append a unit); the stored load
+        # is normalized to a bare percent so the designer's suffix isn't doubled.
+        plan, _, presc = make_percent_plan()
+        cleaned, errors = validation.clean_change(
+            base_change(kind="progress", prescription_id=presc.pk, new_load="82.5 %"),
+            plan,
+        )
+        assert errors == []
+        assert cleaned["payload"] == {"load": "82.5"}
+
+    def test_rejects_an_absolute_looking_load(self):
+        # 180 is a plausible kg/lb load but an absurd %1RM — the bound catches a
+        # model that ignored the type and progressed it like an absolute weight.
+        plan, _, presc = make_percent_plan()
+        cleaned, errors = validation.clean_change(
+            base_change(kind="progress", prescription_id=presc.pk, new_load="180"),
+            plan,
+        )
+        assert cleaned is None
+        assert any("out of range" in e for e in errors)
+
+    def test_rejects_a_non_numeric_percent(self):
+        plan, _, presc = make_percent_plan()
+        cleaned, errors = validation.clean_change(
+            base_change(kind="progress", prescription_id=presc.pk, new_load="heavy"),
+            plan,
+        )
+        assert cleaned is None
+        assert any("number" in e for e in errors)
+
+    def test_allows_legitimate_supramaximal_percent(self):
+        # Eccentric/walkout work above 100% is real programming; the ceiling is
+        # set so it passes while a clearly-absolute number does not.
+        plan, _, presc = make_percent_plan()
+        cleaned, errors = validation.clean_change(
+            base_change(kind="progress", prescription_id=presc.pk, new_load="105"),
+            plan,
+        )
+        assert errors == []
+        assert cleaned["payload"] == {"load": "105"}
+
+    def test_absolute_progress_is_not_bounded(self):
+        # Regression guard: the bound is %1RM-only. An absolute lift can carry a
+        # large numeric load (and its unit text) exactly as before Phase 2a.
+        plan, _, presc = make_plan()  # default ABSOLUTE
+        cleaned, errors = validation.clean_change(
+            base_change(kind="progress", prescription_id=presc.pk, new_load="180 kg"),
+            plan,
+        )
+        assert errors == []
+        assert cleaned["payload"] == {"load": "180 kg"}
+
+
+class TestPercentAwarePrompt:
+    """The prompt is what teaches the type-agnostic model about %1RM (S2 Phase 2a).
+
+    A ``load_type`` of ``pct`` means the load is a percent of 1RM; the system
+    prompt and the ``new_load`` tool field must say so.
+    """
+
+    def test_system_prompt_explains_load_type(self):
+        assert "load_type" in client.SYSTEM_PROMPT
+        assert "1RM" in client.SYSTEM_PROMPT
+
+    def test_new_load_tool_field_mentions_percent(self):
+        props = client.PROPOSE_TOOL["input_schema"]["properties"]
+        new_load = props["changes"]["items"]["properties"]["new_load"]
+        assert "%" in new_load["description"] or "1RM" in new_load["description"]

--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -148,7 +148,7 @@ claim, reusing allauth. Detailed design when we build the relationship.
 | # | Decision | Note |
 |---|----------|------|
 | S1 | **Groups** — "shared program + per-athlete auto-adjust" modeling (template + override diffs) | 🟡 In progress — Phase 1 (group + membership spine + read surface) + Phase 2a (shared group program + Group-mode designer) + Phase 3 (per-athlete overrides — the `adj` overlay) built; plan in [`groups-plan.md`](./groups-plan.md) |
-| S2 | **Units & RPE vs %1RM** | 🟡 In progress — units (kg/lb) shipped with earlier slices (`Unit`/`CoachProfile.default_unit`/`Plan.unit`); the **%1RM** half (a `load_type` on the prescription) is now building. Plan in [`units-rpe-plan.md`](./units-rpe-plan.md) |
+| S2 | **Units & RPE vs %1RM** | 🟡 In progress — units (kg/lb) shipped with earlier slices; Phase 1 (first-class `load_type` `abs`/`pct`) + Phase 2a (agent %1RM-awareness — prompt + a deterministic %1RM progression bound) deployed. Only Phase 2b (athlete %1RM logging ergonomics) remains. Plan in [`units-rpe-plan.md`](./units-rpe-plan.md) |
 | S3 | **Delivery & notifications** | Push needs PWA + push infra; email via existing `django-ses` + `notifications` app |
 | S4 | **Results ↔ `challenges`/records** | Results screen shows a PR — reuse the records model or keep separate? |
 | S5 | **Real-time transport** | HTMX polling vs SSE/websockets for chat/drafting |
@@ -426,4 +426,13 @@ _(Append dated entries here as decisions land.)_
   toggles `%` ⇄ the unit and autosaves the type; the athlete sees a `%` target and the coach results screen
   labels a %1RM target with `%`. Migration `meso.0011`. Agent %1RM-awareness deferred to Phase 2 (the agent
   is type-agnostic — a %1RM number progresses as a number). Plan + phasing in
+  [`units-rpe-plan.md`](./units-rpe-plan.md).
+- 2026-06-28 — **S2 Phase 2a — agent %1RM-awareness** (branch `meso-units-rpe-phase2a-agent`, **no
+  migration**). Phase 2 split 2a/2b (groups-slice cadence). The agent grounding already carried each row's
+  `load_type` (Phase 1 wired `serialize_prescription`), so the two real gaps were the **prompt** (never
+  explained `load_type`) and the **validation backstop** (never bounded a %1RM progression). Closed both:
+  `SYSTEM_PROMPT` + the `new_load` tool field now explain `abs` vs `pct` (%1RM); `clean_change` bounds a
+  `progress` on a `PERCENT`-typed target to `0 < pct ≤ 120` (rejects an absolute-looking "180" or a
+  non-numeric value, normalizes `'82.5 %'` → `'82.5'`), leaving the absolute path unbounded. The agent still
+  does **not** change a row's type. Athlete %1RM logging ergonomics remain → **Phase 2b**. Plan in
   [`units-rpe-plan.md`](./units-rpe-plan.md).

--- a/docs/meso/units-rpe-plan.md
+++ b/docs/meso/units-rpe-plan.md
@@ -133,14 +133,18 @@ through `serialize_prescription`, and `build_context` → `serialize_plan` → `
   and never convert one type into the other — and widened the `new_load` tool-field description
   to give both the `'92.5 kg'` and the `'82'` (%1RM) forms.
 - **Validation bound** (`agent/validation.py`): the deterministic backstop now bounds a
-  `progress` whose **target row** is `LoadType.PERCENT`. The new load must parse as a number in
-  `0 < pct ≤ MAX_PERCENT_1RM` (120 — above legitimate supramaximal eccentric/walkout work, below
-  a plainly-absolute number like "180"); a non-numeric or out-of-band value is **rejected** (the
-  candidate is dropped before it reaches the review screen, exactly like a contraindicated swap),
-  and a valid one is **normalized to a bare percent** (`'82.5 %'` → `'82.5'`) so the designer's
-  `%` suffix isn't doubled. The absolute path is deliberately left unbounded (no sane ceiling on
-  a kg/lb load). Keyed on the *target prescription's* type — the change dict itself carries no
-  type — so it reuses the prescription `clean_change` already resolves.
+  `progress` whose **target row** is `LoadType.PERCENT`. The new load must be a **clean percent**
+  — a bare number with an optional `%` (`'82'`, `'82.5 %'`) — in `0 < pct ≤ MAX_PERCENT_1RM`
+  (120 — above legitimate supramaximal eccentric/walkout work, below a plainly-absolute number
+  like "180"). Three things are **rejected** (the candidate is dropped before it reaches the
+  review screen, exactly like a contraindicated swap): an out-of-band number (`'180'`), a
+  non-numeric value (`'heavy'`), and — importantly — a **unit-suffixed** value (`'100 lb'`),
+  which is the model converting the lift to an absolute weight; silently storing that as `100%`
+  would corrupt the prescribed intensity, so it is *not* coerced. A valid one is **normalized to
+  a bare percent** (`'82.5 %'` → `'82.5'`) so the designer's `%` suffix isn't doubled. The
+  absolute path is deliberately left unbounded (no sane ceiling on a kg/lb load). Keyed on the
+  *target prescription's* type — the change dict itself carries no type — so it reuses the
+  prescription `clean_change` already resolves.
 
 Deliberately **not** in 2a: the agent does not *change* a row's `load_type` (it only progresses
 within the existing type), and nothing here touches the athlete logger (→ Phase 2b).
@@ -150,8 +154,8 @@ within the existing type), and nothing here touches the athlete logger (→ Phas
 `meso/tests/test_agent_validation.py`:
 
 - `TestPercentProgressBound` — a %1RM progress accepts a sane percent (`'82'`), strips a `%`
-  sign / stray unit (`'82.5 %'` → `'82.5'`), rejects an absolute-looking load (`'180'`), rejects
-  a non-numeric value (`'heavy'`), allows legitimate supramaximal (`'105'`), and leaves the
-  **absolute** path unbounded (`'180 kg'` still passes).
+  sign (`'82.5 %'` → `'82.5'`), rejects a unit-suffixed load (`'100 lb'`), an absolute-looking
+  load (`'180'`), and a non-numeric value (`'heavy'`), allows legitimate supramaximal (`'105'`),
+  and leaves the **absolute** path unbounded (`'180 kg'` still passes).
 - `TestPercentAwarePrompt` — the `SYSTEM_PROMPT` mentions `load_type` + `1RM`, and the `new_load`
   tool field mentions the percent form (locks the prompt contract so it can't silently regress).

--- a/docs/meso/units-rpe-plan.md
+++ b/docs/meso/units-rpe-plan.md
@@ -54,12 +54,15 @@ agent, athlete, and groups slices.
   and autosaves the type; the per-athlete override resolution and the group deliver-to-all
   fan-out carry the type through; the athlete sees a `%` target on a %1RM-prescribed lift;
   the coach results screen labels a %1RM target with `%`. The seed gets a demo %1RM row.
-- **Phase 2 — %1RM ergonomics + agent awareness (future).** The athlete logger surfacing
-  the % target distinctly and capturing the *actual* load lifted against an estimated 1RM;
-  the agent's grounding + validation understanding that a `progress` change on a %1RM lift
-  moves a percentage (and bounding it sanely); optional estimated-1RM math (% ↔ load). Out
-  of scope for Phase 1, which keeps the agent type-agnostic (it already treats `load` as an
-  opaque numeric string, so a %1RM number progresses as a number — nothing breaks).
+- **Phase 2 — %1RM ergonomics + agent awareness.** Split into two PR-sized slices, the same
+  2a/2b cadence as the groups slice:
+  - **Phase 2a — agent %1RM-awareness (this PR, DONE).** The grounding already carries each
+    row's `load_type` (Phase 1 wired `serialize_prescription`), so the two real gaps were: the
+    **prompt** never explained what `load_type` means, and the **validation backstop** never
+    bounded a %1RM progression. Both closed — see below.
+  - **Phase 2b — athlete %1RM logging ergonomics (future).** The athlete logger surfacing the
+    % target distinctly and capturing the *actual* load lifted against an estimated 1RM;
+    optional estimated-1RM math (% ↔ load).
 
 ## Phase 1 — build notes
 
@@ -117,3 +120,38 @@ fan-out:
 - `toggleLoadType(ex)` flips `abs` ⇄ `pct` and (when live) autosaves via `persistRow`.
 - `persistRow` includes `load_type` in the autosave body.
 - A locally added row (offline `addExercise`) defaults `load_type: "abs"`.
+
+## Phase 2a — agent %1RM-awareness (build notes)
+
+The agent context already carried each prescription's `load_type` (Phase 1 threaded it
+through `serialize_prescription`, and `build_context` → `serialize_plan` → `serialize_session`
+→ `serialize_prescription`). So no grounding *data* was missing. The two real gaps:
+
+- **Prompt** (`agent/client.py`): the model was never told what `load_type` means. Added a
+  `SYSTEM_PROMPT` rule — `abs` is an absolute weight in the plan's unit, `pct` is a percentage
+  of 1RM; when progressing a `pct` lift the `new_load` is a percentage (kept sane, ≤ ~100%),
+  and never convert one type into the other — and widened the `new_load` tool-field description
+  to give both the `'92.5 kg'` and the `'82'` (%1RM) forms.
+- **Validation bound** (`agent/validation.py`): the deterministic backstop now bounds a
+  `progress` whose **target row** is `LoadType.PERCENT`. The new load must parse as a number in
+  `0 < pct ≤ MAX_PERCENT_1RM` (120 — above legitimate supramaximal eccentric/walkout work, below
+  a plainly-absolute number like "180"); a non-numeric or out-of-band value is **rejected** (the
+  candidate is dropped before it reaches the review screen, exactly like a contraindicated swap),
+  and a valid one is **normalized to a bare percent** (`'82.5 %'` → `'82.5'`) so the designer's
+  `%` suffix isn't doubled. The absolute path is deliberately left unbounded (no sane ceiling on
+  a kg/lb load). Keyed on the *target prescription's* type — the change dict itself carries no
+  type — so it reuses the prescription `clean_change` already resolves.
+
+Deliberately **not** in 2a: the agent does not *change* a row's `load_type` (it only progresses
+within the existing type), and nothing here touches the athlete logger (→ Phase 2b).
+
+### Tests (Phase 2a)
+
+`meso/tests/test_agent_validation.py`:
+
+- `TestPercentProgressBound` — a %1RM progress accepts a sane percent (`'82'`), strips a `%`
+  sign / stray unit (`'82.5 %'` → `'82.5'`), rejects an absolute-looking load (`'180'`), rejects
+  a non-numeric value (`'heavy'`), allows legitimate supramaximal (`'105'`), and leaves the
+  **absolute** path unbounded (`'180 kg'` still passes).
+- `TestPercentAwarePrompt` — the `SYSTEM_PROMPT` mentions `load_type` + `1RM`, and the `new_load`
+  tool field mentions the percent form (locks the prompt contract so it can't silently regress).


### PR DESCRIPTION
## What & why

S2 Phase 1 gave a prescription a first-class `load_type` (`abs`/`pct`) — but the **agent** stayed type-agnostic: it treats `load` as an opaque string, so it could turn a `75%` lift into an absolute `180` and nothing would stop it. Phase 2a closes that.

Phase 2 is split **2a/2b** (the groups-slice cadence). This is **2a — agent %1RM-awareness**. Athlete %1RM logging ergonomics remain → 2b.

The grounding already carried each row's `load_type` (Phase 1 wired `serialize_prescription` → `serialize_session` → `serialize_plan` → `build_context`), so the two real gaps were:

- **Prompt** (`agent/client.py`): the model was never *told* what `load_type` means. Added a `SYSTEM_PROMPT` rule — `abs` = absolute weight in the plan's unit, `pct` = % of 1RM; when progressing a `pct` lift the `new_load` is a percentage (kept sane, ≤ ~100%), never converted to/from an absolute weight — and widened the `new_load` tool-field description to give both the `'92.5 kg'` and `'82'` forms.
- **Validation bound** (`agent/validation.py`): the deterministic backstop now bounds a `progress` whose **target row** is `LoadType.PERCENT`. The new load must be a **clean percent** — a bare number with an optional `%` — in `0 < pct ≤ 120` (above legitimate supramaximal eccentric/walkout work, below a plainly-absolute number like `180`). Rejected (dropped before the review screen, like a contraindicated swap): an out-of-band number (`180`), a non-numeric value (`heavy`), and a **unit-suffixed** value (`100 lb`) — the model converting the lift to absolute; silently storing that as `100%` would corrupt the prescribed intensity. A valid one is normalized to a bare percent (`'82.5 %'` → `'82.5'`) so the designer's `%` suffix isn't doubled. The absolute path is left unbounded.

Keyed on the *target prescription's* type (the change dict carries no type), reusing the prescription `clean_change` already resolves. The agent still does **not** change a row's `load_type`.

## No migration

Pure logic + prompt; no schema change.

## Tests

`meso/tests/test_agent_validation.py` (+9):
- `TestPercentProgressBound` — accepts a sane percent (`'82'`), strips a `%` sign (`'82.5 %'` → `'82.5'`), rejects a unit-suffixed load (`'100 lb'`), an absolute-looking load (`'180'`), and a non-numeric value (`'heavy'`), allows supramaximal (`'105'`), and leaves the **absolute** path unbounded (`'180 kg'` still passes).
- `TestPercentAwarePrompt` — the `SYSTEM_PROMPT` mentions `load_type` + `1RM`, and the `new_load` tool field mentions the percent form (locks the prompt contract).

`563 passed` (full meso suite). Ruff clean. Codex review loop: CLEAN (1 P2 fixed — reject unit-suffixed loads).

https://claude.ai/code/session_015G62Gs7papVMJAfYqeExrN