### PR TITLE
Fix multi-line Django template comments rendering as visible text

### DIFF
--- a/app/store_project/templates/meso/_meso_base.html
+++ b/app/store_project/templates/meso/_meso_base.html
@@ -4,8 +4,10 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    {# Filled before any external resource (fonts) loads — e.g. a no-referrer
-       policy on token-bearing pages. Must precede the font <link>s below. #}
+    {% comment %}
+      Filled before any external resource (fonts) loads — e.g. a no-referrer
+      policy on token-bearing pages. Must precede the font <link>s below.
+    {% endcomment %}
     {% block head_top %}{% endblock %}
     <title>{% block title %}Meso{% endblock %} · Mastering Fitness</title>
     <link rel="shortcut icon" href="{% static 'png/favicon-black.png' %}" />

--- a/app/store_project/templates/meso/invite_claim.html
+++ b/app/store_project/templates/meso/invite_claim.html
@@ -2,9 +2,11 @@
 
 {% block title %}Coach invite · Meso{% endblock %}
 
-{# The claim URL carries the bearer token — don't leak it to font/CDN hosts.
-   head_top renders before the base template's font <link>s, so the policy is in
-   effect before those external requests fire. #}
+{% comment %}
+  The claim URL carries the bearer token — don't leak it to font/CDN hosts.
+  head_top renders before the base template's font <link>s, so the policy is in
+  effect before those external requests fire.
+{% endcomment %}
 {% block head_top %}<meta name="referrer" content="no-referrer" />{% endblock %}
 
 {# A brand-new athlete may have no coach/athlete role yet — strip the coach nav. #}


### PR DESCRIPTION
## Problem

Django's `{# ... #}` inline comment syntax only works on a **single line** — newlines aren't permitted between the delimiters. When a comment wraps across lines, Django doesn't recognize it as a comment and passes the literal text straight through to the rendered HTML.

In `meso/_meso_base.html` this showed up as visible text on the page (the browser rendered the comment text and silently swallowed the `<link>` inside it as a bogus tag, leaving "…Must precede the font s below").

## Fix

I searched every template for `{# ... #}` comments spanning a newline. Exactly two existed, both in the `meso` app and both tied to the same no-referrer / token-bearing-pages feature:

- `meso/_meso_base.html` — the reported instance
- `meso/invite_claim.html` — same bug, same cause (would have rendered visibly on the coach-invite claim page)

Both are converted to `{% comment %}...{% endcomment %}` blocks, the idiomatic Django construct for multi-line comments. The other six single-line `{# #}` comments in the codebase are correct and left untouched.

Confirmed the only configured template backend is `DjangoTemplates` (no Jinja2, where multi-line `{# #}` is valid and `{% comment %}` would not be), so the change is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dk6KbGWEF7DNtVDWUuMEN

---
_Generated by [Claude Code](https://claude.ai/code/session_011dk6KbGWEF7DNtVDWUuMEN)_