### PR TITLE
Meso — agent job onto django-q async_task (off the daemon thread)

### DIFF
--- a/app/config/settings/base.py
+++ b/app/config/settings/base.py
@@ -283,9 +283,10 @@ STRIPE_SECRET_KEY = get_env_var("STRIPE_SECRET_KEY")
 # agent endpoint (it returns 503) so the app boots and CI runs without creds.
 ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
 MESO_AGENT_MODEL = os.environ.get("MESO_AGENT_MODEL", "claude-opus-4-8")
-# Run the proposal job inline instead of in a background thread (Phase 4). Off
-# in real environments (the endpoint returns 202 and the frontend polls); tests
-# set it on for deterministic, thread-free runs.
+# Run the proposal job inline instead of enqueuing it on the django-q cluster
+# (Phase 4). Off in real environments (the endpoint returns 202, the cluster runs
+# the job, and the frontend polls); tests set it on for deterministic, worker-free
+# runs.
 MESO_AGENT_RUN_SYNC = os.environ.get("MESO_AGENT_RUN_SYNC", "false").lower() in (
     "1",
     "true",

--- a/app/store_project/meso/agent/jobs.py
+++ b/app/store_project/meso/agent/jobs.py
@@ -1,61 +1,73 @@
-"""Dispatch the proposal run off the request thread (Phase 4).
+"""Dispatch the proposal run onto the django-q cluster (Phase 4 → app queue).
 
-There is no task queue in this stack (Redis is cache/sessions only), and the
-proposal job is a single short-lived call behind the human review gate, so a
-daemon thread is the right-sized executor: the endpoint creates a ``drafting``
-batch, ``dispatch_proposal`` hands the work to a thread, and the request returns
-immediately. The frontend polls the batch's status endpoint until it resolves.
+The proposal job is a single short-lived call behind the human review gate. It
+used to run on a bare daemon thread because the stack had no task queue; now it
+has django-q2 — the ORM-broker ``qcluster`` that already runs the invite sweeps —
+so the job runs as a real queued task instead of a thread we hand-manage.
 
-The thread boundary is deliberately thin — ``service.run_proposal_job`` already
-never raises and always leaves the batch in a terminal state (``pending`` /
-``failed``). Here we only need to not leak the thread's DB connection and to log
-anything truly unexpected. ``MESO_AGENT_RUN_SYNC`` runs the job inline instead
-(tests, and any environment that prefers a blocking call) so behavior is
-deterministic without a thread.
+The endpoint creates a ``drafting`` batch and ``dispatch_proposal`` enqueues
+``run_proposal_job`` for the cluster to pick up; the request returns immediately
+and the frontend polls the batch's status endpoint until it resolves.
 
-Swapping in a real worker queue later is a drop-in: keep ``run_proposal_job`` as
-the unit of work and replace this dispatch.
+``service.run_proposal_job`` is the unit of work — it never raises and always
+leaves the batch in a terminal state (``pending`` / ``failed``), so the queue
+wrapper stays thin. Only the batch id is enqueued: the worker is a separate
+process that reconstructs its own Claude client (``get_default_client``), and a
+client isn't picklable anyway.
+
+``MESO_AGENT_RUN_SYNC`` runs the job inline instead of enqueuing it (tests, and
+any environment that prefers a blocking, queue-free call) so behavior is
+deterministic without a worker. The test settings also run django-q in ``sync``
+mode, so an enqueued task there executes in-process.
 """
 
 import logging
-import threading
 
 from django.conf import settings
-from django.db import connection
 from django.db import transaction
+from django_q.tasks import async_task
 
 from . import service
 
 logger = logging.getLogger(__name__)
 
+# Dotted path django-q stores and imports in the worker process. It must keep
+# pointing at the unit of work; a rename that misses this string would break
+# dispatch silently in production (a test runs the enqueued task end to end under
+# sync mode to catch exactly that).
+RUN_PROPOSAL_TASK = "store_project.meso.agent.service.run_proposal_job"
+
 
 def dispatch_proposal(batch_id, *, client=None):
-    """Run ``run_proposal_job`` for ``batch_id`` — inline when sync, else threaded."""
+    """Run ``run_proposal_job`` for ``batch_id`` — inline when sync, else queued."""
     if getattr(settings, "MESO_AGENT_RUN_SYNC", False):
         service.run_proposal_job(batch_id, client=client)
         return
-    # ATOMIC_REQUESTS wraps the view in a transaction, so the drafting batch is
-    # not committed (not visible to another connection) until the request ends.
-    # Defer the thread to on_commit so it never queries the row before it lands.
-    transaction.on_commit(lambda: _start_thread(batch_id, client))
+    # ATOMIC_REQUESTS wraps the view in a transaction. Enqueue on commit so the
+    # task lands only once the drafting batch has durably committed (a worker in
+    # another process would otherwise race the row) and never if the request rolls
+    # back.
+    transaction.on_commit(lambda: _enqueue(batch_id))
 
 
-def _start_thread(batch_id, client):
-    thread = threading.Thread(
-        target=_run,
-        args=(batch_id,),
-        kwargs={"client": client},
-        name=f"meso-agent-{batch_id}",
-        daemon=True,
-    )
-    thread.start()
-
-
-def _run(batch_id, *, client=None):
+def _enqueue(batch_id):
+    """Hand the job to the cluster; resolve the batch if the broker write fails."""
     try:
-        service.run_proposal_job(batch_id, client=client)
-    except Exception:  # the thread has no caller to surface to
-        logger.exception("Meso agent thread crashed for batch %s", batch_id)
-    finally:
-        # Don't leak the per-thread DB connection back into the pool.
-        connection.close()
+        async_task(RUN_PROPOSAL_TASK, batch_id)
+    except Exception:  # a broker failure must not strand the batch in ``drafting``
+        logger.exception("Meso agent failed to enqueue job for batch %s", batch_id)
+        _fail_unqueued(batch_id)
+
+
+def _fail_unqueued(batch_id):
+    """Mark a batch ``failed`` when its job could not be queued (no worker will).
+
+    A bare ``update`` so it can't fail on a stale in-memory row and never widens
+    the change beyond the status the status-poll surfaces.
+    """
+    from .. import models
+
+    models.AgentProposalBatch.objects.filter(pk=batch_id).update(
+        status=models.AgentProposalBatch.Status.FAILED,
+        error="The agent run could not be queued.",
+    )

--- a/app/store_project/meso/tests/test_agent_jobs.py
+++ b/app/store_project/meso/tests/test_agent_jobs.py
@@ -5,7 +5,13 @@ creates a ``drafting`` batch and dispatches ``run_proposal_job``, which grounds 
 calls Claude → validates → persists, flipping the batch to ``pending`` (ready for
 review) or ``failed`` (with the reason recorded). ``dispatch_proposal`` runs the
 job inline under the test setting ``MESO_AGENT_RUN_SYNC`` so these never spawn a
-thread or touch the network — the client is a fake.
+worker or touch the network — the client is a fake.
+
+The non-sync path enqueues the job on the django-q cluster (``async_task``). The
+test settings run django-q in ``sync`` mode, so an enqueued task executes
+in-process; the queue tests below assert the enqueue is deferred to commit, that
+the dotted path resolves and runs end to end, and that a broker failure resolves
+the batch instead of stranding it ``drafting``.
 """
 
 import pytest
@@ -142,23 +148,66 @@ class TestDispatch:
         assert batch.status == AgentProposalBatch.Status.PENDING
         assert batch.changes.count() == 1
 
-    def test_threaded_dispatch_defers_the_thread_to_on_commit(
+    def test_queued_dispatch_defers_enqueue_to_on_commit(
         self, settings, monkeypatch, django_capture_on_commit_callbacks
     ):
-        # ATOMIC_REQUESTS: the thread must not start until the request commits,
-        # or it would query the drafting batch before it is visible. Stub the
-        # thread launch so no real thread runs here.
+        # ATOMIC_REQUESTS: the task must not be enqueued until the request
+        # commits, or a worker in another process could pick it up before the
+        # drafting batch is visible. Capture the enqueue so nothing real runs.
         settings.MESO_AGENT_RUN_SYNC = False
-        started = []
+        enqueued = []
         monkeypatch.setattr(
-            jobs, "_start_thread", lambda batch_id, client: started.append(batch_id)
+            jobs, "async_task", lambda func, *args: enqueued.append((func, args))
         )
         plan, _, _ = make_plan()
         batch = service.create_drafting_batch(plan, "go", coach=plan.coach)
 
         with django_capture_on_commit_callbacks(execute=True):
             jobs.dispatch_proposal(batch.pk)
-            # Deferred — nothing launched until the surrounding block commits.
-            assert started == []
+            # Deferred — nothing enqueued until the surrounding block commits.
+            assert enqueued == []
 
-        assert started == [batch.pk]
+        assert enqueued == [(jobs.RUN_PROPOSAL_TASK, (batch.pk,))]
+
+    def test_queued_dispatch_runs_the_job_via_django_q_sync(
+        self, settings, monkeypatch, django_capture_on_commit_callbacks
+    ):
+        # End to end through the queue: with the agent's inline path off, the job
+        # is enqueued and django-q's sync mode runs it in-process. This proves the
+        # dotted path resolves, the batch id pickles, and the unit of work runs —
+        # the worker builds its own client (no client is enqueued).
+        settings.MESO_AGENT_RUN_SYNC = False
+        from store_project.meso.agent import client as client_module
+
+        plan, _, presc = make_plan()
+        fake = FakeClient(one_swap(presc))
+        monkeypatch.setattr(client_module, "get_default_client", lambda: fake)
+        batch = service.create_drafting_batch(plan, "go", coach=plan.coach)
+
+        with django_capture_on_commit_callbacks(execute=True):
+            jobs.dispatch_proposal(batch.pk)
+
+        batch.refresh_from_db()
+        assert batch.status == AgentProposalBatch.Status.PENDING
+        assert batch.changes.count() == 1
+
+    def test_enqueue_failure_marks_batch_failed(
+        self, settings, monkeypatch, django_capture_on_commit_callbacks
+    ):
+        # A broker write that fails must not strand the batch in ``drafting``
+        # (the frontend would poll it forever). Resolve it to ``failed`` instead.
+        settings.MESO_AGENT_RUN_SYNC = False
+
+        def boom(func, *args):
+            raise RuntimeError("broker is down")
+
+        monkeypatch.setattr(jobs, "async_task", boom)
+        plan, _, _ = make_plan()
+        batch = service.create_drafting_batch(plan, "go", coach=plan.coach)
+
+        with django_capture_on_commit_callbacks(execute=True):
+            jobs.dispatch_proposal(batch.pk)
+
+        batch.refresh_from_db()
+        assert batch.status == AgentProposalBatch.Status.FAILED
+        assert batch.error

--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -569,3 +569,19 @@ _(Append dated entries here as decisions land.)_
   Built red→green: **+38 pytest** (`test_invite_lifecycle.py`); full project suite 904 + 83 Vitest
   green. Plan + deferred (configurable TTL, expiry reminder, cron scheduling, stub-athlete) in
   [`invites-plan.md`](./invites-plan.md).
+- 2026-06-29 — **Agent job → django-q `async_task` built** (branch `meso-agent-django-q`,
+  **no migration**). Closes the top deferred item of the scheduling plan: `meso/agent/jobs.py` ran
+  the proposal job on a bare daemon thread because there was no queue; now that django-q2 + the
+  `qcluster` exist (the invite sweeps' scheduler), the agent job rides that same cluster.
+  `dispatch_proposal` enqueues `run_proposal_job` (the unchanged unit of work) via `async_task`
+  **on commit** — so a worker in another process never races the not-yet-committed drafting batch,
+  and a rolled-back request enqueues nothing. **Only the batch id is enqueued**: the worker is a
+  separate process that rebuilds its own Claude client (`get_default_client` off the shared `.env`
+  `ANTHROPIC_API_KEY`), and a client isn't picklable. The dotted path lives in one constant
+  (`RUN_PROPOSAL_TASK`) covered by an end-to-end test that runs the enqueued job under django-q's
+  `sync` mode (catches a rename that would break dispatch silently). `MESO_AGENT_RUN_SYNC` still runs
+  the job inline (tests + any queue-free env); a broker-write failure resolves the batch to `failed`
+  rather than stranding it `drafting` (mirrors the service's "never leave a batch stuck drafting"
+  invariant). No compose change — the `qcluster` already runs and shares web's image + `.env`. Built
+  red→green: **+3 pytest** (`test_agent_jobs.py` `TestDispatch`, net; the daemon-thread test
+  retired). Plan + remaining deferred in [`scheduling-plan.md`](./scheduling-plan.md).

--- a/docs/meso/scheduling-plan.md
+++ b/docs/meso/scheduling-plan.md
@@ -54,11 +54,18 @@ un-versioned approach we're moving away from).
 - The entrypoint only migrates/collectstatic for the `gunicorn` command, so the
   `qcluster` command passes straight through without re-running them.
 
+## Done after this plan
+
+- **Migrated `meso/agent/jobs.py`** off its daemon thread onto `async_task`
+  (PR #316). `dispatch_proposal` enqueues `run_proposal_job` on the existing
+  `qcluster` (on commit, so the drafting batch has landed; the worker rebuilds its
+  own client so only the batch id is enqueued); `MESO_AGENT_RUN_SYNC` still runs it
+  inline, and a broker-write failure resolves the batch to `failed` instead of
+  stranding it `drafting`. No migration — the agent job rides the same cluster +
+  ORM broker the sweeps already use.
+
 ## Deferred
 
-- **Migrate `meso/agent/jobs.py`** off its daemon thread onto `async_task` (the
-  unit of work, `run_proposal_job`, already exists — it's a drop-in dispatch
-  swap). Bigger + changes the agent endpoint's async behavior; its own PR.
 - **Configurable schedule times / per-coach cadence**; an admin surface beyond
   the raw `Schedule` rows.
 - **Result monitoring / alerting** on a failed sweep (today: cluster logs + the


### PR DESCRIPTION
## What

Move the Meso agent's proposal job off its bare **daemon thread** onto the **django-q `qcluster`** that already runs the N4 invite sweeps (PR #314). Closes the top deferred item in `docs/meso/scheduling-plan.md`.

`dispatch_proposal` now enqueues `run_proposal_job` (the unchanged unit of work) via `async_task` instead of spawning a thread.

## Why this shape

- **Enqueue on commit.** `ATOMIC_REQUESTS` wraps the view; enqueuing in `transaction.on_commit` means a worker in another process never races the not-yet-committed `drafting` batch, and a rolled-back request enqueues nothing.
- **Only the batch id is enqueued.** The worker is a separate process that rebuilds its own Claude client (`get_default_client` off the shared `.env` `ANTHROPIC_API_KEY` — the `qcluster` service already loads the same env_file as `web`). A client isn't picklable anyway.
- **One dotted-path constant** (`RUN_PROPOSAL_TASK`), covered by an end-to-end test that runs the enqueued job under django-q's `sync` mode — catches a rename that would otherwise break dispatch silently in prod.
- **`MESO_AGENT_RUN_SYNC`** still runs the job inline (tests + any queue-free env).
- **Broker-write failure resolves the batch to `failed`** instead of stranding it `drafting` (the poller would otherwise spin forever) — mirrors the service's existing "never leave a batch stuck drafting" invariant.

## Scope

- **No migration** — the agent job rides the same cluster + ORM broker the sweeps already use.
- **No compose change** — the `qcluster` already runs and shares `web`'s image + `.env`.

## Tests

Built red→green. `test_agent_jobs.py::TestDispatch` retires the daemon-thread test and adds:
- enqueue deferred to `on_commit` (nothing before commit),
- end-to-end run through django-q `sync` mode (proves the dotted path resolves + the job runs),
- a broker failure resolves the batch to `failed`.

Full meso suite green (791 passed); ruff + format + `makemigrations --check` clean. **Codex review loop: CLEAN on iteration 1.**

https://claude.ai/code/session_015G62Gs7papVMJAfYqeExrN