### PR TITLE
Meso — N4 Phase 2: athlete→coach request loop (bidirectional invites)

### DIFF
--- a/app/store_project/meso/management/commands/seed_meso_demo.py
+++ b/app/store_project/meso/management/commands/seed_meso_demo.py
@@ -348,6 +348,11 @@ GROUP = {
 # person the coach invited who hasn't claimed an account yet.
 PENDING_INVITE_EMAIL = "prospect@example.com"
 
+# A pending athlete→coach request (N4 Phase 2) so the roster's request surface is
+# visible — an existing user who has asked to train under the coach.
+PENDING_REQUEST_EMAIL = "hopeful@example.com"
+PENDING_REQUEST_NAME = "Hopeful Newcomer"
+
 
 def _months_before(today, months):
     """The date ``months`` whole months before ``today`` (day clamped to ≤28)."""
@@ -394,12 +399,14 @@ class Command(BaseCommand):
                 self._ensure_log(athlete, plan, today)
         self._ensure_group(coach)
         self._ensure_pending_invite(coach)
+        self._ensure_pending_request(coach)
 
         self.stdout.write(
             self.style.SUCCESS(
                 f"✓ Meso demo seeded for {coach.email}: "
                 f"{len(ATHLETES)} athletes, 1 group (+ shared program), "
-                "1 sample plan, 1 logged session, 1 pending invite."
+                "1 sample plan, 1 logged session, 1 pending invite, "
+                "1 pending request."
             )
         )
 
@@ -412,6 +419,8 @@ class Command(BaseCommand):
         CoachInvite.objects.filter(
             coach__email=coach_email, email=PENDING_INVITE_EMAIL
         ).delete()
+        # Drop the requester (their pending request link cascades with the user).
+        User.objects.filter(email=PENDING_REQUEST_EMAIL).delete()
         emails = [spec["email"] for spec in ATHLETES]
         deleted, _ = User.objects.filter(email__in=emails).delete()
         self.stdout.write(
@@ -486,6 +495,32 @@ class Command(BaseCommand):
             coach=coach,
             email=PENDING_INVITE_EMAIL,
             status=CoachInvite.Status.PENDING,
+        )
+
+    def _ensure_pending_request(self, coach):
+        """A pending athlete→coach request (N4 Phase 2) so the surface shows.
+
+        An existing user (with no prior link to the coach) who has asked to
+        train under them. ``update_or_create`` on the link keeps a reseed
+        idempotent and repairs the row to ``pending_athlete_request`` if a prior
+        run (or a manual accept/decline) left it elsewhere.
+        """
+        requester, created = User.objects.get_or_create(
+            email=PENDING_REQUEST_EMAIL,
+            defaults={"username": PENDING_REQUEST_EMAIL, "name": PENDING_REQUEST_NAME},
+        )
+        if created:
+            requester.set_unusable_password()
+            requester.save(update_fields=["password"])
+        CoachAthlete.objects.update_or_create(
+            coach=coach,
+            athlete=requester,
+            defaults={
+                "status": CoachAthlete.Status.PENDING_ATHLETE_REQUEST,
+                "invited_by": CoachAthlete.InvitedBy.ATHLETE,
+                "responded_at": None,
+                "ended_at": None,
+            },
         )
 
     def _ensure_link(self, coach, athlete):

--- a/app/store_project/meso/models.py
+++ b/app/store_project/meso/models.py
@@ -332,6 +332,19 @@ class CoachAthlete(models.Model):
             return self.coach
         return None
 
+    def initiator(self):
+        """The party who opened a pending link (None if not pending).
+
+        The mirror of ``recipient()``: a coach invite is initiated by the coach,
+        an athlete request by the athlete. The initiator is who may *withdraw* a
+        pending link, as the recipient is who may accept/decline it.
+        """
+        if self.status == self.Status.PENDING_COACH_INVITE:
+            return self.coach
+        if self.status == self.Status.PENDING_ATHLETE_REQUEST:
+            return self.athlete
+        return None
+
 
 class CoachInviteQuerySet(models.QuerySet):
     def for_coach(self, user):

--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -13,6 +13,7 @@ from collections import defaultdict
 from django.urls import reverse
 from django.utils import timezone
 
+from .models import CoachAthlete
 from .models import LoadType
 from .models import Plan
 from .models import SessionLog
@@ -131,6 +132,51 @@ def pending_invite(invite):
         "token": invite.token,
         "when": invite.created_at,
     }
+
+
+def pending_request(link):
+    """A pending athlete→coach request row in the coach's roster (N4 Phase 2).
+
+    The coach accepts/declines via the recipient token views, so the row carries
+    the link's ``token`` to address them.
+    """
+    name = link.athlete.display_name()
+    return {
+        "name": name,
+        "initials": initials(name),
+        "token": link.token,
+        "when": link.created_at,
+    }
+
+
+def athlete_pending(user):
+    """Pending coach links the athlete sees on their training home (N4 Phase 2).
+
+    Splits the athlete's pending links into ``invites`` (a coach invited them —
+    they accept/decline) and ``requests`` (they asked a coach — awaiting, with a
+    withdraw). Each row names the coach and carries the link ``token`` for the
+    accept/decline/withdraw forms.
+    """
+    links = (
+        CoachAthlete.objects.for_athlete(user)
+        .pending()
+        .select_related("coach")
+        .order_by("-created_at")
+    )
+    invites, requests = [], []
+    for link in links:
+        name = link.coach.display_name()
+        row = {
+            "coach": name,
+            "initials": initials(name),
+            "token": link.token,
+            "when": link.created_at,
+        }
+        if link.status == CoachAthlete.Status.PENDING_COACH_INVITE:
+            invites.append(row)
+        else:
+            requests.append(row)
+    return {"invites": invites, "requests": requests}
 
 
 def group_detail(group):

--- a/app/store_project/meso/tests/test_requests.py
+++ b/app/store_project/meso/tests/test_requests.py
@@ -1,0 +1,411 @@
+"""N4 Phase 2 — closing the bidirectional invite loop.
+
+Phase 1 gave a coach an email-onboarding flow (``CoachInvite``). Phase 2 adds
+the *other* direction the relationship spine always supported in the model but
+never in the UI: an athlete asks to train under a coach
+(``CoachAthlete.request`` → ``pending_athlete_request``), the coach sees the
+request on their roster and accepts/declines it (the recipient side, which the
+existing ``invite_accept`` / ``invite_decline`` token views already handle), and
+either party sees the pending state on their own home. The athlete can also
+**withdraw** a request they sent (the initiator side).
+
+These tests cover:
+
+- the ``CoachAthlete.initiator()`` mirror of ``recipient()``;
+- the coach-request email helper (sends to the coach, names the athlete + URL;
+  skips a coach with no address);
+- the athlete request view (login + POST only; coach-by-email lookup scoped to
+  real coaches; unknown/non-coach/self rejected; active + already-pending +
+  reopen-a-closed-link handling; best-effort on-commit mail that never 500s);
+- the withdraw view (initiator-only; recipient/stranger forbidden; pending-only);
+- the coach responding to a request via the existing recipient views;
+- the athlete-home pending surface (invites awaiting me + requests I sent + the
+  request form);
+- the coach roster pending-request surface;
+- the roster routing that now sends any non-coach to their training home so a
+  brand-new athlete can reach the request form.
+"""
+
+from unittest import mock
+
+import pytest
+from django.core import mail
+from django.urls import reverse
+
+from store_project.meso.factories import CoachAthleteFactory
+from store_project.meso.factories import CoachProfileFactory
+from store_project.meso.models import CoachAthlete
+from store_project.users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def make_coach(email="coach@example.com", name="Coach Carter"):
+    """A User who *is* a coach — a ``CoachProfile`` is what the lookup keys on."""
+    coach = UserFactory(email=email, name=name)
+    CoachProfileFactory(user=coach)
+    return coach
+
+
+# -- model -----------------------------------------------------------------
+
+
+class TestInitiator:
+    def test_initiator_of_a_request_is_the_athlete(self):
+        coach = UserFactory()
+        athlete = UserFactory()
+        link = CoachAthlete.request(athlete=athlete, coach=coach)
+        assert link.initiator() == athlete
+
+    def test_initiator_of_an_invite_is_the_coach(self):
+        coach = UserFactory()
+        athlete = UserFactory()
+        link = CoachAthlete.invite(coach=coach, athlete=athlete)
+        assert link.initiator() == coach
+
+    def test_initiator_none_when_not_pending(self):
+        link = CoachAthleteFactory()  # active
+        assert link.initiator() is None
+
+
+# -- email helper ----------------------------------------------------------
+
+
+class TestCoachRequestEmail:
+    def test_sends_to_coach_with_athlete_and_url(self):
+        from store_project.notifications.emails import send_coach_request_email
+
+        coach = make_coach(email="coach@example.com")
+        athlete = UserFactory(name="Ana Athlete")
+        sent = send_coach_request_email(
+            athlete=athlete,
+            coach=coach,
+            roster_url="https://x.test/meso/",
+        )
+        assert sent is True
+        assert len(mail.outbox) == 1
+        msg = mail.outbox[0]
+        assert msg.to == ["coach@example.com"]
+        assert "Ana Athlete" in msg.subject + msg.body
+        assert "https://x.test/meso/" in msg.body
+
+    def test_skips_coach_with_no_address(self):
+        from store_project.notifications.emails import send_coach_request_email
+
+        coach = UserFactory(email="")
+        sent = send_coach_request_email(
+            athlete=UserFactory(), coach=coach, roster_url="https://x.test/meso/"
+        )
+        assert sent is False
+        assert mail.outbox == []
+
+
+# -- athlete request view --------------------------------------------------
+
+
+class TestAthleteRequestCoachView:
+    url = None
+
+    def setup_method(self):
+        self.url = reverse("meso:athlete_request_coach")
+
+    def test_requires_login(self, client):
+        resp = client.post(self.url, {"email": "coach@example.com"})
+        assert resp.status_code == 302
+        assert "/accounts/login/" in resp.url
+
+    def test_get_not_allowed(self, client):
+        client.force_login(UserFactory())
+        resp = client.get(self.url)
+        assert resp.status_code == 405
+
+    def test_valid_coach_creates_request_and_emails(
+        self, client, django_capture_on_commit_callbacks
+    ):
+        coach = make_coach(email="coach@example.com")
+        athlete = UserFactory()
+        client.force_login(athlete)
+        with django_capture_on_commit_callbacks(execute=True):
+            resp = client.post(self.url, {"email": "Coach@Example.com"})
+        assert resp.status_code == 302
+        assert resp.url == reverse("meso:athlete_home")
+        link = CoachAthlete.objects.get(coach=coach, athlete=athlete)
+        assert link.status == CoachAthlete.Status.PENDING_ATHLETE_REQUEST
+        assert link.invited_by == CoachAthlete.InvitedBy.ATHLETE
+        assert len(mail.outbox) == 1
+        assert mail.outbox[0].to == ["coach@example.com"]
+
+    def test_unknown_email_creates_nothing(self, client):
+        athlete = UserFactory()
+        client.force_login(athlete)
+        resp = client.post(self.url, {"email": "nobody@example.com"})
+        assert resp.status_code == 302
+        assert not CoachAthlete.objects.filter(athlete=athlete).exists()
+        assert mail.outbox == []
+
+    def test_non_coach_email_creates_nothing(self, client):
+        # A real user, but not a coach (no CoachProfile) — not a valid target.
+        plain = UserFactory(email="plain@example.com")
+        athlete = UserFactory()
+        client.force_login(athlete)
+        resp = client.post(self.url, {"email": "plain@example.com"})
+        assert resp.status_code == 302
+        assert not CoachAthlete.objects.filter(coach=plain, athlete=athlete).exists()
+
+    def test_invalid_email_creates_nothing(self, client):
+        athlete = UserFactory()
+        client.force_login(athlete)
+        resp = client.post(self.url, {"email": "not-an-email"})
+        assert resp.status_code == 302
+        assert not CoachAthlete.objects.filter(athlete=athlete).exists()
+
+    def test_self_request_rejected(self, client):
+        # A coach who posts their own email can't request themselves.
+        coach = make_coach(email="solo@example.com")
+        client.force_login(coach)
+        resp = client.post(self.url, {"email": "solo@example.com"})
+        assert resp.status_code == 302
+        assert not CoachAthlete.objects.filter(coach=coach, athlete=coach).exists()
+
+    def test_already_active_link_makes_no_pending(self, client):
+        coach = make_coach()
+        athlete = UserFactory()
+        CoachAthleteFactory(coach=coach, athlete=athlete)  # active
+        client.force_login(athlete)
+        resp = client.post(self.url, {"email": coach.email})
+        assert resp.status_code == 302
+        link = CoachAthlete.objects.get(coach=coach, athlete=athlete)
+        assert link.is_active  # unchanged, not flipped to pending
+        assert mail.outbox == []
+
+    def test_duplicate_request_is_idempotent(
+        self, client, django_capture_on_commit_callbacks
+    ):
+        coach = make_coach()
+        athlete = UserFactory()
+        client.force_login(athlete)
+        with django_capture_on_commit_callbacks(execute=True):
+            client.post(self.url, {"email": coach.email})
+        client.post(self.url, {"email": coach.email})  # second time
+        assert CoachAthlete.objects.filter(coach=coach, athlete=athlete).count() == 1
+
+    def test_reopens_a_previously_declined_link(
+        self, client, django_capture_on_commit_callbacks
+    ):
+        coach = make_coach()
+        athlete = UserFactory()
+        link = CoachAthlete.request(athlete=athlete, coach=coach)
+        link.decline()  # closed
+        client.force_login(athlete)
+        with django_capture_on_commit_callbacks(execute=True):
+            client.post(self.url, {"email": coach.email})
+        link.refresh_from_db()
+        assert link.status == CoachAthlete.Status.PENDING_ATHLETE_REQUEST
+
+    def test_mail_failure_does_not_500(
+        self, client, django_capture_on_commit_callbacks
+    ):
+        coach = make_coach()
+        athlete = UserFactory()
+        client.force_login(athlete)
+        with mock.patch(
+            "store_project.meso.views.send_coach_request_email",
+            side_effect=RuntimeError("smtp down"),
+        ):
+            with django_capture_on_commit_callbacks(execute=True):
+                resp = client.post(self.url, {"email": coach.email})
+        assert resp.status_code == 302
+        assert CoachAthlete.objects.filter(coach=coach, athlete=athlete).exists()
+
+
+# -- withdraw view ---------------------------------------------------------
+
+
+class TestRequestWithdrawView:
+    def _url(self, token):
+        return reverse("meso:request_withdraw", kwargs={"token": token})
+
+    def test_initiator_withdraws_pending_request(self, client):
+        coach = UserFactory()
+        athlete = UserFactory()
+        link = CoachAthlete.request(athlete=athlete, coach=coach)
+        client.force_login(athlete)
+        resp = client.post(self._url(link.token))
+        assert resp.status_code == 302
+        assert resp.url == reverse("meso:athlete_home")
+        link.refresh_from_db()
+        assert link.status == CoachAthlete.Status.DECLINED
+
+    def test_recipient_cannot_withdraw(self, client):
+        coach = UserFactory()
+        athlete = UserFactory()
+        link = CoachAthlete.request(athlete=athlete, coach=coach)
+        client.force_login(coach)  # the recipient, not the initiator
+        resp = client.post(self._url(link.token))
+        assert resp.status_code == 403
+        link.refresh_from_db()
+        assert link.is_pending
+
+    def test_stranger_cannot_withdraw(self, client):
+        coach = UserFactory()
+        athlete = UserFactory()
+        link = CoachAthlete.request(athlete=athlete, coach=coach)
+        client.force_login(UserFactory())
+        resp = client.post(self._url(link.token))
+        assert resp.status_code == 403
+
+    def test_cannot_withdraw_active_link(self, client):
+        coach = UserFactory()
+        athlete = UserFactory()
+        link = CoachAthleteFactory(coach=coach, athlete=athlete)  # active
+        client.force_login(athlete)
+        resp = client.post(self._url(link.token))
+        assert resp.status_code == 403
+
+    def test_requires_login(self, client):
+        link = CoachAthlete.request(athlete=UserFactory(), coach=UserFactory())
+        resp = client.post(self._url(link.token))
+        assert resp.status_code == 302
+        assert "/accounts/login/" in resp.url
+
+
+# -- coach responds to a request (recipient side) --------------------------
+
+
+class TestCoachRespondsToRequest:
+    def test_coach_accepts_request(self, client):
+        coach = make_coach()
+        athlete = UserFactory()
+        link = CoachAthlete.request(athlete=athlete, coach=coach)
+        client.force_login(coach)
+        resp = client.post(reverse("meso:invite_accept", kwargs={"token": link.token}))
+        assert resp.status_code == 302
+        link.refresh_from_db()
+        assert link.is_active
+
+    def test_coach_declines_request(self, client):
+        coach = make_coach()
+        athlete = UserFactory()
+        link = CoachAthlete.request(athlete=athlete, coach=coach)
+        client.force_login(coach)
+        resp = client.post(reverse("meso:invite_decline", kwargs={"token": link.token}))
+        assert resp.status_code == 302
+        link.refresh_from_db()
+        assert link.status == CoachAthlete.Status.DECLINED
+
+    def test_athlete_cannot_accept_own_request(self, client):
+        # The athlete is the initiator, not the recipient — they can't self-accept.
+        coach = make_coach()
+        athlete = UserFactory()
+        link = CoachAthlete.request(athlete=athlete, coach=coach)
+        client.force_login(athlete)
+        resp = client.post(reverse("meso:invite_accept", kwargs={"token": link.token}))
+        assert resp.status_code == 403
+        link.refresh_from_db()
+        assert link.is_pending
+
+
+# -- athlete home pending surface ------------------------------------------
+
+
+class TestAthleteHomePending:
+    home = None
+
+    def setup_method(self):
+        self.home = reverse("meso:athlete_home")
+
+    def test_home_shows_request_form(self, client):
+        client.force_login(UserFactory())
+        body = client.get(self.home).content.decode()
+        assert reverse("meso:athlete_request_coach") in body
+
+    def test_home_shows_sent_request_with_withdraw(self, client):
+        coach = make_coach(name="Coach Carter")
+        athlete = UserFactory()
+        link = CoachAthlete.request(athlete=athlete, coach=coach)
+        client.force_login(athlete)
+        body = client.get(self.home).content.decode()
+        assert "Coach Carter" in body
+        assert reverse("meso:request_withdraw", kwargs={"token": link.token}) in body
+
+    def test_home_shows_incoming_invite_with_accept_decline(self, client):
+        coach = make_coach(name="Coach Carter")
+        athlete = UserFactory()
+        link = CoachAthlete.invite(coach=coach, athlete=athlete)  # awaiting athlete
+        client.force_login(athlete)
+        body = client.get(self.home).content.decode()
+        assert "Coach Carter" in body
+        assert reverse("meso:invite_accept", kwargs={"token": link.token}) in body
+        assert reverse("meso:invite_decline", kwargs={"token": link.token}) in body
+
+
+# -- coach roster pending-request surface ----------------------------------
+
+
+class TestRosterPendingRequests:
+    def test_roster_shows_pending_request(self, client):
+        coach = make_coach()
+        athlete = UserFactory(name="Ana Athlete")
+        link = CoachAthlete.request(athlete=athlete, coach=coach)
+        client.force_login(coach)
+        body = client.get(reverse("meso:roster")).content.decode()
+        assert "Ana Athlete" in body
+        assert reverse("meso:invite_accept", kwargs={"token": link.token}) in body
+        assert reverse("meso:invite_decline", kwargs={"token": link.token}) in body
+
+    def test_roster_hides_other_coachs_request(self, client):
+        coach = make_coach()
+        other = make_coach(email="other@example.com")
+        CoachAthlete.request(athlete=UserFactory(name="Not Mine"), coach=other)
+        client.force_login(coach)
+        body = client.get(reverse("meso:roster")).content.decode()
+        assert "Not Mine" not in body
+
+    def test_roster_has_no_request_row_without_requests(self, client):
+        coach = make_coach()
+        CoachAthleteFactory(coach=coach, athlete=UserFactory())  # active, not a request
+        client.force_login(coach)
+        body = client.get(reverse("meso:roster")).content.decode()
+        # No pending requests → the "wants to train with you" affordance is absent.
+        assert "wants to train" not in body
+
+
+# -- roster routing --------------------------------------------------------
+
+
+class TestRosterRouting:
+    def test_brand_new_user_redirected_to_home(self, client):
+        # No CoachProfile, no links, no sent invites → treated as an athlete.
+        client.force_login(UserFactory())
+        resp = client.get(reverse("meso:roster"))
+        assert resp.status_code == 302
+        assert resp.url == reverse("meso:athlete_home")
+
+    def test_pending_invite_recipient_reaches_home(self, client):
+        # An athlete with only a pending coach-invite (no active link) must still
+        # reach their home to respond to it.
+        coach = make_coach()
+        athlete = UserFactory()
+        CoachAthlete.invite(coach=coach, athlete=athlete)
+        client.force_login(athlete)
+        resp = client.get(reverse("meso:roster"))
+        assert resp.status_code == 302
+        assert resp.url == reverse("meso:athlete_home")
+
+    def test_coach_with_only_a_sent_invite_stays_on_roster(self, client):
+        # A coach identified solely by an email invite they sent keeps the roster.
+        from store_project.meso.models import CoachInvite
+
+        coach = UserFactory()
+        CoachInvite.open_for(coach=coach, email="prospect@example.com")
+        client.force_login(coach)
+        resp = client.get(reverse("meso:roster"))
+        assert resp.status_code == 200
+
+    def test_coach_with_a_pending_request_stays_on_roster(self, client):
+        # A coach awaiting an athlete's request keeps the roster (they coach).
+        coach = UserFactory()
+        CoachAthlete.request(athlete=UserFactory(), coach=coach)
+        client.force_login(coach)
+        resp = client.get(reverse("meso:roster"))
+        assert resp.status_code == 200

--- a/app/store_project/meso/tests/test_seed_demo.py
+++ b/app/store_project/meso/tests/test_seed_demo.py
@@ -96,6 +96,33 @@ class TestSeedCreatesDemo:
         seed(delete=True)
         assert not CoachInvite.objects.filter(email="prospect@example.com").exists()
 
+    def test_creates_a_pending_request(self):
+        # N4 Phase 2: an athlete who has asked to train under the coach, so the
+        # roster's pending-request surface is visible on a fresh DB.
+        seed()
+        coach = User.objects.get(email=COACH_EMAIL)
+        pending = CoachAthlete.objects.for_coach(coach).filter(
+            status=CoachAthlete.Status.PENDING_ATHLETE_REQUEST
+        )
+        assert pending.count() == 1
+        assert pending.get().athlete.email == "hopeful@example.com"
+
+    def test_reseed_does_not_duplicate_pending_request(self):
+        seed()
+        seed()
+        coach = User.objects.get(email=COACH_EMAIL)
+        assert (
+            CoachAthlete.objects.for_coach(coach)
+            .filter(status=CoachAthlete.Status.PENDING_ATHLETE_REQUEST)
+            .count()
+            == 1
+        )
+
+    def test_delete_removes_pending_request(self):
+        seed()
+        seed(delete=True)
+        assert not User.objects.filter(email="hopeful@example.com").exists()
+
     def test_creates_one_sample_plan(self):
         seed()
         coach = User.objects.get(email=COACH_EMAIL)
@@ -315,7 +342,9 @@ class TestIdempotent:
         seed()
         coach = User.objects.get(email=COACH_EMAIL)
         assert User.objects.filter(email__in=ATHLETE_EMAILS).count() == 5
-        assert CoachAthlete.objects.for_coach(coach).count() == 5
+        # 5 active athletes + 1 pending athlete→coach request (N4 Phase 2).
+        assert CoachAthlete.objects.for_coach(coach).active().count() == 5
+        assert CoachAthlete.objects.for_coach(coach).count() == 6
         assert Plan.objects.for_coach(coach).count() == 1
         # Children are not re-created on a second run (the individual sample plan;
         # ``for_coach`` excludes the group-delivery snapshots seeded in Phase 4).

--- a/app/store_project/meso/tests/test_views.py
+++ b/app/store_project/meso/tests/test_views.py
@@ -135,7 +135,11 @@ class TestScreensRender:
     """
 
     def test_roster_renders(self, client):
-        client.force_login(UserFactory())
+        # The roster is a coach surface: a non-coach is now routed to their
+        # training home (N4 Phase 2), so log in an actual coach.
+        coach = UserFactory()
+        CoachAthleteFactory(coach=coach, athlete=UserFactory())
+        client.force_login(coach)
         resp = client.get(reverse("meso:roster"))
         assert resp.status_code == 200
 

--- a/app/store_project/meso/urls.py
+++ b/app/store_project/meso/urls.py
@@ -84,6 +84,13 @@ urlpatterns = [
         views.relationship_end,
         name="relationship_end",
     ),
+    # Athlete → coach requests (N4 Phase 2): the athlete asks, then may withdraw.
+    path("request/", views.athlete_request_coach, name="athlete_request_coach"),
+    path(
+        "request/<uuid:token>/withdraw/",
+        views.request_withdraw,
+        name="request_withdraw",
+    ),
     # Designer autosave API (Phase 3).
     path(
         "api/plan/<int:plan_id>/prescription/<int:pk>/",

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import ValidationError
@@ -30,6 +31,7 @@ from django.views.decorators.http import require_POST
 from django.views.generic import TemplateView
 
 from store_project.notifications.emails import send_coach_invite_email
+from store_project.notifications.emails import send_coach_request_email
 from store_project.notifications.emails import send_week_delivered_email
 
 from . import one_rm as meso_one_rm
@@ -66,6 +68,8 @@ from .serializers import serialize_session_log
 from .serializers import serialize_week_snapshot
 
 logger = logging.getLogger(__name__)
+
+User = get_user_model()
 
 
 def _coach_working_plan(user, *, plans=None):
@@ -171,17 +175,25 @@ class MesoDesignerView(LoginRequiredMixin, TemplateView):
 class RosterView(LoginRequiredMixin, TemplateView):
     """Front door: the coach's athletes (scoped to active relationships).
 
-    A *pure* athlete — someone with an active coach link but no ``CoachProfile``
-    — has no roster of their own, so they're sent to their training surface
-    instead. A coach (or a coach who also trains) keeps the roster.
+    The roster is a *coach* surface, so anyone who isn't acting as a coach is
+    sent to their training home instead — where they see their delivered
+    programs, respond to a coach's invite, and request a coach (N4 Phase 2). A
+    user counts as a coach if they have a ``CoachProfile`` *or* any coach-side
+    link (athletes they coach, including a pending request awaiting them) *or* a
+    sent email invite. Everyone else — a pure athlete, an athlete awaiting an
+    invite, or a brand-new user — lands on ``/meso/me/``.
     """
 
     template_name = "meso/roster.html"
 
     def get(self, request, *args, **kwargs):
-        is_coach = CoachProfile.objects.filter(user=request.user).exists()
-        is_athlete = CoachAthlete.objects.for_athlete(request.user).active().exists()
-        if not is_coach and is_athlete:
+        user = request.user
+        is_coach = (
+            CoachProfile.objects.filter(user=user).exists()
+            or CoachAthlete.objects.for_coach(user).exists()
+            or CoachInvite.objects.for_coach(user).exists()
+        )
+        if not is_coach:
             return redirect("meso:athlete_home")
         return super().get(request, *args, **kwargs)
 
@@ -210,6 +222,16 @@ class RosterView(LoginRequiredMixin, TemplateView):
         pending_invites = CoachInvite.objects.for_coach(self.request.user).pending()
         ctx["pending_invites"] = [
             presenters.pending_invite(inv) for inv in pending_invites
+        ]
+        # Pending athlete→coach requests awaiting this coach's reply (N4 Phase 2).
+        pending_requests = (
+            CoachAthlete.objects.for_coach(self.request.user)
+            .filter(status=CoachAthlete.Status.PENDING_ATHLETE_REQUEST)
+            .select_related("athlete")
+            .order_by("-created_at")
+        )
+        ctx["pending_requests"] = [
+            presenters.pending_request(link) for link in pending_requests
         ]
         ctx["activity"] = []
         ctx["needs_review"] = 0
@@ -432,6 +454,9 @@ class AthleteHomeView(LoginRequiredMixin, TemplateView):
         ctx = super().get_context_data(**kwargs)
         ctx["active"] = "training"
         ctx["plans"] = presenters.athlete_home(self.request.user)
+        # Pending coach links (N4 Phase 2): invites awaiting my reply + requests
+        # I've sent + the request-a-coach form all live on this surface.
+        ctx["pending"] = presenters.athlete_pending(self.request.user)
         ctx["athlete_name"] = self.request.user.display_name()
         ctx["athlete_initials"] = presenters.initials(ctx["athlete_name"])
         ctx.update(_pwa_context())
@@ -909,6 +934,93 @@ def relationship_end(request, token):
     link.end()
     messages.success(request, "Relationship ended.")
     return redirect("meso:roster")
+
+
+# -- athlete → coach requests (N4 Phase 2) ---------------------------------
+#
+# The reverse of the coach email invite: an athlete who already has an account
+# asks to train under a coach (CoachAthlete.request → pending_athlete_request).
+# The coach accepts/declines it via the recipient views above (invite_accept /
+# invite_decline); the athlete may withdraw their own pending request.
+
+
+@login_required
+@require_POST
+def athlete_request_coach(request):
+    """An athlete asks to train under a coach, found by the coach's email.
+
+    A plain form POST from the athlete's training home. The email is validated
+    and resolved to a *coach* (a User with a ``CoachProfile`` — a non-coach or
+    unknown address is rejected, as is the requester's own). An already-active
+    link is left untouched; an already-pending request is a no-op; otherwise a
+    pending request is opened (reopening a previously closed link). The coach is
+    notified by email on ``transaction.on_commit``, best-effort — a mail failure
+    is logged, never a 500 or a lost request. Always lands back on the home.
+    """
+    email = CoachInvite.normalize_email(request.POST.get("email"))
+    try:
+        validate_email(email)
+    except ValidationError:
+        messages.error(request, "Enter a valid email address.")
+        return redirect("meso:athlete_home")
+    coach = (
+        User.objects.filter(email__iexact=email, coach_profile__isnull=False)
+        .exclude(pk=request.user.pk)
+        .first()
+    )
+    if coach is None:
+        messages.error(request, "We couldn't find a coach with that email.")
+        return redirect("meso:athlete_home")
+
+    existing = CoachAthlete.objects.filter(coach=coach, athlete=request.user).first()
+    if existing and existing.is_active:
+        messages.info(request, f"You're already training with {coach.display_name()}.")
+        return redirect("meso:athlete_home")
+    if existing and existing.status == CoachAthlete.Status.PENDING_ATHLETE_REQUEST:
+        messages.info(
+            request, f"You've already asked to train with {coach.display_name()}."
+        )
+        return redirect("meso:athlete_home")
+    if existing and existing.status == CoachAthlete.Status.PENDING_COACH_INVITE:
+        messages.info(
+            request,
+            f"{coach.display_name()} already invited you — accept it below.",
+        )
+        return redirect("meso:athlete_home")
+
+    CoachAthlete.request(athlete=request.user, coach=coach)
+    athlete = request.user
+    roster_url = request.build_absolute_uri(reverse("meso:roster"))
+
+    def _send():
+        try:
+            send_coach_request_email(
+                athlete=athlete, coach=coach, roster_url=roster_url
+            )
+        except Exception:  # mail is best-effort; never fail the request on it
+            logger.exception("Failed to send coach request email to %s", coach.email)
+
+    transaction.on_commit(_send)
+    messages.success(request, f"Request sent to {coach.display_name()}.")
+    return redirect("meso:athlete_home")
+
+
+@login_required
+@require_POST
+def request_withdraw(request, token):
+    """The initiator of a pending link withdraws it (an athlete cancels a request).
+
+    The mirror of ``invite_decline`` (the *recipient* declines): only the party
+    who opened the pending link may withdraw it, which marks it declined. Lands
+    the athlete back on their home, a coach on the roster.
+    """
+    link = get_object_or_404(CoachAthlete, token=token)
+    if not link.is_pending or request.user != link.initiator():
+        return HttpResponseForbidden("You cannot withdraw this request.")
+    link.decline()
+    messages.success(request, "Request withdrawn.")
+    target = "meso:athlete_home" if request.user == link.athlete else "meso:roster"
+    return redirect(target)
 
 
 # -- email invites / onboarding (N4) ---------------------------------------

--- a/app/store_project/notifications/emails.py
+++ b/app/store_project/notifications/emails.py
@@ -87,6 +87,49 @@ def send_coach_invite_email(*, coach, email, accept_url) -> bool:
     return True
 
 
+def send_coach_request_email(*, athlete, coach, roster_url) -> bool:
+    """Email a coach that an athlete has asked to train under them.
+
+    Meso N4 Phase 2 (athlete onboarding, the reverse direction): an athlete who
+    already has an account asks to be coached. This notifies the coach so they
+    can accept or decline on their roster — the symmetric counterpart to
+    ``send_coach_invite_email``.
+
+    Args:
+        athlete: the requesting ``User`` (named in the message).
+        coach: the ``User`` being asked to coach (the recipient).
+        roster_url: absolute URL of the coach's roster (``/meso/``), where the
+            pending request is accepted or declined.
+
+    Returns:
+        ``True`` if a message was sent, ``False`` if skipped because the coach
+        has no email address on file.
+
+    Raises a mail backend exception (``fail_silently=False``); callers that must
+    not fail the request on a bounced email should treat this as best-effort.
+    """
+    if not coach.email:
+        return False
+    context = {
+        "athlete_name": athlete.display_name(),
+        "roster_url": roster_url,
+    }
+    subject = render_to_string(
+        "notifications/coach_request_subject.txt", context
+    ).strip()
+    msg_plain = render_to_string("notifications/coach_request.md", context)
+    msg_html = render_to_string("notifications/coach_request.html", context)
+    send_mail(
+        subject=subject,
+        message=msg_plain,
+        html_message=msg_html,
+        from_email=None,  # defaults to settings.DEFAULT_FROM_EMAIL
+        recipient_list=[coach.email],
+        fail_silently=False,
+    )
+    return True
+
+
 def send_week_delivered_email(*, athlete, coach, plan, week, home_url) -> bool:
     """Email an athlete that their coach delivered a new training week.
 

--- a/app/store_project/templates/meso/athlete_home.html
+++ b/app/store_project/templates/meso/athlete_home.html
@@ -35,6 +35,57 @@
       </button>
     {% endif %}
 
+    <!-- Your coaches (N4 Phase 2): invites awaiting you, requests you've sent,
+         and the request-a-coach form. -->
+    <div class="meso-card meso-card--pad" style="margin-bottom:14px;">
+      <p class="meso-eyebrow">Your coaches</p>
+
+      {% for inv in pending.invites %}
+        <div class="meso-row" style="cursor:default;padding-left:0;padding-right:0;">
+          <div class="meso-avatar meso-avatar--sm">{{ inv.initials }}</div>
+          <div style="min-width:0;">
+            <div class="meso-row-name">{{ inv.coach }}</div>
+            <div class="meso-row-meta">Invited you to train · {{ inv.when|date:"M j" }}</div>
+          </div>
+          <div class="meso-spacer"></div>
+          <form method="post" action="{% url 'meso:invite_accept' token=inv.token %}" style="margin:0;">
+            {% csrf_token %}
+            <button type="submit" class="meso-btn meso-btn--primary" style="padding:5px 10px;font-size:12px;">Accept</button>
+          </form>
+          <form method="post" action="{% url 'meso:invite_decline' token=inv.token %}" style="margin:0;">
+            {% csrf_token %}
+            <button type="submit" class="meso-btn meso-btn--ghost" style="padding:5px 10px;font-size:12px;">Decline</button>
+          </form>
+        </div>
+      {% endfor %}
+
+      {% for req in pending.requests %}
+        <div class="meso-row" style="cursor:default;padding-left:0;padding-right:0;">
+          <div class="meso-avatar meso-avatar--sm">{{ req.initials }}</div>
+          <div style="min-width:0;">
+            <div class="meso-row-name">{{ req.coach }}</div>
+            <div class="meso-row-meta">Requested {{ req.when|date:"M j" }} · awaiting reply</div>
+          </div>
+          <div class="meso-spacer"></div>
+          <span class="meso-badge"><i></i>Pending</span>
+          <form method="post" action="{% url 'meso:request_withdraw' token=req.token %}" style="margin:0;">
+            {% csrf_token %}
+            <button type="submit" class="meso-btn meso-btn--ghost" style="padding:5px 10px;font-size:12px;">Withdraw</button>
+          </form>
+        </div>
+      {% endfor %}
+
+      <details {% if not pending.invites and not pending.requests %}open{% endif %} style="margin-top:6px;">
+        <summary style="list-style:none;cursor:pointer;font-size:12.5px;font-weight:650;color:var(--accent-ink);">+ Request a coach</summary>
+        <form method="post" action="{% url 'meso:athlete_request_coach' %}" style="display:flex;gap:9px;margin-top:10px;">
+          {% csrf_token %}
+          <input name="email" type="email" required maxlength="254" placeholder="coach@email.com" style="flex:1;appearance:none;border:1px solid var(--line);border-radius:8px;background:var(--rail);font:inherit;font-size:13px;color:var(--ink);padding:8px 10px;outline:none;" />
+          <button type="submit" class="meso-btn meso-btn--primary">Send request</button>
+        </form>
+        <p class="meso-row-meta" style="margin-top:8px;">Enter your coach's email to ask to train with them.</p>
+      </details>
+    </div>
+
     {% for plan in plans %}
       <div class="meso-card meso-card--pad" style="margin-bottom:14px;">
         <div style="display:flex;align-items:baseline;gap:10px;margin-bottom:4px;flex-wrap:wrap;">

--- a/app/store_project/templates/meso/roster.html
+++ b/app/store_project/templates/meso/roster.html
@@ -75,6 +75,26 @@
             </div>
           {% endfor %}
 
+          <!-- Pending athlete→coach requests (N4 Phase 2): accept or decline. -->
+          {% for req in pending_requests %}
+            <div class="meso-row" style="cursor:default;">
+              <div class="meso-avatar">{{ req.initials }}</div>
+              <div style="min-width:0;">
+                <div class="meso-row-name">{{ req.name }}</div>
+                <div class="meso-row-meta">Requested {{ req.when|date:"M j" }} · wants to train with you</div>
+              </div>
+              <div class="meso-spacer"></div>
+              <form method="post" action="{% url 'meso:invite_accept' token=req.token %}" style="margin:0;">
+                {% csrf_token %}
+                <button type="submit" class="meso-btn meso-btn--primary" style="padding:5px 10px;font-size:12px;">Accept</button>
+              </form>
+              <form method="post" action="{% url 'meso:invite_decline' token=req.token %}" style="margin:0;">
+                {% csrf_token %}
+                <button type="submit" class="meso-btn meso-btn--ghost" style="padding:5px 10px;font-size:12px;">Decline</button>
+              </form>
+            </div>
+          {% endfor %}
+
           <!-- Invite a new athlete by email (N4). -->
           <details style="border-top:1px solid var(--line-2);">
             <summary style="list-style:none;cursor:pointer;padding:11px 16px;font-size:12.5px;font-weight:650;color:var(--accent-ink);">+ Invite an athlete</summary>

--- a/app/store_project/templates/notifications/coach_request.html
+++ b/app/store_project/templates/notifications/coach_request.html
@@ -1,0 +1,10 @@
+<p>Hi,</p>
+
+<p><strong>{{ athlete_name }}</strong> asked to train with you on Mastering
+  Fitness — where you build their program and they log their training.</p>
+
+<p><a href="{{ roster_url }}">Accept or decline the request</a> from your roster.</p>
+
+<p>If you weren't expecting this, you can ignore this email.</p>
+
+<p>Train hard,<br>Mastering Fitness</p>

--- a/app/store_project/templates/notifications/coach_request.md
+++ b/app/store_project/templates/notifications/coach_request.md
@@ -1,0 +1,13 @@
+Hi,
+
+{{ athlete_name }} asked to train with you on Mastering Fitness — where you
+build their program and they log their training.
+
+Accept or decline the request from your roster:
+
+{{ roster_url }}
+
+If you weren't expecting this, you can ignore this email.
+
+Train hard,
+Mastering Fitness

--- a/app/store_project/templates/notifications/coach_request_subject.txt
+++ b/app/store_project/templates/notifications/coach_request_subject.txt
@@ -1,0 +1,1 @@
+{{ athlete_name }} asked to train with you on Mastering Fitness

--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -136,12 +136,15 @@ Mark via a `CoachProfile`/`AthleteProfile`, Django groups, or boolean flags. **R
 `CoachProfile` (presence = is-a-coach) + the `CoachAthlete` link (presence = is-an-athlete);
 avoids overloading the User model.
 
-### N4 · Athlete onboarding / invites 🟢 (Phase 1 built)
+### N4 · Athlete onboarding / invites 🟢 (Phases 1–2 built)
 How an athlete joins a coach: coach invites by email → athlete signs up (allauth) → link
 created; or coach creates a stub athlete and sends a claim link. **Decision:** email invite +
 claim, reusing allauth — **Phase 1 built** (the `CoachInvite` email artifact → bearer-token
 claim → materialized active `CoachAthlete`; rides allauth's `?next=` with no custom adapter).
-Plan + deferred items in [`invites-plan.md`](./invites-plan.md).
+**Phase 2 built** — the reverse direction: an athlete *requests* a coach by email
+(`CoachAthlete.request`), the coach accepts/declines on the roster, both sides see the pending
+state on their own surface, and any non-coach now lands on their training home (where the
+request form lives). Plan + deferred items in [`invites-plan.md`](./invites-plan.md).
 
 ---
 
@@ -519,3 +522,26 @@ _(Append dated entries here as decisions land.)_
   P2 claim race — `select_for_update` on the invite row in the claim/revoke views). Plan +
   deferred (athlete→coach request UI, resend/expiry, stub-athlete) in
   [`invites-plan.md`](./invites-plan.md).
+- 2026-06-29 — **N4 — athlete onboarding / invites — Phase 2 built** (branch
+  `meso-invites-phase2`, **no migration**). Closes the bidirectional half the relationship spine
+  always supported in the model (`CoachAthlete.request` → `pending_athlete_request`) but never in
+  the UI: an athlete who already has an account asks to train under a coach, the coach
+  accepts/declines on the roster, and either party sees the pending state on their own surface.
+  New `CoachAthlete.initiator()` (mirror of `recipient()` — who may *withdraw* a pending link).
+  **`athlete_request_coach`** (`POST /meso/request/`): resolves the posted email to a *coach* (a
+  `User` with a `CoachProfile`, excluding self), rejecting unknown/non-coach/own; an already-active
+  link is untouched, an already-pending request (or coach-invite already awaiting the athlete) is a
+  friendly no-op, else `request()` opens/reopens; emails the coach best-effort on
+  `transaction.on_commit`. **`request_withdraw`** (`POST /meso/request/<token>/withdraw/`):
+  initiator-only (recipient/stranger → 403), pending-only → declined. The coach's accept/decline
+  rides the **existing** `invite_accept`/`invite_decline` recipient views unchanged (a request's
+  recipient *is* the coach). `notifications.send_coach_request_email` (+ 3 templates), mirror of the
+  invite email. Surfaces: the roster gains a pending-request list (Accept/Decline), the athlete home
+  gains a "Your coaches" card (incoming invites + sent requests + a request-a-coach form).
+  **Routing change:** `RosterView` now sends *any* non-coach to `/meso/me/` (coach = `CoachProfile`
+  **or** a coach-side link **or** a sent invite), so a brand-new athlete (or one merely awaiting an
+  invite) reaches the request form instead of an empty coach roster. Seeded a demo pending request
+  (`hopeful@example.com`) so the surface shows on a fresh DB (idempotent + torn down). Built
+  red→green: **+34 pytest** (`test_requests.py`) + 3 seed assertions; full suite green (867).
+  **Codex review loop CLEAN on iteration 1.** Plan + deferred (resend/expiry, stub-athlete,
+  attribution) in [`invites-plan.md`](./invites-plan.md).

--- a/docs/meso/invites-plan.md
+++ b/docs/meso/invites-plan.md
@@ -81,11 +81,55 @@ Built **red→green** with a new `test_invites.py` (model state machine, the fou
 views with auth/scoping/validation, the email send/skip + on-commit best-effort,
 the roster surface) plus an email-helper test.
 
-## Deferred (Phase 2+)
+## Phase 2 (built) — close the bidirectional invite loop
 
-- **Athlete → coach request** UI (the `CoachAthlete.request` half) and a pending
-  surface on the athlete home.
+The reverse direction the relationship spine always supported in the model
+(`CoachAthlete.request` → `pending_athlete_request`) but never in the UI: an
+athlete who already has an account asks to train under a coach, the coach
+accepts/declines on their roster, and either party sees the pending state on
+their own surface. **No migration** — the state machine + the recipient token
+views (`invite_accept`/`invite_decline`) already existed; Phase 2 adds the
+*initiator* side and the surfaces.
+
+1. **`CoachAthlete.initiator()`** — the mirror of `recipient()`: who opened a
+   pending link (coach for an invite, athlete for a request). The initiator is
+   who may *withdraw* a pending link, as the recipient is who accepts/declines.
+2. **Athlete request view** — `POST /meso/request/` (`athlete_request_coach`):
+   resolves the posted email to a *coach* (a `User` with a `CoachProfile`,
+   excluding self), rejecting an unknown/non-coach/own address. An already-active
+   link is left untouched; an already-pending request (or a coach-invite already
+   awaiting the athlete) is a friendly no-op; otherwise `request()` opens (or
+   reopens a closed) pending link. The coach is emailed on
+   `transaction.on_commit`, best-effort.
+3. **Withdraw view** — `POST /meso/request/<token>/withdraw/`
+   (`request_withdraw`): initiator-only (the recipient/stranger get 403),
+   pending-only; marks the link declined.
+4. **Coach response** rides the existing `invite_accept`/`invite_decline`
+   recipient views unchanged — a request's recipient *is* the coach.
+5. **Request email** — `notifications.send_coach_request_email(athlete, coach,
+   roster_url)` + subject/`.md`/`.html` templates, mirroring the invite email;
+   skips a coach with no address.
+6. **Surfaces** — the coach roster gains a pending-request list (Accept/Decline
+   per row); the athlete home gains a "Your coaches" card: incoming invites
+   (Accept/Decline), sent requests (Pending + Withdraw), and a request-a-coach
+   form.
+7. **Routing** — `RosterView` now sends *any* non-coach to `/meso/me/` (a coach =
+   has a `CoachProfile`, a coach-side link, or a sent invite), so a brand-new
+   athlete or one merely awaiting an invite reaches the request form / pending
+   surface instead of an empty coach roster.
+8. **Seed** — a seeded pending athlete→coach request (`hopeful@example.com`) so
+   the roster's request surface shows on a fresh DB; idempotent + torn down.
+
+Built **red→green** with a new `test_requests.py` (the `initiator()` mirror, the
+email helper, the request + withdraw views with auth/scoping/validation, the
+coach-response recipient path, both pending surfaces, and the routing) + seed
+coverage. **Codex review loop: CLEAN on iteration 1.**
+
+## Deferred (Phase 3+)
+
 - **Resend / expiry** of an invite (today re-inviting reuses the pending row and
   re-sends; no TTL).
 - **Stub-athlete** pre-creation (we never create a placeholder `User`).
 - **Coach/athlete attribution beyond `accepted_by`**; richer invite history.
+- **Coach-side roster filtering by relationship state** beyond pending (e.g. a
+  declined/ended history view).


### PR DESCRIPTION
## What

Closes the bidirectional half of **N4** the relationship spine always supported in the model (`CoachAthlete.request` → `pending_athlete_request`) but never in the UI: an athlete who already has an account asks to train under a coach, the coach accepts/declines on their roster, and either party sees the pending state on their own surface.

**No migration** — the state machine and the recipient token views (`invite_accept`/`invite_decline`) already existed; this adds the *initiator* side and the surfaces.

## Changes

- **`CoachAthlete.initiator()`** — mirror of `recipient()`; the party who may *withdraw* a pending link.
- **`athlete_request_coach`** (`POST /meso/request/`): resolves the posted email to a real coach (a `User` with a `CoachProfile`, excluding self); rejects unknown/non-coach/own; leaves an active link untouched; no-ops an already-pending request (or a coach-invite already awaiting the athlete); else opens/reopens a request. Emails the coach best-effort on `transaction.on_commit`.
- **`request_withdraw`** (`POST /meso/request/<token>/withdraw/`): initiator-only (recipient/stranger → 403), pending-only.
- **Coach response** rides the existing `invite_accept`/`invite_decline` recipient views unchanged.
- **`send_coach_request_email`** + 3 templates (mirror of `send_coach_invite_email`).
- **Surfaces**: roster pending-request list (Accept/Decline); athlete-home "Your coaches" card (incoming invites + sent requests + request-a-coach form).
- **Routing**: `RosterView` now sends *any* non-coach to `/meso/me/` (coach = `CoachProfile`, a coach-side link, or a sent invite), so a brand-new athlete reaches the request form instead of an empty coach roster.
- **Seed**: a demo pending request (`hopeful@example.com`) so the surface shows on a fresh DB (idempotent + torn down).

## Tests

Built red→green. New `test_requests.py` (+34): the `initiator()` mirror, the email helper, the request + withdraw views (auth/scoping/validation/idempotency/mail-failure), the coach-response recipient path, both pending surfaces, and the routing. +3 seed tests. Full project suite green (**867 passed**), ruff + format clean, `makemigrations --check` clean.

**Codex review loop: CLEAN on iteration 1.**

Docs: `docs/meso/invites-plan.md` (Phase 2 section) + `docs/meso/decisions.md` (N4 status + dated log entry).

https://claude.ai/code/session_015G62Gs7papVMJAfYqeExrN