### PR TITLE
Meso — S6 billing Phase 3: enforcement + paywall UI

### DIFF
--- a/app/store_project/meso/billing/access.py
+++ b/app/store_project/meso/billing/access.py
@@ -10,9 +10,10 @@ athletes when active, else ``FREE_SEAT_LIMIT``) and the **AI agent** (paid-only
 A coach with **no subscription row** gates exactly as ``free`` — existing
 coaches predate billing, and a missing row should never crash or over-grant.
 
-Phase 1 is these accessors + the model state only; **nothing is enforced yet**.
-The invite/request choke points (``can_add_athlete``) and the agent endpoint
-(``can_use_agent``) wire these in at Phase 3. See ``docs/meso/billing-plan.md``.
+Phase 3 wires these gates into the choke points: ``can_add_athlete`` at the
+invite/request endpoints (block a free coach past the cap), ``can_use_agent`` at
+the agent endpoint (402 for the free tier), and ``can_edit`` at the edit/deliver
+endpoints (the D6 over-limit freeze). See ``docs/meso/billing-plan.md``.
 """
 
 import math
@@ -65,3 +66,29 @@ def can_add_athlete(coach):
     unlimited (a paid coach is never *blocked* — they just pay for the seat).
     """
     return active_seat_count(coach) < effective_seat_limit(coach)
+
+
+def is_over_limit(coach):
+    """Is this coach holding more active athletes than their tier allows (D6)?
+
+    The downgrade-landing state: an active/trial/comped coach is never over (their
+    limit is unbounded), so this only ever fires for a free/lapsed coach who held
+    paid seats and then dropped to free (Stripe cancel/lapse, or comp removal). The
+    seat gate prevents *reaching* this state through the app, so it's reachable
+    only by a downgrade — and while over the limit the coach is blocked from
+    editing and delivering until back within the cap or re-subscribed.
+    """
+    return not is_active(coach) and active_seat_count(coach) > effective_seat_limit(
+        coach
+    )
+
+
+def can_edit(coach):
+    """Edit/deliver gate (D6) — may this coach mutate or deliver programs?
+
+    Everyone can edit/deliver *except* a coach who is over their seat limit after a
+    downgrade (``is_over_limit``); they keep read access but can't change or deliver
+    a program until they re-subscribe or end relationships to get back within the
+    free cap. Never deletes data — only freezes writes.
+    """
+    return not is_over_limit(coach)

--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -8,13 +8,16 @@ neutral values (``compliance=None``, ``status=""``, ``has_program=False``) so
 the layout holds without inventing numbers.
 """
 
+import math
 from collections import defaultdict
 
 from django.urls import reverse
 from django.utils import timezone
 
+from .billing import access as billing_access
 from .models import CoachAthlete
 from .models import CoachInvite
+from .models import CoachSubscription
 from .models import LoadType
 from .models import Plan
 from .models import SessionLog
@@ -153,6 +156,43 @@ def pending_request(link):
         "initials": initials(name),
         "token": link.token,
         "when": link.created_at,
+    }
+
+
+def billing_state(coach):
+    """The coach's billing/paywall state for the roster (S6 Phase 3).
+
+    A template-friendly read over ``billing/access.py`` + the subscription row:
+    the tier, seat usage, and which upgrade CTAs to offer. The free tier sees
+    "start your no-card trial" (single-use) and "subscribe"; a coach with a real
+    Stripe subscription sees "manage billing" (the hosted Portal); an over-limit
+    coach (post-downgrade, D6) sees the freeze warning. ``seat_limit`` is ``None``
+    for an unlimited (active/trial/comped) coach so the template hides the cap.
+    """
+    sub = getattr(coach, "coach_subscription", None)
+    status = sub.status if sub else CoachSubscription.Status.FREE
+    seat_limit = billing_access.effective_seat_limit(coach)
+    active = billing_access.is_active(coach)
+    # The no-card trial is single-use: offer it only to a free coach who has never
+    # trialed (no row, or a row whose ``trial_end`` was never set).
+    can_start_trial = (
+        not active
+        and status == CoachSubscription.Status.FREE
+        and (sub is None or sub.trial_end is None)
+    )
+    return {
+        "status": status,
+        "status_label": CoachSubscription.Status(status).label,
+        "is_active": active,
+        "on_trial": active and status == CoachSubscription.Status.TRIALING,
+        "trial_end": sub.trial_end if sub else None,
+        "seat_count": billing_access.active_seat_count(coach),
+        "seat_limit": None if seat_limit == math.inf else int(seat_limit),
+        "can_add_athlete": billing_access.can_add_athlete(coach),
+        "can_use_agent": billing_access.can_use_agent(coach),
+        "over_limit": billing_access.is_over_limit(coach),
+        "can_start_trial": can_start_trial,
+        "has_stripe_subscription": bool(sub and sub.stripe_subscription_id),
     }
 
 

--- a/app/store_project/meso/tests/test_agent_validation.py
+++ b/app/store_project/meso/tests/test_agent_validation.py
@@ -18,6 +18,7 @@ from store_project.meso.factories import MesocycleFactory
 from store_project.meso.factories import PlanFactory
 from store_project.meso.factories import SessionFactory
 from store_project.meso.factories import WeekFactory
+from store_project.meso.models import CoachSubscription
 from store_project.meso.models import LoadType
 from store_project.users.factories import UserFactory
 
@@ -26,6 +27,9 @@ pytestmark = pytest.mark.django_db
 
 def make_plan(athlete=None):
     rel = CoachAthleteFactory(athlete=athlete or UserFactory())
+    # The AI agent is paid-only (S6 Phase 3, D4), so a coach iterating a plan
+    # with the agent in these tests has full access — comp keeps the gate open.
+    CoachSubscription.comp(rel.coach)
     plan = PlanFactory(relationship=rel)
     meso = MesocycleFactory(plan=plan, order=0)
     week = WeekFactory(mesocycle=meso, index=1, is_current=True)

--- a/app/store_project/meso/tests/test_billing_enforcement.py
+++ b/app/store_project/meso/tests/test_billing_enforcement.py
@@ -1,0 +1,406 @@
+"""S6 — billing, Phase 3: enforcement + paywall UI.
+
+Phase 1 stood up the ``CoachSubscription`` spine + the ``billing/access.py``
+gating accessor; Phase 2 added Stripe Checkout / Portal / webhook + seat sync —
+but **nothing was enforced**. Phase 3 wires the gates into the choke points and
+ships the paywall UI. See ``docs/meso/billing-plan.md``.
+
+These tests cover:
+
+- the two new ``billing/access.py`` predicates: ``is_over_limit`` (the
+  downgrade-landing state — a free coach holding more active athletes than the
+  cap) and ``can_edit`` (its negation, the D6 edit/deliver freeze);
+- the **seat gate** (``can_add_athlete``) at the three points a new active link
+  is created — opening a coach email invite, accepting an athlete's request, and
+  claiming an email invite — each blocked for a free coach at the cap, allowed
+  for a coach with room;
+- the **agent gate** (``can_use_agent``) at ``agent_propose`` — a free coach gets
+  a 402 (no drafting batch), a paid/comped coach passes;
+- the **D6 edit/deliver block** (``can_edit``) at the autosave / deliver / group
+  endpoints — an over-limit coach gets a 402 (API) or a flashed redirect (group
+  forms) and nothing is mutated; a within-cap free coach is unaffected;
+- the **local trial-start endpoint** — a coach starts the no-card trial,
+  single-use, non-coach bounced;
+- the **paywall UI** — the roster billing card's CTAs + the designer's agent
+  composer vs. upgrade CTA, both driven by the gates.
+"""
+
+import json
+from datetime import timedelta
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+
+from store_project.meso.billing import access
+from store_project.meso.factories import CoachAthleteFactory
+from store_project.meso.factories import CoachSubscriptionFactory
+from store_project.meso.factories import ExercisePrescriptionFactory
+from store_project.meso.factories import GroupMembershipFactory
+from store_project.meso.factories import MesocycleFactory
+from store_project.meso.factories import MesoGroupFactory
+from store_project.meso.factories import PlanFactory
+from store_project.meso.factories import SessionFactory
+from store_project.meso.factories import WeekFactory
+from store_project.meso.models import CoachAthlete
+from store_project.meso.models import CoachInvite
+from store_project.meso.models import CoachProfile
+from store_project.meso.models import CoachSubscription
+from store_project.meso.models import Plan
+from store_project.users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _plan_with_prescription(coach, athlete=None):
+    """A minimal individual plan the ``coach`` owns: week → session → prescription."""
+    rel = CoachAthleteFactory(
+        coach=coach,
+        athlete=athlete or UserFactory(),
+        status=CoachAthlete.Status.ACTIVE,
+    )
+    plan = PlanFactory(relationship=rel, status=Plan.Status.ACTIVE)
+    meso = MesocycleFactory(plan=plan, order=0)
+    week = WeekFactory(mesocycle=meso, index=1, is_current=True)
+    session = SessionFactory(week=week, day_number=1, name="Lower")
+    presc = ExercisePrescriptionFactory(session=session, name="Back Squat")
+    return plan, session, presc
+
+
+# ---------------------------------------------------------------------------
+# billing/access.py — the new D6 predicates
+# ---------------------------------------------------------------------------
+
+
+class TestAccessOverLimit:
+    def test_free_over_cap_is_over_limit(self):
+        coach = UserFactory()  # no row → free, cap 1
+        for _ in range(CoachSubscription.FREE_SEAT_LIMIT + 1):
+            CoachAthleteFactory(coach=coach, status=CoachAthlete.Status.ACTIVE)
+        assert access.is_over_limit(coach) is True
+        assert access.can_edit(coach) is False
+
+    def test_free_at_cap_is_not_over_limit(self):
+        coach = UserFactory()
+        for _ in range(CoachSubscription.FREE_SEAT_LIMIT):
+            CoachAthleteFactory(coach=coach, status=CoachAthlete.Status.ACTIVE)
+        assert access.is_over_limit(coach) is False
+        assert access.can_edit(coach) is True
+
+    def test_no_row_no_athletes_can_edit(self):
+        coach = UserFactory()
+        assert access.is_over_limit(coach) is False
+        assert access.can_edit(coach) is True
+
+    def test_active_coach_is_never_over_limit(self):
+        sub = CoachSubscriptionFactory(status=CoachSubscription.Status.ACTIVE)
+        for _ in range(CoachSubscription.FREE_SEAT_LIMIT + 5):
+            CoachAthleteFactory(coach=sub.coach, status=CoachAthlete.Status.ACTIVE)
+        assert access.is_over_limit(sub.coach) is False
+        assert access.can_edit(sub.coach) is True
+
+    def test_lapsed_trial_over_cap_is_over_limit(self):
+        sub = CoachSubscriptionFactory(
+            status=CoachSubscription.Status.TRIALING,
+            trial_end=timezone.now() - timedelta(minutes=1),
+        )
+        for _ in range(CoachSubscription.FREE_SEAT_LIMIT + 1):
+            CoachAthleteFactory(coach=sub.coach, status=CoachAthlete.Status.ACTIVE)
+        assert access.is_over_limit(sub.coach) is True
+        assert access.can_edit(sub.coach) is False
+
+
+# ---------------------------------------------------------------------------
+# The seat gate — can_add_athlete at the three choke points
+# ---------------------------------------------------------------------------
+
+
+class TestSeatGateCoachInvite:
+    def test_free_coach_at_cap_cannot_open_invite(self, client):
+        coach = UserFactory()
+        CoachAthleteFactory(coach=coach, status=CoachAthlete.Status.ACTIVE)  # at cap
+        client.force_login(coach)
+        resp = client.post(reverse("meso:coach_invite"), data={"email": "new@x.com"})
+        assert resp.status_code == 302
+        assert CoachInvite.objects.filter(coach=coach).count() == 0
+
+    def test_free_coach_with_room_can_open_invite(self, client):
+        coach = UserFactory()
+        CoachProfile.objects.create(user=coach)  # a coach with zero athletes
+        client.force_login(coach)
+        resp = client.post(reverse("meso:coach_invite"), data={"email": "new@x.com"})
+        assert resp.status_code == 302
+        assert CoachInvite.objects.filter(coach=coach, email="new@x.com").count() == 1
+
+    def test_active_coach_over_free_cap_can_open_invite(self, client):
+        sub = CoachSubscriptionFactory(status=CoachSubscription.Status.ACTIVE)
+        for _ in range(CoachSubscription.FREE_SEAT_LIMIT + 2):
+            CoachAthleteFactory(coach=sub.coach, status=CoachAthlete.Status.ACTIVE)
+        client.force_login(sub.coach)
+        resp = client.post(reverse("meso:coach_invite"), data={"email": "new@x.com"})
+        assert resp.status_code == 302
+        assert CoachInvite.objects.filter(coach=sub.coach).count() == 1
+
+
+class TestSeatGateInviteAccept:
+    def test_free_coach_at_cap_cannot_accept_request(self, client):
+        coach = UserFactory()
+        CoachAthleteFactory(coach=coach, status=CoachAthlete.Status.ACTIVE)  # at cap
+        link = CoachAthlete.request(athlete=UserFactory(), coach=coach)
+        client.force_login(coach)
+        resp = client.post(reverse("meso:invite_accept", kwargs={"token": link.token}))
+        assert resp.status_code == 302
+        link.refresh_from_db()
+        assert link.status == CoachAthlete.Status.PENDING_ATHLETE_REQUEST
+
+    def test_coach_with_room_accepts_request(self, client):
+        coach = UserFactory()
+        CoachProfile.objects.create(user=coach)  # zero athletes → room for one
+        link = CoachAthlete.request(athlete=UserFactory(), coach=coach)
+        client.force_login(coach)
+        resp = client.post(reverse("meso:invite_accept", kwargs={"token": link.token}))
+        assert resp.status_code == 302
+        link.refresh_from_db()
+        assert link.status == CoachAthlete.Status.ACTIVE
+
+
+class TestSeatGateInviteClaim:
+    def test_free_coach_at_cap_blocks_claim(self, client):
+        coach = UserFactory()
+        CoachAthleteFactory(coach=coach, status=CoachAthlete.Status.ACTIVE)  # at cap
+        invite, _ = CoachInvite.open_for(coach=coach, email="newbie@x.com")
+        claimer = UserFactory()
+        client.force_login(claimer)
+        resp = client.post(
+            reverse("meso:invite_claim", kwargs={"token": invite.token}),
+            data={"action": "accept"},
+        )
+        assert resp.status_code == 302
+        invite.refresh_from_db()
+        assert invite.status == CoachInvite.Status.PENDING
+        assert not CoachAthlete.objects.filter(coach=coach, athlete=claimer).exists()
+
+    def test_coach_with_room_allows_claim(self, client):
+        coach = UserFactory()
+        CoachProfile.objects.create(user=coach)
+        invite, _ = CoachInvite.open_for(coach=coach, email="newbie@x.com")
+        claimer = UserFactory()
+        client.force_login(claimer)
+        resp = client.post(
+            reverse("meso:invite_claim", kwargs={"token": invite.token}),
+            data={"action": "accept"},
+        )
+        assert resp.status_code == 302
+        invite.refresh_from_db()
+        assert invite.status == CoachInvite.Status.ACCEPTED
+        assert CoachAthlete.objects.filter(
+            coach=coach, athlete=claimer, status=CoachAthlete.Status.ACTIVE
+        ).exists()
+
+
+# ---------------------------------------------------------------------------
+# The agent gate — can_use_agent at agent_propose
+# ---------------------------------------------------------------------------
+
+
+def _agent_url(plan):
+    return reverse("meso:api_plan_agent", kwargs={"plan_id": plan.pk})
+
+
+class TestAgentGate:
+    def test_free_coach_gets_402(self, client):
+        coach = UserFactory()
+        plan, _, _ = _plan_with_prescription(coach)  # no sub → free
+        client.force_login(coach)
+        resp = client.post(
+            _agent_url(plan),
+            data=json.dumps({"instruction": "Make it knee-safe."}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 402
+        body = resp.json()
+        assert body["ok"] is False
+        assert body["upgrade"] is True
+
+    def test_comped_coach_passes_the_gate(self, client):
+        coach = UserFactory()
+        plan, _, _ = _plan_with_prescription(coach)
+        CoachSubscription.comp(coach)
+        client.force_login(coach)
+        resp = client.post(
+            _agent_url(plan),
+            data=json.dumps({"instruction": "Make it knee-safe."}),
+            content_type="application/json",
+        )
+        # The billing gate is passed; the run then proceeds normally (here it hits
+        # the no-API-key 503, never a 402). The point is the paywall let it through.
+        assert resp.status_code != 402
+
+
+# ---------------------------------------------------------------------------
+# The D6 edit/deliver block — can_edit at the mutating endpoints
+# ---------------------------------------------------------------------------
+
+
+def _patch_url(plan, presc):
+    return reverse(
+        "meso:api_prescription_patch",
+        kwargs={"plan_id": plan.pk, "pk": presc.pk},
+    )
+
+
+class TestEditGateIndividual:
+    def test_over_limit_coach_cannot_patch(self, client):
+        coach = UserFactory()
+        plan, _, presc = _plan_with_prescription(coach)  # 1 active link
+        CoachAthleteFactory(coach=coach, status=CoachAthlete.Status.ACTIVE)  # → over
+        assert access.is_over_limit(coach) is True
+        client.force_login(coach)
+        resp = client.post(
+            _patch_url(plan, presc),
+            data=json.dumps({"sets": "9"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 402
+        assert resp.json()["over_limit"] is True
+        presc.refresh_from_db()
+        assert presc.sets != "9"
+
+    def test_within_cap_free_coach_can_patch(self, client):
+        coach = UserFactory()
+        plan, _, presc = _plan_with_prescription(coach)  # exactly 1 = at cap
+        assert access.is_over_limit(coach) is False
+        client.force_login(coach)
+        resp = client.post(
+            _patch_url(plan, presc),
+            data=json.dumps({"sets": "9"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        presc.refresh_from_db()
+        assert presc.sets == "9"
+
+    def test_over_limit_coach_cannot_deliver(self, client):
+        coach = UserFactory()
+        plan, _, _ = _plan_with_prescription(coach)
+        CoachAthleteFactory(coach=coach, status=CoachAthlete.Status.ACTIVE)
+        client.force_login(coach)
+        resp = client.post(
+            reverse("meso:api_plan_deliver", kwargs={"plan_id": plan.pk})
+        )
+        assert resp.status_code == 402
+
+
+class TestEditGateGroup:
+    def test_over_limit_coach_cannot_design_group(self, client):
+        coach = UserFactory()
+        group = MesoGroupFactory(coach=coach)
+        GroupMembershipFactory(group=group)
+        GroupMembershipFactory(group=group)  # two active members → over the cap
+        assert access.is_over_limit(coach) is True
+        client.force_login(coach)
+        resp = client.post(reverse("meso:group_design", kwargs={"pk": group.pk}))
+        assert resp.status_code == 302
+        assert resp.url == reverse("meso:group", kwargs={"pk": group.pk})
+        assert group.shared_plan() is None  # nothing created
+
+    def test_over_limit_coach_cannot_group_deliver(self, client):
+        coach = UserFactory()
+        group = MesoGroupFactory(coach=coach)
+        GroupMembershipFactory(group=group)
+        GroupMembershipFactory(group=group)
+        client.force_login(coach)
+        resp = client.post(reverse("meso:group_deliver", kwargs={"pk": group.pk}))
+        assert resp.status_code == 302
+        assert resp.url == reverse("meso:group", kwargs={"pk": group.pk})
+
+
+# ---------------------------------------------------------------------------
+# The local trial-start endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestTrialStartEndpoint:
+    def test_coach_starts_trial(self, client):
+        coach = UserFactory()
+        CoachProfile.objects.create(user=coach)
+        client.force_login(coach)
+        resp = client.post(reverse("meso:billing_start_trial"))
+        assert resp.status_code == 302
+        sub = CoachSubscription.objects.get(coach=coach)
+        assert sub.status == CoachSubscription.Status.TRIALING
+        assert access.is_active(coach) is True
+
+    def test_trial_is_single_use(self, client):
+        coach = UserFactory()
+        CoachProfile.objects.create(user=coach)
+        CoachSubscriptionFactory(
+            coach=coach,
+            status=CoachSubscription.Status.FREE,
+            trial_end=timezone.now() - timedelta(days=1),  # already trialed
+        )
+        client.force_login(coach)
+        resp = client.post(reverse("meso:billing_start_trial"))
+        assert resp.status_code == 302
+        sub = CoachSubscription.objects.get(coach=coach)
+        assert sub.status == CoachSubscription.Status.FREE  # unchanged
+
+    def test_non_coach_cannot_start_trial(self, client):
+        athlete = UserFactory()  # no coach profile / links / invites
+        client.force_login(athlete)
+        resp = client.post(reverse("meso:billing_start_trial"))
+        assert resp.status_code == 302
+        assert not CoachSubscription.objects.filter(coach=athlete).exists()
+
+    def test_get_is_rejected(self, client):
+        coach = UserFactory()
+        CoachProfile.objects.create(user=coach)
+        client.force_login(coach)
+        resp = client.get(reverse("meso:billing_start_trial"))
+        assert resp.status_code == 405
+
+
+# ---------------------------------------------------------------------------
+# Paywall UI — roster billing card + designer agent composer/CTA
+# ---------------------------------------------------------------------------
+
+
+class TestRosterBillingCard:
+    def test_free_coach_sees_trial_cta(self, client):
+        coach = UserFactory()
+        CoachProfile.objects.create(user=coach)
+        client.force_login(coach)
+        resp = client.get(reverse("meso:roster"))
+        assert resp.status_code == 200
+        assert resp.context["billing"]["can_start_trial"] is True
+        assert b"Start free trial" in resp.content
+
+    def test_comped_coach_hides_trial_cta(self, client):
+        coach = UserFactory()
+        CoachProfile.objects.create(user=coach)
+        CoachSubscription.comp(coach)
+        client.force_login(coach)
+        resp = client.get(reverse("meso:roster"))
+        assert resp.context["billing"]["is_active"] is True
+        assert resp.context["billing"]["can_start_trial"] is False
+        assert b"Start free trial" not in resp.content
+
+
+class TestDesignerAgentCta:
+    def test_free_coach_sees_upgrade_cta(self, client):
+        coach = UserFactory()
+        plan, _, _ = _plan_with_prescription(coach)
+        client.force_login(coach)
+        resp = client.get(reverse("meso:designer_plan", kwargs={"plan_id": plan.pk}))
+        assert resp.status_code == 200
+        assert resp.context["can_use_agent"] is False
+        assert b"Upgrade to use the agent" in resp.content
+
+    def test_comped_coach_sees_composer(self, client):
+        coach = UserFactory()
+        plan, _, _ = _plan_with_prescription(coach)
+        CoachSubscription.comp(coach)
+        client.force_login(coach)
+        resp = client.get(reverse("meso:designer_plan", kwargs={"plan_id": plan.pk}))
+        assert resp.context["can_use_agent"] is True
+        assert b"Upgrade to use the agent" not in resp.content

--- a/app/store_project/meso/tests/test_billing_enforcement.py
+++ b/app/store_project/meso/tests/test_billing_enforcement.py
@@ -33,6 +33,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from store_project.meso.billing import access
+from store_project.meso.factories import AgentProposalBatchFactory
 from store_project.meso.factories import CoachAthleteFactory
 from store_project.meso.factories import CoachSubscriptionFactory
 from store_project.meso.factories import ExercisePrescriptionFactory
@@ -42,6 +43,7 @@ from store_project.meso.factories import MesoGroupFactory
 from store_project.meso.factories import PlanFactory
 from store_project.meso.factories import SessionFactory
 from store_project.meso.factories import WeekFactory
+from store_project.meso.models import AgentProposalBatch
 from store_project.meso.models import CoachAthlete
 from store_project.meso.models import CoachInvite
 from store_project.meso.models import CoachProfile
@@ -289,6 +291,22 @@ class TestEditGateIndividual:
             reverse("meso:api_plan_deliver", kwargs={"plan_id": plan.pk})
         )
         assert resp.status_code == 402
+
+    def test_over_limit_coach_cannot_apply_pending_batch(self, client):
+        # A batch drafted while paid, then a downgrade: applying it would mutate
+        # the program, so the D6 freeze must block it (the agent gate alone only
+        # stops *new* runs).
+        coach = UserFactory()
+        plan, _, _ = _plan_with_prescription(coach)
+        CoachAthleteFactory(coach=coach, status=CoachAthlete.Status.ACTIVE)  # → over
+        batch = AgentProposalBatchFactory(plan=plan, coach=coach)
+        client.force_login(coach)
+        resp = client.post(
+            reverse("meso:api_batch_apply", kwargs={"batch_id": batch.pk})
+        )
+        assert resp.status_code == 402
+        batch.refresh_from_db()
+        assert batch.status == AgentProposalBatch.Status.PENDING  # not applied
 
 
 class TestEditGateGroup:

--- a/app/store_project/meso/tests/test_designer_agent_chat.py
+++ b/app/store_project/meso/tests/test_designer_agent_chat.py
@@ -21,6 +21,7 @@ import pytest
 from django.contrib.staticfiles import finders
 from django.urls import reverse
 
+from store_project.meso.models import CoachSubscription
 from store_project.meso.tests.test_designer_save import seed_plan
 
 pytestmark = pytest.mark.django_db
@@ -96,6 +97,9 @@ class TestPhase4BackgroundJobWiring:
 class TestDesignerStillRendersChatColumn:
     def test_designer_page_renders_the_agent_column(self, client):
         plan, _, _ = seed_plan()
+        # The AI agent is paid-only (S6 Phase 3, D4), so a coach iterating a plan
+        # with the agent in these tests has full access — comp keeps the gate open.
+        CoachSubscription.comp(plan.relationship.coach)
         client.force_login(plan.relationship.coach)
         resp = client.get(reverse("meso:designer_plan", kwargs={"plan_id": plan.pk}))
         assert resp.status_code == 200

--- a/app/store_project/meso/tests/test_group_deliver.py
+++ b/app/store_project/meso/tests/test_group_deliver.py
@@ -29,6 +29,7 @@ from store_project.meso.factories import CoachAthleteFactory
 from store_project.meso.factories import MesoGroupFactory
 from store_project.meso.factories import SessionLogFactory
 from store_project.meso.models import CoachAthlete
+from store_project.meso.models import CoachSubscription
 from store_project.meso.models import ExercisePrescription
 from store_project.meso.models import InvalidTransition
 from store_project.meso.models import Plan
@@ -48,6 +49,9 @@ def seed_group(coach=None, *, member_count=2, focus="Strength"):
     ``(group, shared_plan, [membership, ...])``.
     """
     coach = coach or UserFactory()
+    # A coach with a multi-member group is a paying coach (S6 Phase 3) —
+    # comp so the D6 over-limit edit/deliver freeze doesn't fire here.
+    CoachSubscription.comp(coach)
     group = MesoGroupFactory(coach=coach, focus=focus)
     memberships = []
     for _ in range(member_count):

--- a/app/store_project/meso/tests/test_group_program.py
+++ b/app/store_project/meso/tests/test_group_program.py
@@ -30,6 +30,7 @@ from store_project.meso.factories import GroupPlanFactory
 from store_project.meso.factories import MesoGroupFactory
 from store_project.meso.factories import PlanFactory
 from store_project.meso.models import CoachAthlete
+from store_project.meso.models import CoachSubscription
 from store_project.meso.models import Mesocycle
 from store_project.meso.models import Plan
 from store_project.meso.models import Session
@@ -346,6 +347,9 @@ class TestGroupPlanEndpoints:
     def test_agent_rejects_group_plan(self, client):
         # The group agent is a later phase; grounding assumes an athlete.
         coach = UserFactory()
+        # The AI agent is paid-only (S6 Phase 3, D4), so a coach iterating a plan
+        # with the agent in these tests has full access — comp keeps the gate open.
+        CoachSubscription.comp(coach)
         group = MesoGroupFactory(coach=coach)
         plan = group.create_shared_plan()
         client.force_login(coach)

--- a/app/store_project/meso/tests/test_one_rm.py
+++ b/app/store_project/meso/tests/test_one_rm.py
@@ -38,6 +38,7 @@ from store_project.meso.factories import SessionLogFactory
 from store_project.meso.factories import WeekFactory
 from store_project.meso.models import AthleteOneRm
 from store_project.meso.models import CoachAthlete
+from store_project.meso.models import CoachSubscription
 from store_project.meso.models import LoadType
 from store_project.meso.models import Plan
 from store_project.meso.models import SessionLog
@@ -1033,6 +1034,9 @@ class TestCoachSetOneRmEndpoint:
 
     def test_prescription_outside_the_plan_is_404(self, client):
         coach = UserFactory()
+        # The same coach training two athletes is over the free seat cap; comp
+        # so this exercises the cross-plan 404, not the D6 over-limit 402.
+        CoachSubscription.comp(coach)
         athlete = UserFactory()
         plan, _, (squat,) = make_session(
             athlete, coach=coach, prescriptions=[{"name": "Back Squat"}]

--- a/app/store_project/meso/tests/test_views.py
+++ b/app/store_project/meso/tests/test_views.py
@@ -11,6 +11,7 @@ from store_project.meso.factories import PlanFactory
 from store_project.meso.factories import SessionFactory
 from store_project.meso.factories import WeekFactory
 from store_project.meso.models import CoachAthlete
+from store_project.meso.models import CoachSubscription
 from store_project.meso.models import Plan
 from store_project.users.factories import UserFactory
 
@@ -199,6 +200,9 @@ class TestBareDesignerDeliver:
         coach = UserFactory()
         plan_a, presc_a = self._plan_with_prescription(coach)
         plan_b, presc_b = self._plan_with_prescription(coach)
+        # Two athletes puts a free coach over the cap; comp so the autosaves
+        # land (D6) and the test measures last-edited ordering, not the gate.
+        CoachSubscription.comp(coach)
         client.force_login(coach)
 
         def patch(plan, presc):

--- a/app/store_project/meso/urls.py
+++ b/app/store_project/meso/urls.py
@@ -162,5 +162,7 @@ urlpatterns = [
     # and the clean subscription webhook (separate from the products webhook).
     path("billing/subscribe/", views.billing_subscribe, name="billing_subscribe"),
     path("billing/portal/", views.billing_portal, name="billing_portal"),
+    # Start the no-card local trial (S6 Phase 3) — the free path to full access.
+    path("billing/trial/", views.billing_start_trial, name="billing_start_trial"),
     path("billing/webhook/", views.billing_webhook, name="billing_webhook"),
 ]

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -1938,6 +1938,11 @@ def change_set_status(request, pk):
 def batch_apply(request, batch_id):
     """Apply the batch's approved changes back into the program."""
     batch = _coach_batch_or_404(request, batch_id)
+    # Applying a batch writes the approved edits into the program — an edit, so it
+    # respects the D6 over-limit freeze (a batch drafted before a downgrade can't
+    # be applied while the coach is over their seat limit).
+    if not billing_access.can_edit(batch.plan.coach):
+        return _over_limit_json()
     if batch.status != AgentProposalBatch.Status.PENDING:
         return JsonResponse(
             {"ok": False, "error": "This batch has already been resolved."}, status=409

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -43,6 +43,7 @@ from .agent import apply as agent_apply
 from .agent import client as agent_client
 from .agent import jobs as agent_jobs
 from .agent import service as agent_service
+from .billing import access as billing_access
 from .billing import seats as billing_seats
 from .billing import stripe_gateway as billing_gateway
 from .billing import webhooks as billing_webhooks
@@ -93,6 +94,43 @@ def _is_coach(user):
         CoachProfile.objects.filter(user=user).exists()
         or CoachAthlete.objects.for_coach(user).exists()
         or CoachInvite.objects.for_coach(user).exists()
+    )
+
+
+# -- billing gates (S6 Phase 3) -------------------------------------------
+#
+# The paywall gets teeth here. ``billing/access.py`` owns the predicates; these
+# shape the rejection per surface — a flashed redirect for the form views, a 402
+# JSON body for the autosave/deliver API. Three gates: the seat cap blocks a free
+# coach past the limit at the relationship choke points (``can_add_athlete``); the
+# AI agent is paid-only (``can_use_agent``); and an over-limit coach (post-downgrade,
+# D6) is frozen out of edits/deliver (``can_edit``).
+
+#: Flashed when a free coach hits the seat cap — the upgrade CTA the roster shows.
+SEAT_LIMIT_MESSAGE = (
+    "You've reached your free athlete limit. Start your free trial or subscribe "
+    "to add more athletes."
+)
+
+#: Flashed on a form view when an over-limit coach (D6) tries to edit/deliver.
+OVER_LIMIT_MESSAGE = (
+    "You're over your plan's athlete limit. Re-subscribe or end a relationship "
+    "to edit or deliver programs."
+)
+
+
+def _over_limit_json():
+    """402 JSON for an API edit/deliver blocked by the D6 over-limit freeze."""
+    return JsonResponse(
+        {
+            "ok": False,
+            "error": (
+                "You're over your plan's athlete limit. Re-subscribe or end a "
+                "relationship to keep editing."
+            ),
+            "over_limit": True,
+        },
+        status=402,
     )
 
 
@@ -193,6 +231,10 @@ class MesoDesignerView(LoginRequiredMixin, TemplateView):
         # batches so the chat survives a reload (the JS hydrates ``messages``
         # from it, falling back to the greeting when empty).
         ctx["chat_thread"] = serialize_chat_thread(plan)
+        # Agent gate (S6 Phase 3, D4): the AI agent is paid-only. When the coach
+        # can't use it, the composer is replaced by an upgrade CTA (the endpoint
+        # also 402s, so the gate is defended server-side, not just hidden).
+        ctx["can_use_agent"] = billing_access.can_use_agent(self.request.user)
         return ctx
 
 
@@ -254,6 +296,9 @@ class RosterView(LoginRequiredMixin, TemplateView):
         ctx["pending_requests"] = [
             presenters.pending_request(link) for link in pending_requests
         ]
+        # Billing/paywall state (S6 Phase 3): tier, seat usage, and the upgrade
+        # CTAs (start trial / subscribe / manage billing).
+        ctx["billing"] = presenters.billing_state(self.request.user)
         ctx["activity"] = []
         ctx["needs_review"] = 0
         return ctx
@@ -380,6 +425,10 @@ def group_design(request, pk):
         )
         if group is None:
             raise Http404("Unknown group")
+        # Edit gate (D6): an over-limit coach is frozen out of designing programs.
+        if not billing_access.can_edit(request.user):
+            messages.error(request, OVER_LIMIT_MESSAGE)
+            return redirect("meso:group", pk=group.pk)
         plan = group.shared_plan() or group.create_shared_plan()
     return redirect("meso:designer_plan", plan_id=plan.pk)
 
@@ -399,6 +448,10 @@ def group_deliver(request, pk):
     group = MesoGroup.objects.for_coach(request.user).filter(pk=pk).first()
     if group is None:
         raise Http404("Unknown group")
+    # Deliver gate (D6): an over-limit coach can't deliver until back within the cap.
+    if not billing_access.can_edit(request.user):
+        messages.error(request, OVER_LIMIT_MESSAGE)
+        return redirect("meso:group", pk=group.pk)
     plan = group.shared_plan()
     if plan is None:
         messages.error(request, "Design a shared program before delivering.")
@@ -930,6 +983,19 @@ def invite_accept(request, token):
     link = get_object_or_404(CoachAthlete, token=token)
     if not link.is_pending or request.user != link.recipient():
         return HttpResponseForbidden("You cannot respond to this invite.")
+    # Seat gate (D4): activating this link consumes one of the coach's seats. A
+    # free coach at the cap can't accept an athlete's request (and can't have a
+    # coach-invite they sent accepted) until they upgrade. Worded for whichever
+    # side is acting — the coach themselves vs. the athlete accepting the coach.
+    if not billing_access.can_add_athlete(link.coach):
+        if request.user == link.coach:
+            messages.error(request, SEAT_LIMIT_MESSAGE)
+        else:
+            messages.error(
+                request,
+                f"{link.coach.display_name()} can't take on new athletes right now.",
+            )
+        return redirect("meso:roster")
     link.accept()
     # A new active link is a billable seat — best-effort sync the coach's Stripe
     # quantity (no-op unless they're paid; the daily sweep is the backstop).
@@ -1078,6 +1144,11 @@ def coach_invite(request):
     if email == CoachInvite.normalize_email(request.user.email):
         messages.error(request, "You can't invite yourself.")
         return redirect("meso:roster")
+    # Seat gate (D4): a free coach at the cap can't open a new invite — accepting
+    # it would create a billable seat they aren't paying for.
+    if not billing_access.can_add_athlete(request.user):
+        messages.error(request, SEAT_LIMIT_MESSAGE)
+        return redirect("meso:roster")
     invite, _ = CoachInvite.open_for(coach=request.user, email=email)
     accept_url = request.build_absolute_uri(
         reverse("meso:invite_claim", kwargs={"token": invite.token})
@@ -1199,6 +1270,16 @@ def invite_claim(request, token):
                 )
                 return redirect("meso:athlete_home")
             if action == "accept":
+                # Seat gate (D4): claiming materializes an active link — a billable
+                # seat for the coach. A coach who has since hit their cap can't take
+                # on the athlete until they upgrade; the athlete sees why.
+                if not billing_access.can_add_athlete(invite.coach):
+                    messages.error(
+                        request,
+                        f"{invite.coach.display_name()} has reached their athlete "
+                        "limit and can't add you right now.",
+                    )
+                    return redirect("meso:athlete_home")
                 try:
                     invite.accept(request.user)
                 except InvalidTransition as exc:
@@ -1272,6 +1353,22 @@ def _coach_plan_or_forbidden(request, plan_id):
     return plan, None
 
 
+def _editable_plan_or_response(request, plan_id):
+    """The plan the requester may *edit*, or an error response (S6 Phase 3, D6).
+
+    Ownership first (``_coach_plan_or_forbidden`` → 404/403), then the billing
+    gate: a coach over their seat limit after a downgrade (``can_edit`` False) gets
+    a 402 instead of mutating — they keep read access but can't change or deliver a
+    program until back within the cap or re-subscribed.
+    """
+    plan, forbidden = _coach_plan_or_forbidden(request, plan_id)
+    if forbidden is not None:
+        return None, forbidden
+    if not billing_access.can_edit(plan.coach):
+        return None, _over_limit_json()
+    return plan, None
+
+
 def _touch_plan(plan):
     """Bump the plan's ``modified`` so it reads as the coach's working plan.
 
@@ -1287,7 +1384,7 @@ def _touch_plan(plan):
 @require_POST
 def prescription_patch(request, plan_id, pk):
     """Patch one prescription cell (or a small batch of cells)."""
-    plan, forbidden = _coach_plan_or_forbidden(request, plan_id)
+    plan, forbidden = _editable_plan_or_response(request, plan_id)
     if forbidden is not None:
         return forbidden
     prescription = get_object_or_404(
@@ -1333,7 +1430,7 @@ def prescription_patch(request, plan_id, pk):
 @require_POST
 def session_add_exercise(request, plan_id, pk):
     """Append a blank prescription row to a session."""
-    plan, forbidden = _coach_plan_or_forbidden(request, plan_id)
+    plan, forbidden = _editable_plan_or_response(request, plan_id)
     if forbidden is not None:
         return forbidden
     session = get_object_or_404(Session, pk=pk, week__mesocycle__plan=plan)
@@ -1463,7 +1560,7 @@ def prescription_override(request, plan_id, pk):
     ``prescription_patch``); send a field empty to clear just that part, and an
     adjust left with no parts is removed. Fully validated before any write.
     """
-    plan, forbidden = _coach_plan_or_forbidden(request, plan_id)
+    plan, forbidden = _editable_plan_or_response(request, plan_id)
     if forbidden is not None:
         return forbidden
     if not plan.is_group:
@@ -1517,7 +1614,7 @@ def coach_set_one_rm(request, plan_id, pk):
     ``set_manual_one_rm`` the athlete logger uses. Returns ``{one_rm, source}`` so
     the badge repaints.
     """
-    plan, forbidden = _coach_plan_or_forbidden(request, plan_id)
+    plan, forbidden = _editable_plan_or_response(request, plan_id)
     if forbidden is not None:
         return forbidden
     if plan.is_group:
@@ -1572,7 +1669,7 @@ def _fan_out_group_delivery(request, plan):
 @require_POST
 def plan_deliver(request, plan_id):
     """Deliver the plan's current week: stamp ``delivered_at`` + snapshot it (Phase 4)."""
-    plan, forbidden = _coach_plan_or_forbidden(request, plan_id)
+    plan, forbidden = _editable_plan_or_response(request, plan_id)
     if forbidden is not None:
         return forbidden
     if plan.is_group:
@@ -1700,6 +1797,22 @@ def agent_propose(request, plan_id):
     plan, forbidden = _coach_plan_or_forbidden(request, plan_id)
     if forbidden is not None:
         return forbidden
+    # Agent gate (D4): the Claude agent has real per-call cost, so it's paid-only —
+    # a free-tier coach gets a 402 (the designer shows an upgrade CTA in place of
+    # the composer). Trial/active/comped coaches pass. Defended here, not just in
+    # the UI, because the API cost is real.
+    if not billing_access.can_use_agent(request.user):
+        return JsonResponse(
+            {
+                "ok": False,
+                "error": (
+                    "The AI agent is available on a paid plan. Start your free "
+                    "trial or subscribe to use it."
+                ),
+                "upgrade": True,
+            },
+            status=402,
+        )
     if plan.is_group:
         # The agent grounds on a single athlete's profile + logs; a group agent
         # (per-athlete auto-adjusts) is groups Phase 3. Reject before any work so
@@ -1929,6 +2042,32 @@ def billing_portal(request):
         messages.error(request, "Could not open the billing portal. Please try again.")
         return redirect("meso:roster")
     return redirect(session.url)
+
+
+@login_required
+@require_POST
+def billing_start_trial(request):
+    """Start the no-card 14-day local trial for a coach (S6 Phase 3, D3).
+
+    The free path to the full toolkit — no Stripe, no card. Get-or-creates the
+    coach's ``CoachSubscription`` row and flips it ``trialing`` for
+    ``TRIAL_DAYS``. Single-use: a coach who has already trialed (even if it
+    lapsed) gets a friendly "already used" notice, never a 500. Coach-surface
+    only; a non-coach is bounced to the roster (which redirects them home).
+    """
+    if not _is_coach(request.user):
+        return redirect("meso:roster")
+    try:
+        CoachSubscription.start_trial_for(request.user)
+    except InvalidTransition:
+        messages.info(request, "You've already used your free trial.")
+    else:
+        messages.success(
+            request,
+            f"Your {CoachSubscription.TRIAL_DAYS}-day free trial has started — "
+            "the full Meso toolkit is unlocked.",
+        )
+    return redirect("meso:roster")
 
 
 @csrf_exempt

--- a/app/store_project/templates/meso/designer.html
+++ b/app/store_project/templates/meso/designer.html
@@ -275,17 +275,27 @@
               The agent works per athlete &#8212; a group agent that auto-adjusts each member arrives in the next phase. Edit the shared program directly for now.
             </div>
           </template>
-          <div x-show="isIndividual" style="flex:0 0 auto;border-top:1px solid var(--line-2);padding:11px 14px 13px;">
-            <div style="display:flex;gap:6px;overflow-x:auto;padding-bottom:9px;">
-              <template x-for="c in chips" :key="c.label">
-                <button data-hover="chip" @click="onChip(c.label)" :disabled="agentTyping" x-text="c.label" style="appearance:none;cursor:pointer;font:inherit;white-space:nowrap;font-size:11.5px;font-weight:550;color:var(--ink);background:var(--surface);border:1px solid var(--line);border-radius:999px;padding:6px 11px;flex:0 0 auto;"></button>
-              </template>
+          {% if can_use_agent %}
+            <div x-show="isIndividual" style="flex:0 0 auto;border-top:1px solid var(--line-2);padding:11px 14px 13px;">
+              <div style="display:flex;gap:6px;overflow-x:auto;padding-bottom:9px;">
+                <template x-for="c in chips" :key="c.label">
+                  <button data-hover="chip" @click="onChip(c.label)" :disabled="agentTyping" x-text="c.label" style="appearance:none;cursor:pointer;font:inherit;white-space:nowrap;font-size:11.5px;font-weight:550;color:var(--ink);background:var(--surface);border:1px solid var(--line);border-radius:999px;padding:6px 11px;flex:0 0 auto;"></button>
+                </template>
+              </div>
+              <div class="meso-composer" style="display:flex;align-items:flex-end;gap:8px;background:var(--rail);border:1px solid var(--line);border-radius:11px;padding:7px 7px 7px 12px;">
+                <input x-model="inputText" @keydown="onInputKey($event)" placeholder="Ask the agent to adjust the program&#8230;" style="flex:1;appearance:none;border:0;background:transparent;outline:none;font:inherit;font-size:13px;color:var(--ink);padding:5px 0;" />
+                <button data-hover="brighten" @click="onSend()" :disabled="agentTyping" :style="agentTyping ? 'opacity:0.55;cursor:default;' : ''" style="appearance:none;cursor:pointer;border:0;width:32px;height:32px;border-radius:8px;background:var(--accent);color:var(--accent-ink);display:flex;align-items:center;justify-content:center;flex:0 0 auto;font-size:15px;">&#8593;</button>
+              </div>
             </div>
-            <div class="meso-composer" style="display:flex;align-items:flex-end;gap:8px;background:var(--rail);border:1px solid var(--line);border-radius:11px;padding:7px 7px 7px 12px;">
-              <input x-model="inputText" @keydown="onInputKey($event)" placeholder="Ask the agent to adjust the program&#8230;" style="flex:1;appearance:none;border:0;background:transparent;outline:none;font:inherit;font-size:13px;color:var(--ink);padding:5px 0;" />
-              <button data-hover="brighten" @click="onSend()" :disabled="agentTyping" :style="agentTyping ? 'opacity:0.55;cursor:default;' : ''" style="appearance:none;cursor:pointer;border:0;width:32px;height:32px;border-radius:8px;background:var(--accent);color:var(--accent-ink);display:flex;align-items:center;justify-content:center;flex:0 0 auto;font-size:15px;">&#8593;</button>
+          {% else %}
+          <!-- Agent gate (S6 Phase 3): the AI agent is paid-only, so the free tier
+               sees an upgrade CTA where the composer would be. Billing actions live
+               on the roster (the endpoint also 402s, so this isn't the only guard). -->
+            <div x-show="isIndividual" style="flex:0 0 auto;border-top:1px solid var(--line-2);padding:13px 14px 15px;">
+              <p style="margin:0 0 9px;font-size:12px;color:var(--dim);line-height:1.4;">The AI program agent is on paid plans. Start your free trial or subscribe to let it draft and adjust programs for you.</p>
+              <a href="{% url 'meso:roster' %}" data-hover="brighten" style="display:inline-block;text-decoration:none;font:inherit;font-size:12.5px;font-weight:650;color:var(--accent-ink);background:var(--accent);border-radius:8px;padding:8px 14px;">Upgrade to use the agent</a>
             </div>
-          </div>
+          {% endif %}
         </div>
 
         <!-- ---------- CANVAS ---------- -->

--- a/app/store_project/templates/meso/roster.html
+++ b/app/store_project/templates/meso/roster.html
@@ -180,29 +180,71 @@
         </div>
       </div>
 
-      <!-- activity column -->
-      <div class="meso-card meso-card--pad">
-        <p class="meso-eyebrow">Recent activity</p>
-        <div style="display:flex;flex-direction:column;gap:14px;margin-top:4px;">
-          {% for ev in activity %}
-            <div style="display:flex;gap:10px;align-items:flex-start;">
-              <div class="meso-avatar meso-avatar--sm {% if ev.athlete.tone == 'accent' %}meso-avatar--accent{% endif %}">{{ ev.athlete.initials }}</div>
-              <div style="min-width:0;line-height:1.35;">
-                <div style="font-size:12.5px;">
-                  <a href="{% url 'meso:athlete' ev.athlete.id %}" style="font-weight:700;color:var(--ink);text-decoration:none;">{{ ev.athlete.name }}</a>
-                  {% if ev.kind == 'flag' %}
-                    <span style="color:var(--warn);"> {{ ev.text }}</span>
-                  {% else %}
-                    <span class="meso-muted"> {{ ev.text }}</span>
-                  {% endif %}
-                </div>
-                <div class="meso-row-meta" style="margin-top:2px;">{{ ev.when }}</div>
-              </div>
-            </div>
-          {% endfor %}
+      <!-- right column: billing + recent activity -->
+      <div style="display:flex;flex-direction:column;gap:18px;">
+
+      <!-- Billing / plan (S6 Phase 3): tier, seat usage, and upgrade CTAs. -->
+        <div class="meso-card meso-card--pad" style="display:flex;flex-direction:column;gap:11px;">
+          <div style="display:flex;align-items:center;gap:8px;">
+            <p class="meso-eyebrow" style="margin:0;">Plan</p>
+            <div class="meso-spacer"></div>
+            <span class="meso-badge {% if billing.is_active %}meso-badge--ok{% else %}meso-badge--muted{% endif %}"><i></i>{{ billing.status_label }}</span>
+          </div>
+          {% if billing.over_limit %}
+            <p class="meso-sub" style="margin:0;color:var(--warn);">Over your plan limit &#8212; {{ billing.seat_count }} of {{ billing.seat_limit }} athlete{{ billing.seat_limit|pluralize }}. Re-subscribe or end a relationship to edit or deliver programs.</p>
+          {% elif billing.on_trial %}
+            <p class="meso-sub" style="margin:0;">Free trial &#8212; ends {{ billing.trial_end|date:"M j" }}. Subscribe to keep full access when it ends.</p>
+          {% elif billing.is_active %}
+            <p class="meso-sub" style="margin:0;">{{ billing.seat_count }} active athlete{{ billing.seat_count|pluralize }} &#183; full access.</p>
+          {% else %}
+            <p class="meso-sub" style="margin:0;">Free plan &#8212; {{ billing.seat_count }} of {{ billing.seat_limit }} athlete{{ billing.seat_limit|pluralize }}. The AI agent and more athletes need a paid plan.</p>
+          {% endif %}
+          <div style="display:flex;gap:8px;flex-wrap:wrap;">
+            {% if billing.can_start_trial %}
+              <form method="post" action="{% url 'meso:billing_start_trial' %}" style="margin:0;">
+                {% csrf_token %}
+                <button type="submit" class="meso-btn meso-btn--primary">Start free trial</button>
+              </form>
+            {% endif %}
+            {% if not billing.is_active or billing.on_trial or billing.over_limit %}
+              <form method="post" action="{% url 'meso:billing_subscribe' %}" style="margin:0;">
+                {% csrf_token %}
+                <button type="submit" class="meso-btn {% if billing.can_start_trial %}meso-btn--ghost{% else %}meso-btn--primary{% endif %}">Subscribe</button>
+              </form>
+            {% endif %}
+            {% if billing.has_stripe_subscription %}
+              <form method="post" action="{% url 'meso:billing_portal' %}" style="margin:0;">
+                {% csrf_token %}
+                <button type="submit" class="meso-btn meso-btn--ghost">Manage billing</button>
+              </form>
+            {% endif %}
+          </div>
         </div>
-        <hr class="meso-hr" />
-        <a class="meso-btn meso-btn--ghost" href="{% url 'meso:results' %}">View latest session results →</a>
+
+      <!-- activity column -->
+        <div class="meso-card meso-card--pad">
+          <p class="meso-eyebrow">Recent activity</p>
+          <div style="display:flex;flex-direction:column;gap:14px;margin-top:4px;">
+            {% for ev in activity %}
+              <div style="display:flex;gap:10px;align-items:flex-start;">
+                <div class="meso-avatar meso-avatar--sm {% if ev.athlete.tone == 'accent' %}meso-avatar--accent{% endif %}">{{ ev.athlete.initials }}</div>
+                <div style="min-width:0;line-height:1.35;">
+                  <div style="font-size:12.5px;">
+                    <a href="{% url 'meso:athlete' ev.athlete.id %}" style="font-weight:700;color:var(--ink);text-decoration:none;">{{ ev.athlete.name }}</a>
+                    {% if ev.kind == 'flag' %}
+                      <span style="color:var(--warn);"> {{ ev.text }}</span>
+                    {% else %}
+                      <span class="meso-muted"> {{ ev.text }}</span>
+                    {% endif %}
+                  </div>
+                  <div class="meso-row-meta" style="margin-top:2px;">{{ ev.when }}</div>
+                </div>
+              </div>
+            {% endfor %}
+          </div>
+          <hr class="meso-hr" />
+          <a class="meso-btn meso-btn--ghost" href="{% url 'meso:results' %}">View latest session results →</a>
+        </div>
       </div>
     </div>
   </div>

--- a/docs/meso/billing-plan.md
+++ b/docs/meso/billing-plan.md
@@ -136,9 +136,14 @@ rule to avoid the app arbitrarily choosing which athletes to freeze.)
 
 ## Phasing
 
-> **Status:** Phase 1 ✅ (PR #319, migration `0020`). Phase 2 ✅ (this slice) —
-> Stripe Checkout + Customer Portal + the clean webhook + best-effort seat sync +
-> the daily `reconcile_seats` sweep. Enforcement + paywall UI is Phase 3 (next).
+> **Status:** Phase 1 ✅ (PR #319, migration `0020`). Phase 2 ✅ (PR #320,
+> migration `0021`) — Stripe Checkout + Customer Portal + the clean webhook +
+> best-effort seat sync + the daily `reconcile_seats` sweep. Phase 3 ✅ (this
+> slice) — the gates have teeth: `can_add_athlete` at the invite/request choke
+> points, `can_use_agent` at the agent endpoint (402), `can_edit` (the D6
+> over-limit freeze) at the edit/deliver endpoints, the local trial-start
+> endpoint, and the paywall UI (roster billing card + designer agent CTA). Next:
+> Phase 4 (self-serve coach signup).
 
 ### Deploying Phase 2 (Stripe configuration)
 
@@ -166,10 +171,13 @@ deploy succeeds without them (like the VAPID push keys):
 2. **Phase 2 — Stripe.** Subscription Checkout + Customer Portal + the clean
    webhook handler + seat-quantity sync + the `reconcile_seats` qcluster sweep.
    Now a coach can actually pay.
-3. **Phase 3 — enforcement + UI.** Wire `can_add_athlete` into the invite/request
-   choke points **and `can_use_agent` into the agent endpoint**; the paywall /
-   upgrade CTA + a billing settings page (trial banner, "manage subscription" →
-   Portal); the D6 downgrade behavior. Now billing has teeth.
+3. **Phase 3 — enforcement + UI (DONE).** `can_add_athlete` wired into the
+   invite/request choke points (open invite, accept request, claim invite),
+   `can_use_agent` into the agent endpoint (402 + designer upgrade CTA),
+   `can_edit` (the D6 over-limit freeze) into the autosave/deliver/group edit
+   endpoints, the local trial-start endpoint (`billing/trial/`), and the roster
+   billing card (tier + seat usage + start-trial / subscribe / manage-billing
+   CTAs). Billing now has teeth. Fully tested in `test_billing_enforcement.py`.
 4. **Phase 4 — self-serve coach signup.** The public become-a-coach → choose
    plan → subscribe → `CoachProfile` created funnel (today coach creation is
    admin/seed-only).


### PR DESCRIPTION
## What

S6 billing **Phase 3** — wire the gates from Phases 1–2 into the choke points and ship the paywall UI. Until now `CoachSubscription` + `billing/access.py` + Stripe Checkout/Portal/webhook existed but **nothing was enforced**. This gives billing teeth.

### `billing/access.py`
- `is_over_limit(coach)` — the downgrade-landing state (a free/lapsed coach holding more active athletes than the cap).
- `can_edit(coach)` — its negation; the D6 edit/deliver freeze.

### Enforcement (`views.py`)
- **Seat gate** (`can_add_athlete`) at the three points a new active link is created: opening a coach email invite, accepting an athlete's request, claiming an email invite. A free coach at the cap is refused with an upgrade CTA.
- **Agent gate** (`can_use_agent`) at `agent_propose`: a free coach gets a **402** (no drafting batch); trial/active/comped pass. Defended at the endpoint, not just the UI, because the API cost is real.
- **D6 over-limit freeze** (`can_edit`) at the autosave/deliver/group edit endpoints via `_editable_plan_or_response` (402 JSON) and the group form views (flashed redirect). Also gates `batch_apply` (applying a pending agent batch is an edit). An over-limit coach keeps **read** access but can't mutate or deliver. Never deletes data.
- **Local trial-start endpoint** (`POST billing/trial/`) → `CoachSubscription.start_trial_for`, single-use, coach-only.

### Paywall UI
- `presenters.billing_state(coach)` — tier, seat usage, and which CTAs to offer.
- Roster billing card (status + seat usage + start-trial / subscribe / manage-billing) and a designer agent **composer-vs-upgrade-CTA** driven by `can_use_agent`.

## Tests
- New `test_billing_enforcement.py` covers every gate, the trial endpoint, the `batch_apply` freeze, and the paywall UI.
- Comped the coach in the agent/group/multi-athlete fixtures that now represent a paying coach (the agent is paid-only; a multi-athlete coach is over the free cap), so they exercise their intended path rather than the new gates.
- **Full suite green (1060 passed).**

## Review
- Self-reviewed via the **Codex review loop** (2 iterations, 0 blockers). Codex's `batch_apply` finding was fixed; the remaining nit — a concurrent-accept seat race — is a deliberately-declined soft-cap +1 edge (a correct cross-row lock is a no-op under the SQLite test DB and is bounded by the daily `reconcile_seats` sweep).

## Deploy notes
Billing stays **dormant** until the owner configures `MESO_SEAT_PRICE_ID` + `MESO_STRIPE_WEBHOOK_SECRET`. The free tier + local trial + comped paths need no Stripe, so enforcement is live on deploy; the subscribe button is a no-op until the Price id is set (handled gracefully).

https://claude.ai/code/session_015G62Gs7papVMJAfYqeExrN