### PR TITLE
Meso — S6 billing Phase 5: free-tier agent allowance

### DIFF
--- a/app/store_project/meso/billing/access.py
+++ b/app/store_project/meso/billing/access.py
@@ -2,22 +2,30 @@
 
 A thin read over ``CoachSubscription`` so a request gates **without calling
 Stripe** (D8) — Stripe is the source of truth, this is the fast local mirror.
-Two gates share one predicate (``is_active``): the **seat cap** (∞ active
-athletes when active, else ``FREE_SEAT_LIMIT``) and the **AI agent** (paid-only
-— the Claude agent has real per-call cost). A billable seat is an *active*
-``CoachAthlete`` link (pending invites/requests don't count).
+The **seat cap** (∞ active athletes when active, else ``FREE_SEAT_LIMIT``) keys
+off one predicate (``is_active``). The **AI agent** gate is the metered refinement
+(S6 Phase 5): an active/comped coach is unlimited, while a free coach gets
+``FREE_AGENT_ALLOWANCE`` runs per calendar month (the Claude agent has real
+per-call cost, so the free tier is a taste, not a binary no). A billable seat is
+an *active* ``CoachAthlete`` link (pending invites/requests don't count); an agent
+run is an ``AgentProposalBatch`` (the batch table is the ledger — no separate
+counter).
 
 A coach with **no subscription row** gates exactly as ``free`` — existing
 coaches predate billing, and a missing row should never crash or over-grant.
 
-Phase 3 wires these gates into the choke points: ``can_add_athlete`` at the
+Phase 3 wired these gates into the choke points: ``can_add_athlete`` at the
 invite/request endpoints (block a free coach past the cap), ``can_use_agent`` at
 the agent endpoint (402 for the free tier), and ``can_edit`` at the edit/deliver
-endpoints (the D6 over-limit freeze). See ``docs/meso/billing-plan.md``.
+endpoints (the D6 over-limit freeze). Phase 5 meters ``can_use_agent`` (free-tier
+allowance). See ``docs/meso/billing-plan.md``.
 """
 
 import math
 
+from django.utils import timezone
+
+from store_project.meso.models import AgentProposalBatch
 from store_project.meso.models import CoachAthlete
 from store_project.meso.models import CoachSubscription
 
@@ -42,9 +50,51 @@ def is_active(coach):
     return bool(sub and sub.is_active)
 
 
+def _current_period_start():
+    """Midnight on the first of the current month — the free agent meter resets here.
+
+    A calendar-month window (cheap to compute, obvious to a coach reading "this
+    month") rather than a rolling 30-day window, which would need a per-coach
+    anchor. ``timezone.now()`` is tz-aware, so the truncated value is too.
+    """
+    return timezone.now().replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+
+def agent_runs_this_month(coach):
+    """Agent runs this coach has started in the current calendar month.
+
+    A run is an ``AgentProposalBatch`` — the endpoint creates exactly one per
+    dispatched run (after the gate and the API-key check), so the batch table *is*
+    the ledger; there's no separate counter to drift. Group runs are rejected
+    before a batch exists, so they never count against the allowance.
+    """
+    return AgentProposalBatch.objects.filter(
+        coach=coach, created_at__gte=_current_period_start()
+    ).count()
+
+
+def free_agent_runs_remaining(coach):
+    """Agent runs left this month — ``math.inf`` when unlimited, else the remainder.
+
+    An active/trial/comped coach is unlimited (``math.inf``); a free coach gets
+    ``FREE_AGENT_ALLOWANCE`` minus what they've used this month, floored at 0. The
+    active short-circuit means a paying coach never runs the count query.
+    """
+    if is_active(coach):
+        return math.inf
+    used = agent_runs_this_month(coach)
+    return max(0, CoachSubscription.FREE_AGENT_ALLOWANCE - used)
+
+
 def can_use_agent(coach):
-    """Agent gate — only an active coach may run the paid AI program agent (D4)."""
-    return is_active(coach)
+    """Agent gate — may this coach run the AI program agent right now (D4)?
+
+    An active/trial/comped coach always; a free coach while they still have runs
+    left in their monthly allowance (S6 Phase 5 — the metered refinement of the old
+    binary free=no-agent gate). Defended at the endpoint, not just the UI, because
+    the per-call API cost is real.
+    """
+    return free_agent_runs_remaining(coach) > 0
 
 
 def active_seat_count(coach):

--- a/app/store_project/meso/models.py
+++ b/app/store_project/meso/models.py
@@ -722,6 +722,14 @@ class CoachSubscription(models.Model):
     #: invite TTL cadence).
     TRIAL_DAYS = 14
 
+    #: Free-tier AI-agent allowance — agent runs a non-paying coach may make per
+    #: calendar month (open value, set to 5). The Phase-5 metered refinement of the
+    #: old binary free=no-agent gate (D4): a free coach gets a taste of the Claude
+    #: agent before paying; beyond this the agent endpoint 402s. Active/trial/comped
+    #: coaches are unlimited. A run = an ``AgentProposalBatch`` (the batch table is
+    #: the ledger — see ``billing/access.py``).
+    FREE_AGENT_ALLOWANCE = 5
+
     class Status(models.TextChoices):
         FREE = "free", _("Free")
         TRIALING = "trialing", _("Trialing")

--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -159,6 +159,35 @@ def pending_request(link):
     }
 
 
+def agent_allowance(coach):
+    """The free-tier AI-agent meter for the designer + roster card (S6 Phase 5).
+
+    A free coach gets ``FREE_AGENT_ALLOWANCE`` agent runs per month (the metered
+    refinement of the old binary gate); ``metered`` is True only then, so the UI
+    shows "N of M free agent runs left" for a free coach and nothing for an
+    unlimited (trial/active/comped) coach. ``can_use`` mirrors
+    ``access.can_use_agent`` so a template can drive the composer/CTA off this one
+    read without a second query.
+    """
+    if billing_access.is_active(coach):
+        return {
+            "metered": False,
+            "allowance": 0,
+            "used": 0,
+            "remaining": None,
+            "can_use": True,
+        }
+    allowance = CoachSubscription.FREE_AGENT_ALLOWANCE
+    remaining = billing_access.free_agent_runs_remaining(coach)
+    return {
+        "metered": True,
+        "allowance": allowance,
+        "used": allowance - remaining,
+        "remaining": remaining,
+        "can_use": remaining > 0,
+    }
+
+
 def billing_state(coach):
     """The coach's billing/paywall state for the roster (S6 Phase 3).
 
@@ -190,6 +219,7 @@ def billing_state(coach):
         "seat_limit": None if seat_limit == math.inf else int(seat_limit),
         "can_add_athlete": billing_access.can_add_athlete(coach),
         "can_use_agent": billing_access.can_use_agent(coach),
+        "agent": agent_allowance(coach),
         "over_limit": billing_access.is_over_limit(coach),
         "can_start_trial": can_start_trial,
         "has_stripe_subscription": bool(sub and sub.stripe_subscription_id),

--- a/app/store_project/meso/tests/test_billing.py
+++ b/app/store_project/meso/tests/test_billing.py
@@ -20,6 +20,9 @@ These tests cover:
   with **no subscription row** gates exactly as free (existing coaches predate
   billing), a seat is an *active* ``CoachAthlete`` link, the free cap blocks the
   next athlete, and an active/trial/comped coach is unlimited;
+- the **free-tier agent allowance** (S6 Phase 5 — added later): a free coach gets
+  ``FREE_AGENT_ALLOWANCE`` agent runs / calendar month (counted from the
+  ``AgentProposalBatch`` ledger), an active coach is unlimited;
 - the seed: the demo coach is ``comped`` so the owner is never paywalled (D12).
 """
 
@@ -31,8 +34,11 @@ from django.core.management import call_command
 from django.utils import timezone
 
 from store_project.meso.billing import access
+from store_project.meso.factories import AgentProposalBatchFactory
 from store_project.meso.factories import CoachAthleteFactory
 from store_project.meso.factories import CoachSubscriptionFactory
+from store_project.meso.factories import PlanFactory
+from store_project.meso.models import AgentProposalBatch
 from store_project.meso.models import CoachAthlete
 from store_project.meso.models import CoachSubscription
 from store_project.meso.models import InvalidTransition
@@ -214,11 +220,88 @@ class TestBillingAccessIsActive:
         )
         assert access.is_active(sub.coach) is False
 
-    def test_can_use_agent_tracks_is_active(self):
-        free = CoachSubscriptionFactory(status=CoachSubscription.Status.FREE)
+    def test_can_use_agent_active_coach_is_unlimited(self):
+        # The agent gate no longer keys purely off ``is_active``: an active/comped
+        # coach is unlimited (no meter), but a fresh free coach has a monthly
+        # allowance (see ``TestAgentAllowance``), so a free row with no runs yet
+        # still passes the gate.
         comped = CoachSubscriptionFactory(status=CoachSubscription.Status.COMPED)
-        assert access.can_use_agent(free.coach) is False
+        fresh_free = CoachSubscriptionFactory(status=CoachSubscription.Status.FREE)
         assert access.can_use_agent(comped.coach) is True
+        assert access.can_use_agent(fresh_free.coach) is True
+
+
+class TestAgentAllowance:
+    """The free-tier agent allowance (S6 Phase 5).
+
+    The metered refinement of the old binary free=no-agent gate (D4): a free coach
+    gets ``FREE_AGENT_ALLOWANCE`` agent runs per calendar month; an active/comped
+    coach is unlimited. A run is an ``AgentProposalBatch`` (the batch table is the
+    ledger — no separate counter), so the count is "batches this coach started this
+    month."
+    """
+
+    def _backdate(self, batch, when):
+        # ``created_at`` is ``auto_now_add``; ``update`` bypasses it to plant a row
+        # in a chosen month for the boundary tests.
+        AgentProposalBatch.objects.filter(pk=batch.pk).update(created_at=when)
+
+    def test_fresh_free_coach_has_full_allowance(self):
+        coach = UserFactory()  # no row → free
+        assert access.agent_runs_this_month(coach) == 0
+        assert (
+            access.free_agent_runs_remaining(coach)
+            == CoachSubscription.FREE_AGENT_ALLOWANCE
+        )
+        assert access.can_use_agent(coach) is True
+
+    def test_runs_this_month_count_against_the_allowance(self):
+        coach = UserFactory()
+        AgentProposalBatchFactory(coach=coach, plan=PlanFactory())
+        AgentProposalBatchFactory(coach=coach, plan=PlanFactory())
+        assert access.agent_runs_this_month(coach) == 2
+        assert (
+            access.free_agent_runs_remaining(coach)
+            == CoachSubscription.FREE_AGENT_ALLOWANCE - 2
+        )
+
+    def test_can_use_agent_false_once_allowance_is_exhausted(self):
+        coach = UserFactory()
+        for _ in range(CoachSubscription.FREE_AGENT_ALLOWANCE):
+            AgentProposalBatchFactory(coach=coach, plan=PlanFactory())
+        assert access.free_agent_runs_remaining(coach) == 0
+        assert access.can_use_agent(coach) is False
+
+    def test_remaining_never_goes_negative(self):
+        coach = UserFactory()
+        for _ in range(CoachSubscription.FREE_AGENT_ALLOWANCE + 3):
+            AgentProposalBatchFactory(coach=coach, plan=PlanFactory())
+        assert access.free_agent_runs_remaining(coach) == 0
+
+    def test_last_months_runs_do_not_count(self):
+        coach = UserFactory()
+        old = AgentProposalBatchFactory(coach=coach, plan=PlanFactory())
+        last_month = timezone.now().replace(day=1) - timedelta(days=1)
+        self._backdate(old, last_month)
+        assert access.agent_runs_this_month(coach) == 0
+        assert (
+            access.free_agent_runs_remaining(coach)
+            == CoachSubscription.FREE_AGENT_ALLOWANCE
+        )
+
+    def test_another_coachs_runs_do_not_count(self):
+        coach = UserFactory()
+        other = UserFactory()
+        AgentProposalBatchFactory(coach=other, plan=PlanFactory())
+        assert access.agent_runs_this_month(coach) == 0
+
+    def test_active_coach_is_unlimited_regardless_of_usage(self):
+        sub = CoachSubscriptionFactory(status=CoachSubscription.Status.COMPED)
+        # Even with runs on the books, an active coach has no meter.
+        for _ in range(CoachSubscription.FREE_AGENT_ALLOWANCE + 1):
+            AgentProposalBatchFactory(coach=sub.coach, plan=PlanFactory())
+        assert access.free_agent_runs_remaining(sub.coach) == math.inf
+        assert access.can_use_agent(sub.coach) is True
 
 
 class TestBillingAccessSeats:

--- a/app/store_project/meso/tests/test_billing_enforcement.py
+++ b/app/store_project/meso/tests/test_billing_enforcement.py
@@ -14,8 +14,9 @@ These tests cover:
   is created — opening a coach email invite, accepting an athlete's request, and
   claiming an email invite — each blocked for a free coach at the cap, allowed
   for a coach with room;
-- the **agent gate** (``can_use_agent``) at ``agent_propose`` — a free coach gets
-  a 402 (no drafting batch), a paid/comped coach passes;
+- the **agent gate** (``can_use_agent``) at ``agent_propose`` — a free coach
+  passes while within their monthly allowance and gets a 402 (no drafting batch)
+  once it's exhausted (S6 Phase 5 metering); a paid/comped coach is unlimited;
 - the **D6 edit/deliver block** (``can_edit``) at the autosave / deliver / group
   endpoints — an over-limit coach gets a 402 (API) or a flashed redirect (group
   forms) and nothing is mutated; a within-cap free coach is unaffected;
@@ -210,9 +211,25 @@ def _agent_url(plan):
 
 
 class TestAgentGate:
-    def test_free_coach_gets_402(self, client):
+    def test_free_coach_within_allowance_passes(self, client):
+        # Phase 5: a fresh free coach gets a monthly agent allowance, so the gate
+        # no longer 402s on the first run — it falls through to the no-API-key 503
+        # (the point is the paywall let it through).
+        coach = UserFactory()
+        plan, _, _ = _plan_with_prescription(coach)  # no sub → free, 0 runs
+        client.force_login(coach)
+        resp = client.post(
+            _agent_url(plan),
+            data=json.dumps({"instruction": "Make it knee-safe."}),
+            content_type="application/json",
+        )
+        assert resp.status_code != 402
+
+    def test_free_coach_gets_402_once_allowance_exhausted(self, client):
         coach = UserFactory()
         plan, _, _ = _plan_with_prescription(coach)  # no sub → free
+        for _ in range(CoachSubscription.FREE_AGENT_ALLOWANCE):
+            AgentProposalBatchFactory(plan=plan, coach=coach)
         client.force_login(coach)
         resp = client.post(
             _agent_url(plan),
@@ -405,9 +422,28 @@ class TestRosterBillingCard:
 
 
 class TestDesignerAgentCta:
-    def test_free_coach_sees_upgrade_cta(self, client):
+    def test_free_coach_within_allowance_sees_composer_and_meter(self, client):
+        # Phase 5: a free coach with allowance left sees the live composer plus a
+        # "runs left" meter — not the upgrade CTA.
+        coach = UserFactory()
+        plan, _, _ = _plan_with_prescription(coach)  # 0 runs
+        client.force_login(coach)
+        resp = client.get(reverse("meso:designer_plan", kwargs={"plan_id": plan.pk}))
+        assert resp.status_code == 200
+        assert resp.context["can_use_agent"] is True
+        assert resp.context["agent_allowance"]["metered"] is True
+        assert (
+            resp.context["agent_allowance"]["remaining"]
+            == CoachSubscription.FREE_AGENT_ALLOWANCE
+        )
+        assert b"Upgrade to use the agent" not in resp.content
+        assert b"free agent run" in resp.content
+
+    def test_free_coach_sees_upgrade_cta_once_allowance_exhausted(self, client):
         coach = UserFactory()
         plan, _, _ = _plan_with_prescription(coach)
+        for _ in range(CoachSubscription.FREE_AGENT_ALLOWANCE):
+            AgentProposalBatchFactory(plan=plan, coach=coach)
         client.force_login(coach)
         resp = client.get(reverse("meso:designer_plan", kwargs={"plan_id": plan.pk}))
         assert resp.status_code == 200

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -1801,59 +1801,70 @@ def agent_propose(request, plan_id):
     plan, forbidden = _coach_plan_or_forbidden(request, plan_id)
     if forbidden is not None:
         return forbidden
-    # Agent gate (D4; Phase 5 metering): the Claude agent has real per-call cost.
-    # An active/trial/comped coach is unlimited; a free coach gets
-    # ``FREE_AGENT_ALLOWANCE`` runs/month and then 402s (the designer shows the
-    # upgrade CTA in place of the composer once exhausted). Only a free coach can
-    # reach this branch, so the message is the allowance-used-up copy. Defended
-    # here, not just in the UI, because the API cost is real.
-    #
-    # Lock the coach row before counting so concurrent runs serialize: the request
-    # is in a transaction (ATOMIC_REQUESTS), so the lock is held until this run's
-    # batch row commits — a second concurrent request blocks here and then re-counts
-    # against the allowance. Without it the count-then-create gate is racy and a
-    # free coach could slip past the cap. (On SQLite/tests the lock is a no-op; the
-    # real serialization is on Postgres in prod.)
-    User.objects.select_for_update().filter(pk=request.user.pk).first()
-    if not billing_access.can_use_agent(request.user):
-        return JsonResponse(
-            {
-                "ok": False,
-                "error": (
-                    f"You've used all {CoachSubscription.FREE_AGENT_ALLOWANCE} free "
-                    "agent runs this month. Start your free trial or subscribe for "
-                    "unlimited agent runs."
-                ),
-                "upgrade": True,
-            },
-            status=402,
-        )
-    if plan.is_group:
-        # The agent grounds on a single athlete's profile + logs; a group agent
-        # (per-athlete auto-adjusts) is groups Phase 3. Reject before any work so
-        # it never dereferences ``plan.athlete``.
-        return HttpResponseBadRequest("The agent isn't available for groups yet.")
-    try:
-        payload = json.loads(request.body or "{}")
-    except json.JSONDecodeError:
-        return HttpResponseBadRequest("Malformed JSON.")
-    if not isinstance(payload, dict):
-        return HttpResponseBadRequest("Expected a JSON object.")
-    instruction = payload.get("instruction")
-    if not isinstance(instruction, str) or not instruction.strip():
-        return HttpResponseBadRequest("An instruction is required.")
-    instruction = instruction.strip()
-    if len(instruction) > MAX_INSTRUCTION_LENGTH:
-        return HttpResponseBadRequest("Instruction is too long.")
+    # Reserve the run atomically (S6 Phase 5 metering): lock the coach row, check
+    # the allowance, and create the batch in one transaction so concurrent
+    # agent_propose calls serialize — the lock is held until the batch row commits,
+    # so a second request blocks and then re-counts against the cap. The
+    # transaction must be *explicit*: the project's module-level ``ATOMIC_REQUESTS``
+    # is inert (Django reads it per-entry from ``DATABASES``, which ``dj_database_url``
+    # doesn't set), so without this ``select_for_update`` would raise in autocommit
+    # on Postgres and the count-then-create gate would be racy. (On SQLite/tests the
+    # lock is a no-op; the real serialization is on Postgres in prod.) Early returns
+    # below just commit an empty transaction — nothing is written on those paths.
+    with transaction.atomic():
+        User.objects.select_for_update().filter(pk=request.user.pk).first()
+        # Agent gate (D4): the Claude agent has real per-call cost. An
+        # active/trial/comped coach is unlimited; a free coach gets
+        # ``FREE_AGENT_ALLOWANCE`` runs/month and then 402s (the designer shows the
+        # upgrade CTA in place of the composer once exhausted). Only a free coach
+        # reaches this branch, so the copy is the allowance-used-up message.
+        # Defended here, not just in the UI, because the API cost is real.
+        if not billing_access.can_use_agent(request.user):
+            return JsonResponse(
+                {
+                    "ok": False,
+                    "error": (
+                        f"You've used all {CoachSubscription.FREE_AGENT_ALLOWANCE} "
+                        "free agent runs this month. Start your free trial or "
+                        "subscribe for unlimited agent runs."
+                    ),
+                    "upgrade": True,
+                },
+                status=402,
+            )
+        if plan.is_group:
+            # The agent grounds on a single athlete's profile + logs; a group agent
+            # (per-athlete auto-adjusts) is groups Phase 3. Reject before any work
+            # so it never dereferences ``plan.athlete``.
+            return HttpResponseBadRequest("The agent isn't available for groups yet.")
+        try:
+            payload = json.loads(request.body or "{}")
+        except json.JSONDecodeError:
+            return HttpResponseBadRequest("Malformed JSON.")
+        if not isinstance(payload, dict):
+            return HttpResponseBadRequest("Expected a JSON object.")
+        instruction = payload.get("instruction")
+        if not isinstance(instruction, str) or not instruction.strip():
+            return HttpResponseBadRequest("An instruction is required.")
+        instruction = instruction.strip()
+        if len(instruction) > MAX_INSTRUCTION_LENGTH:
+            return HttpResponseBadRequest("Instruction is too long.")
 
-    # Guard on the key here so we answer 503 without persisting a dead batch.
-    if agent_client.get_default_client() is None:
-        return JsonResponse(
-            {"ok": False, "error": "The Meso agent is not configured (no API key)."},
-            status=503,
-        )
+        # Guard on the key here so we answer 503 without persisting a dead batch.
+        if agent_client.get_default_client() is None:
+            return JsonResponse(
+                {
+                    "ok": False,
+                    "error": "The Meso agent is not configured (no API key).",
+                },
+                status=503,
+            )
 
-    batch = agent_service.create_drafting_batch(plan, instruction, coach=request.user)
+        batch = agent_service.create_drafting_batch(
+            plan, instruction, coach=request.user
+        )
+    # The batch is committed; enqueue the worker run and bump the plan outside the
+    # lock so neither holds the coach row.
     agent_jobs.dispatch_proposal(batch.pk)
     _touch_plan(plan)
     return JsonResponse(

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -1807,6 +1807,14 @@ def agent_propose(request, plan_id):
     # upgrade CTA in place of the composer once exhausted). Only a free coach can
     # reach this branch, so the message is the allowance-used-up copy. Defended
     # here, not just in the UI, because the API cost is real.
+    #
+    # Lock the coach row before counting so concurrent runs serialize: the request
+    # is in a transaction (ATOMIC_REQUESTS), so the lock is held until this run's
+    # batch row commits — a second concurrent request blocks here and then re-counts
+    # against the allowance. Without it the count-then-create gate is racy and a
+    # free coach could slip past the cap. (On SQLite/tests the lock is a no-op; the
+    # real serialization is on Postgres in prod.)
+    User.objects.select_for_update().filter(pk=request.user.pk).first()
     if not billing_access.can_use_agent(request.user):
         return JsonResponse(
             {

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -231,10 +231,14 @@ class MesoDesignerView(LoginRequiredMixin, TemplateView):
         # batches so the chat survives a reload (the JS hydrates ``messages``
         # from it, falling back to the greeting when empty).
         ctx["chat_thread"] = serialize_chat_thread(plan)
-        # Agent gate (S6 Phase 3, D4): the AI agent is paid-only. When the coach
-        # can't use it, the composer is replaced by an upgrade CTA (the endpoint
-        # also 402s, so the gate is defended server-side, not just hidden).
-        ctx["can_use_agent"] = billing_access.can_use_agent(self.request.user)
+        # Agent gate (S6 Phase 3, D4; Phase 5 metering): an active coach is
+        # unlimited; a free coach gets a monthly allowance. The meter drives the
+        # composer-vs-upgrade-CTA and the "N of M runs left" note; ``can_use_agent``
+        # is derived from it so the page does one read (the endpoint also 402s, so
+        # the gate is defended server-side, not just hidden).
+        agent_meter = presenters.agent_allowance(self.request.user)
+        ctx["agent_allowance"] = agent_meter
+        ctx["can_use_agent"] = agent_meter["can_use"]
         return ctx
 
 
@@ -1797,17 +1801,20 @@ def agent_propose(request, plan_id):
     plan, forbidden = _coach_plan_or_forbidden(request, plan_id)
     if forbidden is not None:
         return forbidden
-    # Agent gate (D4): the Claude agent has real per-call cost, so it's paid-only —
-    # a free-tier coach gets a 402 (the designer shows an upgrade CTA in place of
-    # the composer). Trial/active/comped coaches pass. Defended here, not just in
-    # the UI, because the API cost is real.
+    # Agent gate (D4; Phase 5 metering): the Claude agent has real per-call cost.
+    # An active/trial/comped coach is unlimited; a free coach gets
+    # ``FREE_AGENT_ALLOWANCE`` runs/month and then 402s (the designer shows the
+    # upgrade CTA in place of the composer once exhausted). Only a free coach can
+    # reach this branch, so the message is the allowance-used-up copy. Defended
+    # here, not just in the UI, because the API cost is real.
     if not billing_access.can_use_agent(request.user):
         return JsonResponse(
             {
                 "ok": False,
                 "error": (
-                    "The AI agent is available on a paid plan. Start your free "
-                    "trial or subscribe to use it."
+                    f"You've used all {CoachSubscription.FREE_AGENT_ALLOWANCE} free "
+                    "agent runs this month. Start your free trial or subscribe for "
+                    "unlimited agent runs."
                 ),
                 "upgrade": True,
             },

--- a/app/store_project/templates/meso/designer.html
+++ b/app/store_project/templates/meso/designer.html
@@ -286,13 +286,20 @@
                 <input x-model="inputText" @keydown="onInputKey($event)" placeholder="Ask the agent to adjust the program&#8230;" style="flex:1;appearance:none;border:0;background:transparent;outline:none;font:inherit;font-size:13px;color:var(--ink);padding:5px 0;" />
                 <button data-hover="brighten" @click="onSend()" :disabled="agentTyping" :style="agentTyping ? 'opacity:0.55;cursor:default;' : ''" style="appearance:none;cursor:pointer;border:0;width:32px;height:32px;border-radius:8px;background:var(--accent);color:var(--accent-ink);display:flex;align-items:center;justify-content:center;flex:0 0 auto;font-size:15px;">&#8593;</button>
               </div>
+              {% if agent_allowance.metered %}
+              <!-- Free-tier agent meter (S6 Phase 5): the free plan gets a monthly
+                   allowance; once it's spent the endpoint 402s and this block flips
+                   to the upgrade CTA on the next reload. -->
+                <p style="margin:9px 0 0;font-size:11px;color:var(--dim);line-height:1.4;">{{ agent_allowance.remaining }} of {{ agent_allowance.allowance }} free agent run{{ agent_allowance.allowance|pluralize }} left this month &#183; <a href="{% url 'meso:roster' %}" style="color:var(--accent-ink);text-decoration:underline;">subscribe for unlimited</a></p>
+              {% endif %}
             </div>
           {% else %}
-          <!-- Agent gate (S6 Phase 3): the AI agent is paid-only, so the free tier
-               sees an upgrade CTA where the composer would be. Billing actions live
-               on the roster (the endpoint also 402s, so this isn't the only guard). -->
+          <!-- Agent gate (S6 Phase 3 / Phase 5): a free coach who has spent their
+               monthly agent allowance sees an upgrade CTA where the composer would
+               be. Billing actions live on the roster (the endpoint also 402s, so
+               this isn't the only guard). -->
             <div x-show="isIndividual" style="flex:0 0 auto;border-top:1px solid var(--line-2);padding:13px 14px 15px;">
-              <p style="margin:0 0 9px;font-size:12px;color:var(--dim);line-height:1.4;">The AI program agent is on paid plans. Start your free trial or subscribe to let it draft and adjust programs for you.</p>
+              <p style="margin:0 0 9px;font-size:12px;color:var(--dim);line-height:1.4;">You've used all {{ agent_allowance.allowance }} free agent run{{ agent_allowance.allowance|pluralize }} this month. Start your free trial or subscribe for unlimited agent runs.</p>
               <a href="{% url 'meso:roster' %}" data-hover="brighten" style="display:inline-block;text-decoration:none;font:inherit;font-size:12.5px;font-weight:650;color:var(--accent-ink);background:var(--accent);border-radius:8px;padding:8px 14px;">Upgrade to use the agent</a>
             </div>
           {% endif %}

--- a/app/store_project/templates/meso/roster.html
+++ b/app/store_project/templates/meso/roster.html
@@ -197,7 +197,7 @@
           {% elif billing.is_active %}
             <p class="meso-sub" style="margin:0;">{{ billing.seat_count }} active athlete{{ billing.seat_count|pluralize }} &#183; full access.</p>
           {% else %}
-            <p class="meso-sub" style="margin:0;">Free plan &#8212; {{ billing.seat_count }} of {{ billing.seat_limit }} athlete{{ billing.seat_limit|pluralize }}. The AI agent and more athletes need a paid plan.</p>
+            <p class="meso-sub" style="margin:0;">Free plan &#8212; {{ billing.seat_count }} of {{ billing.seat_limit }} athlete{{ billing.seat_limit|pluralize }} &#183; {{ billing.agent.remaining }} of {{ billing.agent.allowance }} free agent run{{ billing.agent.allowance|pluralize }} left this month. Subscribe for more athletes and unlimited agent runs.</p>
           {% endif %}
           <div style="display:flex;gap:8px;flex-wrap:wrap;">
             {% if billing.can_start_trial %}

--- a/docs/meso/billing-plan.md
+++ b/docs/meso/billing-plan.md
@@ -20,7 +20,7 @@ pricing assumptions into the schema.
 | D1 | **Who pays** | **The coach** (B2B SaaS). Athletes log in as the coach's clients; they never pay the platform. |
 | D2 | **Pricing model** | **Per-active-athlete (seats).** A coach pays per active `CoachAthlete` link, beyond a small free allotment. |
 | D3 | **Free access** | **Free tier + 14-day no-card trial.** A forever-free tier (a few free seats), plus a frictionless trial that needs no card; the free tier is also the lapse/cancel landing spot. |
-| D4 | **What the paywall gates** | **Active-athlete count + the AI agent.** The Claude-powered program agent (B6) has real per-call API cost, so it's paid-only — free tier gets **no** agent; trial/paid/comped get the full agent. Groups (S1) and notifications stay free at every tier. Both gates share one predicate (`is_active`), so the free tier is exactly "capped seats, no agent." |
+| D4 | **What the paywall gates** | **Active-athlete count + the AI agent.** The Claude-powered program agent (B6) has real per-call API cost, so it's paid-only — trial/paid/comped get the full agent. Groups (S1) and notifications stay free at every tier. (v1 gave the free tier **no** agent; **Phase 5 meters it** — a free coach gets a small monthly `FREE_AGENT_ALLOWANCE` of runs, then 402s. The seat gate still shares the `is_active` predicate.) |
 | D5 | **Cadence + currency** | **Monthly, USD** for v1 (annual deferred — annualizing a fluctuating seat count adds proration complexity for little v1 value). |
 | D6 | **Lapse / cancel** | Stripe Smart Retries → on final failure / cancel, **downgrade to free at period end**. Over the free limit ⇒ block *new* athletes + block edits/deliver until back within the limit or re-subscribed; **never delete data** (matches how an ended relationship archives, not deletes). |
 | D11 | **First slice** | **The subscription spine** for existing logged-in coaches. The public self-serve coach-signup funnel is a later phase. |
@@ -147,8 +147,13 @@ rule to avoid the app arbitrarily choosing which athletes to freeze.)
 > `become_coach` landing page (plan tiers + adaptive CTAs) and a `start_coaching`
 > action that creates the `CoachProfile` (idempotent; `plan=trial` also starts
 > the no-card trial), plus an entry-point link from the athlete home. A
-> `CoachProfile` is no longer admin/seed-only. Next: Phase 5 (annual prices,
-> per-athlete suspension, free-tier agent allowance).
+> `CoachProfile` is no longer admin/seed-only. Phase 5 ✅ (this slice, no
+> migration) — the **free-tier agent allowance**, the metered refinement of the
+> binary agent gate: a free coach gets `FREE_AGENT_ALLOWANCE` (5) agent runs per
+> calendar month (counted from the `AgentProposalBatch` ledger — no new model),
+> then the endpoint 402s; the designer shows a "N of M runs left" meter / upgrade
+> CTA and the roster card reflects it. Remaining Phase-5 items: annual prices,
+> per-athlete suspension granularity on downgrade.
 
 ### Deploying Phase 2 (Stripe configuration)
 
@@ -193,9 +198,16 @@ deploy succeeds without them (like the VAPID push keys):
    trial in the same step, then lands on the roster where the Phase 3 billing
    card owns plan choice (free / trial / subscribe). An entry-point link sits on
    the athlete home. No new model/migration. Tested in `test_coach_signup.py`.
-5. **Phase 5 — later.** Annual prices; per-athlete suspension granularity on
-   downgrade; a small free-tier agent *allowance* / metering (Phase 3 ships the
-   binary free=no-agent gate; an allowance is the refinement).
+5. **Phase 5 — partly DONE.** The **free-tier agent allowance** is done (this
+   slice, no migration): `CoachSubscription.FREE_AGENT_ALLOWANCE` (5) +
+   `billing/access.py` (`agent_runs_this_month` / `free_agent_runs_remaining` +
+   the metered `can_use_agent`, counting `AgentProposalBatch` rows in the current
+   calendar month — the batch table is the ledger, no new model) + the
+   `presenters.agent_allowance` meter wired into the designer (composer + "N of M
+   runs left" / upgrade CTA) and the roster card + the allowance-aware 402 copy at
+   `agent_propose`. Tested in `test_billing.py::TestAgentAllowance` and
+   `test_billing_enforcement.py`. **Still later:** annual prices; per-athlete
+   suspension granularity on downgrade.
 
 ## Open values (numbers, not architecture — confirm before/with Phase 1)
 
@@ -203,6 +215,8 @@ deploy succeeds without them (like the VAPID push keys):
 - **Trial length** — rec **14 days** (matches the invite TTL cadence).
 - **Per-seat price** — **needs a number** (e.g. $X / active athlete / month, USD).
 - **Monthly only** for v1 (annual deferred).
+- **Free agent allowance** — set to **5** runs / calendar month (Phase 5; tunable
+  via `CoachSubscription.FREE_AGENT_ALLOWANCE`).
 
 ## Test / dev story
 
@@ -216,7 +230,5 @@ deploy succeeds without them (like the VAPID push keys):
 
 - Annual billing; promo codes / coupons (Stripe supports both when wanted).
 - Per-athlete soft-suspension on downgrade (v1: coarse over-limit rule).
-- A small free-tier agent *allowance* / usage metering (v1 ships a binary gate:
-  free = no agent, paid = full agent).
 - Tax / VAT handling (Stripe Tax) if selling internationally.
 - Email receipts beyond Stripe's own invoice emails.


### PR DESCRIPTION
## What

S6 billing **Phase 5** (first slice): meter the AI program agent for the free
tier instead of the binary free=no-agent gate (D4). A free coach now gets
`FREE_AGENT_ALLOWANCE` (**5**) agent runs per calendar month — a taste of the
Claude agent before paying — and the endpoint 402s once it's spent.
Active/trial/comped coaches stay unlimited.

No new model, **no migration**: a run is an `AgentProposalBatch`, so the batch
table is already the ledger — usage is "batches this coach started this month."

## Changes

- **`CoachSubscription.FREE_AGENT_ALLOWANCE = 5`** (tunable) — the monthly cap.
- **`billing/access.py`**: `agent_runs_this_month` / `free_agent_runs_remaining`
  + the metered `can_use_agent`. Active coaches short-circuit to unlimited
  (`math.inf`) without running the count query.
- **`agent_propose`**: reserves a run **atomically** — `transaction.atomic()`
  + a per-coach `select_for_update` lock around gate→create, so concurrent
  requests serialize and can't slip past the cap. Returns the allowance-used-up
  402 copy when exhausted.
- **`presenters.agent_allowance`** — template-friendly meter (metered /
  allowance / used / remaining / can_use), wired into `billing_state`.
- **UI**: designer shows the composer + "N of M free agent runs left" meter
  while within the allowance, the upgrade CTA once exhausted; the roster billing
  card reflects the remaining runs.
- **Docs**: `docs/meso/billing-plan.md` phasing + open values.

## Tests (red → green)

- `test_billing.py::TestAgentAllowance` — count window, calendar-month boundary,
  exhaustion, remaining-never-negative, per-coach scoping, active-is-unlimited.
- `test_billing_enforcement.py` — agent gate now passes within the allowance and
  402s once exhausted; designer shows composer+meter vs. upgrade CTA.
- Full meso suite: 942 passed; frontend vitest: 83 passed; ruff clean.

## Review

Codex review loop converged clean. It caught two real issues, both fixed:
1. the allowance gate was check-then-create (racy under concurrency) → per-coach
   row lock;
2. the lock relied on the module-level `ATOMIC_REQUESTS`, which Django ignores
   (it's a per-`DATABASES` flag `dj_database_url` doesn't set) — would have
   500'd on Postgres → wrapped in an **explicit** `transaction.atomic()` (the
   existing invite/group pattern). Tests masked this because pytest-django wraps
   each test in its own transaction.

## Deploy notes

Pure backend + UI; **no migration**, no new settings. The free-tier allowance
gate is live on merge. (Stripe subscribe/portal stay dormant until the owner
configures `MESO_SEAT_PRICE_ID` / `MESO_STRIPE_WEBHOOK_SECRET`, unchanged here.)

https://claude.ai/code/session_015G62Gs7papVMJAfYqeExrN