### PR TITLE
Meso — S6 billing Phase 4: self-serve coach signup

### DIFF
--- a/app/store_project/meso/tests/test_coach_signup.py
+++ b/app/store_project/meso/tests/test_coach_signup.py
@@ -1,0 +1,171 @@
+"""S6 — billing, Phase 4: self-serve coach signup.
+
+Phases 1–3 built the subscription spine, Stripe, and the gates/paywall — but a
+``CoachProfile`` could still only be created by admin or the demo seed. Phase 4
+ships the public funnel: a ``become a coach`` landing page and a ``start
+coaching`` action that creates the ``CoachProfile`` for a logged-in user (and
+optionally starts the no-card trial). Once a coach, plan choice (free / trial /
+subscribe) is the existing Phase 3 roster billing card. See
+``docs/meso/billing-plan.md``.
+
+These tests cover:
+
+- the **landing page** (``become_coach``) — public; an existing coach is bounced
+  to the roster, an anonymous visitor sees the allauth signup CTA, a logged-in
+  non-coach sees the ``start coaching`` form;
+- the **start action** (``start_coaching``) — creates the ``CoachProfile``
+  (idempotent), is POST-only + login-required, optionally starts the local trial
+  with ``plan=trial`` (single-use-safe), and does *not* eagerly create a
+  subscription row on the free path;
+- the **entry point** — the athlete home surfaces a link into the funnel.
+"""
+
+import pytest
+from django.urls import reverse
+
+from store_project.meso.billing import access
+from store_project.meso.models import CoachAthlete
+from store_project.meso.models import CoachProfile
+from store_project.meso.models import CoachSubscription
+from store_project.users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+# ---------------------------------------------------------------------------
+# The landing page — become_coach (public)
+# ---------------------------------------------------------------------------
+
+
+class TestBecomeCoachLanding:
+    def test_anonymous_sees_signup_cta(self, client):
+        resp = client.get(reverse("meso:become_coach"))
+        assert resp.status_code == 200
+        # Anonymous visitors are pointed at allauth signup, not the POST action
+        # (a login redirect would come back as a GET the POST view rejects).
+        assert reverse("account_signup").encode() in resp.content
+        assert reverse("meso:start_coaching").encode() not in resp.content, (
+            "the POST action form must not be offered to anonymous visitors"
+        )
+
+    def test_logged_in_non_coach_sees_start_form(self, client):
+        user = UserFactory()  # no CoachProfile / links → a pure visitor
+        client.force_login(user)
+        resp = client.get(reverse("meso:become_coach"))
+        assert resp.status_code == 200
+        assert reverse("meso:start_coaching").encode() in resp.content
+
+    def test_existing_coach_redirected_to_roster(self, client):
+        coach = UserFactory()
+        CoachProfile.objects.create(user=coach)
+        client.force_login(coach)
+        resp = client.get(reverse("meso:become_coach"))
+        assert resp.status_code == 302
+        assert resp.url == reverse("meso:roster")
+
+
+# ---------------------------------------------------------------------------
+# The start action — start_coaching
+# ---------------------------------------------------------------------------
+
+
+class TestStartCoaching:
+    def test_creates_coach_profile_and_redirects(self, client):
+        user = UserFactory()
+        assert not CoachProfile.objects.filter(user=user).exists()
+        client.force_login(user)
+        resp = client.post(reverse("meso:start_coaching"))
+        assert resp.status_code == 302
+        assert resp.url == reverse("meso:roster")
+        assert CoachProfile.objects.filter(user=user).exists()
+
+    def test_new_coach_can_now_load_the_roster(self, client):
+        """The funnel's payoff: a brand-new coach reaches the coach surface."""
+        user = UserFactory()
+        client.force_login(user)
+        client.post(reverse("meso:start_coaching"))
+        resp = client.get(reverse("meso:roster"))
+        assert resp.status_code == 200  # no longer bounced to athlete_home
+
+    def test_idempotent_for_existing_coach(self, client):
+        coach = UserFactory()
+        CoachProfile.objects.create(user=coach)
+        client.force_login(coach)
+        resp = client.post(reverse("meso:start_coaching"))
+        assert resp.status_code == 302
+        assert CoachProfile.objects.filter(user=coach).count() == 1
+
+    def test_free_path_creates_no_subscription_row(self, client):
+        """The free tier is "no row" — signup must not eagerly create one."""
+        user = UserFactory()
+        client.force_login(user)
+        client.post(reverse("meso:start_coaching"))
+        assert not CoachSubscription.objects.filter(coach=user).exists()
+
+    def test_plan_trial_starts_trial(self, client):
+        user = UserFactory()
+        client.force_login(user)
+        resp = client.post(reverse("meso:start_coaching"), data={"plan": "trial"})
+        assert resp.status_code == 302
+        assert CoachProfile.objects.filter(user=user).exists()
+        sub = CoachSubscription.objects.get(coach=user)
+        assert sub.status == CoachSubscription.Status.TRIALING
+        assert access.is_active(user) is True
+
+    def test_plan_trial_already_trialed_is_safe(self, client):
+        """A user who already trialed (e.g. was a coach before) gets no error."""
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        coach = UserFactory()
+        CoachProfile.objects.create(user=coach)
+        CoachSubscription.objects.create(
+            coach=coach,
+            status=CoachSubscription.Status.FREE,
+            trial_end=timezone.now() - timedelta(days=1),  # already used
+        )
+        client.force_login(coach)
+        resp = client.post(reverse("meso:start_coaching"), data={"plan": "trial"})
+        assert resp.status_code == 302
+        sub = CoachSubscription.objects.get(coach=coach)
+        assert sub.status == CoachSubscription.Status.FREE  # unchanged, no crash
+
+    def test_anonymous_redirected_to_login(self, client):
+        resp = client.post(reverse("meso:start_coaching"))
+        assert resp.status_code == 302
+        assert reverse("account_login") in resp.url
+        assert not CoachProfile.objects.exists()
+
+    def test_get_is_rejected(self, client):
+        user = UserFactory()
+        client.force_login(user)
+        resp = client.get(reverse("meso:start_coaching"))
+        assert resp.status_code == 405
+
+
+# ---------------------------------------------------------------------------
+# The entry point — the athlete home links into the funnel
+# ---------------------------------------------------------------------------
+
+
+class TestEntryPoint:
+    def test_athlete_home_links_to_become_coach(self, client):
+        user = UserFactory()  # a non-coach lands on the athlete home
+        client.force_login(user)
+        resp = client.get(reverse("meso:athlete_home"))
+        assert resp.status_code == 200
+        assert reverse("meso:become_coach").encode() in resp.content
+
+    def test_athlete_who_is_already_coach_still_fine(self, client):
+        """Sanity: a user coaching others can still view their own training home."""
+        athlete_coach = UserFactory()
+        pupil = UserFactory()
+        CoachAthlete.objects.create(
+            coach=athlete_coach,
+            athlete=pupil,
+            status=CoachAthlete.Status.ACTIVE,
+        )
+        client.force_login(athlete_coach)
+        resp = client.get(reverse("meso:athlete_home"))
+        assert resp.status_code == 200

--- a/app/store_project/meso/urls.py
+++ b/app/store_project/meso/urls.py
@@ -4,6 +4,7 @@ from . import views
 from .views import AthleteHomeView
 from .views import AthleteProfileView
 from .views import AthleteSessionView
+from .views import BecomeCoachView
 from .views import ChangeReviewView
 from .views import DeliverView
 from .views import GroupDetailView
@@ -158,6 +159,10 @@ urlpatterns = [
         views.batch_dismiss,
         name="api_batch_dismiss",
     ),
+    # Self-serve coach signup (S6 Phase 4): the public become-a-coach funnel —
+    # a landing page + the action that creates the CoachProfile.
+    path("coach/", BecomeCoachView.as_view(), name="become_coach"),
+    path("coach/start/", views.start_coaching, name="start_coaching"),
     # Billing (S6): subscribe via Stripe Checkout, manage via the hosted Portal,
     # and the clean subscription webhook (separate from the products webhook).
     path("billing/subscribe/", views.billing_subscribe, name="billing_subscribe"),

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -2075,6 +2075,82 @@ def billing_start_trial(request):
     return redirect("meso:roster")
 
 
+# -- self-serve coach signup (S6 Phase 4, D11) ----------------------------
+#
+# The public funnel that turns a visitor into a coach. Until now a
+# ``CoachProfile`` was created only by admin or the demo seed (B1 made Meso a
+# multi-coach SaaS, but there was no front door). The landing page pitches the
+# plan tiers; ``start_coaching`` creates the ``CoachProfile``. Plan choice after
+# signup is the existing Phase 3 roster billing card — this slice only needs to
+# create the coach. See ``docs/meso/billing-plan.md``.
+
+
+class BecomeCoachView(TemplateView):
+    """Public "become a coach" landing — the front door to self-serve signup.
+
+    Pitches Meso coaching and the plan tiers (free / no-card trial / per-seat
+    paid), then routes the visitor:
+
+    - an **existing coach** has no use for the pitch → straight to the roster;
+    - an **anonymous** visitor is sent through allauth signup/login first (the
+      template offers those CTAs with ``?next=`` back here) — the POST action is
+      login-required and a login redirect would return as a GET it rejects;
+    - a **logged-in non-coach** sees the "start coaching" form.
+    """
+
+    template_name = "meso/become_coach.html"
+
+    def get(self, request, *args, **kwargs):
+        if request.user.is_authenticated and _is_coach(request.user):
+            return redirect("meso:roster")
+        return super().get(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx["free_seats"] = CoachSubscription.FREE_SEAT_LIMIT
+        ctx["trial_days"] = CoachSubscription.TRIAL_DAYS
+        # allauth returns here after signup/login (?next=), where the visitor —
+        # now authenticated — sees the start-coaching form.
+        ctx["next_url"] = reverse("meso:become_coach")
+        return ctx
+
+
+@login_required
+@require_POST
+def start_coaching(request):
+    """Create the coach's ``CoachProfile`` and land them on the roster (Phase 4).
+
+    The funnel's payoff: turns a logged-in visitor into a coach. Idempotent — a
+    user who already has a profile just goes to the roster (a re-POST / double
+    submit is harmless). With ``plan=trial`` it also starts the no-card local
+    trial in the same step (single-use; an already-trialed coach is silently left
+    as-is, never a 500). The free path creates **no** subscription row — free is
+    "no row" — and subscribing is the roster's Subscribe CTA (Phase 3).
+    """
+    CoachProfile.objects.get_or_create(user=request.user)
+    started_trial = False
+    if request.POST.get("plan") == "trial":
+        try:
+            CoachSubscription.start_trial_for(request.user)
+        except InvalidTransition:
+            # Already trialed (e.g. a returning coach) — keep their current state.
+            pass
+        else:
+            started_trial = True
+    if started_trial:
+        messages.success(
+            request,
+            f"Welcome! Your {CoachSubscription.TRIAL_DAYS}-day free trial has "
+            "started — the full Meso toolkit is unlocked.",
+        )
+    else:
+        messages.success(
+            request,
+            "Welcome to Meso coaching! Invite your first athlete to get started.",
+        )
+    return redirect("meso:roster")
+
+
 @csrf_exempt
 @require_POST
 def billing_webhook(request):

--- a/app/store_project/templates/meso/athlete_home.html
+++ b/app/store_project/templates/meso/athlete_home.html
@@ -120,5 +120,16 @@
         <p class="meso-row-meta">No active programs yet. Once a coach delivers a week, it shows up here.</p>
       </div>
     {% endfor %}
+
+    <!-- Self-serve coach signup (S6 Phase 4): the way into the coach surface. -->
+    <a class="meso-card meso-card--pad" href="{% url 'meso:become_coach' %}"
+       style="display:flex;align-items:center;gap:12px;margin-top:14px;text-decoration:none;color:inherit;border:1px solid var(--line);">
+      <span style="font-size:18px;">🏋️</span>
+      <span style="flex:1;min-width:0;">
+        <span style="display:block;font-size:14px;font-weight:700;letter-spacing:-0.01em;">Are you a coach?</span>
+        <span class="meso-row-meta">Design programs and coach your own athletes with Meso.</span>
+      </span>
+      <span class="meso-badge">Start &rarr;</span>
+    </a>
   </div>
 {% endblock %}

--- a/app/store_project/templates/meso/become_coach.html
+++ b/app/store_project/templates/meso/become_coach.html
@@ -1,0 +1,59 @@
+{% extends "meso/_meso_base.html" %}
+
+{% block title %}Become a coach · Meso{% endblock %}
+
+{# Public marketing page — keep the coach nav (Roster/Designer) out of it. #}
+{% block navlinks %}{% endblock %}
+
+{% block content %}
+  <div class="meso-page">
+    <div class="meso-pagehead">
+      <div>
+        <p class="meso-eyebrow">Meso for coaches</p>
+        <h1 class="meso-h1">Coach smarter with Meso</h1>
+        <p class="meso-sub">Design periodized programs, deliver them straight to your athletes' phones, and let the AI agent draft adjustments you approve. Start free — no card required.</p>
+      </div>
+    </div>
+
+    <!-- Plan tiers -->
+    <div class="meso-flex" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:14px;margin-bottom:18px;">
+      <div class="meso-card meso-card--pad">
+        <span class="meso-badge meso-badge--muted"><i></i>Free</span>
+        <p style="font-size:15px;font-weight:800;letter-spacing:-0.01em;margin:10px 0 4px;">Get started</p>
+        <p class="meso-row-meta">Coach up to {{ free_seats }} athlete{{ free_seats|pluralize }}. Groups and delivery included. No AI agent.</p>
+      </div>
+      <div class="meso-card meso-card--pad">
+        <span class="meso-badge meso-badge--ok"><i></i>Free trial</span>
+        <p style="font-size:15px;font-weight:800;letter-spacing:-0.01em;margin:10px 0 4px;">{{ trial_days }} days, full access</p>
+        <p class="meso-row-meta">The whole toolkit — unlimited athletes and the AI program agent — free for {{ trial_days }} days. No card.</p>
+      </div>
+      <div class="meso-card meso-card--pad">
+        <span class="meso-badge"><i></i>Paid</span>
+        <p style="font-size:15px;font-weight:800;letter-spacing:-0.01em;margin:10px 0 4px;">Per active athlete</p>
+        <p class="meso-row-meta">Pay only for the athletes you actively coach, monthly. Unlimited athletes plus the AI agent.</p>
+      </div>
+    </div>
+
+    <!-- Call to action -->
+    <div class="meso-card meso-card--pad">
+      {% if user.is_authenticated %}
+        <p class="meso-eyebrow">Ready when you are</p>
+        <p style="font-size:16px;font-weight:800;letter-spacing:-0.02em;margin:6px 0 14px;">Start coaching with Meso</p>
+        <form method="post" action="{% url 'meso:start_coaching' %}" style="display:flex;gap:10px;flex-wrap:wrap;margin:0;">
+          {% csrf_token %}
+          <button type="submit" name="plan" value="free" class="meso-btn meso-btn--primary">Start coaching free</button>
+          <button type="submit" name="plan" value="trial" class="meso-btn meso-btn--ghost">Start {{ trial_days }}-day free trial</button>
+        </form>
+        <p class="meso-row-meta" style="margin-top:12px;">You can subscribe for unlimited athletes and the AI agent anytime from your dashboard.</p>
+      {% else %}
+        <p class="meso-eyebrow">First, your account</p>
+        <p style="font-size:16px;font-weight:800;letter-spacing:-0.02em;margin:6px 0 14px;">Create an account to start coaching</p>
+        <div style="display:flex;gap:10px;flex-wrap:wrap;">
+          <a class="meso-btn meso-btn--primary" href="{% url 'account_signup' %}?next={{ next_url|urlencode }}">Create your account</a>
+          <a class="meso-btn meso-btn--ghost" href="{% url 'account_login' %}?next={{ next_url|urlencode }}">Log in</a>
+        </div>
+        <p class="meso-row-meta" style="margin-top:12px;">It's free to begin — you'll choose your plan once you're in.</p>
+      {% endif %}
+    </div>
+  </div>
+{% endblock %}

--- a/docs/meso/billing-plan.md
+++ b/docs/meso/billing-plan.md
@@ -142,8 +142,13 @@ rule to avoid the app arbitrarily choosing which athletes to freeze.)
 > slice) — the gates have teeth: `can_add_athlete` at the invite/request choke
 > points, `can_use_agent` at the agent endpoint (402), `can_edit` (the D6
 > over-limit freeze) at the edit/deliver endpoints, the local trial-start
-> endpoint, and the paywall UI (roster billing card + designer agent CTA). Next:
-> Phase 4 (self-serve coach signup).
+> endpoint, and the paywall UI (roster billing card + designer agent CTA).
+> Phase 4 ✅ (this slice, no migration) — the self-serve signup funnel: a public
+> `become_coach` landing page (plan tiers + adaptive CTAs) and a `start_coaching`
+> action that creates the `CoachProfile` (idempotent; `plan=trial` also starts
+> the no-card trial), plus an entry-point link from the athlete home. A
+> `CoachProfile` is no longer admin/seed-only. Next: Phase 5 (annual prices,
+> per-athlete suspension, free-tier agent allowance).
 
 ### Deploying Phase 2 (Stripe configuration)
 
@@ -178,9 +183,16 @@ deploy succeeds without them (like the VAPID push keys):
    endpoints, the local trial-start endpoint (`billing/trial/`), and the roster
    billing card (tier + seat usage + start-trial / subscribe / manage-billing
    CTAs). Billing now has teeth. Fully tested in `test_billing_enforcement.py`.
-4. **Phase 4 — self-serve coach signup.** The public become-a-coach → choose
-   plan → subscribe → `CoachProfile` created funnel (today coach creation is
-   admin/seed-only).
+4. **Phase 4 — self-serve coach signup (DONE).** The public become-a-coach
+   funnel: a `become_coach` landing page (GET `/meso/coach/`, public — pitches
+   the free / trial / paid tiers; an existing coach is bounced to the roster, an
+   anonymous visitor gets allauth signup/login CTAs with `?next=` back, a
+   logged-in non-coach gets the start form) and `start_coaching` (POST
+   `/meso/coach/start/`, login-required) which `get_or_create`s the
+   `CoachProfile` (idempotent) and — with `plan=trial` — starts the no-card local
+   trial in the same step, then lands on the roster where the Phase 3 billing
+   card owns plan choice (free / trial / subscribe). An entry-point link sits on
+   the athlete home. No new model/migration. Tested in `test_coach_signup.py`.
 5. **Phase 5 — later.** Annual prices; per-athlete suspension granularity on
    downgrade; a small free-tier agent *allowance* / metering (Phase 3 ships the
    binary free=no-agent gate; an allowance is the refinement).


### PR DESCRIPTION
## What

S6 billing **Phase 4 — self-serve coach signup**. Until now a `CoachProfile`
(= being a coach; B1 made Meso a multi-coach SaaS) could only be created by
admin or the demo seed — there was no front door. This ships the public funnel.

- **`BecomeCoachView`** (`GET /meso/coach/`, public): a landing page pitching the
  three tiers (free / 14-day no-card trial / per-seat paid). Adaptive routing:
  - an **existing coach** → bounced straight to the roster (no pitch needed);
  - an **anonymous** visitor → allauth signup/login CTAs with `?next=` back here
    (the POST action is login-required, and a login redirect returns as a GET it
    would reject — so we send anon visitors through auth first);
  - a **logged-in non-coach** → the "start coaching" form.
- **`start_coaching`** (`POST /meso/coach/start/`, login-required): `get_or_create`s
  the `CoachProfile` (idempotent — a double submit is harmless) and, with
  `plan=trial`, starts the no-card local trial in the same step (single-use-safe;
  an already-trialed coach is left as-is, never a 500). The free path creates
  **no** subscription row. Plan choice after signup is the existing Phase 3
  roster billing card (free / start trial / subscribe).
- An **entry-point link** from the athlete home into the funnel.

## Notes

- **No new model or migration** — reuses the existing `CoachProfile` and the
  Phase 1–3 `CoachSubscription` / `billing/access.py` machinery.
- No new Stripe surface: subscribing stays on the roster's Phase 3 Subscribe CTA.

## Test

Red-green TDD in `app/store_project/meso/tests/test_coach_signup.py` (13 tests):
landing-page routing for all three visitor states, profile creation +
idempotency, the `plan=trial` chaining (and its single-use safety), POST-only /
login-required enforcement, the free-path "no subscription row" invariant, and
the athlete-home entry point. Full meso suite (933) green; ruff clean.

Reviewed locally with `codex review` — CLEAN, no findings.

Plan: `docs/meso/billing-plan.md` (Phase 4 marked done).

https://claude.ai/code/session_015G62Gs7papVMJAfYqeExrN