### PR TITLE
Meso — units & RPE/%1RM slice (S2) Phase 2b: athlete %1RM logging ergonomics

### DIFF
--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -593,6 +593,9 @@ def athlete_session(session, athlete):
         "block": week.mesocycle.name,
         "week": f"Wk {week.index}",
         "plan_title": week.mesocycle.plan.title,
+        # The plan's load unit (kg/lb) — the %1RM logger turns a "75%" target into
+        # a bar load in this unit (S2 Phase 2b).
+        "unit": week.mesocycle.plan.unit,
         "notes": log.notes if log else "",
         "log_url": reverse("meso:athlete_log_session", kwargs={"pk": session.pk}),
         "exercises": [
@@ -617,11 +620,17 @@ def athlete_log_payload(session_ctx):
     return {
         "log_url": session_ctx["log_url"],
         "status": session_ctx["status"],
+        # The unit lets the %1RM helper render a suggested bar load (S2 Phase 2b).
+        "unit": session_ctx["unit"],
         "exercises": [
             {
                 "id": e["id"],
                 "name": e["name"],
                 "target": e["target"],
+                # The structured load + its type so the client knows which rows are
+                # %1RM (and the percent value) to offer the estimated-1RM helper.
+                "load": e["load"],
+                "load_type": e["load_type"],
                 "note": e.get("note", ""),
                 "tag": e.get("tag", ""),
                 "set_rows": e["set_rows"],

--- a/app/store_project/meso/tests/test_percent_logging.py
+++ b/app/store_project/meso/tests/test_percent_logging.py
@@ -1,0 +1,81 @@
+"""Units & RPE/%1RM slice (S2) Phase 2b — athlete %1RM logging ergonomics.
+
+Phase 1 gave the prescription a first-class ``load_type`` (``abs``/``pct``) and the
+athlete already sees a ``%`` target (``_target_label``). The remaining gap is
+*ergonomics*: a %1RM target is an intensity, not a weight, so the athlete still
+has to convert "75%" into a bar load by hand. This phase threads the structured
+load type + the plan's unit into the logger payload so the client can offer an
+estimated-1RM helper (% ⇄ load). The maths itself lives in ``meso_athlete.js``
+(Vitest); these tests pin the **data contract** the client hydrates from.
+
+No model change — a ``LoggedSet`` still records the *actual* (absolute) weight,
+and the athlete's estimated 1RM lives client-side (localStorage), the same
+"reuse what exists, defer new tables" taste as the offline log queue.
+"""
+
+import pytest
+
+from store_project.meso import presenters
+from store_project.meso.factories import CoachAthleteFactory
+from store_project.meso.factories import ExercisePrescriptionFactory
+from store_project.meso.factories import MesocycleFactory
+from store_project.meso.factories import PlanFactory
+from store_project.meso.factories import SessionFactory
+from store_project.meso.factories import WeekFactory
+from store_project.meso.models import LoadType
+from store_project.meso.models import Plan
+from store_project.meso.models import Unit
+from store_project.users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def seed_session(unit=Unit.KILOGRAMS):
+    """A delivered-shape session with one absolute + one %1RM prescription."""
+    rel = CoachAthleteFactory(coach=UserFactory(), athlete=UserFactory())
+    plan = PlanFactory(relationship=rel, status=Plan.Status.ACTIVE, unit=unit)
+    meso = MesocycleFactory(plan=plan, name="Hypertrophy", order=0)
+    week = WeekFactory(mesocycle=meso, index=1, is_current=True)
+    session = SessionFactory(week=week, day_number=1, name="Lower")
+    absolute = ExercisePrescriptionFactory(
+        session=session, name="Back Squat", sets="4", reps="6", load="70", order=0
+    )
+    percent = ExercisePrescriptionFactory(
+        session=session,
+        name="Front Squat",
+        sets="3",
+        reps="5",
+        load="75",
+        load_type=LoadType.PERCENT,
+        order=1,
+    )
+    return plan, session, absolute, percent
+
+
+class TestAthleteSessionUnit:
+    def test_session_ctx_carries_plan_unit(self):
+        plan, session, _, _ = seed_session(unit=Unit.POUNDS)
+        ctx = presenters.athlete_session(session, plan.relationship.athlete)
+        assert ctx["unit"] == Unit.POUNDS
+
+
+class TestLogPayloadLoadType:
+    def test_payload_carries_unit(self):
+        plan, session, _, _ = seed_session()
+        ctx = presenters.athlete_session(session, plan.relationship.athlete)
+        payload = presenters.athlete_log_payload(ctx)
+        assert payload["unit"] == Unit.KILOGRAMS
+
+    def test_payload_exercises_carry_load_and_load_type(self):
+        plan, session, absolute, percent = seed_session()
+        ctx = presenters.athlete_session(session, plan.relationship.athlete)
+        payload = presenters.athlete_log_payload(ctx)
+        by_id = {e["id"]: e for e in payload["exercises"]}
+
+        abs_row = by_id[absolute.pk]
+        assert abs_row["load"] == "70"
+        assert abs_row["load_type"] == LoadType.ABSOLUTE
+
+        pct_row = by_id[percent.pk]
+        assert pct_row["load"] == "75"
+        assert pct_row["load_type"] == LoadType.PERCENT

--- a/app/store_project/static/js/meso_athlete.js
+++ b/app/store_project/static/js/meso_athlete.js
@@ -7,11 +7,59 @@
  * — re-saving updates the one log — so "Save progress" and "Log session" hit the
  * same endpoint, differing only in the status they stamp (pending vs done).
  */
+// ---- %1RM ergonomics helpers (S2 Phase 2b) ----
+// Pure maths shared by the logger and its tests. A %1RM target ("75%") is an
+// intensity, not a weight; given the athlete's estimated 1RM these turn it into a
+// bar load and back, so the athlete knows what to put on the bar.
+
+// Parse a strictly-numeric cell to a Number, or null. Rejects the program grid's
+// free-text loads/reps ("BW", "AMRAP", "8-10", "") that can't enter the maths.
+function parseNum(text) {
+  const s = String(text == null ? "" : text).trim();
+  if (s === "" || !/^[0-9]*\.?[0-9]+$/.test(s)) return null;
+  const n = parseFloat(s);
+  return Number.isNaN(n) ? null : n;
+}
+
+// Format a computed number for display: a whole number stays integral, otherwise
+// it's trimmed to 2 decimals (116.6666… → 116.67).
+function fmtNum(n) {
+  if (n == null || Number.isNaN(n)) return "";
+  return Number.isInteger(n) ? String(n) : String(Math.round(n * 100) / 100);
+}
+
+// Round to the nearest loadable step (2.5 for plates), matching the designer's
+// round25 so a suggested load lands on a real plate.
+function roundToStep(value, step) {
+  return Math.round(value / step) * step;
+}
+
+// Estimated 1RM from a logged set via Epley: w × (1 + reps/30). A single rep IS a
+// 1RM, so it returns the load unchanged (not the formula's slight overshoot).
+// Null when either cell isn't a usable number (load > 0, reps ≥ 1).
+function epleyOneRm(load, reps) {
+  const w = parseNum(load);
+  const r = parseNum(reps);
+  if (w == null || r == null || w <= 0 || r < 1) return null;
+  if (r === 1) return w;
+  return w * (1 + r / 30);
+}
+
+// The bar load for a percent of an estimated 1RM, plate-rounded. Null without a
+// usable 1RM and percent.
+function loadForPercent(oneRm, percent) {
+  const one = parseNum(oneRm);
+  const pct = parseNum(percent);
+  if (one == null || pct == null || one <= 0 || pct <= 0) return null;
+  return roundToStep((one * pct) / 100, 2.5);
+}
+
 function createLogger() {
   return {
     logUrl: "",
     csrf: "",
     status: "pending",
+    unit: "", // the plan's load unit (kg/lb), for the %1RM helper
     exercises: [],
     saving: false,
     saved: false,
@@ -30,7 +78,14 @@ function createLogger() {
       }
       this.logUrl = data.log_url;
       this.status = data.status;
+      this.unit = data.unit || "";
       this.exercises = data.exercises || [];
+      // Restore each exercise's saved 1RM estimate (entered client-side, kept in
+      // localStorage — the maths is local, so no model/migration; S2 Phase 2b).
+      const e1rms = this.readE1rms();
+      for (const ex of this.exercises) {
+        ex.e1rm = e1rms[ex.id] || "";
+      }
       const csrfEl = document.getElementById("meso-csrf");
       this.csrf = csrfEl ? csrfEl.dataset.token : "";
       // Flush anything logged while offline (S7), now and whenever wifi returns.
@@ -237,6 +292,62 @@ function createLogger() {
         }
       }
     },
+
+    // ---- %1RM ergonomics (S2 Phase 2b) ----
+    // A %1RM-prescribed lift: the target Load is a percent of 1RM, not a weight.
+    isPercentLift(ex) {
+      return !!ex && ex.load_type === "pct";
+    },
+
+    // The suggested bar load for a %1RM lift given the athlete's estimated 1RM,
+    // with the plan's unit ("90 kg"). Empty when it isn't a %1RM lift or no usable
+    // 1RM is entered yet.
+    suggestedLoad(ex) {
+      if (!this.isPercentLift(ex)) return "";
+      const load = loadForPercent(ex.e1rm, ex.load);
+      if (load == null) return "";
+      return fmtNum(load) + (this.unit ? " " + this.unit : "");
+    },
+
+    // The 1RM a logged set implies (Epley), with the unit — shown on a %1RM lift so
+    // the athlete can refine their estimate from what they actually lifted. Empty
+    // until the set carries a numeric load + reps.
+    setImpliedOneRm(row) {
+      const one = epleyOneRm(row.load, row.reps);
+      if (one == null) return "";
+      return fmtNum(one) + (this.unit ? " " + this.unit : "");
+    },
+
+    // ---- estimated-1RM store (localStorage, keyed by exercise id) ----
+    // The estimate is per-device convenience, not coach-owned program data, so it
+    // lives client-side — same "reuse what exists, defer new tables" taste as the
+    // offline log queue.
+    e1rmKey: "meso-e1rm",
+
+    readE1rms() {
+      try {
+        return JSON.parse(localStorage.getItem(this.e1rmKey) || "{}") || {};
+      } catch (e) {
+        return {};
+      }
+    },
+
+    writeE1rms(map) {
+      try {
+        localStorage.setItem(this.e1rmKey, JSON.stringify(map));
+      } catch (e) {
+        console.error("Could not persist 1RM estimates", e);
+      }
+    },
+
+    // Persist (or clear) one exercise's 1RM estimate as the athlete edits it.
+    persistE1rm(ex) {
+      const map = this.readE1rms();
+      const value = (ex.e1rm || "").toString().trim();
+      if (value === "") delete map[ex.id];
+      else map[ex.id] = value;
+      this.writeE1rms(map);
+    },
   };
 }
 
@@ -254,5 +365,5 @@ if (
 // Test hook: expose the factory to Node-based runners (vitest). Skipped in the
 // browser, where `module` is undefined.
 if (typeof module !== "undefined" && module.exports) {
-  module.exports = { createLogger };
+  module.exports = { createLogger, epleyOneRm, roundToStep, loadForPercent };
 }

--- a/app/store_project/templates/meso/athlete_session.html
+++ b/app/store_project/templates/meso/athlete_session.html
@@ -47,6 +47,17 @@
         <div style="padding:11px 16px 9px;border-bottom:1px solid var(--line-2);">
           <div style="font-size:14px;font-weight:700;letter-spacing:-0.01em;" x-text="ex.name"></div>
           <div class="meso-row-meta meso-mono">target <span x-text="ex.target"></span><template x-if="ex.note"><span> · <span x-text="ex.note"></span></span></template></div>
+          <template x-if="isPercentLift(ex)">
+            <div style="display:flex;align-items:center;gap:8px;margin-top:7px;flex-wrap:wrap;">
+              <span class="meso-badge meso-badge--accent">%1RM</span>
+              <label class="meso-row-meta" style="display:flex;align-items:center;gap:5px;margin:0;">your 1RM
+                <input class="meso-phone-input" x-model="ex.e1rm" @input="persistE1rm(ex)" placeholder="1RM" inputmode="decimal"
+                       style="width:58px;text-align:center;appearance:none;border:1px solid var(--line);border-radius:7px;background:var(--rail);font:inherit;font-family:'IBM Plex Mono',monospace;font-size:13px;padding:5px 4px;outline:none;color:var(--ink);" />
+                <span x-text="unit"></span>
+              </label>
+              <span class="meso-row-meta meso-mono" style="color:var(--accent);font-weight:700;" x-show="suggestedLoad(ex)" x-cloak x-text="ex.load + '% ≈ ' + suggestedLoad(ex)"></span>
+            </div>
+          </template>
         </div>
         <template x-for="r in ex.set_rows" :key="r.set_number">
           <div style="display:flex;align-items:center;gap:9px;padding:9px 16px;border-bottom:1px solid var(--line-2);">
@@ -58,6 +69,9 @@
                    style="width:60px;text-align:center;appearance:none;border:1px solid var(--line);border-radius:7px;background:var(--rail);font:inherit;font-family:'IBM Plex Mono',monospace;font-size:13px;padding:6px 4px;outline:none;color:var(--ink);" />
             <input class="meso-phone-input" x-model="r.rpe" placeholder="rpe" inputmode="decimal"
                    style="width:48px;text-align:center;appearance:none;border:1px solid var(--line);border-radius:7px;background:var(--rail);font:inherit;font-family:'IBM Plex Mono',monospace;font-size:13px;padding:6px 4px;outline:none;color:var(--ink);" />
+            <template x-if="isPercentLift(ex)">
+              <span class="meso-row-meta meso-mono" style="white-space:nowrap;" x-show="setImpliedOneRm(r)" x-cloak x-text="'1RM ≈ ' + setImpliedOneRm(r)"></span>
+            </template>
             <div class="meso-spacer"></div>
             <button type="button" @click="toggle(r)" :aria-pressed="r.done" aria-label="Mark set done"
                     style="appearance:none;border:0;background:none;cursor:pointer;padding:0;flex:0 0 auto;">

--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -148,7 +148,7 @@ claim, reusing allauth. Detailed design when we build the relationship.
 | # | Decision | Note |
 |---|----------|------|
 | S1 | **Groups** — "shared program + per-athlete auto-adjust" modeling (template + override diffs) | 🟡 In progress — Phase 1 (group + membership spine + read surface) + Phase 2a (shared group program + Group-mode designer) + Phase 3 (per-athlete overrides — the `adj` overlay) built; plan in [`groups-plan.md`](./groups-plan.md) |
-| S2 | **Units & RPE vs %1RM** | 🟡 In progress — units (kg/lb) shipped with earlier slices; Phase 1 (first-class `load_type` `abs`/`pct`) + Phase 2a (agent %1RM-awareness — prompt + a deterministic %1RM progression bound) deployed. Only Phase 2b (athlete %1RM logging ergonomics) remains. Plan in [`units-rpe-plan.md`](./units-rpe-plan.md) |
+| S2 | **Units & RPE vs %1RM** | ✅ Complete — units (kg/lb) shipped with earlier slices; Phase 1 (first-class `load_type` `abs`/`pct`) + Phase 2a (agent %1RM-awareness — prompt + a deterministic %1RM progression bound) + Phase 2b (athlete %1RM logging ergonomics — the estimated-1RM helper) all built & deployed. Plan in [`units-rpe-plan.md`](./units-rpe-plan.md) |
 | S3 | **Delivery & notifications** | Push needs PWA + push infra; email via existing `django-ses` + `notifications` app |
 | S4 | **Results ↔ `challenges`/records** | Results screen shows a PR — reuse the records model or keep separate? |
 | S5 | **Real-time transport** | HTMX polling vs SSE/websockets for chat/drafting |
@@ -436,3 +436,20 @@ _(Append dated entries here as decisions land.)_
   non-numeric value, normalizes `'82.5 %'` → `'82.5'`), leaving the absolute path unbounded. The agent still
   does **not** change a row's type. Athlete %1RM logging ergonomics remain → **Phase 2b**. Plan in
   [`units-rpe-plan.md`](./units-rpe-plan.md).
+- 2026-06-28 — **S2 Phase 2b — athlete %1RM logging ergonomics → S2 COMPLETE** (branch
+  `meso-units-rpe-phase2b`, **no migration**). A %1RM target is an *intensity, not a weight*: Phase 1 let
+  the athlete *see* the `%`, but converting "75%" to a bar load was still manual. Phase 2b adds an
+  **estimated-1RM helper** (% ⇄ load). The data contract is the only backend change — `athlete_session`
+  carries the plan's `unit`, and `athlete_log_payload` threads `unit` + each row's structured
+  `load`/`load_type` — so the client knows which rows are %1RM. The maths is **client-side** (the athlete's
+  1RM estimate is per-device convenience, not coach-owned program data): `meso_athlete.js` gains pure
+  helpers (`epleyOneRm` — Epley, single-rep = the load itself; `loadForPercent` — plate-rounded à la the
+  designer's `round25`) + component methods (`isPercentLift`/`suggestedLoad`/`setImpliedOneRm`), with the
+  estimate persisted in **localStorage** keyed by exercise id (same "defer new tables" taste as the offline
+  log queue). The logger renders a `%1RM` badge, a "your 1RM" input, the suggested load (`75% ≈ 90 kg`), and
+  a per-set implied-1RM hint — all gated on a %1RM lift (absolute lifts untouched). A `LoggedSet` still
+  records the *actual* (absolute) weight. Built red→green: **+3 pytest** (566 meso) + **+14 Vitest** (60
+  frontend), ruff + prettier clean, `makemigrations --check` clean. **Local Codex review: CLEAN on
+  iteration 1.** **Deferred:** a persisted/coach-visible estimated 1RM (model + migration) and
+  auto-deriving it from logged history. **The whole Meso feature area is now real & deployed; S2 is
+  complete — no obvious next big slice, ask the user.** Plan in [`units-rpe-plan.md`](./units-rpe-plan.md).

--- a/docs/meso/units-rpe-plan.md
+++ b/docs/meso/units-rpe-plan.md
@@ -60,9 +60,9 @@ agent, athlete, and groups slices.
     row's `load_type` (Phase 1 wired `serialize_prescription`), so the two real gaps were: the
     **prompt** never explained what `load_type` means, and the **validation backstop** never
     bounded a %1RM progression. Both closed — see below.
-  - **Phase 2b — athlete %1RM logging ergonomics (future).** The athlete logger surfacing the
-    % target distinctly and capturing the *actual* load lifted against an estimated 1RM;
-    optional estimated-1RM math (% ↔ load).
+  - **Phase 2b — athlete %1RM logging ergonomics (this PR, DONE).** The athlete logger surfaces
+    the % target distinctly and offers an **estimated-1RM helper** (% ⇄ load) so a "75%" target
+    becomes a bar load. See below.
 
 ## Phase 1 — build notes
 
@@ -159,3 +159,49 @@ within the existing type), and nothing here touches the athlete logger (→ Phas
   and leaves the **absolute** path unbounded (`'180 kg'` still passes).
 - `TestPercentAwarePrompt` — the `SYSTEM_PROMPT` mentions `load_type` + `1RM`, and the `new_load`
   tool field mentions the percent form (locks the prompt contract so it can't silently regress).
+
+## Phase 2b — athlete %1RM logging ergonomics (build notes)
+
+A %1RM target ("75%") is an **intensity, not a weight**: Phase 1 made the athlete *see* the
+`%` (`_target_label`), but they still had to convert it to a bar load by hand. Phase 2b closes
+that with an **estimated-1RM helper** in the logger — %1RM ⇄ load, both directions — without a
+model change (a `LoggedSet` still records the *actual*, absolute weight lifted, per Phase 1).
+
+- **Presenter** (`meso/presenters.py`): the data contract the client needs to offer the helper.
+  `athlete_session` carries the plan's **`unit`** (kg/lb) into its context, and
+  `athlete_log_payload` threads that `unit` (top-level) plus each row's structured **`load`** and
+  **`load_type`** into the trimmed payload — so the client knows which rows are %1RM (and the
+  percent value) rather than only the pre-rendered `target` string. No new query (`plan.unit` is
+  on the already-`select_related`'d plan).
+- **Client** (`static/js/meso_athlete.js`): the maths is client-side (the athlete's 1RM estimate
+  is per-device convenience, not coach-owned program data). Pure, Vitest-exported helpers —
+  `epleyOneRm(load, reps)` (Epley `w × (1 + reps/30)`; a single rep returns the load itself, not
+  the formula's slight overshoot; null for any non-numeric cell), `loadForPercent(oneRm, percent)`
+  (plate-rounded via `roundToStep`, mirroring the designer's `round25`), and `fmtNum`/`parseNum`.
+  Component methods `isPercentLift(ex)`, `suggestedLoad(ex)` (% → "90 kg"), and
+  `setImpliedOneRm(row)` (a logged set's implied 1RM, so the athlete can refine the estimate from
+  what they actually lifted). The estimate lives in **localStorage** keyed by exercise id
+  (`meso-e1rm`), hydrated on `init()` — the same "reuse what exists, defer new tables" taste as the
+  offline log queue (S7); a persisted, coach-visible 1RM is a deferred follow-up.
+- **Template** (`templates/meso/athlete_session.html`): for a %1RM lift only — a `%1RM` badge, a
+  "your 1RM" input (`@input` persists), the suggested bar load (`75% ≈ 90 kg`), and a per-set
+  `1RM ≈ …` hint. Absolute lifts are untouched (all gated on `isPercentLift`).
+
+### Tests (Phase 2b)
+
+`meso/tests/test_percent_logging.py` (pytest, the data contract):
+
+- `athlete_session` context carries the plan's `unit`.
+- `athlete_log_payload` carries a top-level `unit` and, per exercise, the structured `load` +
+  `load_type` (a %1RM row → `pct`/"75", an absolute row → `abs`/"70").
+
+`frontend/meso_athlete.test.js` (Vitest, the maths + persistence):
+
+- `epleyOneRm` — single-rep returns the load, multi-rep uses Epley, null for BW/AMRAP/ranges/0.
+- `roundToStep` / `loadForPercent` — plate-rounded suggested load (120 @ 75% → 90).
+- `isPercentLift` / `suggestedLoad` (with unit) / `setImpliedOneRm` — only %1RM lifts get a
+  suggestion; an absolute lift or a missing 1RM yields "".
+- estimated-1RM persistence — round-trips per exercise, drops a cleared estimate, hydrates on init.
+
+Deliberately **not** in 2b: a persisted/coach-visible estimated 1RM (a model + migration), and
+auto-deriving the estimate from logged history — both deferred.

--- a/frontend/meso_athlete.test.js
+++ b/frontend/meso_athlete.test.js
@@ -6,7 +6,12 @@
 // (rowFilled / buildPayload / syncFromLog) are covered too since the queue
 // payloads are built from them.
 
-import { createLogger } from "../app/store_project/static/js/meso_athlete.js";
+import {
+  createLogger,
+  epleyOneRm,
+  roundToStep,
+  loadForPercent,
+} from "../app/store_project/static/js/meso_athlete.js";
 
 const LOG_URL = "/meso/api/me/session/42/log/";
 
@@ -221,5 +226,122 @@ describe("flushQueue", () => {
     global.fetch = vi.fn();
     await c.flushQueue();
     expect(global.fetch).not.toHaveBeenCalled();
+  });
+});
+
+// ---- %1RM logging ergonomics (S2 Phase 2b) ----
+// A %1RM target is an intensity, not a weight. These helpers turn the coach's
+// "75%" into a bar load (given the athlete's estimated 1RM) and back — the
+// estimate is entered in the logger and persisted client-side.
+
+describe("epleyOneRm", () => {
+  it("returns the load itself for a single rep", () => {
+    expect(epleyOneRm("100", "1")).toBe(100);
+  });
+  it("estimates 1RM from reps via Epley", () => {
+    // 100 × (1 + 5/30) = 116.666…
+    expect(epleyOneRm("100", "5")).toBeCloseTo(116.667, 2);
+  });
+  it("is null for a non-numeric load or reps (BW, AMRAP, ranges)", () => {
+    expect(epleyOneRm("BW", "5")).toBeNull();
+    expect(epleyOneRm("100", "AMRAP")).toBeNull();
+    expect(epleyOneRm("100", "8-10")).toBeNull();
+    expect(epleyOneRm("", "")).toBeNull();
+  });
+  it("is null for non-positive load or sub-1 reps", () => {
+    expect(epleyOneRm("0", "5")).toBeNull();
+    expect(epleyOneRm("100", "0")).toBeNull();
+  });
+});
+
+describe("roundToStep", () => {
+  it("rounds to the nearest plate step", () => {
+    expect(roundToStep(91.2, 2.5)).toBe(90);
+    expect(roundToStep(81.3, 2.5)).toBe(82.5);
+  });
+});
+
+describe("loadForPercent", () => {
+  it("scales an estimated 1RM by a percent, rounded to a loadable plate", () => {
+    expect(loadForPercent("120", "75")).toBe(90); // 0.75 × 120 = 90
+    expect(loadForPercent("100", "82")).toBe(82.5); // 82 → nearest 2.5
+  });
+  it("is null without a usable 1RM or percent", () => {
+    expect(loadForPercent("", "75")).toBeNull();
+    expect(loadForPercent("120", "")).toBeNull();
+    expect(loadForPercent("0", "75")).toBeNull();
+  });
+});
+
+describe("isPercentLift / suggestedLoad / setImpliedOneRm", () => {
+  function pctLogger() {
+    const c = createLogger();
+    c.unit = "kg";
+    c.exercises = [
+      { id: 1, load: "75", load_type: "pct", e1rm: "120", set_rows: [] },
+      { id: 2, load: "70", load_type: "abs", e1rm: "", set_rows: [] },
+    ];
+    return c;
+  }
+
+  it("identifies a %1RM lift", () => {
+    const c = pctLogger();
+    expect(c.isPercentLift(c.exercises[0])).toBe(true);
+    expect(c.isPercentLift(c.exercises[1])).toBe(false);
+  });
+
+  it("suggests a bar load (with unit) for a %1RM lift with a known 1RM", () => {
+    const c = pctLogger();
+    expect(c.suggestedLoad(c.exercises[0])).toBe("90 kg");
+  });
+
+  it("suggests nothing for an absolute lift or a missing 1RM", () => {
+    const c = pctLogger();
+    expect(c.suggestedLoad(c.exercises[1])).toBe("");
+    c.exercises[0].e1rm = "";
+    expect(c.suggestedLoad(c.exercises[0])).toBe("");
+  });
+
+  it("shows the implied 1RM from a logged set", () => {
+    const c = pctLogger();
+    expect(c.setImpliedOneRm({ load: "100", reps: "1" })).toBe("100 kg");
+    expect(c.setImpliedOneRm({ load: "", reps: "" })).toBe("");
+  });
+});
+
+describe("estimated-1RM persistence", () => {
+  it("round-trips per-exercise 1RM estimates through localStorage", () => {
+    const c = createLogger();
+    c.exercises = [{ id: 7, e1rm: "" }];
+    c.exercises[0].e1rm = "140";
+    c.persistE1rm(c.exercises[0]);
+    expect(c.readE1rms()).toEqual({ 7: "140" });
+  });
+
+  it("drops an estimate cleared back to blank", () => {
+    const c = createLogger();
+    c.exercises = [{ id: 7, e1rm: "140" }];
+    c.persistE1rm(c.exercises[0]);
+    c.exercises[0].e1rm = "";
+    c.persistE1rm(c.exercises[0]);
+    expect(c.readE1rms()).toEqual({});
+  });
+
+  it("hydrates each exercise's 1RM from storage on init", () => {
+    document.body.innerHTML =
+      '<span id="meso-csrf" data-token="tok"></span>' +
+      '<script id="meso-log-data" type="application/json">' +
+      JSON.stringify({
+        log_url: LOG_URL,
+        status: "pending",
+        unit: "kg",
+        exercises: [{ id: 7, load: "75", load_type: "pct", set_rows: [] }],
+      }) +
+      "</script>";
+    localStorage.setItem("meso-e1rm", JSON.stringify({ 7: "140" }));
+    const c = createLogger();
+    c.init();
+    expect(c.unit).toBe("kg");
+    expect(c.exercises[0].e1rm).toBe("140");
   });
 });


### PR DESCRIPTION
## What & why

Closes the **S2 (units & RPE/%1RM)** slice. A %1RM target like "75%" is an **intensity, not a weight** — Phase 1 let the athlete *see* the `%`, but converting it to a bar load was still manual. This phase adds an **estimated-1RM helper** (% ⇄ load) to the athlete logger.

No model change / **no migration** — a `LoggedSet` still records the *actual* (absolute) weight lifted, and the athlete's 1RM estimate lives client-side (localStorage), the same "reuse what exists, defer new tables" taste as the offline log queue.

## Changes

- **Presenter** (`meso/presenters.py`) — the data contract: `athlete_session` carries the plan's `unit`; `athlete_log_payload` threads `unit` (top-level) + each row's structured `load`/`load_type`, so the client knows which rows are %1RM (and the percent value), not just the pre-rendered target string. No new query.
- **Client** (`static/js/meso_athlete.js`) — pure, Vitest-exported maths: `epleyOneRm` (Epley; a single rep returns the load itself), `loadForPercent` (plate-rounded via `roundToStep`, mirroring the designer's `round25`). Component helpers `isPercentLift` / `suggestedLoad` (% → "90 kg") / `setImpliedOneRm` (a logged set's implied 1RM). The estimate persists in localStorage keyed by exercise id, hydrated on `init()`.
- **Template** (`templates/meso/athlete_session.html`) — for a %1RM lift only: a `%1RM` badge, a "your 1RM" input, the suggested bar load (`75% ≈ 90 kg`), and a per-set `1RM ≈ …` hint. Absolute lifts untouched.

## Tests

Built red→green. **+3 pytest** (`test_percent_logging.py`; 566 meso) pin the payload/contract; **+14 Vitest** (`meso_athlete.test.js`; 60 frontend) cover the maths + localStorage persistence. ruff + prettier clean, `makemigrations --check` clean.

## Review

Local **Codex review: CLEAN on iteration 1** (0 blocking, 0 nits).

## Deferred

A persisted / coach-visible estimated 1RM (model + migration) and auto-deriving the estimate from logged history.

Plan + build notes: `docs/meso/units-rpe-plan.md` (Phase 2b).

https://claude.ai/code/session_015G62Gs7papVMJAfYqeExrN