### PR TITLE
Meso — S6 billing Phase 5: per-athlete suspension granularity

### DIFF
--- a/app/store_project/meso/billing/access.py
+++ b/app/store_project/meso/billing/access.py
@@ -18,7 +18,10 @@ Phase 3 wired these gates into the choke points: ``can_add_athlete`` at the
 invite/request endpoints (block a free coach past the cap), ``can_use_agent`` at
 the agent endpoint (402 for the free tier), and ``can_edit`` at the edit/deliver
 endpoints (the D6 over-limit freeze). Phase 5 meters ``can_use_agent`` (free-tier
-allowance). See ``docs/meso/billing-plan.md``.
+allowance) and refines the edit freeze **per athlete** (``can_edit_plan`` /
+``suspended_athlete_ids``): an over-limit coach keeps editing their oldest
+``FREE_SEAT_LIMIT`` athletes and is frozen only on the rest. See
+``docs/meso/billing-plan.md``.
 """
 
 import math
@@ -134,11 +137,56 @@ def is_over_limit(coach):
 
 
 def can_edit(coach):
-    """Edit/deliver gate (D6) — may this coach mutate or deliver programs?
+    """Coarse edit/deliver gate (D6) — may this coach mutate or deliver *anything*?
 
     Everyone can edit/deliver *except* a coach who is over their seat limit after a
     downgrade (``is_over_limit``); they keep read access but can't change or deliver
     a program until they re-subscribe or end relationships to get back within the
-    free cap. Never deletes data — only freezes writes.
+    free cap. Never deletes data — only freezes writes. This is the coach-wide
+    predicate; ``can_edit_plan`` is the per-athlete refinement (S6 Phase 5) and the
+    fallback for a group plan, which has no single relationship to keep live.
     """
     return not is_over_limit(coach)
+
+
+def suspended_athlete_ids(coach):
+    """Active ``CoachAthlete`` ids a downgrade has soft-suspended (D6, S6 Phase 5).
+
+    When a coach drops below their active-athlete count (``is_over_limit``), the app
+    keeps their **oldest** ``FREE_SEAT_LIMIT`` active relationships live and freezes
+    the rest: those plans go read-only for the coach (no edit/deliver) until they
+    re-subscribe or end relationships to get back within the cap. Nothing is deleted.
+    Keeping the *oldest* avoids the app arbitrarily picking which athletes to
+    freeze — the longest-standing relationships stay editable; the most recently
+    added (likely the ones that pushed the coach onto a paid plan) are the ones that
+    suspend on a lapse.
+
+    An active/comped coach (or one within the cap) is never over the limit, so this
+    is an empty set for them — cheap, since ``is_over_limit`` short-circuits before
+    any per-link query.
+    """
+    if not is_over_limit(coach):
+        return frozenset()
+    active_ids = list(
+        CoachAthlete.objects.for_coach(coach)
+        .active()
+        .order_by("created_at", "pk")
+        .values_list("pk", flat=True)
+    )
+    # Keep the oldest FREE_SEAT_LIMIT live; everything after the cutoff is frozen.
+    return frozenset(active_ids[CoachSubscription.FREE_SEAT_LIMIT :])
+
+
+def can_edit_plan(plan):
+    """Per-plan edit/deliver gate (D6) — may this plan be mutated or delivered?
+
+    The per-athlete refinement of ``can_edit`` (S6 Phase 5): an **individual** plan
+    is frozen only when *its own* relationship is soft-suspended, so an over-limit
+    coach keeps full control of their oldest ``FREE_SEAT_LIMIT`` athletes' plans and
+    is blocked only on the suspended ones. A **group** plan serves many athletes
+    through no single relationship, so it falls back to the coarse coach-wide freeze
+    (``can_edit``). Defended at the mutating endpoints, not just the UI.
+    """
+    if plan.relationship_id is None:  # a group plan — no single link to keep live
+        return can_edit(plan.coach)
+    return plan.relationship_id not in suspended_athlete_ids(plan.coach)

--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -61,8 +61,14 @@ def _active_contraindications(user):
     return [c for c in user.contraindications.all() if c.active]
 
 
-def roster_athlete(user):
-    """A row in the coach's roster list."""
+def roster_athlete(user, *, suspended=False):
+    """A row in the coach's roster list.
+
+    ``suspended`` marks an athlete whose link a downgrade froze (S6 Phase 5): the
+    coach keeps read access but can't edit/deliver this athlete's program until back
+    within the free cap. It surfaces as a warning badge so the coach sees *which*
+    athletes are frozen, not just that they're over the limit.
+    """
     name = user.display_name()
     meta_parts = [p for p in [_training_label(user)] if p]
     return {
@@ -74,8 +80,8 @@ def roster_athlete(user):
         "flags": [c.label for c in _active_contraindications(user)],
         # Phase 2 (program/agent) and Phase 3 (logs) — hidden until they exist.
         "compliance": None,
-        "status": "",
-        "status_label": "",
+        "status": "suspended" if suspended else "",
+        "status_label": "Suspended" if suspended else "",
     }
 
 
@@ -195,8 +201,9 @@ def billing_state(coach):
     the tier, seat usage, and which upgrade CTAs to offer. The free tier sees
     "start your no-card trial" (single-use) and "subscribe"; a coach with a real
     Stripe subscription sees "manage billing" (the hosted Portal); an over-limit
-    coach (post-downgrade, D6) sees the freeze warning. ``seat_limit`` is ``None``
-    for an unlimited (active/trial/comped) coach so the template hides the cap.
+    coach (post-downgrade, D6) sees the freeze warning naming how many athletes are
+    suspended (``suspended_count``, S6 Phase 5). ``seat_limit`` is ``None`` for an
+    unlimited (active/trial/comped) coach so the template hides the cap.
     """
     sub = getattr(coach, "coach_subscription", None)
     status = sub.status if sub else CoachSubscription.Status.FREE
@@ -221,6 +228,9 @@ def billing_state(coach):
         "can_use_agent": billing_access.can_use_agent(coach),
         "agent": agent_allowance(coach),
         "over_limit": billing_access.is_over_limit(coach),
+        # How many active athletes are soft-suspended by the downgrade (S6 Phase 5):
+        # 0 unless over the limit, then the count beyond the oldest free cap.
+        "suspended_count": len(billing_access.suspended_athlete_ids(coach)),
         "can_start_trial": can_start_trial,
         "has_stripe_subscription": bool(sub and sub.stripe_subscription_id),
     }

--- a/app/store_project/meso/tests/test_billing_enforcement.py
+++ b/app/store_project/meso/tests/test_billing_enforcement.py
@@ -271,8 +271,11 @@ def _patch_url(plan, presc):
 class TestEditGateIndividual:
     def test_over_limit_coach_cannot_patch(self, client):
         coach = UserFactory()
-        plan, _, presc = _plan_with_prescription(coach)  # 1 active link
-        CoachAthleteFactory(coach=coach, status=CoachAthlete.Status.ACTIVE)  # → over
+        # The plan under test belongs to a *suspended* link: an older link (created
+        # first → kept live) plus this newer one pushes the coach over the cap, so
+        # the per-athlete freeze (S6 Phase 5) freezes the newer one.
+        CoachAthleteFactory(coach=coach, status=CoachAthlete.Status.ACTIVE)  # kept
+        plan, _, presc = _plan_with_prescription(coach)  # newer → suspended → over
         assert access.is_over_limit(coach) is True
         client.force_login(coach)
         resp = client.post(
@@ -301,8 +304,8 @@ class TestEditGateIndividual:
 
     def test_over_limit_coach_cannot_deliver(self, client):
         coach = UserFactory()
-        plan, _, _ = _plan_with_prescription(coach)
-        CoachAthleteFactory(coach=coach, status=CoachAthlete.Status.ACTIVE)
+        CoachAthleteFactory(coach=coach, status=CoachAthlete.Status.ACTIVE)  # kept
+        plan, _, _ = _plan_with_prescription(coach)  # newer → suspended → over
         client.force_login(coach)
         resp = client.post(
             reverse("meso:api_plan_deliver", kwargs={"plan_id": plan.pk})
@@ -312,10 +315,11 @@ class TestEditGateIndividual:
     def test_over_limit_coach_cannot_apply_pending_batch(self, client):
         # A batch drafted while paid, then a downgrade: applying it would mutate
         # the program, so the D6 freeze must block it (the agent gate alone only
-        # stops *new* runs).
+        # stops *new* runs). The batch's plan is on a suspended link (an older link
+        # is kept live; this newer one is frozen).
         coach = UserFactory()
-        plan, _, _ = _plan_with_prescription(coach)
-        CoachAthleteFactory(coach=coach, status=CoachAthlete.Status.ACTIVE)  # → over
+        CoachAthleteFactory(coach=coach, status=CoachAthlete.Status.ACTIVE)  # kept
+        plan, _, _ = _plan_with_prescription(coach)  # newer → suspended → over
         batch = AgentProposalBatchFactory(plan=plan, coach=coach)
         client.force_login(coach)
         resp = client.post(

--- a/app/store_project/meso/tests/test_billing_suspension.py
+++ b/app/store_project/meso/tests/test_billing_suspension.py
@@ -1,0 +1,300 @@
+"""S6 — billing, Phase 5: per-athlete suspension granularity on downgrade.
+
+D6 lands a coach who drops below their active-athlete count on the free tier with
+read access intact but edits/deliver frozen until they're back within the cap.
+Phase 3 enforced that **coarsely** — the whole coach was frozen
+(``can_edit(coach)``). This slice refines it **per athlete**: the coach keeps full
+control of their *oldest* ``FREE_SEAT_LIMIT`` active relationships and only the
+rest are soft-suspended (frozen, never deleted). Re-subscribing or ending a
+relationship lifts the freeze. See ``docs/meso/billing-plan.md``.
+
+Covered:
+
+- ``access.suspended_athlete_ids`` — empty within the cap and for an active/comped
+  coach; the active links beyond the oldest ``FREE_SEAT_LIMIT`` once a free/lapsed
+  coach is over the cap.
+- ``access.can_edit_plan`` — an individual plan is frozen only when *its*
+  relationship is suspended; a group plan (no single relationship) falls back to
+  the coarse coach-wide freeze.
+- the endpoints: an over-limit coach can still patch / deliver / apply a batch for
+  a kept (oldest) athlete, but is 402'd on a suspended one.
+- the roster surfaces a per-athlete "Suspended" badge and a count.
+"""
+
+import json
+from datetime import timedelta
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+
+from store_project.meso.billing import access
+from store_project.meso.factories import AgentProposalBatchFactory
+from store_project.meso.factories import CoachAthleteFactory
+from store_project.meso.factories import CoachSubscriptionFactory
+from store_project.meso.factories import ExercisePrescriptionFactory
+from store_project.meso.factories import GroupMembershipFactory
+from store_project.meso.factories import GroupPlanFactory
+from store_project.meso.factories import MesocycleFactory
+from store_project.meso.factories import MesoGroupFactory
+from store_project.meso.factories import PlanFactory
+from store_project.meso.factories import SessionFactory
+from store_project.meso.factories import WeekFactory
+from store_project.meso.models import AgentProposalBatch
+from store_project.meso.models import CoachAthlete
+from store_project.meso.models import CoachSubscription
+from store_project.meso.models import Plan
+from store_project.users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _aged_link(coach, days_ago):
+    """An active ``CoachAthlete`` for ``coach`` whose ``created_at`` is back-dated.
+
+    ``created_at`` is ``auto_now_add``, so a ``.update()`` (raw SQL, no auto-stamp)
+    is the only way to set a deterministic relationship age — the ordering the
+    oldest-kept rule turns on.
+    """
+    link = CoachAthleteFactory(coach=coach, status=CoachAthlete.Status.ACTIVE)
+    CoachAthlete.objects.filter(pk=link.pk).update(
+        created_at=timezone.now() - timedelta(days=days_ago)
+    )
+    link.refresh_from_db()
+    return link
+
+
+def _aged_plan(coach, days_ago):
+    """A minimal individual plan (week → session → prescription) on an aged link."""
+    rel = _aged_link(coach, days_ago)
+    plan = PlanFactory(relationship=rel, status=Plan.Status.ACTIVE)
+    meso = MesocycleFactory(plan=plan, order=0)
+    week = WeekFactory(mesocycle=meso, index=1, is_current=True)
+    session = SessionFactory(week=week, day_number=1, name="Lower")
+    presc = ExercisePrescriptionFactory(session=session, name="Back Squat")
+    return rel, plan, presc
+
+
+# ---------------------------------------------------------------------------
+# access.suspended_athlete_ids — which active links are frozen
+# ---------------------------------------------------------------------------
+
+
+class TestSuspendedAthleteIds:
+    def test_within_cap_no_suspensions(self):
+        coach = UserFactory()  # no row → free, cap 1
+        CoachAthleteFactory(coach=coach, status=CoachAthlete.Status.ACTIVE)
+        assert access.suspended_athlete_ids(coach) == frozenset()
+
+    def test_over_limit_suspends_all_but_oldest(self):
+        coach = UserFactory()
+        oldest = _aged_link(coach, days_ago=30)
+        mid = _aged_link(coach, days_ago=20)
+        newest = _aged_link(coach, days_ago=10)
+        suspended = access.suspended_athlete_ids(coach)
+        # The oldest FREE_SEAT_LIMIT (1) link is kept live; the rest are frozen.
+        assert oldest.pk not in suspended
+        assert suspended == frozenset({mid.pk, newest.pk})
+        assert len(suspended) == 3 - CoachSubscription.FREE_SEAT_LIMIT
+
+    def test_active_coach_no_suspensions(self):
+        sub = CoachSubscriptionFactory(status=CoachSubscription.Status.ACTIVE)
+        for _ in range(3):
+            CoachAthleteFactory(coach=sub.coach, status=CoachAthlete.Status.ACTIVE)
+        assert access.suspended_athlete_ids(sub.coach) == frozenset()
+
+    def test_comped_coach_no_suspensions(self):
+        coach = UserFactory()
+        for _ in range(3):
+            CoachAthleteFactory(coach=coach, status=CoachAthlete.Status.ACTIVE)
+        CoachSubscription.comp(coach)
+        assert access.suspended_athlete_ids(coach) == frozenset()
+
+    def test_lapsed_trial_suspends_newest(self):
+        sub = CoachSubscriptionFactory(
+            status=CoachSubscription.Status.TRIALING,
+            trial_end=timezone.now() - timedelta(minutes=1),  # lapsed → free-equivalent
+        )
+        oldest = _aged_link(sub.coach, days_ago=9)
+        newest = _aged_link(sub.coach, days_ago=2)
+        assert access.suspended_athlete_ids(sub.coach) == frozenset({newest.pk})
+        assert oldest.pk not in access.suspended_athlete_ids(sub.coach)
+
+    def test_ended_links_are_not_suspended(self):
+        # Only *active* links count toward seats, so an ended one is never a
+        # suspension candidate — and doesn't push the coach over the cap.
+        coach = UserFactory()
+        CoachAthleteFactory(coach=coach, status=CoachAthlete.Status.ACTIVE)
+        CoachAthleteFactory(coach=coach, status=CoachAthlete.Status.ENDED)
+        assert access.is_over_limit(coach) is False
+        assert access.suspended_athlete_ids(coach) == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# access.can_edit_plan — the per-plan gate
+# ---------------------------------------------------------------------------
+
+
+class TestCanEditPlan:
+    def test_kept_individual_plan_editable(self):
+        coach = UserFactory()
+        _, kept_plan, _ = _aged_plan(coach, days_ago=30)  # oldest → kept
+        _aged_plan(coach, days_ago=1)  # newer → suspended, pushes over cap
+        assert access.is_over_limit(coach) is True
+        assert access.can_edit_plan(kept_plan) is True
+
+    def test_suspended_individual_plan_not_editable(self):
+        coach = UserFactory()
+        _aged_plan(coach, days_ago=30)  # oldest → kept
+        _, suspended_plan, _ = _aged_plan(coach, days_ago=1)  # newer → suspended
+        assert access.can_edit_plan(suspended_plan) is False
+
+    def test_within_cap_individual_plan_editable(self):
+        coach = UserFactory()
+        _, plan, _ = _aged_plan(coach, days_ago=5)  # only athlete → at cap
+        assert access.is_over_limit(coach) is False
+        assert access.can_edit_plan(plan) is True
+
+    def test_group_plan_frozen_by_coarse_freeze_when_over(self):
+        coach = UserFactory()
+        group = MesoGroupFactory(coach=coach)
+        GroupMembershipFactory(group=group)
+        GroupMembershipFactory(group=group)  # two active links → over the cap
+        plan = GroupPlanFactory(group=group)
+        assert access.is_over_limit(coach) is True
+        # A group plan has no single relationship to keep live, so it falls back to
+        # the coarse coach-wide freeze.
+        assert access.can_edit_plan(plan) is False
+
+    def test_group_plan_editable_within_cap(self):
+        coach = UserFactory()
+        group = MesoGroupFactory(coach=coach)
+        GroupMembershipFactory(group=group)  # one active link → at cap
+        plan = GroupPlanFactory(group=group)
+        assert access.can_edit_plan(plan) is True
+
+    def test_active_coach_any_plan_editable(self):
+        sub = CoachSubscriptionFactory(status=CoachSubscription.Status.ACTIVE)
+        _, kept_plan, _ = _aged_plan(sub.coach, days_ago=30)
+        _, newer_plan, _ = _aged_plan(sub.coach, days_ago=1)
+        assert access.can_edit_plan(kept_plan) is True
+        assert access.can_edit_plan(newer_plan) is True
+
+
+# ---------------------------------------------------------------------------
+# Endpoints — an over-limit coach edits the kept plan, is 402'd on a suspended one
+# ---------------------------------------------------------------------------
+
+
+def _patch_url(plan, presc):
+    return reverse(
+        "meso:api_prescription_patch", kwargs={"plan_id": plan.pk, "pk": presc.pk}
+    )
+
+
+def _over_limit_coach_two_plans():
+    """A free coach over the cap with a kept (oldest) plan and a suspended one."""
+    coach = UserFactory()
+    _, kept, kept_presc = _aged_plan(coach, days_ago=30)
+    _, suspended, suspended_presc = _aged_plan(coach, days_ago=1)
+    return coach, (kept, kept_presc), (suspended, suspended_presc)
+
+
+class TestPerAthleteEditEndpoints:
+    def test_over_limit_can_patch_kept_plan(self, client):
+        coach, (kept, kept_presc), _ = _over_limit_coach_two_plans()
+        assert access.is_over_limit(coach) is True
+        client.force_login(coach)
+        resp = client.post(
+            _patch_url(kept, kept_presc),
+            data=json.dumps({"sets": "9"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        kept_presc.refresh_from_db()
+        assert kept_presc.sets == "9"
+
+    def test_over_limit_cannot_patch_suspended_plan(self, client):
+        coach, _, (suspended, suspended_presc) = _over_limit_coach_two_plans()
+        client.force_login(coach)
+        resp = client.post(
+            _patch_url(suspended, suspended_presc),
+            data=json.dumps({"sets": "9"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 402
+        assert resp.json()["over_limit"] is True
+        suspended_presc.refresh_from_db()
+        assert suspended_presc.sets != "9"
+
+    def test_over_limit_can_deliver_kept_plan(self, client):
+        coach, (kept, _), _ = _over_limit_coach_two_plans()
+        client.force_login(coach)
+        resp = client.post(
+            reverse("meso:api_plan_deliver", kwargs={"plan_id": kept.pk})
+        )
+        assert resp.status_code != 402  # gate let it through (delivers the week)
+
+    def test_over_limit_cannot_deliver_suspended_plan(self, client):
+        coach, _, (suspended, _) = _over_limit_coach_two_plans()
+        client.force_login(coach)
+        resp = client.post(
+            reverse("meso:api_plan_deliver", kwargs={"plan_id": suspended.pk})
+        )
+        assert resp.status_code == 402
+
+    def test_over_limit_can_apply_batch_for_kept_plan(self, client):
+        coach, (kept, _), _ = _over_limit_coach_two_plans()
+        batch = AgentProposalBatchFactory(plan=kept, coach=coach)
+        client.force_login(coach)
+        resp = client.post(
+            reverse("meso:api_batch_apply", kwargs={"batch_id": batch.pk})
+        )
+        assert resp.status_code != 402
+
+    def test_over_limit_cannot_apply_batch_for_suspended_plan(self, client):
+        coach, _, (suspended, _) = _over_limit_coach_two_plans()
+        batch = AgentProposalBatchFactory(plan=suspended, coach=coach)
+        client.force_login(coach)
+        resp = client.post(
+            reverse("meso:api_batch_apply", kwargs={"batch_id": batch.pk})
+        )
+        assert resp.status_code == 402
+        batch.refresh_from_db()
+        assert batch.status == AgentProposalBatch.Status.PENDING  # not applied
+
+
+# ---------------------------------------------------------------------------
+# Roster surface — per-athlete badge + count
+# ---------------------------------------------------------------------------
+
+
+class TestRosterSuspensionUI:
+    def test_roster_marks_suspended_athlete(self, client):
+        coach = UserFactory()
+        kept_rel, _, _ = _aged_plan(coach, days_ago=30)
+        suspended_rel, _, _ = _aged_plan(coach, days_ago=1)
+        client.force_login(coach)
+        resp = client.get(reverse("meso:roster"))
+        assert resp.status_code == 200
+        by_id = {a["id"]: a for a in resp.context["athletes"]}
+        assert by_id[kept_rel.athlete_id]["status"] != "suspended"
+        assert by_id[suspended_rel.athlete_id]["status"] == "suspended"
+        assert b"Suspended" in resp.content
+
+    def test_roster_no_suspended_badge_within_cap(self, client):
+        coach = UserFactory()
+        _aged_plan(coach, days_ago=5)  # one athlete → at cap
+        client.force_login(coach)
+        resp = client.get(reverse("meso:roster"))
+        assert all(a["status"] != "suspended" for a in resp.context["athletes"])
+        assert b"Suspended" not in resp.content
+
+    def test_billing_state_reports_suspended_count(self, client):
+        coach = UserFactory()
+        _aged_plan(coach, days_ago=30)
+        _aged_plan(coach, days_ago=2)
+        _aged_plan(coach, days_ago=1)
+        client.force_login(coach)
+        resp = client.get(reverse("meso:roster"))
+        assert resp.context["billing"]["suspended_count"] == 2

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -270,7 +270,13 @@ class RosterView(LoginRequiredMixin, TemplateView):
             .prefetch_related("athlete__contraindications")
             .order_by("athlete__name", "athlete__email")
         )
-        athletes = [presenters.roster_athlete(link.athlete) for link in links]
+        # The downgrade soft-suspends every active link beyond the oldest free cap
+        # (S6 Phase 5); flag those rows so the roster shows a "Suspended" badge.
+        suspended = billing_access.suspended_athlete_ids(self.request.user)
+        athletes = [
+            presenters.roster_athlete(link.athlete, suspended=link.pk in suspended)
+            for link in links
+        ]
         groups = (
             MesoGroup.objects.for_coach(self.request.user)
             .active()
@@ -1361,14 +1367,16 @@ def _editable_plan_or_response(request, plan_id):
     """The plan the requester may *edit*, or an error response (S6 Phase 3, D6).
 
     Ownership first (``_coach_plan_or_forbidden`` → 404/403), then the billing
-    gate: a coach over their seat limit after a downgrade (``can_edit`` False) gets
-    a 402 instead of mutating — they keep read access but can't change or deliver a
-    program until back within the cap or re-subscribed.
+    gate: a coach over their seat limit after a downgrade gets a 402 instead of
+    mutating — they keep read access but can't change or deliver a program until
+    back within the cap or re-subscribed. The freeze is **per athlete** (S6 Phase
+    5, ``can_edit_plan``): only the soft-suspended links — the active ones beyond
+    the oldest ``FREE_SEAT_LIMIT`` — are frozen; the kept athletes stay editable.
     """
     plan, forbidden = _coach_plan_or_forbidden(request, plan_id)
     if forbidden is not None:
         return None, forbidden
-    if not billing_access.can_edit(plan.coach):
+    if not billing_access.can_edit_plan(plan):
         return None, _over_limit_json()
     return plan, None
 
@@ -1965,9 +1973,10 @@ def batch_apply(request, batch_id):
     """Apply the batch's approved changes back into the program."""
     batch = _coach_batch_or_404(request, batch_id)
     # Applying a batch writes the approved edits into the program — an edit, so it
-    # respects the D6 over-limit freeze (a batch drafted before a downgrade can't
-    # be applied while the coach is over their seat limit).
-    if not billing_access.can_edit(batch.plan.coach):
+    # respects the D6 over-limit freeze (a batch drafted before a downgrade can't be
+    # applied while its athlete's link is soft-suspended). Per-plan (S6 Phase 5), so
+    # a batch for a kept athlete still applies while the coach is over the cap.
+    if not billing_access.can_edit_plan(batch.plan):
         return _over_limit_json()
     if batch.status != AgentProposalBatch.Status.PENDING:
         return JsonResponse(

--- a/app/store_project/templates/meso/roster.html
+++ b/app/store_project/templates/meso/roster.html
@@ -43,7 +43,9 @@
                   <span class="meso-row-meta meso-mono">{{ a.compliance }}%</span>
                 </div>
               {% endif %}
-              {% if a.status == 'needs_review' %}
+              {% if a.status == 'suspended' %}
+                <span class="meso-badge meso-badge--warn"><i></i>{{ a.status_label }}</span>
+              {% elif a.status == 'needs_review' %}
                 <span class="meso-badge meso-badge--accent"><i></i>{{ a.status_label }}</span>
               {% elif a.status == 'delivered' %}
                 <span class="meso-badge meso-badge--ok"><i></i>{{ a.status_label }}</span>
@@ -191,7 +193,7 @@
             <span class="meso-badge {% if billing.is_active %}meso-badge--ok{% else %}meso-badge--muted{% endif %}"><i></i>{{ billing.status_label }}</span>
           </div>
           {% if billing.over_limit %}
-            <p class="meso-sub" style="margin:0;color:var(--warn);">Over your plan limit &#8212; {{ billing.seat_count }} of {{ billing.seat_limit }} athlete{{ billing.seat_limit|pluralize }}. Re-subscribe or end a relationship to edit or deliver programs.</p>
+            <p class="meso-sub" style="margin:0;color:var(--warn);">Over your plan limit &#8212; {{ billing.seat_count }} of {{ billing.seat_limit }} athlete{{ billing.seat_limit|pluralize }}. Your longest-standing athletes stay editable; the other {{ billing.suspended_count }} {{ billing.suspended_count|pluralize:"is,are" }} suspended until you re-subscribe or end a relationship.</p>
           {% elif billing.on_trial %}
             <p class="meso-sub" style="margin:0;">Free trial &#8212; ends {{ billing.trial_end|date:"M j" }}. Subscribe to keep full access when it ends.</p>
           {% elif billing.is_active %}

--- a/docs/meso/billing-plan.md
+++ b/docs/meso/billing-plan.md
@@ -22,7 +22,7 @@ pricing assumptions into the schema.
 | D3 | **Free access** | **Free tier + 14-day no-card trial.** A forever-free tier (a few free seats), plus a frictionless trial that needs no card; the free tier is also the lapse/cancel landing spot. |
 | D4 | **What the paywall gates** | **Active-athlete count + the AI agent.** The Claude-powered program agent (B6) has real per-call API cost, so it's paid-only — trial/paid/comped get the full agent. Groups (S1) and notifications stay free at every tier. (v1 gave the free tier **no** agent; **Phase 5 meters it** — a free coach gets a small monthly `FREE_AGENT_ALLOWANCE` of runs, then 402s. The seat gate still shares the `is_active` predicate.) |
 | D5 | **Cadence + currency** | **Monthly, USD** for v1 (annual deferred — annualizing a fluctuating seat count adds proration complexity for little v1 value). |
-| D6 | **Lapse / cancel** | Stripe Smart Retries → on final failure / cancel, **downgrade to free at period end**. Over the free limit ⇒ block *new* athletes + block edits/deliver until back within the limit or re-subscribed; **never delete data** (matches how an ended relationship archives, not deletes). |
+| D6 | **Lapse / cancel** | Stripe Smart Retries → on final failure / cancel, **downgrade to free at period end**. Over the free limit ⇒ block *new* athletes + block edits/deliver until back within the limit or re-subscribed; **never delete data** (matches how an ended relationship archives, not deletes). (Phase 5 makes the edit freeze **per athlete** — the oldest `FREE_SEAT_LIMIT` links stay editable, the rest soft-suspend; v1 froze the whole coach.) |
 | D11 | **First slice** | **The subscription spine** for existing logged-in coaches. The public self-serve coach-signup funnel is a later phase. |
 
 ### Architecture decisions (recommended; proceed unless overridden)
@@ -127,12 +127,17 @@ are unaffected. (Defended at the endpoint, not just the UI — the API cost is r
 
 On trial-end-without-subscription or a final failed payment / cancel at
 `current_period_end`: `status=free`. If the coach is over `FREE_SEAT_LIMIT`,
-they keep **read access** to everything but cannot deliver / edit / add until
-they end relationships to get back within the free limit or re-subscribe.
-Nothing is deleted; re-subscribing restores full access. (A finer per-athlete
-suspension — auto-keeping the N oldest active links live and soft-suspending the
-rest — is a Phase-5 refinement; v1 keeps the coarse "coach is over the limit"
-rule to avoid the app arbitrarily choosing which athletes to freeze.)
+they keep **read access** to everything and cannot **add** new athletes; nothing
+is deleted; re-subscribing restores full access. The edit/deliver freeze is
+**per athlete** (Phase 5): the app keeps the coach's **oldest `FREE_SEAT_LIMIT`
+active links** editable and soft-suspends the rest — those plans go read-only
+(no edit/deliver/agent-apply) until the coach re-subscribes or ends relationships
+to get back within the cap. Keeping the *oldest* avoids the app arbitrarily
+choosing which athletes to freeze. (A **group** plan serves many athletes through
+no single relationship, so it falls back to the coarse coach-wide freeze.)
+`billing/access.py` owns this: `suspended_athlete_ids(coach)` (the frozen-link
+set) and `can_edit_plan(plan)` (the per-plan gate at the mutating endpoints);
+v1 froze the whole coach via the coarse `can_edit(coach)`.
 
 ## Phasing
 
@@ -152,8 +157,13 @@ rule to avoid the app arbitrarily choosing which athletes to freeze.)
 > binary agent gate: a free coach gets `FREE_AGENT_ALLOWANCE` (5) agent runs per
 > calendar month (counted from the `AgentProposalBatch` ledger — no new model),
 > then the endpoint 402s; the designer shows a "N of M runs left" meter / upgrade
-> CTA and the roster card reflects it. Remaining Phase-5 items: annual prices,
-> per-athlete suspension granularity on downgrade.
+> CTA and the roster card reflects it. Phase 5 also adds **per-athlete suspension
+> granularity** (this slice, no migration) — the D6 downgrade edit freeze is now
+> per-athlete (`can_edit_plan` / `suspended_athlete_ids`): an over-limit coach
+> keeps editing/delivering their oldest `FREE_SEAT_LIMIT` athletes and is frozen
+> only on the rest (group plans keep the coarse coach-wide freeze), with a
+> per-athlete "Suspended" badge on the roster. Remaining Phase-5 item: annual
+> prices.
 
 ### Deploying Phase 2 (Stripe configuration)
 
@@ -206,8 +216,15 @@ deploy succeeds without them (like the VAPID push keys):
    `presenters.agent_allowance` meter wired into the designer (composer + "N of M
    runs left" / upgrade CTA) and the roster card + the allowance-aware 402 copy at
    `agent_propose`. Tested in `test_billing.py::TestAgentAllowance` and
-   `test_billing_enforcement.py`. **Still later:** annual prices; per-athlete
-   suspension granularity on downgrade.
+   `test_billing_enforcement.py`. **Per-athlete suspension granularity** is also
+   done (this slice, no migration): `billing/access.py` gains
+   `suspended_athlete_ids(coach)` (the active links beyond the oldest
+   `FREE_SEAT_LIMIT`, frozen on a downgrade) + `can_edit_plan(plan)` (per-plan
+   gate; a group plan falls back to the coarse `can_edit(coach)`), wired into
+   `_editable_plan_or_response` + `batch_apply` so an over-limit coach keeps
+   editing/delivering their kept athletes; `presenters` surface a per-athlete
+   "Suspended" roster badge + a `suspended_count` on the billing card. Tested in
+   `test_billing_suspension.py`. **Still later:** annual prices.
 
 ## Open values (numbers, not architecture — confirm before/with Phase 1)
 
@@ -229,6 +246,5 @@ deploy succeeds without them (like the VAPID push keys):
 ## Deferred
 
 - Annual billing; promo codes / coupons (Stripe supports both when wanted).
-- Per-athlete soft-suspension on downgrade (v1: coarse over-limit rule).
 - Tax / VAT handling (Stripe Tax) if selling internationally.
 - Email receipts beyond Stripe's own invoice emails.


### PR DESCRIPTION
## What

Refines the D6 downgrade edit freeze from **coach-wide** to **per athlete** — the second remaining S6 Phase-5 item (annual prices is still deferred, blocked on owner pricing + a new Stripe Price).

When a coach drops below their active-athlete count and lands on the free tier, the app now keeps their **oldest `FREE_SEAT_LIMIT` active relationships fully editable** and **soft-suspends only the rest**: those plans go read-only (no edit / deliver / agent-apply) until the coach re-subscribes or ends relationships to get back within the cap. Nothing is deleted. Keeping the *oldest* avoids the app arbitrarily choosing which athletes to freeze (the longest-standing relationships stay live; the most-recently-added — likely the ones that pushed the coach onto a paid plan — are the ones that suspend on a lapse).

Phase 3 froze the **whole coach** (`can_edit(coach)`); this makes the downgrade graceful.

## Changes

- **`billing/access.py`** — `suspended_athlete_ids(coach)` (active links beyond the oldest free cap, ordered by `created_at`) + `can_edit_plan(plan)` (per-plan gate; a **group** plan has no single relationship to keep live, so it falls back to the coarse `can_edit(coach)`).
- **`views.py`** — `_editable_plan_or_response` + `batch_apply` gate on `can_edit_plan`, so an over-limit coach keeps editing/delivering their kept athletes but is 402'd on a suspended one; `RosterView` flags suspended rows.
- **`presenters.py`** — `roster_athlete` grows a "Suspended" badge; `billing_state` adds `suspended_count`.
- **`roster.html`** — per-athlete Suspended badge + over-limit card copy reflecting the per-athlete freeze.
- **docs** — `billing-plan.md` D6 + phasing updated; per-athlete suspension moved out of *Deferred*.

**No model / migration.**

## Tests

- New `test_billing_suspension.py` (21 tests): `suspended_athlete_ids` (within cap / over / active / comped / lapsed-trial / ended-links), `can_edit_plan` (kept vs suspended individual, group coarse-fallback, active), the endpoints (over-limit coach can patch/deliver/apply for a kept athlete, 402 on a suspended one), and the roster badge + `suspended_count`.
- The three `TestEditGateIndividual` cases in `test_billing_enforcement.py` updated to target a *suspended* (not kept) plan — they encoded the old coarse behavior.
- Full suite green (1103 passed); ruff lint + format clean.
- Codex review loop: **CLEAN**, no blocking issues.

https://claude.ai/code/session_015G62Gs7papVMJAfYqeExrN