### PR TITLE
Meso — coach-editable 1RM (1RM follow-up Phase 3)

### DIFF
--- a/app/store_project/meso/serializers.py
+++ b/app/store_project/meso/serializers.py
@@ -632,6 +632,10 @@ def serialize_plan(plan, week=None):
                     one_rm = one_rm_map.get(exercise["id"])
                     if one_rm is not None:
                         exercise["one_rm"] = _fmt_num(one_rm.value)
+                        # The coach designer distinguishes a log-derived estimate
+                        # from a value the coach/athlete set, and repaints it after
+                        # an edit (1RM Phase 3 — the editable %1RM badge).
+                        exercise["one_rm_source"] = one_rm.source
         else:
             # A group plan instead carries the per-athlete adjust overlay (groups
             # Phase 3): a per-row ``adj`` badge driven by the members' real

--- a/app/store_project/meso/tests/test_one_rm.py
+++ b/app/store_project/meso/tests/test_one_rm.py
@@ -917,3 +917,160 @@ class TestPresenterCarriesSource:
         )
         ctx = presenters.athlete_session(session, athlete)
         assert ctx["exercises"][0]["one_rm_source"] == ""
+
+
+# -- coach-editable 1RM (1RM Phase 3) ---------------------------------------
+
+
+def post_coach_one_rm(client, plan, prescription, payload):
+    return client.post(
+        reverse(
+            "meso:api_coach_set_one_rm",
+            kwargs={"plan_id": plan.pk, "pk": prescription.pk},
+        ),
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+
+
+class TestCoachSetOneRmEndpoint:
+    """The coach sets/clears the athlete's 1RM from the designer's %1RM badge.
+
+    The athlete logger already persists a manual 1RM (Phase 2); Phase 3 gives the
+    coach the same write path, scoped to a plan they own, so a %1RM target they
+    prescribe resolves to a real bar load even before the athlete logs the lift.
+    """
+
+    def test_coach_sets_an_athletes_manual_1rm(self, client):
+        coach = UserFactory()
+        athlete = UserFactory()
+        plan, _, (squat,) = make_session(
+            athlete,
+            coach=coach,
+            prescriptions=[{"name": "Back Squat", "load_type": LoadType.PERCENT}],
+        )
+        client.force_login(coach)
+        resp = post_coach_one_rm(client, plan, squat, {"value": "150"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["one_rm"] == "150"
+        assert body["source"] == "manual"
+        row = AthleteOneRm.objects.get(athlete=athlete, key="name:back squat")
+        assert row.value == Decimal("150.00")
+        assert row.source == AthleteOneRm.Source.MANUAL
+        assert row.unit == Unit.KILOGRAMS
+
+    def test_coach_value_is_in_the_plans_unit(self, client):
+        coach = UserFactory()
+        athlete = UserFactory()
+        plan, _, (squat,) = make_session(
+            athlete,
+            coach=coach,
+            unit=Unit.POUNDS,
+            prescriptions=[{"name": "Back Squat", "load_type": LoadType.PERCENT}],
+        )
+        client.force_login(coach)
+        post_coach_one_rm(client, plan, squat, {"value": "315"})
+        row = AthleteOneRm.objects.get(athlete=athlete, key="name:back squat")
+        assert row.unit == Unit.POUNDS
+
+    def test_coach_clears_back_to_log_derived(self, client):
+        coach = UserFactory()
+        athlete = UserFactory()
+        plan, session, (squat,) = make_session(
+            athlete,
+            coach=coach,
+            prescriptions=[{"name": "Back Squat", "load_type": LoadType.PERCENT}],
+        )
+        # A logged set means clearing the manual value reverts to the estimate.
+        log_session(athlete, session, [(squat, 1, "1", "120", "9")])
+        client.force_login(coach)
+        post_coach_one_rm(client, plan, squat, {"value": "200"})
+        resp = post_coach_one_rm(client, plan, squat, {"value": ""})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["one_rm"] == "120"
+        assert body["source"] == "logged"
+        row = AthleteOneRm.objects.get(athlete=athlete, key="name:back squat")
+        assert row.source == AthleteOneRm.Source.LOGGED
+
+    @pytest.mark.parametrize("value", ["abc", "0", "-5", "nan"])
+    def test_rejects_a_bad_value(self, client, value):
+        coach = UserFactory()
+        athlete = UserFactory()
+        plan, _, (squat,) = make_session(
+            athlete, coach=coach, prescriptions=[{"name": "Back Squat"}]
+        )
+        client.force_login(coach)
+        resp = post_coach_one_rm(client, plan, squat, {"value": value})
+        assert resp.status_code == 400
+        assert not AthleteOneRm.objects.filter(athlete=athlete).exists()
+
+    def test_group_plan_is_400(self, client):
+        # A group plan has no single athlete, so a 1RM does not apply.
+        coach = UserFactory()
+        group_plan = GroupPlanFactory(status=Plan.Status.ACTIVE, group__coach=coach)
+        meso = MesocycleFactory(plan=group_plan, order=0)
+        week = WeekFactory(mesocycle=meso, index=1, is_current=True)
+        session = SessionFactory(week=week, day_number=1)
+        squat = ExercisePrescriptionFactory(
+            session=session, order=0, name="Back Squat", load_type=LoadType.PERCENT
+        )
+        client.force_login(coach)
+        resp = post_coach_one_rm(client, group_plan, squat, {"value": "150"})
+        assert resp.status_code == 400
+        assert not AthleteOneRm.objects.exists()
+
+    def test_foreign_coach_is_403(self, client):
+        plan, _, (squat,) = make_session(
+            UserFactory(), prescriptions=[{"name": "Back Squat"}]
+        )
+        intruder = UserFactory()
+        client.force_login(intruder)
+        resp = post_coach_one_rm(client, plan, squat, {"value": "150"})
+        assert resp.status_code == 403
+        assert not AthleteOneRm.objects.exists()
+
+    def test_prescription_outside_the_plan_is_404(self, client):
+        coach = UserFactory()
+        athlete = UserFactory()
+        plan, _, (squat,) = make_session(
+            athlete, coach=coach, prescriptions=[{"name": "Back Squat"}]
+        )
+        # A prescription that exists but in another plan (a different athlete the
+        # same coach trains) is not this plan's.
+        _, _, (other,) = make_session(
+            UserFactory(), coach=coach, prescriptions=[{"name": "Bench"}]
+        )
+        client.force_login(coach)
+        resp = post_coach_one_rm(client, plan, other, {"value": "150"})
+        assert resp.status_code == 404
+
+    def test_login_required(self, client):
+        plan, _, (squat,) = make_session(
+            UserFactory(), prescriptions=[{"name": "Back Squat"}]
+        )
+        resp = post_coach_one_rm(client, plan, squat, {"value": "150"})
+        assert resp.status_code in (301, 302)
+        assert not AthleteOneRm.objects.exists()
+
+
+class TestSerializerCarriesSource:
+    def test_individual_plan_row_carries_one_rm_source(self):
+        athlete = UserFactory()
+        plan, _, (squat,) = make_session(
+            athlete,
+            prescriptions=[
+                {"name": "Back Squat", "load": "75", "load_type": LoadType.PERCENT}
+            ],
+        )
+        AthleteOneRmFactory(
+            athlete=athlete,
+            name="Back Squat",
+            value=Decimal("140"),
+            source=AthleteOneRm.Source.MANUAL,
+        )
+        data = serialize_plan(plan)
+        row = data["program"][0]["exercises"][0]
+        assert row["one_rm"] == "140"
+        assert row["one_rm_source"] == "manual"

--- a/app/store_project/meso/urls.py
+++ b/app/store_project/meso/urls.py
@@ -92,6 +92,12 @@ urlpatterns = [
         views.prescription_override,
         name="api_prescription_override",
     ),
+    # Coach sets/clears an athlete's 1RM from the designer (1RM follow-up Phase 3).
+    path(
+        "api/plan/<int:plan_id>/prescription/<int:pk>/one-rm/",
+        views.coach_set_one_rm,
+        name="api_coach_set_one_rm",
+    ),
     path(
         "api/plan/<int:plan_id>/deliver/",
         views.plan_deliver,

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -1163,6 +1163,51 @@ def prescription_override(request, plan_id, pk):
     return _override_response(plan, prescription)
 
 
+@login_required
+@require_POST
+def coach_set_one_rm(request, plan_id, pk):
+    """Set or clear an athlete's 1RM from the designer's %1RM badge (1RM Phase 3).
+
+    The coach-side companion to ``athlete_set_one_rm``: a coach prescribing a
+    %1RM target needs the athlete's max for it to mean anything, so they can set
+    it here directly — useful before the athlete has ever logged the lift.
+    Individual plans only (a group plan has no single athlete → 400). Coach-scoped
+    via ``_coach_plan_or_forbidden`` (403); the prescription must belong to the
+    plan (404). Body ``{"value": "140"}`` — a blank/absent ``value`` *clears* it
+    back to the log-derived estimate. The 1RM is the athlete's own
+    (``source=manual``, global across their coaches), persisted through the same
+    ``set_manual_one_rm`` the athlete logger uses. Returns ``{one_rm, source}`` so
+    the badge repaints.
+    """
+    plan, forbidden = _coach_plan_or_forbidden(request, plan_id)
+    if forbidden is not None:
+        return forbidden
+    if plan.is_group:
+        return HttpResponseBadRequest("A 1RM belongs to a single athlete, not a group.")
+    prescription = get_object_or_404(
+        ExercisePrescription, pk=pk, session__week__mesocycle__plan=plan
+    )
+    try:
+        payload = json.loads(request.body or "{}")
+    except json.JSONDecodeError:
+        return HttpResponseBadRequest("Malformed JSON.")
+    if not isinstance(payload, dict):
+        return HttpResponseBadRequest("Expected a JSON object.")
+
+    value, ok = meso_one_rm.clean_manual_value(payload.get("value"))
+    if not ok:
+        return HttpResponseBadRequest("value must be a positive number or blank.")
+
+    row = meso_one_rm.set_manual_one_rm(plan.athlete, prescription, value, plan.unit)
+    return JsonResponse(
+        {
+            "ok": True,
+            "one_rm": presenters._one_rm_label(row),
+            "source": row.source if row is not None else "",
+        }
+    )
+
+
 def _fan_out_group_delivery(request, plan):
     """Deliver a group plan's current week to every active member (groups Phase 4).
 

--- a/app/store_project/static/js/meso.js
+++ b/app/store_project/static/js/meso.js
@@ -37,6 +37,10 @@ function createMeso() {
     // the selected member id, and an editable `draft` of their adjust.
     override: null,
 
+    // Individual mode only: the open coach 1RM editor (one %1RM row), or null
+    // when closed. Holds the targeted row (`ex`) and an editable `value`.
+    oneRm: null,
+
     // The agent runs as a background job (Phase 4): POST kicks it off, then we
     // poll the batch's status until it lands. `agentTyping` stays true (the
     // "drafting…" indicator) for the whole poll.
@@ -321,6 +325,65 @@ function createMeso() {
         console.error("Override save failed", err);
         this.override.error = "Couldn't save that adjust. Please try again.";
         this.override.saving = false;
+      }
+    },
+
+    // ---- coach 1RM editor (individual mode) ----
+    //
+    // On an individual plan a %1RM target ("75%") needs the athlete's max to
+    // resolve to a bar load. The designer shows the athlete's stored 1RM (their
+    // log-derived estimate or their own manual value) on a %1RM row; the coach
+    // can set or override it here, persisted server-side as the athlete's own
+    // (source=manual) number — the 1RM Phase 3 companion to the athlete logger's
+    // input. Group rows have no single athlete, so the editor is individual-only.
+
+    openOneRm(ex) {
+      // Only an individual plan's %1RM row is editable here; a group plan's rows
+      // belong to many athletes (use the per-athlete override editor instead).
+      if (this.isGroup || !this.live || !ex || ex.load_type !== "pct") return;
+      this.oneRm = { ex, value: ex.one_rm || "", saving: false, error: "" };
+    },
+
+    closeOneRm() {
+      // Don't dismiss mid-save (mirrors closeOverride): a failed save keeps the
+      // editor open to surface a retry, which needs this.oneRm to stay non-null.
+      if (this.oneRm && this.oneRm.saving) return;
+      this.oneRm = null;
+    },
+
+    // Parse the input to the value the endpoint expects: "" clears (back to the
+    // log-derived estimate), a positive number sets, anything else is rejected
+    // here so the badge never repaints off a server 400.
+    parseOneRm() {
+      const raw = (this.oneRm.value || "").trim();
+      if (raw === "") return { ok: true, value: "" };
+      if (!this.numeric(raw) || parseFloat(raw) <= 0) return { ok: false };
+      return { ok: true, value: raw };
+    },
+
+    async saveOneRm() {
+      if (!this.oneRm || this.oneRm.saving) return;
+      const parsed = this.parseOneRm();
+      if (!parsed.ok) {
+        this.oneRm.error = "Enter a positive number, or leave blank to clear.";
+        return;
+      }
+      const { ex } = this.oneRm;
+      this.oneRm.saving = true;
+      this.oneRm.error = "";
+      try {
+        const data = await this.apiPost(
+          `/meso/api/plan/${this.planId}/prescription/${ex.id}/one-rm/`,
+          { value: parsed.value },
+        );
+        ex.one_rm = data.one_rm || "";
+        ex.one_rm_source = data.source || "";
+        this.oneRm.saving = false; // clear before the guarded close
+        this.closeOneRm();
+      } catch (err) {
+        console.error("1RM save failed", err);
+        this.oneRm.error = "Couldn't save that 1RM. Please try again.";
+        this.oneRm.saving = false;
       }
     },
 

--- a/app/store_project/templates/meso/designer.html
+++ b/app/store_project/templates/meso/designer.html
@@ -342,7 +342,21 @@
                         <div style="display:flex;flex-wrap:wrap;gap:5px;align-items:center;padding:1px 6px;margin-top:1px;min-height:15px;">
                           <template x-if="ex.tag"><span style="display:inline-flex;align-items:center;gap:3px;font-size:10px;font-weight:700;color:var(--accent-deep);background:var(--soft);border:1px solid var(--soft-line);padding:0 5px;border-radius:4px;" x-text="ex.tag"></span></template>
                           <template x-if="ex.last"><span style="font-size:10.5px;color:var(--dim);font-family:'IBM Plex Mono',monospace;" x-text="'last: ' + ex.last"></span></template>
-                          <template x-if="ex.one_rm && ex.load_type === 'pct'"><span style="font-size:10.5px;color:var(--accent-deep);font-family:'IBM Plex Mono',monospace;" :title="'Athlete\'s estimated 1RM, from their logged history'" x-text="'1RM: ' + ex.one_rm + (unit ? ' ' + unit : '')"></span></template>
+                          <!-- Individual %1RM row: the athlete's 1RM, editable by the coach (1RM Phase 3). Closed = the value (or a prompt); open = a small inline input. -->
+                          <template x-if="!isGroup && ex.load_type === 'pct' && !(oneRm && oneRm.ex.id === ex.id)">
+                            <button type="button" @click="openOneRm(ex)" data-hover="brighten" :title="ex.one_rm ? (ex.one_rm_source === 'manual' ? 'Athlete\'s 1RM (manually set) — tap to edit' : 'Athlete\'s estimated 1RM, from their logged history — tap to edit') : 'Set this athlete\'s 1RM so the % target resolves to a load'" :style="`appearance:none;cursor:pointer;font:inherit;font-size:10.5px;font-family:'IBM Plex Mono',monospace;border:0;background:transparent;padding:0;border-radius:4px;color:${ex.one_rm ? 'var(--accent-deep)' : 'var(--dim)'}`">
+                              <span x-show="ex.one_rm" x-text="(ex.one_rm_source === 'manual' ? '1RM: ' : '1RM ≈ ') + ex.one_rm + (unit ? ' ' + unit : '')"></span>
+                              <span x-show="!ex.one_rm">+ set 1RM</span>
+                            </button>
+                          </template>
+                          <template x-if="!isGroup && ex.load_type === 'pct' && oneRm && oneRm.ex.id === ex.id">
+                            <span style="display:inline-flex;align-items:center;gap:3px;">
+                              <input x-model="oneRm.value" type="text" inputmode="decimal" :placeholder="unit" @keydown.enter.prevent="saveOneRm()" @keydown.escape.prevent="closeOneRm()" x-init="$nextTick(() => $el.focus())" style="width:46px;text-align:right;appearance:none;border:1px solid var(--line);background:var(--surface);font-family:'IBM Plex Mono',monospace;font-size:10.5px;color:var(--ink);padding:2px 4px;border-radius:4px;outline:none;" />
+                              <button type="button" @click="saveOneRm()" :disabled="oneRm.saving" data-hover="brighten" style="appearance:none;cursor:pointer;font:inherit;font-size:10px;font-weight:600;border:0;background:transparent;color:var(--accent-deep);padding:0 2px;">save</button>
+                              <button type="button" @click="closeOneRm()" :disabled="oneRm.saving" data-hover="brighten" title="Cancel" style="appearance:none;cursor:pointer;font:inherit;font-size:11px;border:0;background:transparent;color:var(--dim);padding:0 2px;">&#215;</button>
+                              <template x-if="oneRm.error"><span style="font-size:10px;color:var(--warn);" x-text="oneRm.error"></span></template>
+                            </span>
+                          </template>
                           <template x-if="isGroup">
                             <button @click="openOverride(ex)" data-hover="brighten" :title="ex.adj ? (ex.adjusts || []).map(a => a.name + ': ' + a.label).join('\n') : 'Set a per-athlete adjust'" style="appearance:none;cursor:pointer;font:inherit;font-size:10px;font-weight:600;line-height:1.6;border:1px solid var(--soft-line);border-radius:4px;padding:0 5px;color:var(--accent-deep);background:var(--soft);">
                               <span x-show="ex.adj" x-text="ex.adj"></span>

--- a/docs/meso/one-rm-plan.md
+++ b/docs/meso/one-rm-plan.md
@@ -1,6 +1,6 @@
 # Meso — persisted estimated 1RM (S2 follow-up)
 
-**Status:** Phase 1 built · Phase 2 built (branch `meso-one-rm-phase2`)
+**Status:** Phase 1 built · Phase 2 built · Phase 3 built (branch `meso-one-rm-phase3`)
 **Context:** the deferred follow-up flagged at the end of the **units & RPE/%1RM
 slice (S2)**. Phase 2b gave the athlete a client-side estimated-1RM helper so a
 "75%" target could be turned into a bar load — but the estimate lived only in the
@@ -142,13 +142,48 @@ value to a real row.
 - **Admin.** `source` is in `list_display` + a `list_filter`, so manual vs logged
   is visible at a glance.
 
-## Deferred (Phase 3+)
+## Phase 3 — coach-editable 1RM (the designer's editable %1RM badge)
 
-- **Coach-editable 1RM** (a coach setting an athlete's max directly from the
-  designer — Phase 2 is athlete-set only; the `source` field already supports it).
+Phases 1–2 are athlete-driven: the 1RM is derived from the athlete's logs or
+typed by the athlete. But a coach prescribing a `75%` target needs the athlete's
+max for it to resolve to a real load — and the most useful moment is *before*
+the athlete has ever logged that lift (no derived value exists yet). Phase 3
+gives the coach the same write path from the designer, reusing the Phase 2
+domain functions wholesale.
+
+- **Endpoint.** `POST /meso/api/plan/<plan_id>/prescription/<pk>/one-rm/` —
+  the coach companion to the athlete's `one-rm` endpoint. Coach-scoped via
+  `_coach_plan_or_forbidden` (404 unknown plan / 403 not the coach over an
+  active link), individual plans only (a group plan has no single athlete →
+  400), and the prescription must belong to the plan (404). Body `{"value":
+  "140"}` — a blank/absent value *clears* it back to the log-derived estimate.
+  The athlete is `plan.athlete`, the unit `plan.unit`; the write goes through
+  the **same** `clean_manual_value` + `set_manual_one_rm` the athlete logger
+  uses, so a coach-set value is `source=manual` (the athlete's own number,
+  global across their coaches) and survives later logs exactly like an
+  athlete-set one. Returns `{one_rm, source}`.
+- **Serializer.** `serialize_plan` now threads `one_rm_source` alongside the
+  existing `one_rm` on an individual plan's grid rows (a group plan still
+  carries neither), so the designer can distinguish a log-derived estimate from
+  a set value and repaint after an edit.
+- **Designer UI** (`meso.js` + `designer.html`): on an individual `%1RM` row the
+  read-only `1RM: …` badge becomes an editable control — a closed state showing
+  the value (`1RM: 140 kg` for a set value, `1RM ≈ 140 kg` for a log-derived
+  estimate, or `+ set 1RM` when there's none yet) that opens a small inline
+  input (`openOneRm`/`saveOneRm`/`closeOneRm`/`parseOneRm`); Enter saves, Escape
+  cancels, blank clears. A failed save keeps the editor open with a retry
+  (mirrors the override editor's guarded close). Group rows are untouched (they
+  use the per-athlete override editor instead).
+- **No model / no migration.** `AthleteOneRm.source` already supported a manual
+  value (Phase 2); Phase 3 is purely a second writer of it.
+
+## Deferred (Phase 4+)
+
 - **Offline persistence of a manual edit** — the manual POST is best-effort; an
   offline edit persists only on the next online edit (the high-stakes set-logging
   path keeps its full offline outbox). A small outbox would close this.
 - **Smarter derivation** — e.g. an average of recent tops, or unit conversion
   when an athlete trains plans in different units (today the value records its
   own unit but isn't converted across plans).
+- **Attribution** — a coach-set and an athlete-set value are both `source=manual`
+  with no record of *who* set it; a `set_by` field would let the UI say so.

--- a/frontend/meso.test.js
+++ b/frontend/meso.test.js
@@ -386,3 +386,115 @@ describe("load type (%1RM)", () => {
     expect(c.program[0].exercises[0].load_type).toBe("abs");
   });
 });
+
+// Coach-editable 1RM (1RM follow-up Phase 3): on an individual %1RM row the
+// coach can set or clear the athlete's estimated 1RM straight from the designer.
+// It posts to the coach endpoint and repaints the row's badge from the reply.
+describe("coach 1RM editor", () => {
+  function pctRow(overrides = {}) {
+    return Object.assign(
+      {
+        id: 21,
+        name: "Back Squat",
+        load: "75",
+        load_type: "pct",
+        one_rm: "140",
+        one_rm_source: "logged",
+      },
+      overrides,
+    );
+  }
+
+  it("opens on an individual %1RM row, seeding the current value", () => {
+    const c = makeMeso();
+    const ex = pctRow();
+    c.openOneRm(ex);
+    expect(c.oneRm).not.toBe(null);
+    expect(c.oneRm.ex).toBe(ex);
+    expect(c.oneRm.value).toBe("140");
+  });
+
+  it("seeds a blank value when the row has no stored 1RM", () => {
+    const c = makeMeso();
+    c.openOneRm(pctRow({ one_rm: "" }));
+    expect(c.oneRm.value).toBe("");
+  });
+
+  it("is a no-op in group mode or on a non-percent row", () => {
+    const grp = makeGroupMeso();
+    grp.openOneRm(pctRow());
+    expect(grp.oneRm == null).toBe(true);
+
+    const c = makeMeso();
+    c.openOneRm(pctRow({ load_type: "abs" }));
+    expect(c.oneRm == null).toBe(true);
+  });
+
+  it("saves a value, posts it to the coach endpoint, and repaints the badge", async () => {
+    const c = makeMeso();
+    const ex = pctRow({ one_rm: "", one_rm_source: "" });
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(res({ body: { ok: true, one_rm: "150", source: "manual" } }));
+    c.openOneRm(ex);
+    c.oneRm.value = "150";
+    await c.saveOneRm();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch.mock.calls[0][0]).toBe(
+      "/meso/api/plan/7/prescription/21/one-rm/",
+    );
+    expect(sentBody()).toEqual({ value: "150" });
+    expect(ex.one_rm).toBe("150");
+    expect(ex.one_rm_source).toBe("manual");
+    expect(c.oneRm).toBe(null);
+  });
+
+  it("clears by saving a blank value, reverting to the log-derived estimate", async () => {
+    const c = makeMeso();
+    const ex = pctRow();
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(res({ body: { ok: true, one_rm: "130", source: "logged" } }));
+    c.openOneRm(ex);
+    c.oneRm.value = "";
+    await c.saveOneRm();
+    expect(sentBody()).toEqual({ value: "" });
+    expect(ex.one_rm).toBe("130");
+    expect(ex.one_rm_source).toBe("logged");
+  });
+
+  it("rejects a non-numeric or non-positive value without posting", async () => {
+    const c = makeMeso();
+    global.fetch = vi.fn();
+    c.openOneRm(pctRow());
+    c.oneRm.value = "heavy";
+    await c.saveOneRm();
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(c.oneRm.error).toMatch(/positive number/);
+
+    c.oneRm.value = "0";
+    await c.saveOneRm();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("keeps the editor open and surfaces an error when the save fails", async () => {
+    const c = makeMeso();
+    const ex = pctRow();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    global.fetch = vi.fn().mockResolvedValue(res({ ok: false, status: 500 }));
+    c.openOneRm(ex);
+    c.oneRm.value = "160";
+    await c.saveOneRm();
+    expect(c.oneRm).not.toBe(null);
+    expect(c.oneRm.error).toMatch(/Couldn't save/);
+    expect(ex.one_rm).toBe("140"); // unchanged
+  });
+
+  it("ignores a dismiss while a save is in flight", () => {
+    const c = makeMeso();
+    c.openOneRm(pctRow());
+    c.oneRm.saving = true;
+    c.closeOneRm();
+    expect(c.oneRm).not.toBe(null);
+  });
+});


### PR DESCRIPTION
## What & why

The athlete logger persists a manual 1RM (Phase 2). **Phase 3 gives the coach the same write path from the designer's `%1RM` badge**, so a `75%` target resolves to a real bar load even *before* the athlete has ever logged that lift (the moment a derived estimate doesn't exist yet — the most useful case for the coach).

## Changes

- **New coach endpoint** `POST /meso/api/plan/<plan_id>/prescription/<pk>/one-rm/` — the coach companion to `athlete_set_one_rm`. Coach-scoped via `_coach_plan_or_forbidden` (404 unknown plan / 403 not the coach over an active link), **individual plans only** (a group plan has no single athlete → 400), prescription must belong to the plan (404). Body `{"value": "140"}`; a blank/absent value **clears** back to the log-derived estimate. The athlete is `plan.athlete`, unit `plan.unit`; the write reuses the **same** `clean_manual_value` + `set_manual_one_rm` the athlete logger uses, so a coach-set value is `source=manual` (the athlete's own number, global across their coaches) and survives later logs. Returns `{one_rm, source}`.
- **Serializer:** `serialize_plan` threads `one_rm_source` on an individual plan's grid rows (a group plan still carries neither `one_rm` nor `one_rm_source`).
- **Designer UI** (`meso.js` + `designer.html`): the read-only `1RM: …` badge becomes an editable inline control on an individual `%1RM` row — `1RM ≈ 140 kg` for a log-derived estimate, `1RM: 140 kg` for a set value, `+ set 1RM` when there's none yet. Opens a small input (`openOneRm`/`saveOneRm`/`closeOneRm`/`parseOneRm`); Enter saves, Escape cancels, blank clears; a failed save keeps the editor open with a retry (mirrors the override editor's guarded close). Group rows are untouched (they use the per-athlete override editor).
- **No model / no migration** — `AthleteOneRm.source` already supported a manual value (Phase 2); Phase 3 is purely a second writer of it.

## Tests

- **+12 pytest** (`test_one_rm.py` — `TestCoachSetOneRmEndpoint` + `TestSerializerCarriesSource`): set / clear-to-derived / unit / bad-value-400 / group-400 / foreign-coach-403 / prescription-outside-plan-404 / login-required, plus the serializer source threading. 793 project-wide green.
- **+8 Vitest** (`meso.test.js` — "coach 1RM editor"): open/seed, group & non-pct no-op, save+repaint+POST shape, clear, reject-without-posting, error-keeps-open, dismiss-mid-save guard. 83 frontend green.
- Built **red → green**; ruff + ruff format + `makemigrations --check` clean. **Local Codex review: CLEAN on iteration 1.**

Plan + build notes in `docs/meso/one-rm-plan.md`.

https://claude.ai/code/session_015G62Gs7papVMJAfYqeExrN