### PR TITLE
Meso — app-managed scheduling: django-q2 + invite-sweep schedules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,8 @@ Uses django-allauth with email-only login, social authentication (Facebook, Goog
 ## Key Technologies
 - Django 5.2+ with PostgreSQL database
 - Redis for caching and sessions
+- django-q2 for scheduled/background tasks (ORM broker; `qcluster` worker runs
+  the `django_q.Schedule` rows — see `docs/meso/scheduling-plan.md`)
 - Stripe for payments
 - AWS S3 for media storage
 - WhiteNoise for static files

--- a/app/config/settings/base.py
+++ b/app/config/settings/base.py
@@ -96,6 +96,7 @@ INSTALLED_APPS = [
     "corsheaders",
     "crispy_bulma",
     "crispy_forms",
+    "django_q",
     "embed_video",
     "markdownx",
     # Local
@@ -327,3 +328,26 @@ if REDIS_URL.startswith("rediss://"):
 
 SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 SESSION_CACHE_ALIAS = "default"
+
+
+# django-q2 — the app-managed scheduler / task queue.
+#
+# Broker is the Django ORM (the Postgres DB), deliberately NOT Redis: the
+# shared box's Redis is small + `noeviction` (cache + sessions), so a task
+# backlog there could starve logins. Task volume is tiny (a couple of daily
+# invite sweeps today), so a DB-backed broker is more than adequate and keeps
+# Redis pressure off. Periodic work lives in `django_q.Schedule` rows
+# (registered by a data migration; editable in admin) and is executed by the
+# `qcluster` process — one small worker in the production compose stack.
+Q_CLUSTER = {
+    "name": "fitness-store",
+    "orm": "default",  # DB-backed broker (no Redis dependency)
+    "workers": 1,  # low task volume — a single worker is plenty
+    "timeout": 300,  # kill a task that runs longer than 5 min
+    "retry": 600,  # must exceed `timeout` so a live task isn't double-run
+    "max_attempts": 1,  # sweeps are idempotent; the next schedule retries
+    "catch_up": False,  # after downtime, don't fire every missed run at once
+    "poll": 4,  # ORM broker poll interval (s) — easy on the DB
+    "save_limit": 250,  # cap retained successful-task rows
+    "label": "Scheduled tasks",
+}

--- a/app/config/settings/test.py
+++ b/app/config/settings/test.py
@@ -125,6 +125,19 @@ PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
 # https://docs.djangoproject.com/en/dev/ref/settings/#email-backend
 EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
 
+# DJANGO-Q
+# ------------------------------------------------------------------------------
+# Run any enqueued task inline and never spin up a cluster during tests.
+# (timeout/retry kept consistent — retry > timeout — to avoid django-q's
+# misconfiguration warning leaking into test output.)
+Q_CLUSTER = {
+    "name": "fitness-store-test",
+    "orm": "default",
+    "sync": True,
+    "timeout": 30,
+    "retry": 60,
+}
+
 # Your stuff...
 # ------------------------------------------------------------------------------
 

--- a/app/store_project/meso/migrations/0018_register_invite_schedules.py
+++ b/app/store_project/meso/migrations/0018_register_invite_schedules.py
@@ -1,0 +1,45 @@
+"""Register the daily invite-sweep schedules (django-q2).
+
+Creates the ``django_q.Schedule`` rows that drive the two N4 invite sweeps so
+scheduling is *versioned and deploys with the code* — no manual admin step, no
+box cron. Idempotent (keyed on ``name``) and reversible. Depends on
+``django_q``'s own migrations (``__latest__``) so the ``Schedule`` table exists.
+
+Each schedule points at a stable wrapper in ``store_project.meso.tasks``; the
+``qcluster`` worker runs them daily. A coach can still pause/retime them in the
+admin afterwards — this one-time migration won't clobber later edits.
+"""
+
+from django.db import migrations
+
+#: name -> dotted task path. DAILY ("D") cadence; the cluster anchors the first
+#: run at ``next_run`` (defaults to creation time) and repeats every 24h.
+SCHEDULES = {
+    "meso-expire-invites": "store_project.meso.tasks.expire_invites",
+    "meso-remind-expiring-invites": "store_project.meso.tasks.remind_expiring_invites",
+}
+
+
+def create_schedules(apps, schema_editor):
+    Schedule = apps.get_model("django_q", "Schedule")
+    for name, func in SCHEDULES.items():
+        Schedule.objects.update_or_create(
+            name=name,
+            defaults={"func": func, "schedule_type": "D"},  # Schedule.DAILY
+        )
+
+
+def remove_schedules(apps, schema_editor):
+    Schedule = apps.get_model("django_q", "Schedule")
+    Schedule.objects.filter(name__in=list(SCHEDULES)).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("meso", "0017_coachinvite_reminder_sent_at"),
+        ("django_q", "__latest__"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_schedules, remove_schedules),
+    ]

--- a/app/store_project/meso/tasks.py
+++ b/app/store_project/meso/tasks.py
@@ -1,0 +1,24 @@
+"""Scheduled task entry points for the Meso invite sweeps (django-q2).
+
+These are the stable, importable callables that ``django_q.Schedule`` rows point
+at (registered by migration ``0018_register_invite_schedules``). Each is a thin
+wrapper over the existing management command so the sweep logic has a single home
+(the command), runs identically from the CLI and the scheduler, and the dotted
+path the schedule stores never has to track refactors of that logic.
+
+The cluster (``manage.py qcluster``) executes these on the cadence the Schedule
+rows define — daily today. Both commands are idempotent, so an extra run (e.g. a
+deploy-day catch-up) is harmless.
+"""
+
+from django.core.management import call_command
+
+
+def expire_invites():
+    """Sweep overdue pending invites to ``expired`` (``meso_expire_invites``)."""
+    call_command("meso_expire_invites")
+
+
+def remind_expiring_invites():
+    """Email reminders for invites nearing expiry (``meso_remind_expiring_invites``)."""
+    call_command("meso_remind_expiring_invites")

--- a/app/store_project/meso/tests/test_scheduler.py
+++ b/app/store_project/meso/tests/test_scheduler.py
@@ -1,0 +1,78 @@
+"""App-managed scheduling for the N4 invite sweeps (django-q2).
+
+Rather than a hand-rolled box cron, the two invite sweeps run as
+``django_q.Schedule`` rows registered by migration
+``0018_register_invite_schedules`` and executed by the ``qcluster`` worker. This
+covers the two halves that live in *our* code:
+
+- ``store_project.meso.tasks`` — the stable wrappers the schedules point at, each
+  driving its management command (so the sweep logic has one home);
+- the registered schedules themselves — present, daily, and pointing at an
+  importable callable (a rename of ``tasks`` that didn't update the migration
+  would break the scheduler silently in prod; this catches it).
+
+The cluster process and the ORM broker aren't exercised here (no cluster spins up
+under ``Q_CLUSTER["sync"]``); we test the unit of work and its registration.
+"""
+
+import importlib
+from datetime import timedelta
+
+import pytest
+from django.core import mail
+from django.utils import timezone
+from django_q.models import Schedule
+
+from store_project.meso import tasks
+from store_project.meso.models import CoachInvite
+from store_project.users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+# -- task wrappers run the sweeps ------------------------------------------
+
+
+class TestInviteTasks:
+    def test_expire_invites_task_expires_overdue(self):
+        coach = UserFactory()
+        invite, _ = CoachInvite.open_for(coach=coach, email="ath@example.com")
+        invite.expires_at = timezone.now() - timedelta(days=1)
+        invite.save(update_fields=["expires_at"])
+        tasks.expire_invites()
+        invite.refresh_from_db()
+        assert invite.status == CoachInvite.Status.EXPIRED
+
+    def test_remind_task_sends_and_stamps(self):
+        coach = UserFactory()
+        invite, _ = CoachInvite.open_for(coach=coach, email="ath@example.com")
+        invite.expires_at = timezone.now() + timedelta(days=1)  # inside the lead
+        invite.save(update_fields=["expires_at"])
+        tasks.remind_expiring_invites()
+        invite.refresh_from_db()
+        assert invite.reminder_sent_at is not None
+        assert len(mail.outbox) == 1
+        assert mail.outbox[0].to == ["ath@example.com"]
+
+
+# -- the registered schedules ----------------------------------------------
+
+
+class TestScheduleRegistration:
+    EXPECTED = {
+        "meso-expire-invites": "store_project.meso.tasks.expire_invites",
+        "meso-remind-expiring-invites": "store_project.meso.tasks.remind_expiring_invites",
+    }
+
+    def test_invite_schedules_registered_daily(self):
+        for name, func in self.EXPECTED.items():
+            sched = Schedule.objects.get(name=name)
+            assert sched.func == func
+            assert sched.schedule_type == Schedule.DAILY
+
+    def test_schedule_funcs_are_importable_callables(self):
+        """Every registered func path resolves to a callable (catches renames)."""
+        for func in self.EXPECTED.values():
+            module_path, _, attr = func.rpartition(".")
+            resolved = getattr(importlib.import_module(module_path), attr)
+            assert callable(resolved)

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -43,6 +43,7 @@ services:
   web:
     build:
       context: .
+    image: fitness-store-app # shared by the qcluster worker (same code, diff command)
     restart: unless-stopped
     env_file:
       - .env
@@ -87,6 +88,38 @@ services:
       proxy:
         aliases:
           - fitness-store-web
+
+  # django-q2 cluster: runs the DB-backed scheduled tasks (the N4 invite sweeps;
+  # see Q_CLUSTER in settings + meso migration 0018). Same image as web, run with
+  # a different command. The entrypoint only migrates/collectstatic for the
+  # `gunicorn` command, so `python manage.py qcluster` falls straight through.
+  # Waits on web being healthy so the schema/migrations are in place first.
+  qcluster:
+    image: fitness-store-app
+    restart: unless-stopped
+    command: ["python", "manage.py", "qcluster"]
+    env_file:
+      - .env
+    environment:
+      - DJANGO_SETTINGS_MODULE=config.settings.production
+      - ENVIRONMENT=PRODUCTION
+      - DEBUG=0
+      - DJANGO_ALLOWED_HOSTS=${ALLOWED_HOSTS} www.${ALLOWED_HOSTS}
+      - SQL_DATABASE=${DB_NAME}
+      - SQL_USER=${DB_USER}
+      - SQL_PASSWORD=${DB_PASSWORD}
+      - SQL_HOST=postgres
+      - SQL_PORT=5432
+      - REDIS_URL=redis://redis:6379/0
+    depends_on:
+      postgres:
+        condition: service_healthy
+      web:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          memory: 256M
 
 volumes:
   postgres_data:

--- a/docs/meso/invites-plan.md
+++ b/docs/meso/invites-plan.md
@@ -209,12 +209,16 @@ Built **red→green** with a new `test_invite_reminders.py` (the reminder window
 flag, the command's send/stamp/dry-run/idempotency/skip/mail-failure paths, and
 the notifications function).
 
+## Scheduling (done)
+
+The `meso_expire_invites` + `meso_remind_expiring_invites` sweeps are no longer
+hand-run: they're registered as daily `django_q.Schedule` rows (migration
+`meso/0018`) and executed by an app-managed **django-q2** `qcluster` worker
+(ORM broker). Design + rationale in [`scheduling-plan.md`](./scheduling-plan.md).
+
 ## Deferred (Phase 5+)
 
 - **Configurable TTL** per coach (today a fixed 14-day `INVITE_TTL`).
-- **Scheduling** the `meso_expire_invites` + `meso_remind_expiring_invites`
-  sweeps on a real cron (both are manual / cron-ready today — e.g. a daily
-  `docker compose exec` on the box; no in-repo scheduler).
 - **Configurable reminder lead** / multiple reminders (today one, 3 days out).
 - **Stub-athlete** pre-creation (we never create a placeholder `User`).
 - **Coach/athlete attribution beyond `accepted_by`**; richer invite history.

--- a/docs/meso/scheduling-plan.md
+++ b/docs/meso/scheduling-plan.md
@@ -1,0 +1,65 @@
+# Meso — app-managed scheduling (django-q2)
+
+## Why
+
+The N4 invite lifecycle needs two recurring sweeps — `meso_expire_invites`
+(age out past-due claim links) and `meso_remind_expiring_invites` (email a
+reminder before a link lapses). Phase 4 shipped them as cron-ready management
+commands but with *no scheduler*: they only ran if someone invoked them.
+
+Hand-rolling a cron on the Hetzner box would work but isn't versioned, doesn't
+deploy with the code, and dies on a box rebuild. So scheduling is **managed by
+the app** instead.
+
+## Decision
+
+**django-q2 with the Django ORM as the broker.**
+
+- **ORM broker, not Redis.** The shared box's Redis is small and `noeviction`
+  (it backs cache + sessions); a task backlog there could starve logins. Task
+  volume is tiny (two daily sweeps), so the Postgres-backed broker is more than
+  enough and keeps Redis pressure off. (`Q_CLUSTER["orm"] = "default"`.)
+- **Lightest "real" option.** One extra worker process (`qcluster`) versus
+  Celery's worker **+** beat. Schedules are DB rows editable in the Django admin.
+- **Doubles as the queue the agent wants.** `meso/agent/jobs.py` runs proposal
+  work on a bare daemon thread today and its own comments ask for "a real worker
+  queue later." Migrating that onto `async_task` is a clean follow-up (see
+  Deferred) now that a cluster exists.
+
+Considered and rejected: **Celery + beat** (heavier — two processes + a broker —
+for two daily sweeps on a memory-tight box); a **bespoke loop container /
+APScheduler** (doesn't generalize, no admin visibility); **box cron** (the
+un-versioned approach we're moving away from).
+
+## Shape
+
+- **`Q_CLUSTER`** (`config/settings/base.py`): ORM broker, 1 worker,
+  `catch_up=False` (no burst of missed runs after downtime), `retry > timeout`.
+  Tests override with `sync=True` so no cluster ever spins up.
+- **`store_project/meso/tasks.py`**: stable wrappers (`expire_invites`,
+  `remind_expiring_invites`) that each call their management command — one home
+  for the sweep logic, a stable dotted path for the schedule to point at.
+- **Migration `meso/0018_register_invite_schedules`**: idempotent data migration
+  that registers the two `django_q.Schedule` rows (DAILY), keyed on name and
+  reversible, depending on `("django_q", "__latest__")`. Versioned + deploys with
+  the code; a coach can still pause/retime in admin afterward.
+- **`qcluster` service** (`docker-compose.production.yml`): same image as `web`,
+  run as `python manage.py qcluster`; waits on `web` being healthy so migrations
+  are applied first; 256 MB limit. Locally: `just qcluster`.
+
+## Operating notes
+
+- The box's committed memory grows by the qcluster limit (256 MB). Confirm
+  headroom; tune `workers` / the limit if needed.
+- The entrypoint only migrates/collectstatic for the `gunicorn` command, so the
+  `qcluster` command passes straight through without re-running them.
+
+## Deferred
+
+- **Migrate `meso/agent/jobs.py`** off its daemon thread onto `async_task` (the
+  unit of work, `run_proposal_job`, already exists — it's a drop-in dispatch
+  swap). Bigger + changes the agent endpoint's async behavior; its own PR.
+- **Configurable schedule times / per-coach cadence**; an admin surface beyond
+  the raw `Schedule` rows.
+- **Result monitoring / alerting** on a failed sweep (today: cluster logs + the
+  admin's task list).

--- a/justfile
+++ b/justfile
@@ -8,6 +8,10 @@ dev:
 docker-dev:
     docker compose up -d --build
 
+# Run the django-q2 cluster (executes scheduled tasks, e.g. the invite sweeps)
+qcluster:
+    uv run python app/manage.py qcluster
+
 # Django management commands
 manage *args:
     uv run python app/manage.py {{ args }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
   "google-genai>=1.26.0",
   "anthropic>=0.112.0",
   "pywebpush>=2.3.0",
+  "django-q2>=1.10.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -658,6 +658,31 @@ wheels = [
 ]
 
 [[package]]
+name = "django-picklefield"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/03/13114bccbd1ec8c026ac1ff33dae75ae6c6a5632e4769ee9cda283b9f57e/django_picklefield-3.4.0.tar.gz", hash = "sha256:3a1f740536c0e60d0dba43aa89ccdbe86760d4c3f8ec47799eae122baa741d0a", size = 12555, upload-time = "2025-11-27T03:11:53.13Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/b7/139eb1419ca7b27fd714925b8d0eed6efb592479dcf2155fed6c0c87c956/django_picklefield-3.4.0-py3-none-any.whl", hash = "sha256:929bcfbae5b48bd22a52bc04521fdfdd152eee36abb9f20228f9480f9df65f45", size = 10031, upload-time = "2025-11-27T03:11:51.937Z" },
+]
+
+[[package]]
+name = "django-q2"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "django-picklefield" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/ea/a97c24d04345b20afd3f04711642d7f27921dd8bbaba8ebfdbb77448be0a/django_q2-1.10.0.tar.gz", hash = "sha256:cc805008986c560ed4e0a3ef08776c1b41f403a60477b2726a2545ae64b71504", size = 86438, upload-time = "2026-05-01T17:39:20.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/72/92b531a3f794f1869a89e480045c82fd1cf27a98a73a83402ff7ad3f3234/django_q2-1.10.0-py3-none-any.whl", hash = "sha256:7746c1cb7178551d81f25f47603ed29b80599e93d82ffd198c493a2b2323f3b5", size = 106170, upload-time = "2026-05-01T17:39:22.184Z" },
+]
+
+[[package]]
 name = "django-ses"
 version = "4.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -765,6 +790,7 @@ dependencies = [
     { name = "django-filter" },
     { name = "django-lifecycle" },
     { name = "django-markdownx" },
+    { name = "django-q2" },
     { name = "django-ses", extra = ["events"] },
     { name = "django-storages", extra = ["s3"] },
     { name = "google-genai" },
@@ -812,6 +838,7 @@ requires-dist = [
     { name = "django-filter", specifier = ">=25.1" },
     { name = "django-lifecycle" },
     { name = "django-markdownx" },
+    { name = "django-q2", specifier = ">=1.10.0" },
     { name = "django-ses", extras = ["events"], specifier = "==4.1.1" },
     { name = "django-storages", extras = ["s3"] },
     { name = "google-genai", specifier = ">=1.26.0" },


### PR DESCRIPTION
## What & why

Closes the scheduling gap from N4 Phase 4. The two invite sweeps (`meso_expire_invites`, `meso_remind_expiring_invites`) were cron-*ready* but nothing ran them. Rather than a hand-rolled cron on the box (not versioned, dies on a rebuild), scheduling is now **managed by the app**: the sweeps run as daily `django_q.Schedule` rows executed by a `qcluster` worker — versioned, deploys with the code, editable in admin.

## Decision: django-q2 with the ORM broker

- **ORM broker, not Redis.** The box's Redis is small + `noeviction` (cache/sessions); a task backlog there could starve logins. Two daily sweeps → a Postgres-backed broker is ample and keeps Redis pressure off.
- **Lightest "real" option** (one worker vs Celery's worker + beat), and it gives the agent's daemon-thread dispatch a durable queue to migrate onto later (its own comments ask for one). Rationale + alternatives in `docs/meso/scheduling-plan.md`.

## Changes

- `django-q2` dep (+`django-picklefield`); **Django stays 6.0.1** (no downgrade).
- `Q_CLUSTER` in `base.py` (ORM broker, 1 worker, `catch_up=False`, `retry>timeout`); test settings override `sync=True` so no cluster spins up in tests.
- `meso/tasks.py` — stable wrappers over the management commands (one home for the sweep logic; a stable dotted path for the schedules).
- Migration `0018` — idempotent, reversible data migration registering the two DAILY schedules; depends on `("django_q", "__latest__")`.
- `qcluster` service in `docker-compose.production.yml` (shared image as `web`, waits on `web` healthy so migrations are applied first, 256 MB); `just qcluster` for local.
- Docs: `scheduling-plan.md`, plus `invites-plan.md` + `CLAUDE.md`.

## Tests / verification

+4 tests (`test_scheduler.py`): task wrappers run the sweeps; schedules registered daily + funcs importable. **Full suite 929 green.** `qcluster` boots clean on the ORM broker locally (starts → workers ready → graceful stop); compose validates; no missing migrations.

## Operating note

Committed memory on the box grows by the qcluster limit (256 MB) — confirm headroom; `workers`/limit are tunable.

## Deferred

Migrate `meso/agent/jobs.py` off its daemon thread onto `async_task` (drop-in dispatch swap; its own PR).

https://claude.ai/code/session_015G62Gs7papVMJAfYqeExrN