### PR TITLE
Meso — first-time UX Phase 1: individual plan creation

### DIFF
--- a/app/store_project/meso/models.py
+++ b/app/store_project/meso/models.py
@@ -354,6 +354,39 @@ class CoachAthlete(models.Model):
             return self.athlete
         return None
 
+    def working_plan(self):
+        """This relationship's current individual program (most-recent non-archived).
+
+        The individual-side analogue of ``MesoGroup.shared_plan`` — the plan the
+        designer reopens, or ``None`` when the coach hasn't built one yet.
+        """
+        return (
+            self.plans.exclude(status=Plan.Status.ARCHIVED)
+            .order_by("-modified")
+            .first()
+        )
+
+    def create_plan(self, *, title="New program", goal="", unit=None, status=None):
+        """Create an individual program rooted at this relationship, with a scaffold.
+
+        The individual-side mirror of ``MesoGroup.create_shared_plan``: a starter
+        ``Plan`` plus ``Plan.scaffold``'s minimal-but-usable tree, so the designer
+        opens onto an editable, deliverable grid. ``unit`` defaults to the coach's
+        preferred unit; ``status`` to a draft.
+        """
+        if unit is None:
+            profile = getattr(self.coach, "coach_profile", None)
+            unit = profile.default_unit if profile else Unit.KILOGRAMS
+        plan = Plan.objects.create(
+            relationship=self,
+            title=title,
+            goal=goal,
+            status=status or Plan.Status.DRAFT,
+            unit=unit,
+        )
+        plan.scaffold()
+        return plan
+
 
 class CoachInviteQuerySet(models.QuerySet):
     def for_coach(self, user):
@@ -1074,6 +1107,41 @@ class Plan(models.Model):
             return self.group.coach_id == user.id
         return False
 
+    def scaffold(self, *, days=2):
+        """Seed a minimal-but-usable starter tree onto this (bare) plan.
+
+        One block, the current week, and ``days`` empty training days each with a
+        starter row — so the designer opens onto an editable, deliverable grid
+        rather than an empty shell (there is no add-mesocycle / add-week UI yet,
+        and a day needs a row to edit). Shared by individual plan creation
+        (``CoachAthlete.create_plan``) and the group's shared program
+        (``MesoGroup.create_shared_plan``). Returns ``self``.
+        """
+        mesocycle = Mesocycle.objects.create(
+            plan=self, name="Block 1", order=0, week_count=4
+        )
+        week = Week.objects.create(
+            mesocycle=mesocycle,
+            index=1,
+            phase="Accum",
+            volume=70,
+            intensity=65,
+            is_current=True,
+        )
+        for day in range(1, days + 1):
+            session = Session.objects.create(
+                week=week, day_number=day, name=f"Day {day}", order=day - 1
+            )
+            ExercisePrescription.objects.create(
+                session=session,
+                name="New exercise",
+                order=0,
+                sets="3",
+                reps="10",
+                rpe="7",
+            )
+        return self
+
 
 class Mesocycle(models.Model):
     """A training block within a plan — one bar in the macrocycle rail."""
@@ -1666,11 +1734,10 @@ class MesoGroup(models.Model):
     def create_shared_plan(self):
         """Create the group's shared program rooted at the group, with a scaffold.
 
-        Seeds a minimal-but-usable structure (one block, the current week, two
-        training days each with a starter row) so the designer opens onto an
-        editable grid — there is no add-session / add-week endpoint yet, so a
-        bare plan would be uneditable. The coach then shapes it (and, Phase 3,
-        layers per-athlete auto-adjusts).
+        ``Plan.scaffold`` seeds the minimal-but-usable starter tree (one block,
+        the current week, two training days each with a starter row) so the
+        designer opens onto an editable grid. The coach then shapes it (and,
+        Phase 3, layers per-athlete auto-adjusts).
         """
         profile = getattr(self.coach, "coach_profile", None)
         unit = profile.default_unit if profile else Unit.KILOGRAMS
@@ -1681,29 +1748,7 @@ class MesoGroup(models.Model):
             status=Plan.Status.DRAFT,
             unit=unit,
         )
-        mesocycle = Mesocycle.objects.create(
-            plan=plan, name="Block 1", order=0, week_count=4
-        )
-        week = Week.objects.create(
-            mesocycle=mesocycle,
-            index=1,
-            phase="Accum",
-            volume=70,
-            intensity=65,
-            is_current=True,
-        )
-        for day in (1, 2):
-            session = Session.objects.create(
-                week=week, day_number=day, name=f"Day {day}", order=day - 1
-            )
-            ExercisePrescription.objects.create(
-                session=session,
-                name="New exercise",
-                order=0,
-                sets="3",
-                reps="10",
-                rpe="7",
-            )
+        plan.scaffold()
         return plan
 
 

--- a/app/store_project/meso/models.py
+++ b/app/store_project/meso/models.py
@@ -358,10 +358,16 @@ class CoachAthlete(models.Model):
         """This relationship's current individual program (most-recent non-archived).
 
         The individual-side analogue of ``MesoGroup.shared_plan`` — the plan the
-        designer reopens, or ``None`` when the coach hasn't built one yet.
+        designer reopens, or ``None`` when the coach hasn't built one yet. A
+        *materialized* group-delivery plan (``source_group`` set — a member's
+        resolved snapshot, groups Phase 4) is excluded, matching
+        ``PlanQuerySet.for_coach``/``editable_by``: it's athlete-facing only and
+        the designer 404s on it, so it must never be returned as the editable
+        working plan.
         """
         return (
             self.plans.exclude(status=Plan.Status.ARCHIVED)
+            .filter(source_group__isnull=True)
             .order_by("-modified")
             .first()
         )

--- a/app/store_project/meso/tests/test_plan_create.py
+++ b/app/store_project/meso/tests/test_plan_create.py
@@ -1,0 +1,358 @@
+"""First-time UX — Phase 1: individual plan creation (the structural fix).
+
+Until now the only thing that built an individual ``Plan → Mesocycle → Week →
+Session → ExercisePrescription`` tree was the ``seed_meso_demo`` command — there
+was no UI path, so a real (non-seeded) coach could not build an individual
+program at all. Both individual-plan CTAs ("+ New program", "Build a program")
+bounced off the bare designer back to the roster. This slice makes the core verb
+real:
+
+- ``Plan.scaffold`` — the minimal-but-usable starter tree, shared by individual +
+  group plan creation (``MesoGroup.create_shared_plan`` is refactored onto it).
+- ``CoachAthlete.create_plan`` / ``CoachAthlete.working_plan`` — create (or find)
+  an individual program rooted at the relationship.
+- ``plan_create`` (``POST /meso/athlete/<uuid>/plan/new/``) — coach-scoped,
+  billing-gated (a suspended athlete is frozen, D6), reuse-or-create, lands in
+  the designer.
+- ``session_add`` (``POST /meso/api/plan/<id>/session/``) — append a training day
+  to the current week so the scaffold can grow.
+- the create → edit → deliver → athlete-sees-it round trip works **without the
+  seed**.
+"""
+
+import json
+from datetime import timedelta
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+
+from store_project.meso.billing import access
+from store_project.meso.factories import CoachAthleteFactory
+from store_project.meso.factories import CoachProfileFactory
+from store_project.meso.models import CoachAthlete
+from store_project.meso.models import CoachSubscription
+from store_project.meso.models import Plan
+from store_project.meso.models import Session
+from store_project.meso.models import Unit
+from store_project.meso.models import Week
+from store_project.users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _aged_link(coach, days_ago, **kwargs):
+    """An active ``CoachAthlete`` for ``coach`` whose ``created_at`` is back-dated.
+
+    ``created_at`` is ``auto_now_add``, so a raw ``.update()`` is the only way to
+    set a deterministic relationship age — the ordering the oldest-kept
+    suspension rule turns on.
+    """
+    link = CoachAthleteFactory(coach=coach, status=CoachAthlete.Status.ACTIVE, **kwargs)
+    CoachAthlete.objects.filter(pk=link.pk).update(
+        created_at=timezone.now() - timedelta(days=days_ago)
+    )
+    link.refresh_from_db()
+    return link
+
+
+def _plan_new_url(athlete):
+    return reverse("meso:plan_create", kwargs={"pk": athlete.pk})
+
+
+# ---------------------------------------------------------------------------
+# Plan.scaffold + CoachAthlete.create_plan / working_plan  (the model layer)
+# ---------------------------------------------------------------------------
+
+
+class TestScaffoldAndCreatePlan:
+    def test_create_plan_builds_a_usable_scaffold(self):
+        link = CoachAthleteFactory()
+        plan = link.create_plan()
+
+        assert plan.relationship_id == link.pk
+        assert plan.group_id is None
+        assert plan.status == Plan.Status.DRAFT
+        # One block, one current week, two training days, one starter row each.
+        mesos = list(plan.mesocycles.all())
+        assert len(mesos) == 1
+        weeks = list(mesos[0].weeks.all())
+        assert len(weeks) == 1
+        assert weeks[0].is_current is True
+        sessions = list(weeks[0].sessions.all())
+        assert len(sessions) == 2
+        for session in sessions:
+            assert session.prescriptions.count() == 1
+
+    def test_create_plan_is_editable_and_deliverable(self):
+        link = CoachAthleteFactory()
+        plan = link.create_plan()
+        # The coach owns it (designer gate) and it has a current week to deliver.
+        assert plan.is_editable_by(link.coach) is True
+        from store_project.meso.serializers import current_week
+
+        assert current_week(plan) is not None
+
+    def test_create_plan_uses_coach_default_unit(self):
+        profile = CoachProfileFactory(default_unit=Unit.POUNDS)
+        link = CoachAthleteFactory(coach=profile.user)
+        plan = link.create_plan()
+        assert plan.unit == Unit.POUNDS
+
+    def test_create_plan_unit_falls_back_without_profile(self):
+        link = CoachAthleteFactory()  # coach has no CoachProfile
+        plan = link.create_plan()
+        assert plan.unit == Unit.KILOGRAMS
+
+    def test_working_plan_none_then_latest(self):
+        link = CoachAthleteFactory()
+        assert link.working_plan() is None
+        plan = link.create_plan()
+        assert link.working_plan() == plan
+
+    def test_working_plan_excludes_archived(self):
+        link = CoachAthleteFactory()
+        plan = link.create_plan()
+        plan.status = Plan.Status.ARCHIVED
+        plan.save(update_fields=["status"])
+        assert link.working_plan() is None
+
+    def test_group_create_shared_plan_still_scaffolds(self):
+        """Regression guard for the refactor: the group path is unchanged."""
+        from store_project.meso.factories import MesoGroupFactory
+
+        group = MesoGroupFactory()
+        plan = group.create_shared_plan()
+        assert plan.group_id == group.pk
+        assert plan.relationship_id is None
+        meso = plan.mesocycles.get()
+        week = meso.weeks.get()
+        assert week.is_current is True
+        sessions = list(week.sessions.all())
+        assert len(sessions) == 2
+        for session in sessions:
+            assert session.prescriptions.count() == 1
+
+
+# ---------------------------------------------------------------------------
+# plan_create endpoint — coach-scoped, billing-gated, reuse-or-create
+# ---------------------------------------------------------------------------
+
+
+class TestPlanCreateEndpoint:
+    def test_creates_plan_and_redirects_to_designer(self, client):
+        link = CoachAthleteFactory()
+        client.force_login(link.coach)
+        resp = client.post(_plan_new_url(link.athlete))
+        plan = Plan.objects.get(relationship=link)
+        assert resp.status_code == 302
+        assert resp.url == reverse("meso:designer_plan", kwargs={"plan_id": plan.pk})
+        # The created plan is a real, scaffolded tree.
+        assert plan.mesocycles.count() == 1
+
+    def test_is_idempotent_reuses_existing_plan(self, client):
+        link = CoachAthleteFactory()
+        client.force_login(link.coach)
+        first = client.post(_plan_new_url(link.athlete))
+        second = client.post(_plan_new_url(link.athlete))
+        assert Plan.objects.filter(relationship=link).count() == 1
+        assert first.url == second.url
+
+    def test_requires_active_link(self, client):
+        # A pending (not active) relationship is not yet a coachable athlete.
+        link = CoachAthleteFactory(status=CoachAthlete.Status.PENDING_ATHLETE_REQUEST)
+        client.force_login(link.coach)
+        resp = client.post(_plan_new_url(link.athlete))
+        assert resp.status_code == 404
+        assert not Plan.objects.filter(relationship=link).exists()
+
+    def test_foreign_athlete_is_404(self, client):
+        coach = UserFactory()
+        other = CoachAthleteFactory()  # someone else's athlete
+        client.force_login(coach)
+        resp = client.post(_plan_new_url(other.athlete))
+        assert resp.status_code == 404
+        assert not Plan.objects.filter(relationship=other).exists()
+
+    def test_requires_login(self, client):
+        link = CoachAthleteFactory()
+        resp = client.post(_plan_new_url(link.athlete))
+        assert resp.status_code == 302
+        assert "/accounts/login/" in resp.url
+
+    def test_rejects_get(self, client):
+        link = CoachAthleteFactory()
+        client.force_login(link.coach)
+        resp = client.get(_plan_new_url(link.athlete))
+        assert resp.status_code == 405
+
+    def test_blocked_for_suspended_athlete(self, client):
+        coach = UserFactory()  # free tier, cap 1
+        _aged_link(coach, days_ago=30)  # oldest → kept
+        suspended = _aged_link(coach, days_ago=1)  # newest → over cap → suspended
+        assert suspended.pk in access.suspended_athlete_ids(coach)
+        client.force_login(coach)
+        resp = client.post(_plan_new_url(suspended.athlete))
+        # Frozen: a flashed redirect back to the athlete, no plan created.
+        assert resp.status_code == 302
+        assert resp.url == reverse("meso:athlete", kwargs={"pk": suspended.athlete_id})
+        assert not Plan.objects.filter(relationship=suspended).exists()
+
+    def test_over_limit_can_create_for_kept_athlete(self, client):
+        coach = UserFactory()
+        kept = _aged_link(coach, days_ago=30)  # oldest → kept editable
+        _aged_link(coach, days_ago=1)  # pushes coach over the cap
+        assert access.is_over_limit(coach) is True
+        client.force_login(coach)
+        resp = client.post(_plan_new_url(kept.athlete))
+        assert resp.status_code == 302
+        assert Plan.objects.filter(relationship=kept).exists()
+
+
+# ---------------------------------------------------------------------------
+# session_add endpoint — grow the scaffold (add a training day)
+# ---------------------------------------------------------------------------
+
+
+class TestSessionAddEndpoint:
+    def _url(self, plan):
+        return reverse("meso:api_session_add", kwargs={"plan_id": plan.pk})
+
+    def test_appends_a_day_with_a_starter_row(self, client):
+        link = CoachAthleteFactory()
+        plan = link.create_plan()
+        week = Week.objects.get(mesocycle__plan=plan)
+        before = week.sessions.count()
+        client.force_login(link.coach)
+        resp = client.post(self._url(plan))
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["ok"] is True
+        assert week.sessions.count() == before + 1
+        new_session = Session.objects.get(pk=body["session"]["id"])
+        assert new_session.week_id == week.pk
+        assert new_session.prescriptions.count() == 1
+        # Returned in the designer's day shape so the grid can append it.
+        assert set(body["session"]) >= {"id", "n", "name", "exercises"}
+
+    def test_bumps_plan_modified(self, client):
+        link = CoachAthleteFactory()
+        plan = link.create_plan()
+        before = plan.modified
+        client.force_login(link.coach)
+        client.post(self._url(plan))
+        plan.refresh_from_db()
+        assert plan.modified > before
+
+    def test_foreign_coach_forbidden(self, client):
+        link = CoachAthleteFactory()
+        plan = link.create_plan()
+        client.force_login(UserFactory())  # not this plan's coach
+        resp = client.post(self._url(plan))
+        assert resp.status_code in (403, 404)
+        assert Session.objects.filter(week__mesocycle__plan=plan).count() == 2
+
+    def test_over_limit_suspended_plan_is_402(self, client):
+        coach = UserFactory()
+        _aged_link(coach, days_ago=30)  # kept, pushes nothing
+        suspended = _aged_link(coach, days_ago=1)
+        plan = suspended.create_plan()
+        client.force_login(coach)
+        resp = client.post(self._url(plan))
+        assert resp.status_code == 402
+        assert resp.json()["over_limit"] is True
+
+    def test_rejects_get(self, client):
+        link = CoachAthleteFactory()
+        plan = link.create_plan()
+        client.force_login(link.coach)
+        assert client.get(self._url(plan)).status_code == 405
+
+
+# ---------------------------------------------------------------------------
+# CTA wiring — the dead-end links now POST to plan_create
+# (source/render-level, per the test_designer_agent_chat.py precedent)
+# ---------------------------------------------------------------------------
+
+
+class TestCtaWiring:
+    def test_roster_offers_new_program_per_athlete(self, client):
+        link = CoachAthleteFactory()
+        client.force_login(link.coach)
+        resp = client.get(reverse("meso:roster"))
+        assert resp.status_code == 200
+        # A form posting to plan_create for the coach's athlete is present.
+        assert _plan_new_url(link.athlete).encode() in resp.content
+
+    def test_athlete_profile_build_program_posts_to_create(self, client):
+        link = CoachAthleteFactory()
+        client.force_login(link.coach)
+        resp = client.get(reverse("meso:athlete", kwargs={"pk": link.athlete_id}))
+        assert resp.status_code == 200
+        assert _plan_new_url(link.athlete).encode() in resp.content
+
+    def test_athlete_profile_links_existing_plan_to_designer(self, client):
+        link = CoachAthleteFactory()
+        plan = link.create_plan()
+        client.force_login(link.coach)
+        resp = client.get(reverse("meso:athlete", kwargs={"pk": link.athlete_id}))
+        designer_url = reverse("meso:designer_plan", kwargs={"plan_id": plan.pk})
+        assert designer_url.encode() in resp.content
+
+
+# ---------------------------------------------------------------------------
+# The headline "Done when": create → edit → deliver → athlete sees it, no seed
+# ---------------------------------------------------------------------------
+
+
+class TestFreshCoachRoundTrip:
+    def test_create_edit_deliver_athlete_sees_it(self, client):
+        coach = UserFactory()
+        athlete = UserFactory()
+        link = CoachAthleteFactory(
+            coach=coach, athlete=athlete, status=CoachAthlete.Status.ACTIVE
+        )
+
+        # 1) Coach creates an individual program from the UI.
+        client.force_login(coach)
+        create = client.post(_plan_new_url(athlete))
+        assert create.status_code == 302
+        plan = Plan.objects.get(relationship=link)
+
+        # 2) Coach edits it — autosave one of the scaffold rows.
+        presc = plan.mesocycles.get().weeks.get().sessions.first().prescriptions.first()
+        patch = client.post(
+            reverse(
+                "meso:api_prescription_patch",
+                kwargs={"plan_id": plan.pk, "pk": presc.pk},
+            ),
+            data=json.dumps({"name": "Back Squat", "sets": "5"}),
+            content_type="application/json",
+        )
+        assert patch.status_code == 200
+
+        # 3) Coach delivers the current week.
+        deliver = client.post(
+            reverse("meso:api_plan_deliver", kwargs={"plan_id": plan.pk})
+        )
+        assert deliver.status_code == 201
+
+        # 4) The athlete sees the delivered program on their home — no seed used.
+        client.force_login(athlete)
+        home = client.get(reverse("meso:athlete_home"))
+        assert home.status_code == 200
+        cards = home.context["plans"]
+        card = next(c for c in cards if c["id"] == plan.pk)
+        assert card["awaiting"] is False
+
+
+def test_no_subscription_row_is_free_tier():
+    """Sanity: a brand-new coach (no CoachSubscription) is free-tier, cap 1."""
+    coach = UserFactory()
+    assert not CoachSubscription.objects.filter(coach=coach).exists()
+    first = _aged_link(coach, days_ago=10)  # oldest → kept
+    # One athlete is within the free cap; a newer second would be suspended.
+    assert access.suspended_athlete_ids(coach) == frozenset()
+    second = CoachAthleteFactory(coach=coach, status=CoachAthlete.Status.ACTIVE)
+    assert second.pk in access.suspended_athlete_ids(coach)
+    assert first.pk not in access.suspended_athlete_ids(coach)

--- a/app/store_project/meso/tests/test_plan_create.py
+++ b/app/store_project/meso/tests/test_plan_create.py
@@ -117,6 +117,42 @@ class TestScaffoldAndCreatePlan:
         plan.save(update_fields=["status"])
         assert link.working_plan() is None
 
+    def test_working_plan_excludes_materialized_group_plan(self):
+        """A group-delivery snapshot (``source_group`` set) is not the working plan.
+
+        It's rooted at the relationship but athlete-facing only — the designer 404s
+        on it — so it must never be returned (matches ``for_coach``/``editable_by``).
+        """
+        from store_project.meso.factories import MesoGroupFactory
+        from store_project.meso.factories import PlanFactory
+
+        link = CoachAthleteFactory()
+        group = MesoGroupFactory(coach=link.coach)
+        materialized = PlanFactory(relationship=link, group=None, source_group=group)
+        # Only a materialized snapshot exists → no editable working plan.
+        assert link.working_plan() is None
+        # And a real individual plan still wins over the snapshot.
+        real = link.create_plan()
+        assert link.working_plan() == real
+        assert materialized.source_group_id == group.pk
+
+    def test_plan_create_ignores_materialized_and_makes_a_real_plan(self, client):
+        """plan_create builds an editable draft even when a snapshot exists."""
+        from store_project.meso.factories import MesoGroupFactory
+        from store_project.meso.factories import PlanFactory
+
+        link = CoachAthleteFactory()
+        group = MesoGroupFactory(coach=link.coach)
+        PlanFactory(relationship=link, group=None, source_group=group)
+        client.force_login(link.coach)
+        resp = client.post(_plan_new_url(link.athlete))
+        assert resp.status_code == 302
+        real = link.working_plan()
+        assert real is not None
+        assert real.source_group_id is None
+        # The redirect lands on the editable plan, not the snapshot.
+        assert resp.url == reverse("meso:designer_plan", kwargs={"plan_id": real.pk})
+
     def test_group_create_shared_plan_still_scaffolds(self):
         """Regression guard for the refactor: the group path is unchanged."""
         from store_project.meso.factories import MesoGroupFactory

--- a/app/store_project/meso/urls.py
+++ b/app/store_project/meso/urls.py
@@ -72,6 +72,9 @@ urlpatterns = [
         name="unsubscribe_delivery_email",
     ),
     path("athlete/<uuid:pk>/", AthleteProfileView.as_view(), name="athlete"),
+    # Create (or open) an individual program for an athlete (first-time-UX
+    # Phase 1) — the "+ New program" / "Build a program" CTAs.
+    path("athlete/<uuid:pk>/plan/new/", views.plan_create, name="plan_create"),
     path("group/new/", views.group_create, name="group_create"),
     path("group/<int:pk>/", GroupDetailView.as_view(), name="group"),
     path("group/<int:pk>/design/", views.group_design, name="group_design"),
@@ -114,6 +117,12 @@ urlpatterns = [
         "api/plan/<int:plan_id>/session/<int:pk>/exercise/",
         views.session_add_exercise,
         name="api_session_add_exercise",
+    ),
+    # Add a training day to the plan's current week (first-time-UX Phase 1).
+    path(
+        "api/plan/<int:plan_id>/session/",
+        views.session_add,
+        name="api_session_add",
     ),
     # Per-athlete override on a group's shared program (groups Phase 3).
     path(

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -64,6 +64,7 @@ from .models import ProposedChange
 from .models import PushSubscription
 from .models import Session
 from .models import SessionLog
+from .models import Week
 from .models import WeekDelivery
 from .serializers import current_week
 from .serializers import group_adjustments
@@ -1518,15 +1519,22 @@ def session_add(request, plan_id):
     week = current_week(plan)
     if week is None:
         return HttpResponseBadRequest("This plan has no week to add a day to.")
-    next_order = (week.sessions.aggregate(m=Max("order"))["m"] or 0) + 1
-    next_day = (week.sessions.aggregate(m=Max("day_number"))["m"] or 0) + 1
-    session = Session.objects.create(
-        week=week, day_number=next_day, name=f"Day {next_day}", order=next_order
-    )
-    ExercisePrescription.objects.create(
-        session=session, name="New exercise", order=0, sets="3", reps="10", rpe="7"
-    )
-    _touch_plan(plan)
+    # Allocate the next day_number/order under a row lock on the week so a
+    # double-click or two concurrent submits can't read the same max and create
+    # duplicate "Day N" rows (Session has no uniqueness on these). The explicit
+    # transaction is required: prod views run in autocommit (ATOMIC_REQUESTS is
+    # inert here), so the lock must own its own transaction to be held.
+    with transaction.atomic():
+        Week.objects.select_for_update().filter(pk=week.pk).first()
+        next_order = (week.sessions.aggregate(m=Max("order"))["m"] or 0) + 1
+        next_day = (week.sessions.aggregate(m=Max("day_number"))["m"] or 0) + 1
+        session = Session.objects.create(
+            week=week, day_number=next_day, name=f"Day {next_day}", order=next_order
+        )
+        ExercisePrescription.objects.create(
+            session=session, name="New exercise", order=0, sets="3", reps="10", rpe="7"
+        )
+        _touch_plan(plan)
     return JsonResponse({"ok": True, "session": serialize_session(session)}, status=201)
 
 

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -71,6 +71,7 @@ from .serializers import serialize_chat_thread
 from .serializers import serialize_plan
 from .serializers import serialize_prescription
 from .serializers import serialize_proposed_change
+from .serializers import serialize_session
 from .serializers import serialize_session_log
 from .serializers import serialize_week_snapshot
 from .unsubscribe import athlete_opted_out
@@ -334,6 +335,9 @@ class AthleteProfileView(LoginRequiredMixin, TemplateView):
         ctx["active"] = "roster"
         ctx["athlete"] = presenters.profile_athlete(link.athlete)
         ctx["coach_style"] = presenters.coach_style(self.request.user)
+        # The relationship's working program (first-time-UX Phase 1): when one
+        # exists the CTAs open it in the designer; when not, they create one.
+        ctx["working_plan"] = link.working_plan()
         # Current block / macrocycle / latest results arrive with the program
         # schema (Phase 2) and logging (Phase 3).
         ctx["macrocycle"] = []
@@ -440,6 +444,40 @@ def group_design(request, pk):
             messages.error(request, OVER_LIMIT_MESSAGE)
             return redirect("meso:group", pk=group.pk)
         plan = group.shared_plan() or group.create_shared_plan()
+    return redirect("meso:designer_plan", plan_id=plan.pk)
+
+
+@login_required
+@require_POST
+def plan_create(request, pk):
+    """Create (or open) an individual program for one of the coach's athletes.
+
+    The individual analogue of ``group_design`` — the action behind the
+    "+ New program" / "Build a program" CTAs (first-time-UX Phase 1). Coach-scoped
+    to an *active* link (a foreign, pending, or unknown athlete is a flat 404).
+    Idempotent: reuses the relationship's existing non-archived plan, only
+    creating (with a starter scaffold) when there is none, under a row lock so two
+    concurrent submits can't each create one. Billing (D6): a soft-suspended
+    athlete (an over-limit coach's newer relationships) is frozen — a flashed
+    redirect, no plan created — consistent with the edit gate the designer would
+    hit immediately. Lands in the designer.
+    """
+    with transaction.atomic():
+        relationship = (
+            CoachAthlete.objects.select_for_update()
+            .for_coach(request.user)
+            .active()
+            .filter(athlete_id=pk)
+            .first()
+        )
+        if relationship is None:
+            raise Http404("Unknown athlete")
+        # Per-athlete freeze (D6): a suspended relationship can't be edited, so
+        # don't let one spawn a plan the autosave/deliver endpoints would 402 on.
+        if relationship.pk in billing_access.suspended_athlete_ids(request.user):
+            messages.error(request, OVER_LIMIT_MESSAGE)
+            return redirect("meso:athlete", pk=pk)
+        plan = relationship.working_plan() or relationship.create_plan()
     return redirect("meso:designer_plan", plan_id=plan.pk)
 
 
@@ -1461,6 +1499,35 @@ def session_add_exercise(request, plan_id, pk):
     return JsonResponse(
         {"ok": True, "prescription": serialize_prescription(prescription)}, status=201
     )
+
+
+@login_required
+@require_POST
+def session_add(request, plan_id):
+    """Append a blank training day (with a starter row) to the plan's current week.
+
+    The designer edits the current week, so "add a day" means add a ``Session`` to
+    that week — letting a scaffolded plan grow past its two starter days
+    (first-time-UX Phase 1). Scoped + edit-gated like the other designer writes via
+    ``_editable_plan_or_response`` (403 foreign, 402 over-limit). Returns the new
+    day in the grid's day shape so the client can append it without a reload.
+    """
+    plan, forbidden = _editable_plan_or_response(request, plan_id)
+    if forbidden is not None:
+        return forbidden
+    week = current_week(plan)
+    if week is None:
+        return HttpResponseBadRequest("This plan has no week to add a day to.")
+    next_order = (week.sessions.aggregate(m=Max("order"))["m"] or 0) + 1
+    next_day = (week.sessions.aggregate(m=Max("day_number"))["m"] or 0) + 1
+    session = Session.objects.create(
+        week=week, day_number=next_day, name=f"Day {next_day}", order=next_order
+    )
+    ExercisePrescription.objects.create(
+        session=session, name="New exercise", order=0, sets="3", reps="10", rpe="7"
+    )
+    _touch_plan(plan)
+    return JsonResponse({"ok": True, "session": serialize_session(session)}, status=201)
 
 
 # Free-form per-athlete override cells, mapped to their model ``max_length``.

--- a/app/store_project/static/js/meso.js
+++ b/app/store_project/static/js/meso.js
@@ -506,6 +506,33 @@ function createMeso() {
       });
     },
 
+    // Add a training day to the current week (first-time-UX Phase 1). The server
+    // appends the Session to the plan's current week and returns it in the grid's
+    // day shape; we push it so the new (empty-but-for-a-starter-row) day appears
+    // without a reload.
+    async addDay() {
+      if (this.live) {
+        try {
+          const data = await this.apiPost(
+            `/meso/api/plan/${this.planId}/session/`,
+            null,
+          );
+          this.program.push(data.session);
+        } catch (err) {
+          console.error("Add day failed", err);
+        }
+        return;
+      }
+      const n = this.program.length + 1;
+      this.program.push({
+        id: "d" + this.exSeq++,
+        n,
+        name: "Day " + n,
+        bias: "",
+        exercises: [],
+      });
+    },
+
     // ---- agent chat ----
     //
     // Each coach turn POSTs to the real proposal endpoint and renders the

--- a/app/store_project/templates/meso/athlete_profile.html
+++ b/app/store_project/templates/meso/athlete_profile.html
@@ -4,7 +4,14 @@
 
 {% block topnav_actions %}
   <a class="meso-btn" href="{% url 'meso:results' %}">Latest results</a>
-  <a class="meso-btn meso-btn--primary" href="{% url 'meso:designer' %}">Open in designer</a>
+  {% if working_plan %}
+    <a class="meso-btn meso-btn--primary" href="{% url 'meso:designer_plan' working_plan.id %}">Open in designer</a>
+  {% else %}
+    <form method="post" action="{% url 'meso:plan_create' athlete.id %}" style="margin:0;">
+      {% csrf_token %}
+      <button type="submit" class="meso-btn meso-btn--primary">Build a program</button>
+    </form>
+  {% endif %}
 {% endblock %}
 
 {% block content %}
@@ -127,8 +134,16 @@
         {% else %}
           <div class="meso-card meso-card--pad" style="text-align:center;color:var(--dim);">
             <p class="meso-eyebrow">Current block</p>
-            <p class="meso-sub" style="margin:8px 0 14px;">No active program yet.</p>
-            <a class="meso-btn meso-btn--primary" href="{% url 'meso:designer' %}">Build a program</a>
+            {% if working_plan %}
+              <p class="meso-sub" style="margin:8px 0 14px;">Program in progress &#8212; not yet delivered.</p>
+              <a class="meso-btn meso-btn--primary" href="{% url 'meso:designer_plan' working_plan.id %}">Open in designer</a>
+            {% else %}
+              <p class="meso-sub" style="margin:8px 0 14px;">No active program yet.</p>
+              <form method="post" action="{% url 'meso:plan_create' athlete.id %}" style="margin:0;">
+                {% csrf_token %}
+                <button type="submit" class="meso-btn meso-btn--primary">Build a program</button>
+              </form>
+            {% endif %}
           </div>
         {% endif %}
       </div>

--- a/app/store_project/templates/meso/designer.html
+++ b/app/store_project/templates/meso/designer.html
@@ -402,6 +402,9 @@
                   <button data-hover="add" @click="addExercise(di)" style="appearance:none;border:0;cursor:pointer;width:100%;text-align:left;padding:9px 15px;background:transparent;font:inherit;font-size:12px;font-weight:600;color:var(--dim);">+ Add exercise</button>
                 </div>
               </template>
+
+              <!-- Add a training day to the current week (first-time-UX Phase 1). -->
+              <button data-hover="add" @click="addDay()" style="appearance:none;cursor:pointer;width:100%;text-align:center;padding:11px 15px;background:var(--surface);border:1px dashed var(--line);border-radius:var(--radius);font:inherit;font-size:12.5px;font-weight:650;color:var(--dim);">+ Add day</button>
             </div>
 
             <!-- ===== BLOCK / PERIODIZATION VIEW ===== -->

--- a/app/store_project/templates/meso/roster.html
+++ b/app/store_project/templates/meso/roster.html
@@ -2,10 +2,6 @@
 
 {% block title %}Roster · Meso{% endblock %}
 
-{% block topnav_actions %}
-  <a class="meso-btn meso-btn--primary" href="{% url 'meso:designer' %}">+ New program</a>
-{% endblock %}
-
 {% block content %}
   <div class="meso-page">
     <div class="meso-pagehead">
@@ -118,6 +114,28 @@
               <input name="email" type="email" required maxlength="254" placeholder="athlete@email.com" style="flex:1;appearance:none;border:1px solid var(--line);border-radius:8px;background:var(--rail);font:inherit;font-size:13px;color:var(--ink);padding:8px 10px;outline:none;" />
               <button type="submit" class="meso-btn meso-btn--primary">Send invite</button>
             </form>
+          </details>
+
+          <!-- Build an individual program for an athlete (first-time-UX Phase 1).
+               A program is rooted at one athlete, so this picks the athlete then
+               creates (or reopens) their plan and lands in the designer. -->
+          <details style="border-top:1px solid var(--line-2);">
+            <summary style="list-style:none;cursor:pointer;padding:11px 16px;font-size:12.5px;font-weight:650;color:var(--accent-ink);">+ New program</summary>
+            <div style="display:flex;flex-direction:column;gap:8px;padding:4px 16px 16px;">
+              {% if athletes %}
+                <p class="meso-sub" style="margin:0 0 2px;">Pick an athlete to start a program for.</p>
+                {% for a in athletes %}
+                  <form method="post" action="{% url 'meso:plan_create' a.id %}" style="display:flex;align-items:center;gap:9px;margin:0;">
+                    {% csrf_token %}
+                    <span class="meso-avatar meso-avatar--sm {% if a.tone == 'accent' %}meso-avatar--accent{% endif %}">{{ a.initials }}</span>
+                    <span style="flex:1;min-width:0;font-size:13px;color:var(--ink);">{{ a.name }}</span>
+                    <button type="submit" class="meso-btn meso-btn--ghost" style="padding:5px 10px;font-size:12px;">New program</button>
+                  </form>
+                {% endfor %}
+              {% else %}
+                <p class="meso-sub" style="margin:0;">Invite an athlete first to build them a program.</p>
+              {% endif %}
+            </div>
           </details>
         </div>
 

--- a/frontend/meso.test.js
+++ b/frontend/meso.test.js
@@ -498,3 +498,49 @@ describe("coach 1RM editor", () => {
     expect(c.oneRm).not.toBe(null);
   });
 });
+
+// addDay — append a training day to the current week (first-time-UX Phase 1).
+// Mirrors addExercise: live → POST and push the server's day; offline → a local
+// placeholder; a failed add leaves the grid untouched.
+describe("addDay", () => {
+  it("appends the server's new day to the grid when live", async () => {
+    const c = makeMeso();
+    c.program = [{ id: 1, n: 1, name: "Day 1", exercises: [] }];
+    const newDay = {
+      id: 2,
+      n: 2,
+      name: "Day 2",
+      bias: "",
+      exercises: [{ id: 9, name: "New exercise" }],
+    };
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(res({ status: 201, body: { ok: true, session: newDay } }));
+    await c.addDay();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch.mock.calls[0][0]).toBe("/meso/api/plan/7/session/");
+    expect(c.program).toHaveLength(2);
+    expect(c.program[1]).toEqual(newDay);
+  });
+
+  it("adds a local placeholder day without a network call when not live", async () => {
+    const c = makeMeso();
+    c.live = false;
+    c.program = [];
+    global.fetch = vi.fn();
+    await c.addDay();
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(c.program).toHaveLength(1);
+    expect(c.program[0].name).toBe("Day 1");
+    expect(c.program[0].exercises).toEqual([]);
+  });
+
+  it("leaves the grid unchanged when the add fails", async () => {
+    const c = makeMeso();
+    c.program = [{ id: 1, n: 1, name: "Day 1", exercises: [] }];
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    global.fetch = vi.fn().mockResolvedValue(res({ ok: false, status: 402 }));
+    await c.addDay();
+    expect(c.program).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Meso — first-time UX, Phase 1: individual plan creation

The **headline first-time-UX blocker**: a real (non-seeded) coach **could not build an individual program in the UI at all.** The only `Plan.objects.create` lived in `MesoGroup.create_shared_plan` (groups only); both individual CTAs — roster **"+ New program"** and the athlete profile **"Build a program"** — pointed at the bare designer, which bounced a fresh coach back to the roster ("Pick an athlete to start a program."). Only `seed_meso_demo` ever built an individual `Plan → Mesocycle → Week → Session → ExercisePrescription` tree. This makes the core verb real.

(Plan: `docs/meso/first-time-ux-plan.md`, Phase 1. Decisions Q1–Q4 already locked.)

### What's in it
- **`Plan.scaffold(days=2)`** — the minimal-but-usable starter tree (one block, the current week, two empty training days each with a starter row), extracted so it's **shared** by individual + group creation. `MesoGroup.create_shared_plan` is refactored onto it (behaviour unchanged, regression-guarded).
- **`CoachAthlete.create_plan` / `working_plan`** — the individual-side mirror of `MesoGroup.create_shared_plan` / `shared_plan`. `working_plan` excludes archived **and materialized group-delivery snapshots** (`source_group` set), matching `PlanQuerySet.for_coach`/`editable_by`.
- **`plan_create`** (`POST /meso/athlete/<uuid>/plan/new/`) — coach-scoped to an *active* link (foreign/pending/unknown → 404); billing-gated per D6 (a soft-suspended athlete is frozen → flashed redirect, no plan); idempotent **reuse-or-create** under a row lock; lands in the designer.
- **`session_add`** (`POST /meso/api/plan/<id>/session/`) — append a training day (with a starter row) to the current week so a scaffold can grow; allocation row-locked so a double-click can't make duplicate "Day N". Wired to a **"+ Add day"** button + `addDay()` in the designer (mirrors `addExercise`).
- **CTAs wired**: roster gains a **"+ New program"** per-athlete disclosure (the dead-end topnav button is removed); the athlete profile's **"Build a program"** POSTs to create, and **"Open in designer"** opens an existing plan when one exists.

**Done when** (met): a fresh coach can invite an athlete, click **New program**, and land in a working, editable, **deliverable** designer — and the athlete sees the delivered week — **with no seed required** (covered end-to-end by `TestFreshCoachRoundTrip`).

### Deferred (noted, not silently cut)
**add-week + a week-switcher** — the designer is a single-current-week editor, so an added *non-current* week isn't surfaced yet; low-value until a switcher exists. Add-*day* (visible in the current week) ships now.

### Testing
Red→green. **+30 pytest** (`test_plan_create.py`) + **+3 Vitest** (`addDay`). Full project suite **1130 green**, 86 frontend green, ruff + `ruff format` + `makemigrations --check` + `manage.py check` clean. **No model fields → no migration.**

### Review
Local **Codex review loop: CLEAN after 3 iterations** — fixed a **P1** (materialized group snapshot leaking into `working_plan` → designer 404) and a **P2** (concurrent add-day duplicate allocation → row lock).

https://claude.ai/code/session_019A9KdsVs33wipsGjSaFWXV
