### PR TITLE
Meso — first-time UX Phase 5: designer & agent self-explanation

### DIFF
--- a/app/store_project/meso/serializers.py
+++ b/app/store_project/meso/serializers.py
@@ -598,6 +598,31 @@ def serialize_group_identity(group):
     }
 
 
+def serialize_athlete_identity(plan):
+    """The individual plan's athlete identity for the designer left rail (Phase 5).
+
+    Replaces the prototype's hardcoded athlete chrome ("Maya Okonkwo" + invented
+    contraindications) with the *real* athlete — their name/initials, the plan's
+    goal, and their active contraindications (the same global injuries the agent
+    grounds on, so the coach sees the constraints while programming). A group plan
+    has no single athlete (it carries ``group`` instead), so this returns None.
+    """
+    athlete = plan.athlete
+    if athlete is None:
+        return None
+    name = athlete.display_name()
+    return {
+        "name": name,
+        "initials": initials(name),
+        "goal": plan.goal,
+        "contraindications": [
+            {"label": c.label, "text": c.text}
+            for c in athlete.contraindications.all()
+            if c.active
+        ],
+    }
+
+
 def serialize_plan(plan, week=None):
     """Serialize ``plan`` to the designer's ``program``/``weeks``/``phases`` shape.
 
@@ -665,6 +690,9 @@ def serialize_plan(plan, week=None):
             "unit": plan.unit,
         },
         "group": serialize_group_identity(plan.group) if plan.is_group else None,
+        # The real athlete identity for an individual plan's left rail (Phase 5);
+        # ``None`` for a group plan, which renders off ``group`` instead.
+        "athlete": serialize_athlete_identity(plan),
         "program": program,
         "weeks": week_strip,
         "phases": phases,

--- a/app/store_project/meso/tests/test_designer_onboarding.py
+++ b/app/store_project/meso/tests/test_designer_onboarding.py
@@ -1,0 +1,167 @@
+"""First-time UX Phase 5 — designer & agent self-explanation.
+
+The designer is a self-contained Alpine page that, until now, shipped a pile of
+*prototype chrome*: a hardcoded fake athlete ("Maya Okonkwo" with invented
+contraindications), a fabricated "Coach's programming style" block, and a
+hardcoded macrocycle — all rendered over whatever real plan the coach opened. A
+first-time coach also got no orientation: nothing said the grid autosaves, that
+the agent only *proposes* (changes wait at the review gate), or that the phone
+column is the athlete's real view.
+
+Phase 5 fixes both:
+
+- **Coachmarks.** Three dismissible first-run notes anchor the designer's
+  regions (week grid · agent · phone preview). They show until dismissed; the
+  dismissal persists client-side (``meso.js`` localStorage), like the athlete
+  onboarding chrome. No server "seen" flag, no migration.
+- **Agent self-explanation.** A persistent propose → review → apply note makes
+  the review gate explicit for everyone (not just first-timers).
+- **Real chrome.** The fabricated left-rail athlete/programming-style/macrocycle
+  is replaced with the *real* plan: the athlete's name + active
+  contraindications (now carried in the serialized payload) and the real
+  macrocycle phases.
+
+There is no JS test runner wired into Django, so the dismiss logic is unit-tested
+in ``frontend/meso.test.js`` and these guard the server seam: the serializer
+carries the real identity, the template renders the coachmarks + note and no
+longer renders the fabricated chrome, and ``meso.js`` exposes the dismiss API.
+"""
+
+from pathlib import Path
+
+import pytest
+from django.contrib.staticfiles import finders
+from django.urls import reverse
+
+from store_project.meso.factories import CoachAthleteFactory
+from store_project.meso.factories import ContraindicationFactory
+from store_project.meso.factories import MesoGroupFactory
+from store_project.meso.factories import PlanFactory
+from store_project.meso.serializers import serialize_plan
+from store_project.meso.tests.test_designer_save import seed_plan
+from store_project.users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def read_meso_js():
+    path = finders.find("js/meso.js")
+    assert path, "static js/meso.js must resolve"
+    return Path(path).read_text()
+
+
+def read_designer_template():
+    path = Path(__file__).resolve().parents[2] / "templates" / "meso" / "designer.html"
+    return path.read_text()
+
+
+def render_designer(client, plan):
+    client.force_login(plan.relationship.coach)
+    resp = client.get(reverse("meso:designer_plan", kwargs={"plan_id": plan.pk}))
+    assert resp.status_code == 200
+    return resp.content.decode()
+
+
+class TestCoachmarksRender:
+    """The three dismissible region coachmarks render for a real plan."""
+
+    def test_designer_renders_all_three_coachmarks(self, client):
+        plan, _, _ = seed_plan()
+        body = render_designer(client, plan)
+        assert "The week grid" in body  # grid coachmark
+        assert "Talk to the agent" in body  # agent coachmark
+        assert "Preview as your athlete" in body  # phone-preview coachmark
+
+    def test_each_coachmark_has_a_dismiss_control(self, client):
+        plan, _, _ = seed_plan()
+        body = render_designer(client, plan)
+        for key in ("grid", "agent", "phone"):
+            assert f"dismissCoachmark('{key}')" in body
+
+
+class TestAgentSelfExplanation:
+    """A persistent note makes the propose → review → apply loop explicit."""
+
+    def test_designer_renders_review_gate_note(self, client):
+        plan, _, _ = seed_plan()
+        body = render_designer(client, plan)
+        assert "you review" in body
+        assert "until you approve" in body
+
+
+class TestStaticChromeReplaced:
+    """The fabricated prototype chrome is gone; the real plan shows instead."""
+
+    def test_real_athlete_identity_renders(self, client):
+        athlete = UserFactory(name="Devon Reyes")
+        rel = CoachAthleteFactory(athlete=athlete)
+        plan = PlanFactory(relationship=rel, goal="Return to lifting")
+        ContraindicationFactory(athlete=athlete, text="R shoulder impingement")
+        body = render_designer(client, plan)
+        assert "Devon Reyes" in body  # injected for the left rail to hydrate
+        assert "R shoulder impingement" in body  # the real contraindication
+
+    def test_fabricated_prototype_chrome_is_gone(self, client):
+        # A real athlete with no recorded contraindications must not inherit the
+        # prototype's invented ones (a safety-adjacent mislead), nor the fake
+        # name / experience / programming-style / macrocycle chrome.
+        athlete = UserFactory(name="Devon Reyes")
+        rel = CoachAthleteFactory(athlete=athlete)
+        plan = PlanFactory(relationship=rel)
+        body = render_designer(client, plan)
+        assert "Maya" not in body
+        assert "avoid deep knee flexion" not in body
+        assert "programming style" not in body
+        assert "14 mo trained" not in body
+        assert "Base / GPP" not in body
+        assert "Peak / Test" not in body
+
+
+class TestCoachmarkSource:
+    """``meso.js`` exposes the (unit-tested) dismiss API the template wires to."""
+
+    def test_meso_js_has_coachmark_api(self):
+        js = read_meso_js()
+        for symbol in (
+            "coachmarkStorageKey",
+            "loadCoachmarks",
+            "coachmarkVisible",
+            "dismissCoachmark",
+        ):
+            assert symbol in js, f"meso.js should define {symbol}"
+
+    def test_template_wires_coachmark_visibility(self):
+        html = read_designer_template()
+        assert "coachmarkVisible('grid')" in html
+        assert "coachmarkVisible('agent')" in html
+        assert "coachmarkVisible('phone')" in html
+
+    def test_template_drops_fabricated_left_rail(self):
+        html = read_designer_template()
+        # The macrocycle rail is wired to the real phases, not the hardcoded four.
+        assert "Base / GPP" not in html
+        assert "Coach&#8217;s programming style" not in html
+
+
+class TestSerializerAthleteIdentity:
+    """``serialize_plan`` carries the individual plan's real athlete identity."""
+
+    def test_individual_plan_carries_real_athlete(self):
+        athlete = UserFactory(name="Devon Reyes")
+        rel = CoachAthleteFactory(athlete=athlete)
+        plan = PlanFactory(relationship=rel, goal="Get strong")
+        ContraindicationFactory(athlete=athlete, text="R shoulder impingement")
+        ContraindicationFactory(athlete=athlete, text="ignored", active=False)
+        data = serialize_plan(plan)
+        assert data["athlete"]["name"] == "Devon Reyes"
+        assert data["athlete"]["initials"] == "DR"
+        assert data["athlete"]["goal"] == "Get strong"
+        texts = [c["text"] for c in data["athlete"]["contraindications"]]
+        assert texts == ["R shoulder impingement"]  # active only
+
+    def test_group_plan_has_no_athlete_identity(self):
+        group = MesoGroupFactory()
+        plan = group.create_shared_plan()
+        data = serialize_plan(plan)
+        assert data["athlete"] is None
+        assert data["group"] is not None

--- a/app/store_project/static/js/meso.js
+++ b/app/store_project/static/js/meso.js
@@ -24,6 +24,11 @@ function createMeso() {
     // is a group's shared program; null for an individual plan. Hydrated by
     // init() from the injected plan's `group` payload (serialize_group_identity).
     group: null,
+    // Individual identity (real athlete name / initials / goal / active
+    // contraindications) for the left rail; null for a group plan. Hydrated by
+    // init() from the injected plan's `athlete` payload (serialize_athlete_identity).
+    // Replaces the prototype's hardcoded "Maya Okonkwo" chrome (Phase 5).
+    athlete: null,
     view: "week", // week | block | athlete
     periodStyle: "timeline", // timeline | ladder | calendar
     inputText: "",
@@ -31,6 +36,15 @@ function createMeso() {
     delivered: false,
     checks: {},
     exSeq: 1,
+
+    // ---- first-run coachmarks (first-time UX Phase 5) ----
+    // Three dismissible region notes (week grid / agent / phone preview) orient a
+    // first-time coach. They show until dismissed; the dismissal persists in
+    // localStorage so a coach who waved one away never sees it again (no server
+    // "seen" flag — the persistence lives client-side, like the athlete onboarding
+    // chrome). The reactive map drives `x-show`; init() hydrates it from storage.
+    coachmarkKeys: ["grid", "agent", "phone"],
+    coachmarksDismissed: {},
 
     // Group mode only: the open per-athlete override editor (one shared row),
     // or null when closed. Holds the targeted row (`ex`), the group's members,
@@ -93,8 +107,44 @@ function createMeso() {
       return this.mode !== "group";
     },
 
+    // ---- real plan headers (Phase 5) ----
+    // The prototype hardcoded "Week 2 — Accumulation" / "Hypertrophy block" over
+    // whatever plan was open; these derive the same chrome from the real plan.
+    get currentWeek() {
+      return this.weeks.find((w) => w.current) || this.weeks[0] || null;
+    },
+    get currentPhase() {
+      return (
+        this.phases.find((p) => p.state === "current") || this.phases[0] || null
+      );
+    },
+    // The top-bar cycle chip, e.g. "Hypertrophy · Wk 2 / 4".
+    get cycleLabel() {
+      const p = this.currentPhase;
+      const w = this.currentWeek;
+      const phase = p ? p.name : "";
+      const wk = w
+        ? w.label + (this.weeks.length ? " / " + this.weeks.length : "")
+        : "";
+      return [phase, wk].filter(Boolean).join(" · ");
+    },
+    // The week-view heading, e.g. "Wk 2 — Accum".
+    get weekHeading() {
+      const w = this.currentWeek;
+      if (!w) return "This week";
+      return w.phase ? w.label + " — " + w.phase : w.label;
+    },
+    // The block-view heading, e.g. "Hypertrophy — 4 wk mesocycle".
+    get blockHeading() {
+      const p = this.currentPhase;
+      if (!p) return "Mesocycle";
+      return p.name + " — " + p.weeks + " mesocycle";
+    },
+
     // ---- backend hydration + autosave (Phase 3) ----
     init() {
+      // Hydrate dismissed coachmarks first, so it works even without a plan.
+      this.loadCoachmarks();
       const el = document.getElementById("meso-plan-data");
       if (!el) return; // no plan injected → empty grid (bare URL redirects away)
       let data;
@@ -110,6 +160,8 @@ function createMeso() {
       this.program = data.program;
       this.weeks = data.weeks;
       this.phases = data.phases;
+      // The real athlete identity for the individual left rail (null for groups).
+      this.athlete = data.athlete || null;
       // A group shared program opens in Group mode and renders its real identity
       // (members / flags); an individual plan stays in Individual mode. The group
       // agent (per-athlete auto-adjusts) is a later phase, so swap the agent
@@ -384,6 +436,47 @@ function createMeso() {
         console.error("1RM save failed", err);
         this.oneRm.error = "Couldn't save that 1RM. Please try again.";
         this.oneRm.saving = false;
+      }
+    },
+
+    // ---- first-run coachmarks (Phase 5) ----
+    //
+    // The localStorage key for one region note's dismissal — namespaced under
+    // `-designer-` so it never collides with the athlete onboarding coachmarks
+    // (meso_onboarding.js uses the `meso-coachmark-` prefix too).
+    coachmarkStorageKey(key) {
+      return "meso-coachmark-designer-" + key;
+    },
+    // Read persisted dismissals into reactive state. Storage can be absent/throw
+    // (Safari private mode) — treat that as "nothing dismissed".
+    loadCoachmarks() {
+      const next = {};
+      for (let i = 0; i < this.coachmarkKeys.length; i++) {
+        const key = this.coachmarkKeys[i];
+        if (this.readCoachmark(key)) next[key] = true;
+      }
+      this.coachmarksDismissed = next;
+    },
+    readCoachmark(key) {
+      try {
+        const store = typeof window !== "undefined" && window.localStorage;
+        return !!store && store.getItem(this.coachmarkStorageKey(key)) === "1";
+      } catch (e) {
+        return false;
+      }
+    },
+    coachmarkVisible(key) {
+      return !this.coachmarksDismissed[key];
+    },
+    // Hide a note and remember it. Reassign the map (not mutate) so Alpine
+    // re-evaluates `x-show`; persist best-effort (the note hides regardless).
+    dismissCoachmark(key) {
+      this.coachmarksDismissed = { ...this.coachmarksDismissed, [key]: true };
+      try {
+        const store = typeof window !== "undefined" && window.localStorage;
+        if (store) store.setItem(this.coachmarkStorageKey(key), "1");
+      } catch (e) {
+        /* best-effort — hidden in-page via reactive state regardless */
       }
     },
 

--- a/app/store_project/templates/meso/designer.html
+++ b/app/store_project/templates/meso/designer.html
@@ -34,7 +34,7 @@
       <template x-if="delivered">
         <div style="position:fixed;top:16px;left:50%;transform:translateX(-50%);z-index:80;display:flex;align-items:center;gap:9px;background:var(--ink);color:#fff;padding:10px 16px;border-radius:10px;box-shadow:0 8px 28px rgba(16,18,22,0.24);font-size:13px;font-weight:600;animation:toastIn .22s ease;">
           <div style="width:16px;height:16px;border-radius:50%;background:var(--ok);display:flex;align-items:center;justify-content:center;color:#fff;font-size:11px;">&#10003;</div>
-          Delivered to Maya&#8217;s app &#183; she&#8217;ll see Day 1 on her phone
+          Delivered to the athlete&#8217;s app &#183; they&#8217;ll see it on their phone
         </div>
       </template>
 
@@ -50,12 +50,12 @@
 
         <!-- Individual / Group identity -->
         <div style="display:inline-flex;align-items:center;gap:10px;">
-          <template x-if="isIndividual">
+          <template x-if="isIndividual && athlete">
             <div style="display:flex;align-items:center;gap:9px;">
-              <div style="width:28px;height:28px;border-radius:50%;background:var(--soft);border:1px solid var(--soft-line);display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:700;color:var(--accent-deep);">MO</div>
+              <div style="width:28px;height:28px;border-radius:50%;background:var(--soft);border:1px solid var(--soft-line);display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:700;color:var(--accent-deep);" x-text="athlete.initials"></div>
               <div style="line-height:1.15;">
-                <div style="font-size:13px;font-weight:700;letter-spacing:-0.01em;">Maya Okonkwo</div>
-                <div style="font-size:11px;color:var(--dim);">Intermediate &#183; Hypertrophy block</div>
+                <div style="font-size:13px;font-weight:700;letter-spacing:-0.01em;" x-text="athlete.name"></div>
+                <div x-show="athlete.goal" style="font-size:11px;color:var(--dim);" x-text="athlete.goal"></div>
               </div>
             </div>
           </template>
@@ -84,9 +84,9 @@
 
         <div style="flex:1;"></div>
 
-        <div style="display:flex;align-items:center;gap:6px;padding:5px 11px;border-radius:7px;background:var(--soft);border:1px solid var(--soft-line);font-size:11.5px;font-weight:600;color:var(--accent-deep);">
+        <div x-show="cycleLabel" style="display:flex;align-items:center;gap:6px;padding:5px 11px;border-radius:7px;background:var(--soft);border:1px solid var(--soft-line);font-size:11.5px;font-weight:600;color:var(--accent-deep);">
           <div style="width:6px;height:6px;border-radius:50%;background:var(--accent);"></div>
-          Hypertrophy &#183; Wk 2 / 4
+          <span x-text="cycleLabel"></span>
         </div>
         <button data-hover="rail" @click="view = 'athlete'" style="appearance:none;cursor:pointer;font:inherit;font-size:12.5px;font-weight:600;color:var(--ink);background:var(--surface);border:1px solid var(--line);border-radius:8px;padding:7px 13px;">Preview as athlete</button>
         <!-- Review + Deliver are individual-only flows; group review + deliver-to-all
@@ -102,33 +102,38 @@
         <!-- ---------- LEFT RAIL ---------- -->
         <div style="width:266px;flex:0 0 auto;background:var(--rail);border-right:1px solid var(--line);overflow-y:auto;padding:16px 15px 24px;">
 
-          <template x-if="isIndividual">
+          <!-- Real athlete identity (Phase 5): the prototype hardcoded a fake
+               athlete (a stock name + invented contraindications) over whatever
+               real plan the coach opened. Now it renders the plan's athlete —
+               name, goal, and active contraindications — from the injected
+               payload (serialize_athlete_identity). -->
+          <template x-if="isIndividual && athlete">
             <div>
               <div style="display:flex;align-items:center;gap:11px;margin-bottom:14px;">
-                <div style="width:42px;height:42px;border-radius:11px;background:var(--soft);border:1px solid var(--soft-line);display:flex;align-items:center;justify-content:center;font-size:15px;font-weight:700;color:var(--accent-deep);">MO</div>
+                <div style="width:42px;height:42px;border-radius:11px;background:var(--soft);border:1px solid var(--soft-line);display:flex;align-items:center;justify-content:center;font-size:15px;font-weight:700;color:var(--accent-deep);" x-text="athlete.initials"></div>
                 <div style="line-height:1.2;">
-                  <div style="font-size:15px;font-weight:700;letter-spacing:-0.015em;">Maya Okonkwo</div>
-                  <div style="font-size:11.5px;color:var(--dim);">34 &#183; Intermediate &#183; 14 mo trained</div>
+                  <div style="font-size:15px;font-weight:700;letter-spacing:-0.015em;" x-text="athlete.name"></div>
+                  <div x-show="athlete.goal" style="font-size:11.5px;color:var(--dim);" x-text="athlete.goal"></div>
                 </div>
               </div>
-              <div style="margin-bottom:16px;">
-                <p style="font-size:10.5px;font-weight:700;letter-spacing:0.07em;text-transform:uppercase;color:var(--dim);margin:0 0 8px;">Goals</p>
+              <div style="margin-bottom:16px;" x-show="athlete.goal">
+                <p style="font-size:10.5px;font-weight:700;letter-spacing:0.07em;text-transform:uppercase;color:var(--dim);margin:0 0 8px;">Goal</p>
                 <div style="display:flex;flex-wrap:wrap;gap:6px;">
-                  <span style="display:inline-flex;padding:4px 9px;border-radius:6px;background:var(--soft);border:1px solid var(--soft-line);font-size:11.5px;color:var(--accent-deep);font-weight:600;white-space:nowrap;">Hypertrophy</span>
-                  <span style="display:inline-flex;padding:4px 9px;border-radius:6px;background:var(--soft);border:1px solid var(--soft-line);font-size:11.5px;color:var(--accent-deep);font-weight:600;white-space:nowrap;">Return to lifting</span>
+                  <span style="display:inline-flex;padding:4px 9px;border-radius:6px;background:var(--soft);border:1px solid var(--soft-line);font-size:11.5px;color:var(--accent-deep);font-weight:600;" x-text="athlete.goal"></span>
                 </div>
               </div>
               <div style="margin-bottom:16px;">
                 <p style="font-size:10.5px;font-weight:700;letter-spacing:0.07em;text-transform:uppercase;color:var(--dim);margin:0 0 8px;">Contraindications</p>
                 <div style="display:flex;flex-direction:column;gap:6px;">
-                  <div style="display:flex;gap:8px;align-items:flex-start;padding:7px 9px;border-radius:7px;background:var(--warn-soft);border:1px solid color-mix(in srgb,var(--warn) 22%,#fff);">
-                    <div style="width:5px;height:5px;border-radius:50%;background:var(--warn);margin-top:6px;flex:0 0 auto;"></div>
-                    <div style="font-size:12px;color:var(--warn);font-weight:600;line-height:1.3;">L knee &#8212; avoid deep knee flexion under load</div>
-                  </div>
-                  <div style="display:flex;gap:8px;align-items:flex-start;padding:7px 9px;border-radius:7px;background:var(--warn-soft);border:1px solid color-mix(in srgb,var(--warn) 22%,#fff);">
-                    <div style="width:5px;height:5px;border-radius:50%;background:var(--warn);margin-top:6px;flex:0 0 auto;"></div>
-                    <div style="font-size:12px;color:var(--warn);font-weight:600;line-height:1.3;">No max-effort jumping / impact</div>
-                  </div>
+                  <template x-for="c in athlete.contraindications" :key="c.text">
+                    <div style="display:flex;gap:8px;align-items:flex-start;padding:7px 9px;border-radius:7px;background:var(--warn-soft);border:1px solid color-mix(in srgb,var(--warn) 22%,#fff);">
+                      <div style="width:5px;height:5px;border-radius:50%;background:var(--warn);margin-top:6px;flex:0 0 auto;"></div>
+                      <div style="font-size:12px;color:var(--warn);font-weight:600;line-height:1.3;" x-text="c.text"></div>
+                    </div>
+                  </template>
+                  <template x-if="!athlete.contraindications.length">
+                    <div style="font-size:12px;color:var(--dim);">None noted.</div>
+                  </template>
                 </div>
               </div>
             </div>
@@ -169,46 +174,27 @@
 
           <div style="height:1px;background:var(--line);margin:4px 0 16px;"></div>
 
-          <div style="margin-bottom:18px;">
-            <p style="font-size:10.5px;font-weight:700;letter-spacing:0.07em;text-transform:uppercase;color:var(--dim);margin:0 0 8px;">Coach&#8217;s programming style</p>
-            <div style="display:flex;flex-wrap:wrap;gap:6px;margin-bottom:9px;">
-              <span style="display:inline-flex;padding:4px 9px;border-radius:6px;background:var(--surface);border:1px solid var(--line);font-size:11.5px;font-weight:500;white-space:nowrap;">Compound-first</span>
-              <span style="display:inline-flex;padding:4px 9px;border-radius:6px;background:var(--surface);border:1px solid var(--line);font-size:11.5px;font-weight:500;white-space:nowrap;">RPE-based load</span>
-              <span style="display:inline-flex;padding:4px 9px;border-radius:6px;background:var(--surface);border:1px solid var(--line);font-size:11.5px;font-weight:500;white-space:nowrap;">Free-weight bias</span>
-              <span style="display:inline-flex;padding:4px 9px;border-radius:6px;background:var(--surface);border:1px solid var(--line);font-size:11.5px;font-weight:500;white-space:nowrap;">2-min rest cap</span>
-              <span style="display:inline-flex;padding:4px 9px;border-radius:6px;background:var(--surface);border:1px solid var(--line);font-size:11.5px;font-weight:500;white-space:nowrap;">Unilateral work</span>
-            </div>
-            <div style="font-size:11.5px;color:var(--dim);line-height:1.4;"><span style="font-weight:700;color:var(--warn);">Avoid:</span> machine-only days, untracked progressions, &gt;3 exercises to failure / session.</div>
-          </div>
-
-          <div style="height:1px;background:var(--line);margin:0 0 16px;"></div>
-
+          <!-- Macrocycle (Phase 5): the prototype hardcoded a fixed four-block
+               ladder; this renders the plan's real mesocycles (serialize_plan's
+               `phases`), each coloured by its state (done / current / next). The
+               fabricated coach-preferences block that used to sit above it —
+               invented tags the coach never set — was removed as misleading. -->
           <div>
             <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:9px;">
               <p style="font-size:10.5px;font-weight:700;letter-spacing:0.07em;text-transform:uppercase;color:var(--dim);margin:0;">Macrocycle</p>
               <button @click="view = 'block'" style="appearance:none;border:0;background:none;cursor:pointer;font:inherit;font-size:11px;font-weight:650;color:var(--accent);padding:0;">Open plan &#8594;</button>
             </div>
             <div style="display:flex;flex-direction:column;gap:5px;">
-              <div style="display:flex;align-items:center;gap:9px;padding:8px 10px;border-radius:7px;background:var(--surface);border:1px solid var(--line);opacity:0.62;">
-                <div style="width:7px;height:7px;border-radius:2px;background:var(--dim);"></div>
-                <div style="flex:1;font-size:12px;font-weight:600;">Base / GPP</div>
-                <div style="font-size:10.5px;color:var(--dim);white-space:nowrap;">4 wk &#183; done</div>
-              </div>
-              <div style="display:flex;align-items:center;gap:9px;padding:9px 10px;border-radius:7px;background:var(--soft);border:1px solid var(--soft-line);">
-                <div style="width:7px;height:7px;border-radius:2px;background:var(--accent);"></div>
-                <div style="flex:1;font-size:12px;font-weight:700;color:var(--accent-deep);">Hypertrophy</div>
-                <div style="font-size:10.5px;color:var(--accent-deep);font-weight:600;white-space:nowrap;">wk 2 / 4</div>
-              </div>
-              <div style="display:flex;align-items:center;gap:9px;padding:8px 10px;border-radius:7px;background:var(--surface);border:1px solid var(--line);">
-                <div style="width:7px;height:7px;border-radius:2px;background:var(--line);border:1px solid var(--dim);"></div>
-                <div style="flex:1;font-size:12px;font-weight:600;color:var(--dim);">Strength</div>
-                <div style="font-size:10.5px;color:var(--dim);white-space:nowrap;">4 wk &#183; next</div>
-              </div>
-              <div style="display:flex;align-items:center;gap:9px;padding:8px 10px;border-radius:7px;background:var(--surface);border:1px solid var(--line);">
-                <div style="width:7px;height:7px;border-radius:2px;background:var(--line);border:1px solid var(--dim);"></div>
-                <div style="flex:1;font-size:12px;font-weight:600;color:var(--dim);">Peak / Test</div>
-                <div style="font-size:10.5px;color:var(--dim);white-space:nowrap;">2 wk</div>
-              </div>
+              <template x-for="p in phases" :key="p.name">
+                <div :style="`display:flex;align-items:center;gap:9px;padding:8px 10px;border-radius:7px;background:${p.state === 'current' ? 'var(--soft)' : 'var(--surface)'};border:1px solid ${p.state === 'current' ? 'var(--soft-line)' : 'var(--line)'};opacity:${p.state === 'done' ? '0.62' : '1'};`">
+                  <div :style="`width:7px;height:7px;border-radius:2px;background:${p.state === 'current' ? 'var(--accent)' : (p.state === 'done' ? 'var(--dim)' : 'var(--line)')};border:${(p.state === 'next' || p.state === 'future') ? '1px solid var(--dim)' : '0'};`"></div>
+                  <div :style="`flex:1;font-size:12px;font-weight:${p.state === 'current' ? '700' : '600'};color:${p.state === 'current' ? 'var(--accent-deep)' : (p.state === 'done' ? 'var(--ink)' : 'var(--dim)')};`" x-text="p.name"></div>
+                  <div :style="`font-size:10.5px;white-space:nowrap;font-weight:${p.state === 'current' ? '600' : '400'};color:${p.state === 'current' ? 'var(--accent-deep)' : 'var(--dim)'};`" x-text="p.weeks + (p.state === 'current' ? ' · now' : (p.state === 'done' ? ' · done' : (p.state === 'next' ? ' · next' : '')))"></div>
+                </div>
+              </template>
+              <template x-if="!phases.length">
+                <div style="font-size:12px;color:var(--dim);">No blocks yet.</div>
+              </template>
             </div>
           </div>
         </div>
@@ -222,6 +208,25 @@
             <div x-show="!agentTyping" class="meso-flex" style="align-items:center;gap:5px;font-size:11px;color:var(--dim);"><div style="width:6px;height:6px;border-radius:50%;background:var(--ok);"></div>ready</div>
             <div style="flex:1;"></div>
             <div style="font-size:11px;color:var(--dim);">grounded on profile + logs</div>
+          </div>
+
+          <!-- How the agent works (Phase 5): a persistent note making the review
+               gate explicit — a first-timer won't expect the agent to only
+               *propose*. Always shown for an individual plan (the group agent is
+               a later phase, so its composer is hidden). -->
+          <div x-show="isIndividual" style="flex:0 0 auto;display:flex;align-items:flex-start;gap:7px;padding:8px 16px;border-bottom:1px solid var(--line-2);background:var(--rail);font-size:11px;line-height:1.4;color:var(--dim);">
+            <span style="font-weight:700;color:var(--accent-deep);white-space:nowrap;">Propose &#8594; review &#8594; apply</span>
+            <span>The agent proposes; you review every change before it touches the program — nothing applies until you approve.</span>
+          </div>
+
+          <!-- Agent coachmark (Phase 5): dismissible first-run orientation for the
+               agent column. Individual-only (no live composer in group mode). -->
+          <div x-show="isIndividual && coachmarkVisible('agent')" style="flex:0 0 auto;display:flex;align-items:flex-start;gap:9px;margin:12px 14px 0;padding:11px 12px;background:var(--soft);border:1px solid var(--soft-line);border-left:3px solid var(--accent);border-radius:9px;">
+            <div style="flex:1;min-width:0;line-height:1.4;">
+              <div style="font-size:12.5px;font-weight:700;color:var(--accent-deep);">Talk to the agent</div>
+              <div style="font-size:11.5px;color:var(--accent-deep);opacity:0.85;">Ask in plain words &#8212; &#8220;lighten Friday,&#8221; &#8220;add a deload week.&#8221; It drafts changes you can review.</div>
+            </div>
+            <button @click="dismissCoachmark('agent')" data-hover="rail" aria-label="Dismiss tip" style="appearance:none;cursor:pointer;border:0;background:transparent;font:inherit;font-size:15px;line-height:1;color:var(--dim);padding:2px 4px;flex:0 0 auto;">&times;</button>
           </div>
 
           <div x-ref="thread" style="flex:1;overflow-y:auto;padding:16px;display:flex;flex-direction:column;gap:13px;">
@@ -328,9 +333,19 @@
             <div x-show="view === 'week'" style="padding:18px 20px 40px;max-width:1080px;">
               <div style="display:flex;align-items:flex-end;justify-content:space-between;margin-bottom:16px;">
                 <div>
-                  <h1 style="margin:0 0 3px;font-size:21px;font-weight:800;letter-spacing:-0.025em;">Week 2 &#8212; Accumulation</h1>
-                  <p style="margin:0;font-size:12.5px;color:var(--dim);">3 sessions &#183; hypertrophy emphasis &#183; tap any cell to edit</p>
+                  <h1 style="margin:0 0 3px;font-size:21px;font-weight:800;letter-spacing:-0.025em;" x-text="weekHeading"></h1>
+                  <p style="margin:0;font-size:12.5px;color:var(--dim);" x-text="program.length + (program.length === 1 ? ' session' : ' sessions') + ' · tap any cell to edit'"></p>
                 </div>
+              </div>
+
+              <!-- Grid coachmark (Phase 5): dismissible first-run note for the
+                   week grid. Shown in both modes (the grid edits the same way). -->
+              <div x-show="coachmarkVisible('grid')" style="display:flex;align-items:flex-start;gap:9px;margin-bottom:16px;padding:11px 13px;background:var(--soft);border:1px solid var(--soft-line);border-left:3px solid var(--accent);border-radius:9px;">
+                <div style="flex:1;min-width:0;line-height:1.4;">
+                  <div style="font-size:12.5px;font-weight:700;color:var(--accent-deep);">The week grid</div>
+                  <div style="font-size:11.5px;color:var(--accent-deep);opacity:0.85;">Tap any cell &#8212; sets, reps, load, RPE, or notes &#8212; to edit it. Every change autosaves.</div>
+                </div>
+                <button @click="dismissCoachmark('grid')" data-hover="rail" aria-label="Dismiss tip" style="appearance:none;cursor:pointer;border:0;background:transparent;font:inherit;font-size:15px;line-height:1;color:var(--dim);padding:2px 4px;flex:0 0 auto;">&times;</button>
               </div>
 
               <template x-if="isGroup">
@@ -410,8 +425,8 @@
             <!-- ===== BLOCK / PERIODIZATION VIEW ===== -->
             <div x-show="view === 'block'" style="padding:20px 22px 40px;max-width:1000px;">
               <div style="margin-bottom:8px;">
-                <h1 style="margin:0 0 3px;font-size:21px;font-weight:800;letter-spacing:-0.025em;">Hypertrophy block &#8212; 4-week mesocycle</h1>
-                <p style="margin:0;font-size:12.5px;color:var(--dim);">Mesocycle 2 of 4 in the macrocycle &#183; accumulation into a planned deload</p>
+                <h1 style="margin:0 0 3px;font-size:21px;font-weight:800;letter-spacing:-0.025em;" x-text="blockHeading"></h1>
+                <p style="margin:0;font-size:12.5px;color:var(--dim);">Volume and intensity across this mesocycle.</p>
               </div>
 
               <!-- macro strip -->
@@ -477,6 +492,16 @@
 
             <!-- ===== ATHLETE VIEW ===== -->
             <div x-show="view === 'athlete'" class="meso-flex" style="padding:24px;gap:30px;align-items:flex-start;justify-content:center;flex-wrap:wrap;">
+              <!-- Phone-preview coachmark (Phase 5): dismissible first-run note
+                   making clear this is the athlete's real phone view, and the
+                   path to delivery. Full-width so it sits above the phone. -->
+              <div x-show="coachmarkVisible('phone')" style="flex:0 0 100%;display:flex;align-items:flex-start;gap:9px;max-width:760px;padding:11px 13px;background:var(--soft);border:1px solid var(--soft-line);border-left:3px solid var(--accent);border-radius:9px;">
+                <div style="flex:1;min-width:0;line-height:1.4;">
+                  <div style="font-size:12.5px;font-weight:700;color:var(--accent-deep);">Preview as your athlete</div>
+                  <div style="font-size:11.5px;color:var(--accent-deep);opacity:0.85;">This is exactly what your athlete sees on their phone. Preview it, then Deliver to send the week.</div>
+                </div>
+                <button @click="dismissCoachmark('phone')" data-hover="rail" aria-label="Dismiss tip" style="appearance:none;cursor:pointer;border:0;background:transparent;font:inherit;font-size:15px;line-height:1;color:var(--dim);padding:2px 4px;flex:0 0 auto;">&times;</button>
+              </div>
               <div style="flex:0 0 auto;width:336px;height:680px;border-radius:42px;background:#0e0f12;padding:11px;box-shadow:0 24px 60px rgba(16,18,22,0.28);position:relative;">
                 <div style="width:100%;height:100%;border-radius:32px;background:var(--surface);overflow:hidden;display:flex;flex-direction:column;position:relative;">
                   <div style="height:40px;flex:0 0 auto;display:flex;align-items:center;justify-content:space-between;padding:0 22px;font-size:12px;font-weight:600;color:var(--ink);">

--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -753,3 +753,40 @@ _(Append dated entries here as decisions land.)_
   `meso_onboarding.*.js` (HTTP 200). Resume point → first-time-UX **Phase 5**
   (designer/agent self-explanation) **or** the add-week/week-switcher deferral. Plan in
   [`first-time-ux-plan.md`](./first-time-ux-plan.md).
+- 2026-06-30 — **First-time UX — Phase 5 built** (branch `meso-first-time-ux-phase5`,
+  **no migration**): **designer & agent self-explanation** — the **last first-time-UX
+  phase**. The designer is a self-contained Alpine page that shipped a pile of
+  *prototype chrome*: a hardcoded fake athlete (a stock name + invented
+  contraindications), a fabricated "Coach's programming style" block, and a hardcoded
+  macrocycle — **all rendered over whatever real plan the coach opened**. A first-time
+  coach also got no orientation: nothing said the grid autosaves, that the agent only
+  *proposes* (changes wait at the review gate), or that the phone column is the
+  athlete's real view. Three parts: **(1) Coachmarks** — three **dismissible** first-run
+  notes anchor the designer's regions (week grid · agent · phone preview); they show
+  until dismissed, the dismissal persisting client-side in `localStorage` (`meso.js`,
+  namespaced `meso-coachmark-designer-<key>` so it never collides with the athlete
+  onboarding coachmarks' `meso-coachmark-` prefix) — **no server "seen" flag**, like
+  the athlete chrome. **(2) Agent self-explanation** — a **persistent** "propose →
+  review → apply" note under the agent header makes the review gate explicit for
+  *everyone* (not just first-timers — a newcomer won't expect the agent to only
+  propose); individual-only (the group agent's composer is hidden). **(3) Real chrome**
+  — `serialize_plan` now carries the individual plan's **real athlete identity**
+  (`serialize_athlete_identity`: name / initials / goal / **active** contraindications,
+  the same global injuries the agent grounds on), and the left-rail athlete card,
+  macrocycle rail, top-bar identity/chip, and week/block headers render the real
+  `athlete`/`weeks`/`phases` (new `meso.js` getters `currentWeek`/`currentPhase`/
+  `cycleLabel`/`weekHeading`/`blockHeading`). The invented coach-preferences block was
+  **removed** as misleading; group mode (already real, via `group`) is untouched —
+  `serialize_athlete_identity` returns `None` for a group plan. Built red→green: the
+  dismiss logic is unit-tested in `frontend/meso.test.js` (**+5 vitest**), the server
+  seam (serializer identity, rendered coachmarks + note, absence of the fabricated
+  chrome, `meso.js` dismiss API) in `test_designer_onboarding.py` (**+10 pytest**);
+  1055 meso pytest + 104 vitest green, ruff + format clean, DjHTML clean. **Gotcha
+  (cost me 2 cycles):** the render tests assert the fabricated strings are *gone*
+  (`"Maya"`, `"programming style"` ∉ body) — my own explanatory template comments
+  mentioning those strings tripped the asserts, so dev-facing comments must avoid the
+  very tokens the tests forbid. **Codex review loop CLEAN on iteration 1.** This
+  **completes the first-time-UX slice** (Phases 1–5). Remaining Meso backlog: the
+  **add-week / week-switcher** deferral (designer is single-current-week) and **S6
+  billing Phase 5 annual prices** (blocked on the owner's per-seat number + a Stripe
+  annual Price). Plan in [`first-time-ux-plan.md`](./first-time-ux-plan.md).

--- a/docs/meso/first-time-ux-plan.md
+++ b/docs/meso/first-time-ux-plan.md
@@ -1,9 +1,11 @@
 # Meso — first-time UX / onboarding slice plan
 
-**Status:** 🟢 Building · Q1–Q4 resolved 2026-06-29 · **Phase 1 (individual plan
-creation) + Phase 2 (coach first-run: one-click demo + empty-state teaching) +
-Phase 3 (the front door: anon landing + main-site link) + Phase 4 (athlete
-first-run: install prompt + first-log coachmark) done** · Phase 5 remains
+**Status:** ✅ Slice complete · Q1–Q4 resolved 2026-06-29 · **Phase 1 (individual
+plan creation) + Phase 2 (coach first-run: one-click demo + empty-state teaching)
++ Phase 3 (the front door: anon landing + main-site link) + Phase 4 (athlete
+first-run: install prompt + first-log coachmark) + Phase 5 (designer & agent
+self-explanation: dismissible coachmarks + review-gate note + real left-rail
+chrome) all done**
 **Companion to:** [`decisions.md`](./decisions.md) (B1 multi-coach, B2 athlete
 login, N3 roles, N4 invites) · [`invites-plan.md`](./invites-plan.md) ·
 [`athlete-plan.md`](./athlete-plan.md) · [`groups-plan.md`](./groups-plan.md)
@@ -298,13 +300,32 @@ without confusion.
 > (`test_athlete_onboarding.py` + a precache guard) + 13 vitest
 > (`meso_onboarding.test.js`); Codex review loop **CLEAN** after 3 fix iterations.
 
-### Phase 5 — Designer & agent self-explanation (coach · optional)
+### Phase 5 — Designer & agent self-explanation (coach · optional) ✅ Built
 Dismissible first-run **coachmarks** on the designer's three regions (grid · agent
 · phone preview), a one-line **"how the agent works"** note making the
 propose → review → apply loop explicit (a first-timer won't expect the agent only
 *proposes*), and replacing the static prototype left-rail chrome where it misleads.
 *Done when:* a first-time coach in the designer understands the grid, the agent, and
 the review gate without external help.
+
+> **What shipped (no migration).** Three parts. **(1) Coachmarks** — three
+> dismissible first-run notes anchor the designer's regions (week grid · agent ·
+> phone preview). They show until dismissed; the dismissal persists client-side in
+> `localStorage` (`meso.js`, keys namespaced `meso-coachmark-designer-<key>` so they
+> never collide with the athlete onboarding coachmarks' `meso-coachmark-` prefix) —
+> **no server "seen" flag, no migration**, like the athlete chrome (resolving the
+> plan's "persist where?" Q for the coach side). **(2) Agent self-explanation** — a
+> *persistent* "propose → review → apply" note under the agent header makes the
+> review gate explicit for everyone, not just first-timers; individual-only (the
+> group agent's composer is hidden). **(3) Real chrome** — `serialize_plan` now
+> carries the individual plan's real athlete identity (`serialize_athlete_identity`:
+> name / initials / goal / **active** contraindications — the same global injuries
+> the agent grounds on), and the left-rail athlete card, macrocycle rail, top-bar
+> identity/chip, and week/block headers render the real `athlete`/`weeks`/`phases`
+> (new `meso.js` getters). The fabricated "Coach's programming style" block was
+> removed as misleading; group mode (already real, via `group`) is untouched. +10
+> pytest (`test_designer_onboarding.py`) + 5 vitest (`meso.test.js`); Codex review
+> loop CLEAN on iteration 1. **This completes the first-time-UX slice (Phases 1–5).**
 
 ---
 

--- a/frontend/meso.test.js
+++ b/frontend/meso.test.js
@@ -544,3 +544,57 @@ describe("addDay", () => {
     expect(c.program).toHaveLength(1);
   });
 });
+
+// ---- first-run coachmarks (first-time UX Phase 5) ----
+//
+// Three dismissible region notes (grid / agent / phone) orient a first-time
+// coach. They show until dismissed; the dismissal persists in localStorage so a
+// coach who waved one away never sees it again. The reactive `coachmarksDismissed`
+// map drives `x-show` in the template; here we cover the pure key helper and the
+// load/dismiss/visibility round-trip (jsdom gives us a real localStorage).
+describe("designer coachmarks", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("namespaces each coachmark's storage key", () => {
+    const c = createMeso();
+    expect(c.coachmarkStorageKey("grid")).toBe("meso-coachmark-designer-grid");
+    expect(c.coachmarkStorageKey("phone")).toBe("meso-coachmark-designer-phone");
+  });
+
+  it("shows every coachmark until it is dismissed", () => {
+    const c = createMeso();
+    for (const key of c.coachmarkKeys) {
+      expect(c.coachmarkVisible(key)).toBe(true);
+    }
+  });
+
+  it("hides a coachmark and persists the dismissal", () => {
+    const c = createMeso();
+    c.dismissCoachmark("agent");
+    expect(c.coachmarkVisible("agent")).toBe(false);
+    expect(c.coachmarkVisible("grid")).toBe(true); // others unaffected
+    expect(window.localStorage.getItem("meso-coachmark-designer-agent")).toBe("1");
+  });
+
+  it("loads a previously persisted dismissal into reactive state", () => {
+    window.localStorage.setItem("meso-coachmark-designer-phone", "1");
+    const c = createMeso();
+    c.loadCoachmarks();
+    expect(c.coachmarkVisible("phone")).toBe(false);
+    expect(c.coachmarkVisible("grid")).toBe(true);
+  });
+
+  it("still hides in-page when storage write throws (private mode)", () => {
+    const c = createMeso();
+    const spy = vi
+      .spyOn(window.localStorage.__proto__, "setItem")
+      .mockImplementation(() => {
+        throw new Error("QuotaExceeded");
+      });
+    expect(() => c.dismissCoachmark("grid")).not.toThrow();
+    expect(c.coachmarkVisible("grid")).toBe(false);
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## First-time UX Phase 5 — designer & agent self-explanation

The **last first-time-UX phase.** The designer is a self-contained Alpine page that, until now, shipped a pile of *prototype chrome*: a hardcoded fake athlete (a stock name + invented contraindications), a fabricated "Coach's programming style" block, and a hardcoded macrocycle — **all rendered over whatever real plan the coach opened.** A first-time coach also got no orientation: nothing said the grid autosaves, that the agent only *proposes* (changes wait at the review gate), or that the phone column is the athlete's real view.

Three parts, **no migration:**

### 1. Coachmarks
Three **dismissible** first-run notes anchor the designer's regions (week grid · agent · phone preview). They show until dismissed; the dismissal persists client-side in `localStorage` (`meso.js`, keys namespaced `meso-coachmark-designer-<key>` so they never collide with the athlete onboarding coachmarks' `meso-coachmark-` prefix). **No server "seen" flag** — like the athlete chrome.

### 2. Agent self-explanation
A **persistent** "propose → review → apply" note under the agent header makes the review gate explicit for *everyone*, not just first-timers — a newcomer won't expect the agent to only propose. Individual-only (the group agent's composer is hidden).

### 3. Real chrome
`serialize_plan` now carries the individual plan's **real athlete identity** (`serialize_athlete_identity`: name / initials / goal / **active** contraindications — the same global injuries the agent grounds on). The left-rail athlete card, macrocycle rail, top-bar identity/chip, and week/block headers render the real `athlete`/`weeks`/`phases` (new `meso.js` getters `currentWeek`/`currentPhase`/`cycleLabel`/`weekHeading`/`blockHeading`). The invented coach-preferences block was **removed** as misleading. Group mode (already real, via `group`) is untouched — `serialize_athlete_identity` returns `None` for a group plan.

## Testing (red → green)
- **+5 vitest** (`frontend/meso.test.js`) cover the dismiss logic (key namespacing, show-until-dismissed, persistence, load-from-storage, private-mode storage throw).
- **+10 pytest** (`test_designer_onboarding.py`) guard the server seam: serializer identity, rendered coachmarks + review-gate note, **absence** of the fabricated chrome, and the `meso.js` dismiss API.
- Full meso suite **1055 pytest** + **104 vitest** green; ruff + format + DjHTML clean.
- **Codex review loop CLEAN on iteration 1.**

This **completes the first-time-UX slice (Phases 1–5).**

https://claude.ai/code/session_019A9KdsVs33wipsGjSaFWXV
