### PR TITLE
Meso — first-time UX Phase 4: athlete first-run polish (install prompt + first-log coachmark)

### DIFF
--- a/app/store_project/meso/tests/test_athlete_onboarding.py
+++ b/app/store_project/meso/tests/test_athlete_onboarding.py
@@ -30,6 +30,7 @@ from store_project.meso.factories import SessionLogFactory
 from store_project.meso.factories import WeekFactory
 from store_project.meso.models import CoachAthlete
 from store_project.meso.models import Plan
+from store_project.meso.models import SessionLog
 from store_project.users.factories import UserFactory
 
 pytestmark = pytest.mark.django_db
@@ -87,12 +88,25 @@ class TestFirstLogHintHome:
         body = client.get(HOME).content.decode()
         assert HOME_HINT in body
 
-    def test_hidden_once_the_athlete_has_logged(self, client):
+    def test_hidden_once_the_athlete_has_completed_a_log(self, client):
         athlete, _c, session, _p = seed()
-        SessionLogFactory(session=session, athlete=athlete)
+        SessionLogFactory(
+            session=session, athlete=athlete, status=SessionLog.Status.DONE
+        )
         client.force_login(athlete)
         body = client.get(HOME).content.decode()
         assert HOME_HINT not in body
+
+    def test_a_draft_save_keeps_the_hint(self, client):
+        # "Save progress" writes a *pending* log while the session still reads
+        # "To do" — the athlete hasn't truly logged yet, so keep teaching.
+        athlete, _c, session, _p = seed()
+        SessionLogFactory(
+            session=session, athlete=athlete, status=SessionLog.Status.PENDING
+        )
+        client.force_login(athlete)
+        body = client.get(HOME).content.decode()
+        assert HOME_HINT in body
 
     def test_hidden_when_nothing_is_delivered_yet(self, client):
         # No delivered session to tap → the "tap a session below" nudge would
@@ -108,7 +122,9 @@ class TestFirstLogHintHome:
         # don't re-teach.
         athlete, _coach, _s, _p = seed()
         _a2, _c2, other_session, _p2 = seed(athlete=athlete)
-        SessionLogFactory(session=other_session, athlete=athlete)
+        SessionLogFactory(
+            session=other_session, athlete=athlete, status=SessionLog.Status.DONE
+        )
         client.force_login(athlete)
         body = client.get(HOME).content.decode()
         assert HOME_HINT not in body
@@ -123,12 +139,25 @@ class TestFirstLogHintSession:
         body = client.get(session_url(session)).content.decode()
         assert SESSION_HINT in body
 
-    def test_hidden_once_the_athlete_has_logged(self, client):
+    def test_hidden_once_the_athlete_has_completed_a_log(self, client):
         athlete, _c, session, _p = seed()
-        SessionLogFactory(session=session, athlete=athlete)
+        SessionLogFactory(
+            session=session, athlete=athlete, status=SessionLog.Status.DONE
+        )
         client.force_login(athlete)
         body = client.get(session_url(session)).content.decode()
         assert SESSION_HINT not in body
+
+    def test_a_draft_save_keeps_the_session_hint(self, client):
+        # A pending draft on this very session must not retract the how-to-log
+        # coachmark — the athlete hasn't completed "Log session" yet.
+        athlete, _c, session, _p = seed()
+        SessionLogFactory(
+            session=session, athlete=athlete, status=SessionLog.Status.PENDING
+        )
+        client.force_login(athlete)
+        body = client.get(session_url(session)).content.decode()
+        assert SESSION_HINT in body
 
 
 class TestOnboardingWiring:

--- a/app/store_project/meso/tests/test_athlete_onboarding.py
+++ b/app/store_project/meso/tests/test_athlete_onboarding.py
@@ -1,0 +1,159 @@
+"""First-time UX Phase 4 — athlete first-run polish (athlete surface).
+
+Two affordances make a newly-invited athlete's first run obvious:
+
+- a one-time **first-log coachmark** that teaches the athlete to tap a session
+  and log it. It is **server-driven** (shown only while the athlete has a
+  delivered session to tap but has *never* logged any session), so it is
+  naturally one-time and cross-device — it vanishes the moment the first log
+  lands, with no per-device flag or migration;
+- a dismissible **PWA install card** on the training home, revealed by
+  ``meso_onboarding.js`` (which also persists coachmark dismissals).
+
+The reveal/dismiss logic is browser-side (``beforeinstallprompt`` / standalone
+detection / localStorage) and unit-tested in ``frontend/meso_onboarding.test.js``;
+what is pinned here is the *server-side contract* — when the coachmark renders
+and that the onboarding chrome is wired into the athlete templates only.
+"""
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+
+from store_project.meso.factories import CoachAthleteFactory
+from store_project.meso.factories import CoachProfileFactory
+from store_project.meso.factories import ExercisePrescriptionFactory
+from store_project.meso.factories import MesocycleFactory
+from store_project.meso.factories import PlanFactory
+from store_project.meso.factories import SessionFactory
+from store_project.meso.factories import SessionLogFactory
+from store_project.meso.factories import WeekFactory
+from store_project.meso.models import CoachAthlete
+from store_project.meso.models import Plan
+from store_project.users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def seed(*, athlete=None, coach=None, delivered=True):
+    """A plan → week → session → prescription for one athlete.
+
+    ``delivered`` stamps the week (the athlete's home only surfaces delivered
+    sessions); leaving it false models a coach who's still building.
+    """
+    coach = coach or UserFactory()
+    athlete = athlete or UserFactory()
+    rel = CoachAthleteFactory(
+        coach=coach, athlete=athlete, status=CoachAthlete.Status.ACTIVE
+    )
+    plan = PlanFactory(
+        relationship=rel, title="Hypertrophy Block", status=Plan.Status.ACTIVE
+    )
+    meso = MesocycleFactory(plan=plan, name="Hypertrophy", order=0)
+    week = WeekFactory(
+        mesocycle=meso,
+        index=2,
+        is_current=True,
+        delivered_at=timezone.now() if delivered else None,
+    )
+    session = SessionFactory(week=week, day_number=1, name="Lower", bias="Quad")
+    presc = ExercisePrescriptionFactory(
+        session=session, name="Box Squat", sets="4", reps="6", load="70", rpe="7"
+    )
+    return athlete, coach, session, presc
+
+
+HOME = reverse("meso:athlete_home")
+ROSTER = reverse("meso:roster")
+ONBOARDING_JS = "js/meso_onboarding.js"
+
+# Markers the templates carry; asserting on these keeps the test resilient to
+# copy changes while pinning the behaviour (which coachmark, install card).
+HOME_HINT = 'data-coachmark-key="firstlog-home"'
+SESSION_HINT = 'data-coachmark-key="firstlog-session"'
+INSTALL_CARD = 'id="meso-install-card"'
+
+
+def session_url(session):
+    return reverse("meso:athlete_session", kwargs={"pk": session.pk})
+
+
+class TestFirstLogHintHome:
+    """The home coachmark shows only to an athlete who can — but never has — logged."""
+
+    def test_shows_for_new_athlete_with_a_delivered_session(self, client):
+        athlete, *_ = seed()
+        client.force_login(athlete)
+        body = client.get(HOME).content.decode()
+        assert HOME_HINT in body
+
+    def test_hidden_once_the_athlete_has_logged(self, client):
+        athlete, _c, session, _p = seed()
+        SessionLogFactory(session=session, athlete=athlete)
+        client.force_login(athlete)
+        body = client.get(HOME).content.decode()
+        assert HOME_HINT not in body
+
+    def test_hidden_when_nothing_is_delivered_yet(self, client):
+        # No delivered session to tap → the "tap a session below" nudge would
+        # point at nothing, so it must not show.
+        athlete, *_ = seed(delivered=False)
+        client.force_login(athlete)
+        body = client.get(HOME).content.decode()
+        assert HOME_HINT not in body
+
+    def test_a_log_on_another_session_counts_as_having_logged(self, client):
+        # The hint is about ever-having-logged, not this plan — any prior log
+        # (here under a different coach) means the athlete already knows how, so
+        # don't re-teach.
+        athlete, _coach, _s, _p = seed()
+        _a2, _c2, other_session, _p2 = seed(athlete=athlete)
+        SessionLogFactory(session=other_session, athlete=athlete)
+        client.force_login(athlete)
+        body = client.get(HOME).content.decode()
+        assert HOME_HINT not in body
+
+
+class TestFirstLogHintSession:
+    """The session-logger coachmark teaches a first-ever logger how to log."""
+
+    def test_shows_for_a_first_time_logger(self, client):
+        athlete, _c, session, _p = seed()
+        client.force_login(athlete)
+        body = client.get(session_url(session)).content.decode()
+        assert SESSION_HINT in body
+
+    def test_hidden_once_the_athlete_has_logged(self, client):
+        athlete, _c, session, _p = seed()
+        SessionLogFactory(session=session, athlete=athlete)
+        client.force_login(athlete)
+        body = client.get(session_url(session)).content.decode()
+        assert SESSION_HINT not in body
+
+
+class TestOnboardingWiring:
+    """The install card + onboarding JS belong to the athlete surface only."""
+
+    def test_home_renders_install_card_and_onboarding_js(self, client):
+        athlete, *_ = seed()
+        client.force_login(athlete)
+        body = client.get(HOME).content.decode()
+        assert INSTALL_CARD in body
+        assert ONBOARDING_JS in body
+
+    def test_session_loads_onboarding_js_without_an_install_card(self, client):
+        # The install prompt lives on the training home; the session page still
+        # gets the onboarding JS (it powers the first-log coachmark dismissal).
+        athlete, _c, session, _p = seed()
+        client.force_login(athlete)
+        body = client.get(session_url(session)).content.decode()
+        assert ONBOARDING_JS in body
+        assert INSTALL_CARD not in body
+
+    def test_coach_roster_has_no_onboarding_chrome(self, client):
+        coach = UserFactory()
+        CoachProfileFactory(user=coach)
+        client.force_login(coach)
+        body = client.get(ROSTER).content.decode()
+        assert ONBOARDING_JS not in body
+        assert INSTALL_CARD not in body

--- a/app/store_project/meso/tests/test_athlete_pwa.py
+++ b/app/store_project/meso/tests/test_athlete_pwa.py
@@ -111,6 +111,14 @@ class TestServiceWorker:
         assert OFFLINE in body
         assert HOME in body
 
+    def test_precaches_athlete_scripts(self, client):
+        # Every script the athlete shell loads must be in the precache, or it
+        # silently stops working offline after a worker update.
+        body = client.get(SW).content.decode()
+        assert "js/meso_athlete.js" in body
+        assert "js/meso_push.js" in body
+        assert "js/meso_onboarding.js" in body
+
     def test_no_login_required(self, client):
         assert client.get(SW).status_code == 200
 

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -962,7 +962,8 @@ def manifest_webmanifest(request):
 
 # Bumped when the cached shell changes so the worker drops stale caches on
 # activate. Keep in sync with the cache name baked into the worker template.
-PWA_CACHE_VERSION = "meso-pwa-v1"
+# v2: added meso_onboarding.js to the precached shell (first-time UX Phase 4).
+PWA_CACHE_VERSION = "meso-pwa-v2"
 
 
 @require_GET

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -601,15 +601,20 @@ def _athlete_plans(user):
     return Plan.objects.for_athlete(user).exclude(status=Plan.Status.ARCHIVED)
 
 
-def _athlete_has_logged(user):
-    """Whether the athlete has ever logged any session (first-time UX Phase 4).
+def _athlete_has_completed_log(user):
+    """Whether the athlete has ever *completed* a session log (Phase 4).
 
-    Drives the one-time first-log coachmark: it's a *first*-log nudge, so any
-    prior log (in any plan) means they already know how — the hint must hide.
+    Drives the one-time first-log coachmark: it's a *first*-log nudge, so once
+    they've finished a real session (in any plan) they know how — the hint hides.
+    Gated on a ``done`` log specifically (not any row): a "Save progress" draft
+    writes a ``pending`` log while the session still reads "To do", and the hint
+    teaches that final "Log session" step, so a draft must not suppress it.
     Server-driven, so the nudge is naturally one-time + cross-device with no
     per-device flag or migration; it vanishes the moment the first log lands.
     """
-    return SessionLog.objects.filter(athlete=user).exists()
+    return SessionLog.objects.filter(
+        athlete=user, status=SessionLog.Status.DONE
+    ).exists()
 
 
 def _athlete_session_or_404(user, pk):
@@ -652,7 +657,7 @@ class AthleteHomeView(LoginRequiredMixin, TemplateView):
         # tap *and* the athlete has never logged — pointing "tap a session below"
         # at an empty week would be noise.
         has_delivered = any(card["sessions"] for card in ctx["plans"])
-        ctx["show_first_log_hint"] = has_delivered and not _athlete_has_logged(
+        ctx["show_first_log_hint"] = has_delivered and not _athlete_has_completed_log(
             self.request.user
         )
         ctx.update(_pwa_context())
@@ -680,7 +685,7 @@ class AthleteSessionView(LoginRequiredMixin, TemplateView):
         ctx["athlete_initials"] = presenters.initials(ctx["athlete_name"])
         # First-log coachmark (Phase 4): teach the logger only to a first-ever
         # logger — any prior log means they already know how.
-        ctx["show_first_log_hint"] = not _athlete_has_logged(self.request.user)
+        ctx["show_first_log_hint"] = not _athlete_has_completed_log(self.request.user)
         ctx.update(_pwa_context())
         return ctx
 

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -601,6 +601,17 @@ def _athlete_plans(user):
     return Plan.objects.for_athlete(user).exclude(status=Plan.Status.ARCHIVED)
 
 
+def _athlete_has_logged(user):
+    """Whether the athlete has ever logged any session (first-time UX Phase 4).
+
+    Drives the one-time first-log coachmark: it's a *first*-log nudge, so any
+    prior log (in any plan) means they already know how — the hint must hide.
+    Server-driven, so the nudge is naturally one-time + cross-device with no
+    per-device flag or migration; it vanishes the moment the first log lands.
+    """
+    return SessionLog.objects.filter(athlete=user).exists()
+
+
 def _athlete_session_or_404(user, pk):
     """A delivered session the athlete owns, or ``Http404``.
 
@@ -637,6 +648,13 @@ class AthleteHomeView(LoginRequiredMixin, TemplateView):
         ctx["pending"] = presenters.athlete_pending(self.request.user)
         ctx["athlete_name"] = self.request.user.display_name()
         ctx["athlete_initials"] = presenters.initials(ctx["athlete_name"])
+        # First-log coachmark (Phase 4): only when there's a delivered session to
+        # tap *and* the athlete has never logged — pointing "tap a session below"
+        # at an empty week would be noise.
+        has_delivered = any(card["sessions"] for card in ctx["plans"])
+        ctx["show_first_log_hint"] = has_delivered and not _athlete_has_logged(
+            self.request.user
+        )
         ctx.update(_pwa_context())
         return ctx
 
@@ -660,6 +678,9 @@ class AthleteSessionView(LoginRequiredMixin, TemplateView):
         ctx["log_data"] = presenters.athlete_log_payload(sess)
         ctx["athlete_name"] = self.request.user.display_name()
         ctx["athlete_initials"] = presenters.initials(ctx["athlete_name"])
+        # First-log coachmark (Phase 4): teach the logger only to a first-ever
+        # logger — any prior log means they already know how.
+        ctx["show_first_log_hint"] = not _athlete_has_logged(self.request.user)
         ctx.update(_pwa_context())
         return ctx
 

--- a/app/store_project/static/js/meso_onboarding.js
+++ b/app/store_project/static/js/meso_onboarding.js
@@ -30,6 +30,16 @@
     return { show: false, mode: null };
   }
 
+  // Whether this is an iOS device — the install path with no `beforeinstallprompt`,
+  // where we show manual Add-to-Home-Screen steps instead. iPhone/iPod/iPad report
+  // it in the UA; iPadOS 13+ Safari reports a desktop "Macintosh" UA but is
+  // touch-capable (maxTouchPoints > 1), so detect that too or iPads get nothing.
+  function detectIOS(ua, maxTouchPoints) {
+    const agent = String(ua || "");
+    if (/iphone|ipad|ipod/i.test(agent)) return true;
+    return /macintosh/i.test(agent) && (maxTouchPoints || 0) > 1;
+  }
+
   // Read a dismissal flag, defensively: storage can be absent or throw (Safari
   // private mode), in which case "not dismissed" is the safe default.
   function isDismissed(key, storage) {
@@ -105,13 +115,12 @@
     } catch (e) {
       standalone = false;
     }
-    const ua = (root.navigator && root.navigator.userAgent) || "";
-    const isIOS = /iphone|ipad|ipod/i.test(ua) && !root.MSStream;
+    const nav = root.navigator || {};
     return {
       standalone: standalone,
       dismissed: isDismissed(INSTALL_DISMISS_KEY),
       canPrompt: !!root.__mesoInstallEvent,
-      isIOS: isIOS,
+      isIOS: detectIOS(nav.userAgent, nav.maxTouchPoints),
     };
   }
 
@@ -187,6 +196,6 @@
 
   // Test hook for Node-based runners (vitest); skipped in the browser.
   if (typeof module !== "undefined" && module.exports) {
-    module.exports = { installPromptState, isDismissed };
+    module.exports = { installPromptState, isDismissed, detectIOS };
   }
 })(typeof window !== "undefined" ? window : this);

--- a/app/store_project/static/js/meso_onboarding.js
+++ b/app/store_project/static/js/meso_onboarding.js
@@ -1,0 +1,192 @@
+/* Meso — athlete first-run onboarding chrome (first-time UX Phase 4).
+ *
+ * Two browser-side affordances for a newly-invited athlete:
+ *
+ *  1. The installable-PWA prompt on the training home. Chromium fires
+ *     `beforeinstallprompt`; we stash it (see _pwa_head.html) and reveal the
+ *     install card with a real "Install" button. iOS Safari has no such event,
+ *     so there we show the manual Add-to-Home-Screen instructions instead. When
+ *     the app already runs standalone (installed) or the athlete dismissed the
+ *     card, it stays hidden.
+ *  2. Coachmark dismissal: the first-log coachmarks are *shown* server-side
+ *     (only until the athlete's first log lands), but a dismiss here persists in
+ *     localStorage so a coachmark the athlete waved away stays gone on reload.
+ *
+ * The decision logic is pure + unit-tested (frontend/meso_onboarding.test.js);
+ * the DOM wiring is verified at the render level in the Django tests.
+ */
+(function (root) {
+  // ---- pure logic (unit-tested) ----
+
+  // Decide whether/how to show the install card given the browser's situation.
+  // `env`: { standalone, dismissed, canPrompt, isIOS }. Returns
+  // { show, mode } where mode is "prompt" (a captured native prompt), "ios"
+  // (manual Add-to-Home-Screen), or null (nothing to show).
+  function installPromptState(env) {
+    const e = env || {};
+    if (e.standalone || e.dismissed) return { show: false, mode: null };
+    if (e.canPrompt) return { show: true, mode: "prompt" };
+    if (e.isIOS) return { show: true, mode: "ios" };
+    return { show: false, mode: null };
+  }
+
+  // Read a dismissal flag, defensively: storage can be absent or throw (Safari
+  // private mode), in which case "not dismissed" is the safe default.
+  function isDismissed(key, storage) {
+    try {
+      const store = storage || root.localStorage;
+      return !!store && store.getItem(key) === "1";
+    } catch (e) {
+      return false;
+    }
+  }
+
+  // Persist a dismissal flag. Best-effort: if storage is unavailable the card
+  // still hides for this page load, it just won't remember next time.
+  function setDismissed(key, storage) {
+    try {
+      const store = storage || root.localStorage;
+      if (store) store.setItem(key, "1");
+    } catch (e) {
+      /* best-effort — the element is hidden in-page regardless */
+    }
+  }
+
+  // ---- DOM wiring (browser only) ----
+
+  const INSTALL_DISMISS_KEY = "meso-install-dismissed";
+
+  // Toggle visibility via inline `display` rather than the `hidden` attribute:
+  // these cards carry an inline `display:flex` for layout, and an author inline
+  // style beats the UA `[hidden] { display: none }` rule — so `hidden` alone
+  // wouldn't actually hide them. Setting `style.display` directly always wins.
+  function hide(el) {
+    if (el) el.style.display = "none";
+  }
+  function show(el, display) {
+    if (el) el.style.display = display || "block";
+  }
+
+  // localStorage key for one coachmark's dismissal.
+  function coachmarkKey(key) {
+    return "meso-coachmark-" + key;
+  }
+
+  // Hide any already-dismissed coachmark and wire its dismiss control. The
+  // coachmark itself is rendered (or not) server-side; this only remembers a
+  // manual dismissal across reloads.
+  function initCoachmarks(doc) {
+    const marks = doc.querySelectorAll("[data-coachmark-key]");
+    for (let i = 0; i < marks.length; i++) {
+      const el = marks[i];
+      const storeKey = coachmarkKey(el.dataset.coachmarkKey);
+      if (isDismissed(storeKey)) {
+        hide(el);
+        continue;
+      }
+      const btn = el.querySelector("[data-coachmark-dismiss]");
+      if (btn) {
+        btn.addEventListener("click", function () {
+          setDismissed(storeKey);
+          hide(el);
+        });
+      }
+    }
+  }
+
+  // Snapshot the browser's install situation for installPromptState().
+  function readInstallEnv() {
+    let standalone = false;
+    try {
+      standalone =
+        (root.matchMedia &&
+          root.matchMedia("(display-mode: standalone)").matches) ||
+        root.navigator.standalone === true;
+    } catch (e) {
+      standalone = false;
+    }
+    const ua = (root.navigator && root.navigator.userAgent) || "";
+    const isIOS = /iphone|ipad|ipod/i.test(ua) && !root.MSStream;
+    return {
+      standalone: standalone,
+      dismissed: isDismissed(INSTALL_DISMISS_KEY),
+      canPrompt: !!root.__mesoInstallEvent,
+      isIOS: isIOS,
+    };
+  }
+
+  // Reveal + wire the install card. Re-runs when a deferred `beforeinstallprompt`
+  // arrives after first paint (the inline stash dispatches `meso:installable`).
+  function initInstallCard(doc) {
+    const card = doc.getElementById("meso-install-card");
+    if (!card) return; // home only — absent on other athlete pages
+
+    function render() {
+      const state = installPromptState(readInstallEnv());
+      if (!state.show) {
+        hide(card);
+        return;
+      }
+      const promptBlock = card.querySelector('[data-install-mode="prompt"]');
+      const iosBlock = card.querySelector('[data-install-mode="ios"]');
+      if (state.mode === "prompt") {
+        show(promptBlock, "block");
+        hide(iosBlock);
+      } else {
+        hide(promptBlock);
+        show(iosBlock, "block");
+      }
+      show(card, "flex");
+    }
+
+    const installBtn = doc.getElementById("meso-install-btn");
+    if (installBtn) {
+      installBtn.addEventListener("click", async function () {
+        const evt = root.__mesoInstallEvent;
+        if (!evt) return;
+        evt.prompt();
+        try {
+          await evt.userChoice;
+        } catch (e) {
+          /* user dismissed the native sheet — leave the card for a retry */
+        }
+        // The captured event is single-use; drop it and re-evaluate (a granted
+        // install now reports standalone, so the card hides on its own).
+        root.__mesoInstallEvent = null;
+        render();
+      });
+    }
+
+    const dismissBtn = card.querySelector("[data-install-dismiss]");
+    if (dismissBtn) {
+      dismissBtn.addEventListener("click", function () {
+        setDismissed(INSTALL_DISMISS_KEY);
+        hide(card);
+      });
+    }
+
+    // A late-arriving install event (Chromium often fires it after load).
+    root.addEventListener("meso:installable", render);
+    render();
+  }
+
+  function init() {
+    const doc = root.document;
+    if (!doc) return;
+    initCoachmarks(doc);
+    initInstallCard(doc);
+  }
+
+  if (typeof document !== "undefined" && document.addEventListener) {
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", init);
+    } else {
+      init();
+    }
+  }
+
+  // Test hook for Node-based runners (vitest); skipped in the browser.
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = { installPromptState, isDismissed };
+  }
+})(typeof window !== "undefined" ? window : this);

--- a/app/store_project/templates/meso/_pwa_head.html
+++ b/app/store_project/templates/meso/_pwa_head.html
@@ -32,5 +32,15 @@ theme/apple meta, the service-worker registration, and the push config the
         });
     });
   }
+  // Capture the install prompt as early as possible — Chromium can fire it
+  // before the deferred onboarding script runs. Stash it for the install card
+  // and announce it so a late arrival still reveals the card (Phase 4).
+  window.__mesoInstallEvent = null;
+  window.addEventListener("beforeinstallprompt", function (e) {
+    e.preventDefault();
+    window.__mesoInstallEvent = e;
+    window.dispatchEvent(new Event("meso:installable"));
+  });
 </script>
 <script defer src="{% static 'js/meso_push.js' %}"></script>
+<script defer src="{% static 'js/meso_onboarding.js' %}"></script>

--- a/app/store_project/templates/meso/athlete_home.html
+++ b/app/store_project/templates/meso/athlete_home.html
@@ -35,6 +35,25 @@
       </button>
     {% endif %}
 
+    <!-- Install prompt (first-time UX Phase 4): kept hidden; meso_onboarding.js
+         reveals it only when the app is installable and not already installed or
+         dismissed, and swaps in the native button vs the manual iOS steps. -->
+    <div id="meso-install-card" class="meso-card meso-card--pad"
+         style="display:none;align-items:flex-start;gap:12px;margin-bottom:14px;border:1px solid var(--line);border-left:3px solid var(--accent-ink);">
+      <span style="font-size:18px;line-height:1.3;">📲</span>
+      <span style="flex:1;min-width:0;">
+        <span style="display:block;font-size:14px;font-weight:700;letter-spacing:-0.01em;">Install Meso on your phone</span>
+        <span data-install-mode="prompt" style="display:none;">
+          <span class="meso-row-meta" style="display:block;margin:2px 0 9px;">Add it to your home screen for one-tap access and offline logging at the gym.</span>
+          <button type="button" id="meso-install-btn" class="meso-btn meso-btn--primary" style="padding:6px 12px;font-size:13px;">Install</button>
+        </span>
+        <span data-install-mode="ios" style="display:none;">
+          <span class="meso-row-meta" style="display:block;margin-top:2px;">Tap <strong>Share</strong>, then <strong>Add to Home Screen</strong>, for one-tap access and offline logging at the gym.</span>
+        </span>
+      </span>
+      <button type="button" data-install-dismiss aria-label="Dismiss install prompt" class="meso-btn meso-btn--ghost" style="padding:4px 8px;font-size:14px;line-height:1;">&times;</button>
+    </div>
+
     <!-- Your coaches (N4 Phase 2): invites awaiting you, requests you've sent,
          and the request-a-coach form. -->
     <div class="meso-card meso-card--pad" style="margin-bottom:14px;">
@@ -85,6 +104,21 @@
         <p class="meso-row-meta" style="margin-top:8px;">Enter your coach's email to ask to train with them.</p>
       </details>
     </div>
+
+    {% if show_first_log_hint %}
+      <!-- First-log coachmark (first-time UX Phase 4): server-driven (shown only
+           until the athlete's first log lands), so it's one-time + cross-device;
+           meso_onboarding.js persists a manual dismiss across reloads. -->
+      <div class="meso-card meso-card--pad" data-coachmark-key="firstlog-home"
+           style="display:flex;align-items:flex-start;gap:12px;margin-bottom:14px;border:1px solid var(--line);border-left:3px solid var(--accent-ink);">
+        <span style="font-size:18px;line-height:1.3;">👇</span>
+        <span style="flex:1;min-width:0;">
+          <span style="display:block;font-size:14px;font-weight:700;letter-spacing:-0.01em;">New here? Log your first workout</span>
+          <span class="meso-row-meta">Tap a session below to open the plan, fill in what you did, and check off each set.</span>
+        </span>
+        <button type="button" data-coachmark-dismiss aria-label="Dismiss tip" class="meso-btn meso-btn--ghost" style="padding:4px 8px;font-size:14px;line-height:1;">&times;</button>
+      </div>
+    {% endif %}
 
     {% for plan in plans %}
       <div class="meso-card meso-card--pad" style="margin-bottom:14px;">

--- a/app/store_project/templates/meso/athlete_session.html
+++ b/app/store_project/templates/meso/athlete_session.html
@@ -42,6 +42,20 @@
       <span class="meso-row-meta">sets logged — fill in what you did, then log the session.</span>
     </div>
 
+    {% if show_first_log_hint %}
+      <!-- First-log coachmark (first-time UX Phase 4): server-driven, shown only
+           to a first-ever logger; meso_onboarding.js persists a manual dismiss. -->
+      <div class="meso-card meso-card--pad" data-coachmark-key="firstlog-session"
+           style="display:flex;align-items:flex-start;gap:12px;margin-bottom:14px;border:1px solid var(--line);border-left:3px solid var(--accent-ink);">
+        <span style="font-size:18px;line-height:1.3;">💡</span>
+        <span style="flex:1;min-width:0;">
+          <span style="display:block;font-size:14px;font-weight:700;letter-spacing:-0.01em;">How to log a set</span>
+          <span class="meso-row-meta">For each set, type the reps and weight you did, then tap the circle on the right to check it off. When you're done, tap <strong>Log session</strong> at the bottom.</span>
+        </span>
+        <button type="button" data-coachmark-dismiss aria-label="Dismiss tip" class="meso-btn meso-btn--ghost" style="padding:4px 8px;font-size:14px;line-height:1;">&times;</button>
+      </div>
+    {% endif %}
+
     <template x-for="ex in exercises" :key="ex.id">
       <div class="meso-card" style="margin-bottom:12px;overflow:hidden;">
         <div style="padding:11px 16px 9px;border-bottom:1px solid var(--line-2);">

--- a/app/store_project/templates/meso/sw.js
+++ b/app/store_project/templates/meso/sw.js
@@ -26,6 +26,7 @@ const PRECACHE = [
   "{% static 'css/meso.css' %}",
   "{% static 'js/meso_athlete.js' %}",
   "{% static 'js/meso_push.js' %}",
+  "{% static 'js/meso_onboarding.js' %}",
   "{% static 'js/alpine.min.js' %}",
   "{% static 'png/meso-icon-192.png' %}",
   "{% static 'png/meso-icon-512.png' %}",

--- a/frontend/meso_onboarding.test.js
+++ b/frontend/meso_onboarding.test.js
@@ -11,7 +11,18 @@
 import {
   installPromptState,
   isDismissed,
+  detectIOS,
 } from "../app/store_project/static/js/meso_onboarding.js";
+
+const IPHONE_UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15";
+// iPadOS 13+ Safari reports a desktop "Macintosh" UA but is touch-capable.
+const IPADOS_DESKTOP_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15";
+const MAC_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome";
+const ANDROID_UA =
+  "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 Chrome/120 Mobile";
 
 describe("installPromptState", () => {
   it("hides when the app is already running standalone (installed)", () => {
@@ -52,6 +63,27 @@ describe("installPromptState", () => {
 
   it("treats a missing env as nothing-to-show", () => {
     expect(installPromptState()).toEqual({ show: false, mode: null });
+  });
+});
+
+describe("detectIOS", () => {
+  it("detects an iPhone from its UA", () => {
+    expect(detectIOS(IPHONE_UA, 5)).toBe(true);
+  });
+
+  it("detects iPadOS 13+ Safari posing as desktop Macintosh (touch-capable)", () => {
+    expect(detectIOS(IPADOS_DESKTOP_UA, 5)).toBe(true);
+  });
+
+  it("does not treat a real Mac (no touch) as iOS", () => {
+    expect(detectIOS(MAC_UA, 0)).toBe(false);
+    // A Mac UA with an undefined touch count must not throw or false-positive.
+    expect(detectIOS(MAC_UA)).toBe(false);
+  });
+
+  it("is false for Android and a missing UA", () => {
+    expect(detectIOS(ANDROID_UA, 5)).toBe(false);
+    expect(detectIOS()).toBe(false);
   });
 });
 

--- a/frontend/meso_onboarding.test.js
+++ b/frontend/meso_onboarding.test.js
@@ -1,0 +1,73 @@
+// Tests for the athlete first-run onboarding chrome
+// (app/store_project/static/js/meso_onboarding.js).
+//
+// The DOM wiring (revealing the install card, firing the deferred install
+// prompt, persisting coachmark dismissals) is verified at the render level in
+// the Django tests; what's unit-tested here is the pure logic that decides
+// *whether* and *how* to show the install card across the browser matrix
+// (already-installed / dismissed / Android-promptable / iOS-manual), plus the
+// defensive localStorage read.
+
+import {
+  installPromptState,
+  isDismissed,
+} from "../app/store_project/static/js/meso_onboarding.js";
+
+describe("installPromptState", () => {
+  it("hides when the app is already running standalone (installed)", () => {
+    expect(
+      installPromptState({ standalone: true, canPrompt: true, isIOS: true }),
+    ).toEqual({ show: false, mode: null });
+  });
+
+  it("hides when the athlete previously dismissed it", () => {
+    expect(
+      installPromptState({ dismissed: true, canPrompt: true, isIOS: false }),
+    ).toEqual({ show: false, mode: null });
+  });
+
+  it("offers the native prompt when the browser captured one", () => {
+    expect(
+      installPromptState({ canPrompt: true, isIOS: false }),
+    ).toEqual({ show: true, mode: "prompt" });
+  });
+
+  it("falls back to manual iOS instructions when there's no native prompt", () => {
+    expect(
+      installPromptState({ canPrompt: false, isIOS: true }),
+    ).toEqual({ show: true, mode: "ios" });
+  });
+
+  it("prefers the native prompt over the iOS path when both apply", () => {
+    expect(installPromptState({ canPrompt: true, isIOS: true }).mode).toBe(
+      "prompt",
+    );
+  });
+
+  it("hides on a desktop browser with no prompt and no iOS", () => {
+    expect(
+      installPromptState({ canPrompt: false, isIOS: false }),
+    ).toEqual({ show: false, mode: null });
+  });
+
+  it("treats a missing env as nothing-to-show", () => {
+    expect(installPromptState()).toEqual({ show: false, mode: null });
+  });
+});
+
+describe("isDismissed", () => {
+  it("is true only when the stored flag is exactly '1'", () => {
+    const store = { getItem: (k) => (k === "seen" ? "1" : null) };
+    expect(isDismissed("seen", store)).toBe(true);
+    expect(isDismissed("other", store)).toBe(false);
+  });
+
+  it("is false (never throws) when storage access throws", () => {
+    const store = {
+      getItem() {
+        throw new Error("SecurityError: storage disabled");
+      },
+    };
+    expect(isDismissed("seen", store)).toBe(false);
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -12,7 +12,7 @@ export default defineConfig({
     include: ["frontend/**/*.test.js"],
     coverage: {
       provider: "v8",
-      include: ["app/store_project/static/js/meso.js", "app/store_project/static/js/meso_athlete.js"],
+      include: ["app/store_project/static/js/meso.js", "app/store_project/static/js/meso_athlete.js", "app/store_project/static/js/meso_onboarding.js"],
       reporter: ["text", "html"],
     },
   },


### PR DESCRIPTION
## What

Phase 4 of the Meso first-time-UX slice — **athlete first-run polish**. Closes the last athlete-side onboarding gap from `docs/meso/first-time-ux-plan.md` (Phases 1–3 shipped in #326/#328/#329). A newly-invited athlete now gets:

1. **A dismissible PWA install prompt** on the training home (`/meso/me/`).
2. **A one-time first-log coachmark** on both the training home and the session logger.

## How

- **First-log coachmark is server-driven.** Shown only while the athlete has a *delivered* session to tap but has never *completed* a log — so it's naturally one-time and cross-device, vanishes the moment the first real log lands, and needs **no per-device flag and no migration**. A `pending` "Save progress" draft does **not** suppress it (it teaches the final "Log session" step). `views._athlete_has_completed_log` gates both surfaces.
- **Install prompt** (`meso_onboarding.js`): reveals the card from a captured `beforeinstallprompt` on Chromium, falls back to manual *Add to Home Screen* steps on iOS (incl. iPadOS-13+ Safari's desktop "Macintosh" UA), and stays hidden when already installed or dismissed. `meso_onboarding.js` also persists manual coachmark dismissals.
- Visibility is toggled via inline `style.display` (not the `hidden` attribute), since an inline `display:flex` carried for layout would beat the UA `[hidden]` rule.
- The onboarding script is added to the service-worker **PRECACHE** (cache bumped `v1`→`v2`) so it keeps working offline, consistent with the other athlete scripts.

No model changes, **no migration**.

## Tests

- `+11` pytest (`tests/test_athlete_onboarding.py`) — coachmark visibility matrix (delivered-gating, done vs pending, cross-plan), install-card/onboarding-JS wiring on athlete pages only (not the coach roster).
- `+1` pytest (`tests/test_athlete_pwa.py`) — the SW precaches every athlete script.
- `+13` vitest (`frontend/meso_onboarding.test.js`) — `installPromptState` browser matrix, `detectIOS` (incl. iPadOS-as-Mac), defensive `isDismissed`.
- Full suite green: 1035 meso pytest, 99 vitest.

## Review

Codex review loop: **CLEAN** after 3 fix iterations (iPadOS UA detection → done-log gating → SW precache), final pass found no actionable issues.

https://claude.ai/code/session_019A9KdsVs33wipsGjSaFWXV