### PR TITLE
Meso — multi-week designer: add weeks, view any week, set deliver target

### DIFF
--- a/app/store_project/meso/models.py
+++ b/app/store_project/meso/models.py
@@ -1229,7 +1229,10 @@ class Mesocycle(models.Model):
                 rpe="7",
             )
         else:
-            for src_session in source.sessions.prefetch_related("prescriptions"):
+            carried_overrides = []
+            for src_session in source.sessions.prefetch_related(
+                "prescriptions__overrides"
+            ):
                 new_session = Session.objects.create(
                     week=week,
                     day_number=src_session.day_number,
@@ -1237,24 +1240,38 @@ class Mesocycle(models.Model):
                     bias=src_session.bias,
                     order=src_session.order,
                 )
-                ExercisePrescription.objects.bulk_create(
-                    [
-                        ExercisePrescription(
-                            session=new_session,
-                            exercise_id=presc.exercise_id,
-                            name=presc.name,
-                            order=presc.order,
-                            sets=presc.sets,
-                            reps=presc.reps,
-                            load=presc.load,
-                            load_type=presc.load_type,
-                            rpe=presc.rpe,
-                            note=presc.note,
-                            tags=list(presc.tags or []),
+                for presc in src_session.prescriptions.all():
+                    new_presc = ExercisePrescription.objects.create(
+                        session=new_session,
+                        exercise_id=presc.exercise_id,
+                        name=presc.name,
+                        order=presc.order,
+                        sets=presc.sets,
+                        reps=presc.reps,
+                        load=presc.load,
+                        load_type=presc.load_type,
+                        rpe=presc.rpe,
+                        note=presc.note,
+                        tags=list(presc.tags or []),
+                    )
+                    # Carry each member's per-athlete adjust forward onto the copied
+                    # row (group plans). Without this the new week resolves the
+                    # unadjusted base and silently drops a member's accommodation —
+                    # a swap or load cut they still need every week.
+                    for override in presc.overrides.all():
+                        carried_overrides.append(
+                            PrescriptionOverride(
+                                membership_id=override.membership_id,
+                                prescription=new_presc,
+                                swap_name=override.swap_name,
+                                load_pct=override.load_pct,
+                                sets=override.sets,
+                                reps=override.reps,
+                                note=override.note,
+                            )
                         )
-                        for presc in src_session.prescriptions.all()
-                    ]
-                )
+            if carried_overrides:
+                PrescriptionOverride.objects.bulk_create(carried_overrides)
         if week.index > self.week_count:
             self.week_count = week.index
             self.save(update_fields=["week_count"])

--- a/app/store_project/meso/models.py
+++ b/app/store_project/meso/models.py
@@ -1190,6 +1190,76 @@ class Mesocycle(models.Model):
     def __str__(self):
         return self.name
 
+    def append_week(self):
+        """Materialize the next week in this block, copying the latest week's grid.
+
+        A coach building a multi-week mesocycle progresses from a real template,
+        not a blank slate — so the new week mirrors the latest week's sessions and
+        their prescriptions (loads carried forward as a starting point the coach
+        then tweaks). The new week is a **non-current, undelivered draft**: adding
+        a future week never changes what's live or what delivery targets — making
+        a week the deliver target is the separate ``week_set_current`` action.
+        ``week_count`` grows to stay >= the highest materialized index so the
+        periodization rail stays honest. Returns the new ``Week``.
+
+        A degenerate block with no weeks yet seeds one starter day (mirroring
+        ``Plan.scaffold``) so the result is immediately editable.
+        """
+        source = self.weeks.order_by("-index").first()
+        next_index = (source.index if source else 0) + 1
+        week = Week.objects.create(
+            mesocycle=self,
+            index=next_index,
+            phase=source.phase if source else "",
+            volume=source.volume if source else 0,
+            intensity=source.intensity if source else 0,
+            is_deload=source.is_deload if source else False,
+            is_current=False,
+        )
+        if source is None:
+            session = Session.objects.create(
+                week=week, day_number=1, name="Day 1", order=0
+            )
+            ExercisePrescription.objects.create(
+                session=session,
+                name="New exercise",
+                order=0,
+                sets="3",
+                reps="10",
+                rpe="7",
+            )
+        else:
+            for src_session in source.sessions.prefetch_related("prescriptions"):
+                new_session = Session.objects.create(
+                    week=week,
+                    day_number=src_session.day_number,
+                    name=src_session.name,
+                    bias=src_session.bias,
+                    order=src_session.order,
+                )
+                ExercisePrescription.objects.bulk_create(
+                    [
+                        ExercisePrescription(
+                            session=new_session,
+                            exercise_id=presc.exercise_id,
+                            name=presc.name,
+                            order=presc.order,
+                            sets=presc.sets,
+                            reps=presc.reps,
+                            load=presc.load,
+                            load_type=presc.load_type,
+                            rpe=presc.rpe,
+                            note=presc.note,
+                            tags=list(presc.tags or []),
+                        )
+                        for presc in src_session.prescriptions.all()
+                    ]
+                )
+        if week.index > self.week_count:
+            self.week_count = week.index
+            self.save(update_fields=["week_count"])
+        return week
+
 
 class Week(models.Model):
     """One week within a mesocycle — a column in the designer's week strip."""

--- a/app/store_project/meso/serializers.py
+++ b/app/store_project/meso/serializers.py
@@ -147,8 +147,14 @@ def serialize_session(session):
 
 
 def serialize_week(week):
-    """One column in the designer's week strip."""
+    """One column in the designer's week strip.
+
+    ``id``/``index`` let the client target a week for the switcher (view, add,
+    set-current); ``current`` flags the live (deliver-target) week.
+    """
     return {
+        "id": week.pk,
+        "index": week.index,
         "label": f"Wk {week.index}",
         "phase": week.phase,
         "vol": week.volume,
@@ -695,5 +701,10 @@ def serialize_plan(plan, week=None):
         "athlete": serialize_athlete_identity(plan),
         "program": program,
         "weeks": week_strip,
+        # The id of the week whose grid ``program`` holds — the *viewed* week,
+        # which the multi-week switcher may point away from the live (current)
+        # one. The client tracks this so it can highlight the open week and tell
+        # "viewing" apart from "current" (the deliver target).
+        "viewing": open_week.pk if open_week is not None else None,
         "phases": phases,
     }

--- a/app/store_project/meso/tests/test_serializers.py
+++ b/app/store_project/meso/tests/test_serializers.py
@@ -29,6 +29,7 @@ from store_project.meso.factories import WeekFactory
 from store_project.meso.models import Plan
 from store_project.meso.models import SessionLog
 from store_project.meso.models import Unit
+from store_project.meso.models import Week
 from store_project.meso.serializers import serialize_plan
 
 pytestmark = pytest.mark.django_db
@@ -177,8 +178,17 @@ class TestSerializePlan:
     def test_weeks_match_current_mesocycle(self):
         plan = build_maya_plan()
         result = serialize_plan(plan)
+        # ``id``/``index`` carry the real week pk so the switcher can target it.
+        weeks = list(
+            Week.objects.filter(mesocycle__plan=plan, mesocycle__order=1).order_by(
+                "index"
+            )
+        )
+        ids = [w.pk for w in weeks]
         assert result["weeks"] == [
             {
+                "id": ids[0],
+                "index": 1,
                 "label": "Wk 1",
                 "phase": "Accum",
                 "vol": 70,
@@ -187,6 +197,8 @@ class TestSerializePlan:
                 "current": False,
             },
             {
+                "id": ids[1],
+                "index": 2,
                 "label": "Wk 2",
                 "phase": "Accum",
                 "vol": 85,
@@ -195,6 +207,8 @@ class TestSerializePlan:
                 "current": True,
             },
             {
+                "id": ids[2],
+                "index": 3,
                 "label": "Wk 3",
                 "phase": "Accum",
                 "vol": 100,
@@ -203,6 +217,8 @@ class TestSerializePlan:
                 "current": False,
             },
             {
+                "id": ids[3],
+                "index": 4,
                 "label": "Wk 4",
                 "phase": "Deload",
                 "vol": 55,
@@ -211,6 +227,12 @@ class TestSerializePlan:
                 "current": False,
             },
         ]
+
+    def test_serialize_plan_reports_the_viewed_week(self):
+        plan = build_maya_plan()
+        result = serialize_plan(plan)
+        current = Week.objects.get(mesocycle__plan=plan, is_current=True)
+        assert result["viewing"] == current.pk
 
     def test_program_is_current_weeks_sessions(self):
         plan = build_maya_plan()

--- a/app/store_project/meso/tests/test_week_management.py
+++ b/app/store_project/meso/tests/test_week_management.py
@@ -15,6 +15,7 @@ that long-deferred gap:
   (the open week's id) so the client tracks which week's grid it is showing.
 """
 
+import json
 from datetime import timedelta
 from pathlib import Path
 
@@ -28,6 +29,7 @@ from store_project.meso.factories import MesoGroupFactory
 from store_project.meso.factories import WeekFactory
 from store_project.meso.models import CoachAthlete
 from store_project.meso.models import LoadType
+from store_project.meso.models import Session
 from store_project.meso.models import Week
 from store_project.meso.serializers import serialize_week
 from store_project.users.factories import UserFactory
@@ -395,6 +397,55 @@ class TestGroupWeekManagement:
         new_week = _latest_week(plan)
         # The shared structure is copied so the new week is immediately editable.
         assert new_week.sessions.count() >= 1
+
+
+# ---------------------------------------------------------------------------
+# session_add is week-scoped — "+ Add day" lands on the *viewed* week, not the
+# live one (regression: the switcher can open a non-current week)
+# ---------------------------------------------------------------------------
+
+
+class TestSessionAddWeekScoping:
+    def _url(self, plan):
+        return reverse("meso:api_session_add", kwargs={"plan_id": plan.pk})
+
+    def _two_week_plan(self):
+        link = CoachAthleteFactory()
+        plan = link.create_plan()
+        meso = plan.mesocycles.get()
+        return link, plan, meso.weeks.get(index=1), meso.append_week()
+
+    def test_adds_the_day_to_the_posted_week(self, client):
+        link, plan, week1, week2 = self._two_week_plan()  # week1 is current
+        client.force_login(link.coach)
+        resp = client.post(
+            self._url(plan),
+            data=json.dumps({"week_id": week2.pk}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 201
+        new_session = Session.objects.get(pk=resp.json()["session"]["id"])
+        # The day lands on the viewed (non-current) week, not the live one.
+        assert new_session.week_id == week2.pk
+
+    def test_defaults_to_the_current_week_without_a_week_id(self, client):
+        link, plan, week1, week2 = self._two_week_plan()
+        client.force_login(link.coach)
+        resp = client.post(self._url(plan))  # no body → live week
+        assert resp.status_code == 201
+        new_session = Session.objects.get(pk=resp.json()["session"]["id"])
+        assert new_session.week_id == week1.pk
+
+    def test_404_for_a_week_in_another_plan(self, client):
+        link, plan, week1, week2 = self._two_week_plan()
+        foreign = WeekFactory()
+        client.force_login(link.coach)
+        resp = client.post(
+            self._url(plan),
+            data=json.dumps({"week_id": foreign.pk}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 404
 
 
 # ---------------------------------------------------------------------------

--- a/app/store_project/meso/tests/test_week_management.py
+++ b/app/store_project/meso/tests/test_week_management.py
@@ -25,10 +25,13 @@ from django.urls import reverse
 from django.utils import timezone
 
 from store_project.meso.factories import CoachAthleteFactory
+from store_project.meso.factories import GroupMembershipFactory
 from store_project.meso.factories import MesoGroupFactory
 from store_project.meso.factories import WeekFactory
 from store_project.meso.models import CoachAthlete
+from store_project.meso.models import ExercisePrescription
 from store_project.meso.models import LoadType
+from store_project.meso.models import PrescriptionOverride
 from store_project.meso.models import Session
 from store_project.meso.models import Week
 from store_project.meso.serializers import serialize_week
@@ -397,6 +400,37 @@ class TestGroupWeekManagement:
         new_week = _latest_week(plan)
         # The shared structure is copied so the new week is immediately editable.
         assert new_week.sessions.count() >= 1
+
+    def test_append_week_carries_per_athlete_overrides_forward(self):
+        # A member's per-athlete adjust must survive week duplication — else the
+        # new week resolves the unadjusted base and silently drops it on delivery.
+        group = MesoGroupFactory()
+        membership = GroupMembershipFactory(group=group)
+        plan = group.create_shared_plan()
+        meso = plan.mesocycles.get()
+        week1 = meso.weeks.get()
+        presc = (
+            ExercisePrescription.objects.filter(session__week=week1)
+            .order_by("session__day_number", "order")
+            .first()
+        )
+        presc.name = "Back Squat"  # make the copied row unambiguous
+        presc.save()
+        PrescriptionOverride.objects.create(
+            membership=membership, prescription=presc, load_pct=90, note="knee"
+        )
+
+        new_week = meso.append_week()
+
+        copied = ExercisePrescription.objects.get(
+            session__week=new_week, name="Back Squat"
+        )
+        carried = copied.overrides.get()
+        assert carried.membership_id == membership.pk
+        assert carried.load_pct == 90
+        assert carried.note == "knee"
+        # The source override is untouched (a copy, not a move).
+        assert presc.overrides.count() == 1
 
 
 # ---------------------------------------------------------------------------

--- a/app/store_project/meso/tests/test_week_management.py
+++ b/app/store_project/meso/tests/test_week_management.py
@@ -1,0 +1,437 @@
+"""Multi-week designer — add weeks, view any week, set the deliver target.
+
+Until now a plan was effectively single-week: ``Plan.scaffold`` materialized one
+``Week`` (``is_current``) and the only growth verb was ``session_add`` (a day in
+*that* week). A coach could not build a multi-week mesocycle, review an earlier
+week, or aim delivery at a week other than the scaffold's first. This slice closes
+that long-deferred gap:
+
+- ``Mesocycle.append_week`` — materialize the next week, copying the latest week's
+  session/prescription structure (a real progression starting point, not a blank).
+- ``GET  /meso/api/plan/<id>/week/<week_id>/``          — view/edit any week (read).
+- ``POST /meso/api/plan/<id>/week/``                    — add the next week (write).
+- ``POST /meso/api/plan/<id>/week/<week_id>/current/``  — set the deliver target.
+- ``serialize_week`` gains ``id``/``index``; ``serialize_plan`` gains ``viewing``
+  (the open week's id) so the client tracks which week's grid it is showing.
+"""
+
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+from django.contrib.staticfiles import finders
+from django.urls import reverse
+from django.utils import timezone
+
+from store_project.meso.factories import CoachAthleteFactory
+from store_project.meso.factories import MesoGroupFactory
+from store_project.meso.factories import WeekFactory
+from store_project.meso.models import CoachAthlete
+from store_project.meso.models import LoadType
+from store_project.meso.models import Week
+from store_project.meso.serializers import serialize_week
+from store_project.users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _aged_link(coach, days_ago, **kwargs):
+    """An active ``CoachAthlete`` for ``coach`` whose ``created_at`` is back-dated.
+
+    ``created_at`` is ``auto_now_add``, so a raw ``.update()`` is the only way to
+    set a deterministic relationship age — the ordering the oldest-kept suspension
+    rule turns on (mirrors ``test_plan_create``).
+    """
+    link = CoachAthleteFactory(coach=coach, status=CoachAthlete.Status.ACTIVE, **kwargs)
+    CoachAthlete.objects.filter(pk=link.pk).update(
+        created_at=timezone.now() - timedelta(days=days_ago)
+    )
+    link.refresh_from_db()
+    return link
+
+
+def _latest_week(plan):
+    return Week.objects.filter(mesocycle__plan=plan).order_by("-index").first()
+
+
+# ---------------------------------------------------------------------------
+# Mesocycle.append_week  (the model layer)
+# ---------------------------------------------------------------------------
+
+
+class TestAppendWeek:
+    def test_copies_latest_weeks_structure(self):
+        link = CoachAthleteFactory()
+        plan = link.create_plan()  # scaffold: 1 block, 1 week, 2 days, 1 row each
+        meso = plan.mesocycles.get()
+        source = meso.weeks.get()
+        # Distinguish the source so the copy is unambiguous.
+        source.phase = "Accum"
+        source.volume = 88
+        source.is_deload = False
+        source.save()
+        first_day = source.sessions.order_by("order").first()
+        first_row = first_day.prescriptions.first()
+        first_row.name = "Back Squat"
+        first_row.load = "100"
+        first_row.load_type = LoadType.PERCENT
+        first_row.tags = ["main"]
+        first_row.save()
+
+        new_week = meso.append_week()
+
+        assert new_week.index == 2
+        assert new_week.is_current is False
+        assert new_week.delivered_at is None
+        # Meta carried forward as a starting point.
+        assert new_week.phase == "Accum"
+        assert new_week.volume == 88
+        # Same day structure (count + names + day numbers), fresh rows.
+        src_days = list(source.sessions.order_by("order"))
+        new_days = list(new_week.sessions.order_by("order"))
+        assert [d.name for d in new_days] == [d.name for d in src_days]
+        assert [d.day_number for d in new_days] == [d.day_number for d in src_days]
+        # The copied prescription mirrors the source's fields but is a new row.
+        copied = new_days[0].prescriptions.first()
+        assert copied.pk != first_row.pk
+        assert copied.name == "Back Squat"
+        assert copied.load == "100"
+        assert copied.load_type == LoadType.PERCENT
+        assert copied.tags == ["main"]
+
+    def test_new_week_is_not_current_or_delivered(self):
+        link = CoachAthleteFactory()
+        plan = link.create_plan()
+        meso = plan.mesocycles.get()
+        meso.append_week()
+        # The scaffold's first week stays the live one; the new week is a draft.
+        assert meso.weeks.filter(is_current=True).count() == 1
+        assert meso.weeks.get(index=1).is_current is True
+        assert meso.weeks.filter(delivered_at__isnull=False).count() == 0
+
+    def test_grows_week_count_to_track_materialized_weeks(self):
+        link = CoachAthleteFactory()
+        plan = link.create_plan()
+        meso = plan.mesocycles.get()
+        assert meso.week_count == 4  # scaffold default; 1 week materialized
+        meso.append_week()  # index 2 — within the planned count
+        meso.refresh_from_db()
+        assert meso.week_count == 4
+        for _ in range(3):  # → indexes 3, 4, 5
+            meso.append_week()
+        meso.refresh_from_db()
+        assert meso.weeks.count() == 5
+        assert meso.week_count == 5  # grew past the planned length
+
+    def test_seeds_a_starter_when_block_has_no_weeks(self):
+        # A degenerate block (no weeks) still yields an editable week.
+        link = CoachAthleteFactory()
+        plan = link.create_plan()
+        meso = plan.mesocycles.get()
+        meso.weeks.all().delete()
+        new_week = meso.append_week()
+        assert new_week.index == 1
+        assert new_week.sessions.count() == 1
+        assert new_week.sessions.get().prescriptions.count() == 1
+
+
+# ---------------------------------------------------------------------------
+# serialize_week / serialize_plan shape
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeShape:
+    def test_serialize_week_includes_id_and_index(self):
+        week = WeekFactory(index=3)
+        data = serialize_week(week)
+        assert data["id"] == week.pk
+        assert data["index"] == 3
+        assert data["label"] == "Wk 3"
+
+    def test_serialize_plan_reports_the_open_week(self):
+        from store_project.meso.serializers import serialize_plan
+
+        link = CoachAthleteFactory()
+        plan = link.create_plan()
+        meso = plan.mesocycles.get()
+        new_week = meso.append_week()
+        # Default opens to the current (scaffold) week.
+        assert serialize_plan(plan)["viewing"] == meso.weeks.get(index=1).pk
+        # Pinned to a week reports that week as open.
+        assert serialize_plan(plan, week=new_week)["viewing"] == new_week.pk
+
+
+# ---------------------------------------------------------------------------
+# POST /meso/api/plan/<id>/week/  — add the next week
+# ---------------------------------------------------------------------------
+
+
+class TestWeekAddEndpoint:
+    def _url(self, plan):
+        return reverse("meso:api_week_add", kwargs={"plan_id": plan.pk})
+
+    def test_adds_a_week_and_returns_the_plan_pinned_to_it(self, client):
+        link = CoachAthleteFactory()
+        plan = link.create_plan()
+        client.force_login(link.coach)
+        resp = client.post(self._url(plan))
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["ok"] is True
+        assert Week.objects.filter(mesocycle__plan=plan).count() == 2
+        new_week = _latest_week(plan)
+        # The response opens onto the new week so the client switches to it.
+        assert body["viewing"] == new_week.pk
+        assert len(body["weeks"]) == 2
+        # New week mirrors the scaffold's two days.
+        assert len(body["program"]) == 2
+
+    def test_bumps_plan_modified(self, client):
+        link = CoachAthleteFactory()
+        plan = link.create_plan()
+        before = plan.modified
+        client.force_login(link.coach)
+        client.post(self._url(plan))
+        plan.refresh_from_db()
+        assert plan.modified > before
+
+    def test_foreign_coach_forbidden(self, client):
+        link = CoachAthleteFactory()
+        plan = link.create_plan()
+        client.force_login(UserFactory())  # not this plan's coach
+        resp = client.post(self._url(plan))
+        assert resp.status_code in (403, 404)
+        assert Week.objects.filter(mesocycle__plan=plan).count() == 1
+
+    def test_over_limit_suspended_plan_is_402(self, client):
+        coach = UserFactory()
+        _aged_link(coach, days_ago=30)  # kept (oldest)
+        suspended = _aged_link(coach, days_ago=1)
+        plan = suspended.create_plan()
+        client.force_login(coach)
+        resp = client.post(self._url(plan))
+        assert resp.status_code == 402
+        assert resp.json()["over_limit"] is True
+        assert Week.objects.filter(mesocycle__plan=plan).count() == 1
+
+    def test_requires_login(self, client):
+        link = CoachAthleteFactory()
+        plan = link.create_plan()
+        resp = client.post(self._url(plan))
+        assert resp.status_code in (302, 403)
+
+    def test_rejects_get(self, client):
+        link = CoachAthleteFactory()
+        plan = link.create_plan()
+        client.force_login(link.coach)
+        assert client.get(self._url(plan)).status_code == 405
+
+
+# ---------------------------------------------------------------------------
+# GET /meso/api/plan/<id>/week/<week_id>/  — view any week
+# ---------------------------------------------------------------------------
+
+
+class TestWeekViewEndpoint:
+    def _url(self, plan, week):
+        return reverse(
+            "meso:api_week_view", kwargs={"plan_id": plan.pk, "week_id": week.pk}
+        )
+
+    def _two_week_plan(self):
+        link = CoachAthleteFactory()
+        plan = link.create_plan()
+        meso = plan.mesocycles.get()
+        week1 = meso.weeks.get(index=1)
+        # Rename week 1's first day so we can tell the weeks apart in the program.
+        day = week1.sessions.order_by("order").first()
+        day.name = "Week-One Lower"
+        day.save()
+        week2 = meso.append_week()
+        day2 = week2.sessions.order_by("order").first()
+        day2.name = "Week-Two Lower"
+        day2.save()
+        return link, plan, week1, week2
+
+    def test_returns_the_target_weeks_program(self, client):
+        link, plan, week1, week2 = self._two_week_plan()
+        client.force_login(link.coach)
+        resp = client.get(self._url(plan, week2))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["viewing"] == week2.pk
+        assert "Week-Two Lower" in [d["name"] for d in body["program"]]
+        assert "Week-One Lower" not in [d["name"] for d in body["program"]]
+        assert len(body["weeks"]) == 2
+
+    def test_view_does_not_change_the_current_week(self, client):
+        link, plan, week1, week2 = self._two_week_plan()
+        client.force_login(link.coach)
+        client.get(self._url(plan, week2))
+        week1.refresh_from_db()
+        week2.refresh_from_db()
+        assert week1.is_current is True
+        assert week2.is_current is False
+
+    def test_over_limit_coach_can_still_view(self, client):
+        # Read access is not billing-gated: a suspended coach keeps read access.
+        coach = UserFactory()
+        _aged_link(coach, days_ago=30)
+        suspended = _aged_link(coach, days_ago=1)
+        plan = suspended.create_plan()
+        week = Week.objects.get(mesocycle__plan=plan)
+        client.force_login(coach)
+        assert client.get(self._url(plan, week)).status_code == 200
+
+    def test_foreign_coach_forbidden(self, client):
+        link = CoachAthleteFactory()
+        plan = link.create_plan()
+        week = Week.objects.get(mesocycle__plan=plan)
+        client.force_login(UserFactory())
+        assert client.get(self._url(plan, week)).status_code in (403, 404)
+
+    def test_404_for_a_week_in_another_plan(self, client):
+        link = CoachAthleteFactory()
+        plan = link.create_plan()
+        other_week = WeekFactory()  # belongs to a different plan
+        client.force_login(link.coach)
+        assert client.get(self._url(plan, other_week)).status_code == 404
+
+    def test_requires_login(self, client):
+        link = CoachAthleteFactory()
+        plan = link.create_plan()
+        week = Week.objects.get(mesocycle__plan=plan)
+        resp = client.get(self._url(plan, week))
+        assert resp.status_code in (302, 403)
+
+
+# ---------------------------------------------------------------------------
+# POST /meso/api/plan/<id>/week/<week_id>/current/  — set the deliver target
+# ---------------------------------------------------------------------------
+
+
+class TestWeekSetCurrentEndpoint:
+    def _url(self, plan, week):
+        return reverse(
+            "meso:api_week_set_current",
+            kwargs={"plan_id": plan.pk, "week_id": week.pk},
+        )
+
+    def _two_week_plan(self):
+        link = CoachAthleteFactory()
+        plan = link.create_plan()
+        meso = plan.mesocycles.get()
+        return link, plan, meso.weeks.get(index=1), meso.append_week()
+
+    def test_sets_target_current_and_clears_siblings(self, client):
+        link, plan, week1, week2 = self._two_week_plan()
+        assert week1.is_current is True
+        client.force_login(link.coach)
+        resp = client.post(self._url(plan, week2))
+        assert resp.status_code == 200
+        week1.refresh_from_db()
+        week2.refresh_from_db()
+        assert week2.is_current is True
+        assert week1.is_current is False
+        body = resp.json()
+        assert body["viewing"] == week2.pk
+        # The strip flags exactly the new current week.
+        current = [w for w in body["weeks"] if w["current"]]
+        assert [w["id"] for w in current] == [week2.pk]
+
+    def test_bumps_plan_modified(self, client):
+        link, plan, week1, week2 = self._two_week_plan()
+        before = plan.modified
+        client.force_login(link.coach)
+        client.post(self._url(plan, week2))
+        plan.refresh_from_db()
+        assert plan.modified > before
+
+    def test_over_limit_suspended_plan_is_402(self, client):
+        coach = UserFactory()
+        _aged_link(coach, days_ago=30)
+        suspended = _aged_link(coach, days_ago=1)
+        plan = suspended.create_plan()
+        meso = plan.mesocycles.get()
+        week2 = meso.append_week()
+        client.force_login(coach)
+        resp = client.post(self._url(plan, week2))
+        assert resp.status_code == 402
+        week2.refresh_from_db()
+        assert week2.is_current is False
+
+    def test_foreign_coach_forbidden(self, client):
+        link, plan, week1, week2 = self._two_week_plan()
+        client.force_login(UserFactory())
+        assert client.post(self._url(plan, week2)).status_code in (403, 404)
+
+    def test_404_for_a_week_in_another_plan(self, client):
+        link = CoachAthleteFactory()
+        plan = link.create_plan()
+        other_week = WeekFactory()
+        client.force_login(link.coach)
+        assert client.post(self._url(plan, other_week)).status_code == 404
+
+    def test_rejects_get(self, client):
+        link, plan, week1, week2 = self._two_week_plan()
+        client.force_login(link.coach)
+        assert client.get(self._url(plan, week2)).status_code == 405
+
+
+# ---------------------------------------------------------------------------
+# Groups — the shared program is multi-week too
+# ---------------------------------------------------------------------------
+
+
+class TestGroupWeekManagement:
+    def test_week_add_on_a_group_plan_copies_the_shared_structure(self, client):
+        group = MesoGroupFactory()
+        plan = group.create_shared_plan()
+        before = Week.objects.filter(mesocycle__plan=plan).count()
+        client.force_login(group.coach)
+        resp = client.post(reverse("meso:api_week_add", kwargs={"plan_id": plan.pk}))
+        assert resp.status_code == 201
+        assert Week.objects.filter(mesocycle__plan=plan).count() == before + 1
+        new_week = _latest_week(plan)
+        # The shared structure is copied so the new week is immediately editable.
+        assert new_week.sessions.count() >= 1
+
+
+# ---------------------------------------------------------------------------
+# Designer wiring — the switcher strip is rendered + the JS exposes the verbs
+# (source/render-level, per the test_designer_onboarding.py precedent)
+# ---------------------------------------------------------------------------
+
+
+def _read_designer_template():
+    path = Path(__file__).resolve().parents[2] / "templates" / "meso" / "designer.html"
+    return path.read_text()
+
+
+def _read_meso_js():
+    path = finders.find("js/meso.js")
+    assert path, "static js/meso.js must resolve"
+    return Path(path).read_text()
+
+
+class TestSwitcherWiring:
+    def test_designer_renders_the_week_switcher(self, client):
+        link = CoachAthleteFactory()
+        plan = link.create_plan()
+        client.force_login(link.coach)
+        resp = client.get(reverse("meso:designer_plan", kwargs={"plan_id": plan.pk}))
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert "switchWeek(" in body
+        assert "addWeek()" in body
+        assert "setCurrentWeek(" in body
+
+    def test_template_wires_all_three_verbs(self):
+        tpl = _read_designer_template()
+        assert 'x-show="live && weeks.length"' in tpl
+        assert "weekIsViewed(w)" in tpl
+
+    def test_meso_js_exposes_the_week_methods(self):
+        js = _read_meso_js()
+        for verb in ("switchWeek", "addWeek", "setCurrentWeek", "applyPlanData"):
+            assert verb in js

--- a/app/store_project/meso/urls.py
+++ b/app/store_project/meso/urls.py
@@ -128,6 +128,23 @@ urlpatterns = [
         views.session_add,
         name="api_session_add",
     ),
+    # Multi-week designer: view any week (read), add the next week (write), and
+    # set the live/deliver-target week. ``week/<id>/`` GET views; POST sets current.
+    path(
+        "api/plan/<int:plan_id>/week/",
+        views.week_add,
+        name="api_week_add",
+    ),
+    path(
+        "api/plan/<int:plan_id>/week/<int:week_id>/",
+        views.week_view,
+        name="api_week_view",
+    ),
+    path(
+        "api/plan/<int:plan_id>/week/<int:week_id>/current/",
+        views.week_set_current,
+        name="api_week_set_current",
+    ),
     # Per-athlete override on a group's shared program (groups Phase 3).
     path(
         "api/plan/<int:plan_id>/prescription/<int:pk>/override/",

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -1588,18 +1588,31 @@ def session_add_exercise(request, plan_id, pk):
 @login_required
 @require_POST
 def session_add(request, plan_id):
-    """Append a blank training day (with a starter row) to the plan's current week.
+    """Append a blank training day (with a starter row) to a week of the plan.
 
-    The designer edits the current week, so "add a day" means add a ``Session`` to
-    that week — letting a scaffolded plan grow past its two starter days
-    (first-time-UX Phase 1). Scoped + edit-gated like the other designer writes via
-    ``_editable_plan_or_response`` (403 foreign, 402 over-limit). Returns the new
-    day in the grid's day shape so the client can append it without a reload.
+    "Add a day" adds a ``Session`` to the week the designer is showing. An optional
+    ``week_id`` in the body pins that week — the multi-week switcher can open a week
+    other than the live one, and the day must land where the coach is looking (else
+    a reload shows it on the wrong week). It defaults to ``current_week`` for the
+    first-time-UX caller that predates the switcher. The week is scoped to the plan
+    (a foreign week is a 404). Scoped + edit-gated like the other designer writes via
+    ``_editable_plan_or_response`` (403 foreign, 402 over-limit). Returns the new day
+    in the grid's day shape so the client can append it without a reload.
     """
     plan, forbidden = _editable_plan_or_response(request, plan_id)
     if forbidden is not None:
         return forbidden
-    week = current_week(plan)
+    # An empty / non-JSON body (the pre-switcher callers post no body) means
+    # "no week_id" — fall back to the live week — rather than a 400.
+    try:
+        payload = json.loads(request.body or "{}")
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        payload = {}
+    week_id = payload.get("week_id") if isinstance(payload, dict) else None
+    if week_id is not None:
+        week = get_object_or_404(Week, pk=week_id, mesocycle__plan=plan)
+    else:
+        week = current_week(plan)
     if week is None:
         return HttpResponseBadRequest("This plan has no week to add a day to.")
     # Allocate the next day_number/order under a row lock on the week so a

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -58,6 +58,7 @@ from .models import GroupMembership
 from .models import InvalidTransition
 from .models import LoadType
 from .models import LoggedSet
+from .models import Mesocycle
 from .models import MesoGroup
 from .models import Plan
 from .models import PrescriptionOverride
@@ -1618,6 +1619,84 @@ def session_add(request, plan_id):
         )
         _touch_plan(plan)
     return JsonResponse({"ok": True, "session": serialize_session(session)}, status=201)
+
+
+@login_required
+@require_GET
+def week_view(request, plan_id, week_id):
+    """Serialize one week's grid so the designer can switch to it (multi-week).
+
+    A pure read — viewing a week never changes which week is live or what delivery
+    targets — so it is scoped by ownership only (404/403), **not** billing-gated:
+    an over-limit coach keeps read access to every week. A week that isn't this
+    plan's is a flat 404. Returns the same ``serialize_plan`` shape the page hydrates
+    from, pinned to ``week`` (``viewing`` reports it back).
+    """
+    plan, forbidden = _coach_plan_or_forbidden(request, plan_id)
+    if forbidden is not None:
+        return forbidden
+    week = get_object_or_404(Week, pk=week_id, mesocycle__plan=plan)
+    return JsonResponse({"ok": True, **serialize_plan(plan, week=week)})
+
+
+@login_required
+@require_POST
+def week_add(request, plan_id):
+    """Materialize the next week in the plan's active block and open onto it.
+
+    The designer's "+ Add week": grows the mesocycle of the live (current) week —
+    or, lacking one, the plan's last block — by copying its latest week's grid
+    (``Mesocycle.append_week``). The new week is a non-current draft, so adding it
+    never changes what's live or deliverable. Scoped + edit-gated like the other
+    designer writes (403 foreign, 402 over-limit). Row-locks the mesocycle so two
+    concurrent submits can't both read the same max index and collide on
+    ``unique_week_index`` (explicit transaction — prod views run in autocommit).
+    Returns the plan pinned to the new week so the client switches to it.
+    """
+    plan, forbidden = _editable_plan_or_response(request, plan_id)
+    if forbidden is not None:
+        return forbidden
+    open_week = current_week(plan)
+    mesocycle = (
+        open_week.mesocycle
+        if open_week is not None
+        else plan.mesocycles.order_by("order").last()
+    )
+    if mesocycle is None:
+        return HttpResponseBadRequest("This plan has no block to add a week to.")
+    with transaction.atomic():
+        Mesocycle.objects.select_for_update().filter(pk=mesocycle.pk).first()
+        new_week = mesocycle.append_week()
+        _touch_plan(plan)
+    return JsonResponse({"ok": True, **serialize_plan(plan, week=new_week)}, status=201)
+
+
+@login_required
+@require_POST
+def week_set_current(request, plan_id, week_id):
+    """Make ``week`` the plan's current week — its designer-default + deliver target.
+
+    The designer's "Make current": flips the live pointer to the viewed week so
+    delivery (which sends ``current_week``) targets it and the designer opens onto
+    it next time. Exactly one week is current — the others in the plan are cleared.
+    Scoped + edit-gated (403 foreign, 402 over-limit); a foreign week is a 404.
+    Row-locks the plan so concurrent set-currents serialize. Returns the plan
+    pinned to the new current week.
+    """
+    plan, forbidden = _editable_plan_or_response(request, plan_id)
+    if forbidden is not None:
+        return forbidden
+    week = get_object_or_404(Week, pk=week_id, mesocycle__plan=plan)
+    with transaction.atomic():
+        Plan.objects.select_for_update().filter(pk=plan.pk).first()
+        Week.objects.filter(mesocycle__plan=plan).exclude(pk=week.pk).update(
+            is_current=False
+        )
+        if not week.is_current:
+            week.is_current = True
+            week.save(update_fields=["is_current"])
+        _touch_plan(plan)
+    return JsonResponse({"ok": True, **serialize_plan(plan, week=week)})
 
 
 # Free-form per-athlete override cells, mapped to their model ``max_length``.

--- a/app/store_project/static/js/meso.js
+++ b/app/store_project/static/js/meso.js
@@ -619,16 +619,16 @@ function createMeso() {
       });
     },
 
-    // Add a training day to the current week (first-time-UX Phase 1). The server
-    // appends the Session to the plan's current week and returns it in the grid's
-    // day shape; we push it so the new (empty-but-for-a-starter-row) day appears
-    // without a reload.
+    // Add a training day to the *viewed* week (first-time-UX Phase 1; week-scoped
+    // for the multi-week switcher). The server appends the Session to that week and
+    // returns it in the grid's day shape; we push it so the new
+    // (empty-but-for-a-starter-row) day appears without a reload.
     async addDay() {
       if (this.live) {
         try {
           const data = await this.apiPost(
             `/meso/api/plan/${this.planId}/session/`,
-            null,
+            { week_id: this.viewedWeekId },
           );
           this.program.push(data.session);
         } catch (err) {

--- a/app/store_project/static/js/meso.js
+++ b/app/store_project/static/js/meso.js
@@ -69,6 +69,11 @@ function createMeso() {
     planId: null,
     csrf: "",
 
+    // The week whose grid `program` currently holds (the multi-week switcher can
+    // point this away from the live `current` week). init() seeds it from the
+    // injected plan's `viewing`; switchWeek/addWeek/setCurrentWeek update it.
+    viewedWeekId: null,
+
     // The thread starts with a single orienting greeting. On load, init()
     // replaces it with the plan's persisted conversation (rebuilt server-side
     // from the proposal batches and injected as `meso-chat-thread`) when there
@@ -113,24 +118,41 @@ function createMeso() {
     get currentWeek() {
       return this.weeks.find((w) => w.current) || this.weeks[0] || null;
     },
+    // The week the grid is showing — the switcher can point it away from the
+    // live (`current`) week. Falls back to the current week before a switch.
+    get viewedWeek() {
+      return (
+        this.weeks.find((w) => w.id === this.viewedWeekId) ||
+        this.currentWeek
+      );
+    },
+    weekIsViewed(w) {
+      return !!w && w.id === this.viewedWeekId;
+    },
+    // True when the viewed week is also the live (deliver-target) week — drives
+    // whether the "Make current" affordance shows.
+    get viewedIsCurrent() {
+      const w = this.viewedWeek;
+      return !!(w && w.current);
+    },
     get currentPhase() {
       return (
         this.phases.find((p) => p.state === "current") || this.phases[0] || null
       );
     },
-    // The top-bar cycle chip, e.g. "Hypertrophy · Wk 2 / 4".
+    // The top-bar cycle chip, e.g. "Hypertrophy · Wk 2 / 4" — for the viewed week.
     get cycleLabel() {
       const p = this.currentPhase;
-      const w = this.currentWeek;
+      const w = this.viewedWeek;
       const phase = p ? p.name : "";
       const wk = w
         ? w.label + (this.weeks.length ? " / " + this.weeks.length : "")
         : "";
       return [phase, wk].filter(Boolean).join(" · ");
     },
-    // The week-view heading, e.g. "Wk 2 — Accum".
+    // The week-view heading for the viewed week, e.g. "Wk 2 — Accum".
     get weekHeading() {
-      const w = this.currentWeek;
+      const w = this.viewedWeek;
       if (!w) return "This week";
       return w.phase ? w.label + " — " + w.phase : w.label;
     },
@@ -157,9 +179,7 @@ function createMeso() {
       this.live = true;
       this.planId = data.plan.id;
       if (data.plan.unit) this.unit = data.plan.unit;
-      this.program = data.program;
-      this.weeks = data.weeks;
-      this.phases = data.phases;
+      this.applyPlanData(data);
       // The real athlete identity for the individual left rail (null for groups).
       this.athlete = data.athlete || null;
       // A group shared program opens in Group mode and renders its real identity
@@ -624,6 +644,62 @@ function createMeso() {
         bias: "",
         exercises: [],
       });
+    },
+
+    // ---- multi-week designer (view / add / set-current) ----
+    //
+    // The plan is multi-week: the strip switches which week the grid shows, a
+    // coach can append the next week (the server copies the latest week's grid),
+    // and any week can be made the live (deliver-target) one. Each action hits a
+    // re-serialize endpoint and swaps the grid via applyPlanData.
+
+    // Swap the grid to a (re)serialized plan payload. Shared by init, switchWeek,
+    // addWeek, setCurrentWeek so the program / week strip / phases / viewed-week
+    // pointer always move together.
+    applyPlanData(data) {
+      this.program = data.program;
+      this.weeks = data.weeks;
+      this.phases = data.phases;
+      this.viewedWeekId = data.viewing != null ? data.viewing : null;
+    },
+
+    // Switch the grid to another week — a pure read (viewing never changes what's
+    // live). No-op when already viewing it or before a plan is loaded.
+    async switchWeek(weekId) {
+      if (!this.live || weekId == null || weekId === this.viewedWeekId) return;
+      try {
+        const res = await fetch(`/meso/api/plan/${this.planId}/week/${weekId}/`);
+        if (!res.ok) throw new Error("Request failed: " + res.status);
+        this.applyPlanData(await res.json());
+      } catch (err) {
+        console.error("Switch week failed", err);
+      }
+    },
+
+    // Append the next week to the active block and switch onto it. The server
+    // copies the latest week's grid so the new week starts from a real template.
+    async addWeek() {
+      if (!this.live) return;
+      try {
+        const data = await this.apiPost(`/meso/api/plan/${this.planId}/week/`, null);
+        this.applyPlanData(data);
+      } catch (err) {
+        console.error("Add week failed", err);
+      }
+    },
+
+    // Make a week the live (deliver-target) week — delivery sends current_week.
+    async setCurrentWeek(weekId) {
+      if (!this.live || weekId == null) return;
+      try {
+        const data = await this.apiPost(
+          `/meso/api/plan/${this.planId}/week/${weekId}/current/`,
+          null,
+        );
+        this.applyPlanData(data);
+      } catch (err) {
+        console.error("Set current week failed", err);
+      }
     },
 
     // ---- agent chat ----

--- a/app/store_project/templates/meso/designer.html
+++ b/app/store_project/templates/meso/designer.html
@@ -338,6 +338,20 @@
                 </div>
               </div>
 
+              <!-- Week switcher (multi-week designer): view any week, append the
+                   next one, or make the viewed week the live (deliver-target)
+                   one. Hidden until a real plan is loaded. -->
+              <div x-show="live && weeks.length" style="display:flex;align-items:center;gap:7px;flex-wrap:wrap;margin-bottom:16px;">
+                <template x-for="w in weeks" :key="w.id">
+                  <button type="button" @click="switchWeek(w.id)" data-hover="rail" :title="w.current ? 'Live week — delivery sends this one' : ('View ' + w.label)" :style="`appearance:none;cursor:pointer;font:inherit;display:inline-flex;align-items:center;gap:5px;font-size:11.5px;font-weight:650;padding:6px 11px;border-radius:999px;border:1px solid ${weekIsViewed(w) ? 'var(--accent)' : 'var(--line)'};background:${weekIsViewed(w) ? 'var(--accent)' : 'var(--surface)'};color:${weekIsViewed(w) ? 'var(--accent-ink)' : 'var(--ink)'};`">
+                    <span x-text="w.label"></span>
+                    <span x-show="w.current" title="Live week" :style="`width:6px;height:6px;border-radius:50%;background:${weekIsViewed(w) ? 'var(--accent-ink)' : 'var(--ok)'};`"></span>
+                  </button>
+                </template>
+                <button type="button" @click="addWeek()" data-hover="add" style="appearance:none;cursor:pointer;font:inherit;font-size:11.5px;font-weight:650;padding:6px 11px;border-radius:999px;border:1px dashed var(--line);background:transparent;color:var(--dim);">+ Add week</button>
+                <button type="button" x-show="!viewedIsCurrent" @click="setCurrentWeek(viewedWeekId)" data-hover="brighten" title="Make this the live week — delivery will send it" style="appearance:none;cursor:pointer;font:inherit;font-size:11.5px;font-weight:650;padding:6px 11px;border-radius:999px;border:1px solid var(--accent);background:var(--soft);color:var(--accent-deep);">Make current</button>
+              </div>
+
               <!-- Grid coachmark (Phase 5): dismissible first-run note for the
                    week grid. Shown in both modes (the grid edits the same way). -->
               <div x-show="coachmarkVisible('grid')" style="display:flex;align-items:flex-start;gap:9px;margin-bottom:16px;padding:11px 13px;background:var(--soft);border:1px solid var(--soft-line);border-left:3px solid var(--accent);border-radius:9px;">
@@ -448,8 +462,8 @@
 
                 <!-- timeline -->
                 <div x-show="periodStyle === 'timeline'" class="meso-flex" style="gap:16px;align-items:flex-end;padding:12px 6px 4px;">
-                  <template x-for="w in weeks" :key="w.label">
-                    <div style="flex:1;display:flex;flex-direction:column;align-items:center;gap:9px;">
+                  <template x-for="w in weeks" :key="w.id">
+                    <div @click="switchWeek(w.id)" :title="'View ' + w.label" style="flex:1;display:flex;flex-direction:column;align-items:center;gap:9px;cursor:pointer;">
                       <div style="height:156px;width:100%;display:flex;align-items:flex-end;justify-content:center;gap:7px;">
                         <div :style="`width:20px;height:${barH(w.vol, 156)};border-radius:5px 5px 0 0;background:${w.current ? 'var(--accent)' : (w.deload ? 'color-mix(in srgb,var(--accent) 28%,#fff)' : 'var(--soft-line)')}`"></div>
                         <div :style="`width:20px;height:${barH(w.inten, 156)};border-radius:5px 5px 0 0;background:var(--surface);border:1.5px solid var(--accent)`"></div>

--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -790,3 +790,40 @@ _(Append dated entries here as decisions land.)_
   **add-week / week-switcher** deferral (designer is single-current-week) and **S6
   billing Phase 5 annual prices** (blocked on the owner's per-seat number + a Stripe
   annual Price). Plan in [`first-time-ux-plan.md`](./first-time-ux-plan.md).
+- 2026-06-29 — **Multi-week designer built** (branch `meso-multi-week-designer`,
+  **no migration**): closes the long-standing **add-week / week-switcher** deferral.
+  A plan was effectively **single-week** — `Plan.scaffold` materialized one `Week`
+  (`is_current`) and the only growth verb was `session_add` (a day in *that* week),
+  so a coach could not build a multi-week mesocycle, review an earlier week, or aim
+  delivery anywhere but the scaffold's first week. Three model/seam pieces +
+  three endpoints + a designer strip: **(1)** `Mesocycle.append_week()` materializes
+  the next week by **copying the latest week's grid** (sessions + prescriptions — a
+  real progression starting point, loads carried forward for the coach to tweak, not
+  a blank); the new week is a **non-current, undelivered draft** (adding it never
+  changes what's live or deliverable), and `week_count` grows to track the highest
+  materialized index. **(2)** `serialize_week` gains `id`/`index` and `serialize_plan`
+  gains **`viewing`** (the open week's pk) so the client can tell the *viewed* week
+  apart from the *current* (deliver-target) one. **(3)** three endpoints under
+  `api/plan/<id>/week/…` — `GET week/<id>/` **views** any week (a pure read, scoped by
+  ownership only, **not** billing-gated, so a suspended coach keeps read access);
+  `POST week/` **adds** the next week (edit-gated, mesocycle row-locked against the
+  `unique_week_index` race); `POST week/<id>/current/` **sets the live/deliver-target**
+  week (edit-gated, plan row-locked, clears the other weeks). The designer renders a
+  **week-switcher strip** in the week view (chips → `switchWeek`, a live-week dot,
+  "+ Add week" → `addWeek`, and a "Make current" → `setCurrentWeek` shown only when the
+  viewed week isn't live) and the periodization timeline bars are now click-to-view;
+  `meso.js` tracks `viewedWeekId`, and a shared `applyPlanData` keeps program / week
+  strip / phases / viewed pointer in lockstep across init + the three verbs; the
+  week/cycle **headers follow the viewed week**. **Design call:** *viewing is a pure
+  read; making a week the deliver target is the separate explicit `set-current`
+  action* — so building weeks ahead never silently moves what delivery sends, and
+  reviewing a past week never re-marks it live (no footgun). Deliver code is
+  **unchanged** (still sends `current_week`, now coach-controllable). Built red→green:
+  `test_week_management.py` (**+31 pytest**: `append_week`, the three endpoints incl.
+  scoping/402/404/405, serializer shape, a group variant, render/JS wiring) +
+  `frontend/meso.test.js` (**+9 vitest**: `applyPlanData`, the viewed-week getters,
+  `switchWeek`/`addWeek`/`setCurrentWeek` incl. no-op + failure paths); updated the
+  exact-shape serializer test for `id`/`index`/`viewing`. 1214 pytest + 112 vitest
+  green, ruff + format clean. Remaining Meso backlog: **deliver a chosen non-current
+  week without first making it current** (a natural follow-up) and **S6 billing Phase
+  5 annual prices** (blocked on the owner's per-seat number + a Stripe annual Price).

--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -799,8 +799,10 @@ _(Append dated entries here as decisions land.)_
   three endpoints + a designer strip: **(1)** `Mesocycle.append_week()` materializes
   the next week by **copying the latest week's grid** (sessions + prescriptions — a
   real progression starting point, loads carried forward for the coach to tweak, not
-  a blank); the new week is a **non-current, undelivered draft** (adding it never
-  changes what's live or deliverable), and `week_count` grows to track the highest
+  a blank — **and, for a group shared plan, each member's `PrescriptionOverride`** so
+  a per-athlete swap/load-cut isn't silently dropped on the new week's delivery);
+  the new week is a **non-current, undelivered draft** (adding it never changes
+  what's live or deliverable), and `week_count` grows to track the highest
   materialized index. **(2)** `serialize_week` gains `id`/`index` and `serialize_plan`
   gains **`viewing`** (the open week's pk) so the client can tell the *viewed* week
   apart from the *current* (deliver-target) one. **(3)** three endpoints under
@@ -818,12 +820,17 @@ _(Append dated entries here as decisions land.)_
   read; making a week the deliver target is the separate explicit `set-current`
   action* — so building weeks ahead never silently moves what delivery sends, and
   reviewing a past week never re-marks it live (no footgun). Deliver code is
-  **unchanged** (still sends `current_week`, now coach-controllable). Built red→green:
-  `test_week_management.py` (**+31 pytest**: `append_week`, the three endpoints incl.
-  scoping/402/404/405, serializer shape, a group variant, render/JS wiring) +
-  `frontend/meso.test.js` (**+9 vitest**: `applyPlanData`, the viewed-week getters,
-  `switchWeek`/`addWeek`/`setCurrentWeek` incl. no-op + failure paths); updated the
-  exact-shape serializer test for `id`/`index`/`viewing`. 1214 pytest + 112 vitest
-  green, ruff + format clean. Remaining Meso backlog: **deliver a chosen non-current
+  **unchanged** (still sends `current_week`, now coach-controllable). A Codex review
+  caught two correctness gaps that were fixed in-PR: `session_add` ("+ Add day") still
+  targeted `current_week`, so adding a day while viewing a non-current week landed it
+  on the wrong week — now an optional `week_id` pins the **viewed** week; and
+  `append_week` originally dropped group overrides (above). Built red→green:
+  `test_week_management.py` (**+37 pytest**: `append_week` incl. override carry-forward,
+  the three endpoints incl. scoping/402/404/405, `session_add` week-scoping, serializer
+  shape, a group variant, render/JS wiring) + `frontend/meso.test.js` (**+9 vitest**:
+  `applyPlanData`, the viewed-week getters, `switchWeek`/`addWeek`/`setCurrentWeek`
+  incl. no-op + failure paths) + the `addDay` test now asserts the week scope; updated
+  the exact-shape serializer test for `id`/`index`/`viewing`. 1078 meso pytest + 112
+  vitest green, ruff + format clean. Remaining Meso backlog: **deliver a chosen non-current
   week without first making it current** (a natural follow-up) and **S6 billing Phase
   5 annual prices** (blocked on the owner's per-seat number + a Stripe annual Price).

--- a/frontend/meso.test.js
+++ b/frontend/meso.test.js
@@ -503,8 +503,9 @@ describe("coach 1RM editor", () => {
 // Mirrors addExercise: live → POST and push the server's day; offline → a local
 // placeholder; a failed add leaves the grid untouched.
 describe("addDay", () => {
-  it("appends the server's new day to the grid when live", async () => {
+  it("appends the server's new day to the viewed week when live", async () => {
     const c = makeMeso();
+    c.viewedWeekId = 5; // viewing a week other than the live one
     c.program = [{ id: 1, n: 1, name: "Day 1", exercises: [] }];
     const newDay = {
       id: 2,
@@ -519,6 +520,8 @@ describe("addDay", () => {
     await c.addDay();
     expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(global.fetch.mock.calls[0][0]).toBe("/meso/api/plan/7/session/");
+    // The day is scoped to the viewed week so it lands where the coach is looking.
+    expect(sentBody(0).week_id).toBe(5);
     expect(c.program).toHaveLength(2);
     expect(c.program[1]).toEqual(newDay);
   });

--- a/frontend/meso.test.js
+++ b/frontend/meso.test.js
@@ -598,3 +598,117 @@ describe("designer coachmarks", () => {
     spy.mockRestore();
   });
 });
+
+// ---- multi-week designer (view / add / set-current) ----
+//
+// The plan is multi-week: the switcher strip swaps which week the grid shows,
+// addWeek appends the next week (server copies the latest week's grid), and
+// setCurrentWeek moves the live (deliver-target) pointer. Each swaps the grid via
+// applyPlanData, which keeps program / weeks / phases / viewedWeekId in lockstep.
+describe("week switcher", () => {
+  // A re-serialized plan payload pinned to `viewing`, in the shape the endpoints
+  // return (and init hydrates from).
+  function planData({ viewing = 2 } = {}) {
+    return {
+      ok: true,
+      program: [{ id: 10, n: 1, name: "Lower", exercises: [] }],
+      weeks: [
+        { id: 1, index: 1, label: "Wk 1", current: true },
+        { id: 2, index: 2, label: "Wk 2", current: false },
+      ],
+      phases: [{ name: "Hypertrophy", weeks: "4 wk", state: "current" }],
+      viewing,
+    };
+  }
+
+  it("applyPlanData swaps the grid and tracks the viewed week", () => {
+    const c = makeMeso();
+    c.applyPlanData(planData({ viewing: 2 }));
+    expect(c.program).toHaveLength(1);
+    expect(c.weeks).toHaveLength(2);
+    expect(c.phases[0].name).toBe("Hypertrophy");
+    expect(c.viewedWeekId).toBe(2);
+  });
+
+  it("derives the viewed week and whether it is the live one", () => {
+    const c = makeMeso();
+    c.applyPlanData(planData({ viewing: 2 }));
+    expect(c.viewedWeek.id).toBe(2);
+    expect(c.weekIsViewed(c.weeks[1])).toBe(true);
+    expect(c.weekIsViewed(c.weeks[0])).toBe(false);
+    // Viewing Wk 2 (not current) → the "Make current" affordance shows.
+    expect(c.viewedIsCurrent).toBe(false);
+    // Switch the viewed pointer to the live week.
+    c.viewedWeekId = 1;
+    expect(c.viewedIsCurrent).toBe(true);
+    expect(c.weekHeading).toBe("Wk 1");
+  });
+
+  it("switchWeek GETs the week and applies it", async () => {
+    const c = makeMeso();
+    c.viewedWeekId = 1;
+    global.fetch = vi.fn().mockResolvedValue(res({ body: planData({ viewing: 2 }) }));
+    await c.switchWeek(2);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch.mock.calls[0][0]).toBe("/meso/api/plan/7/week/2/");
+    expect(c.viewedWeekId).toBe(2);
+  });
+
+  it("switchWeek is a no-op when already viewing that week", async () => {
+    const c = makeMeso();
+    c.viewedWeekId = 2;
+    global.fetch = vi.fn();
+    await c.switchWeek(2);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("switchWeek leaves the grid unchanged when the fetch fails", async () => {
+    const c = makeMeso();
+    c.viewedWeekId = 1;
+    c.program = [{ id: 99 }];
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    global.fetch = vi.fn().mockResolvedValue(res({ ok: false, status: 404 }));
+    await c.switchWeek(2);
+    expect(c.viewedWeekId).toBe(1);
+    expect(c.program).toEqual([{ id: 99 }]);
+  });
+
+  it("addWeek POSTs to the week endpoint and switches onto the new week", async () => {
+    const c = makeMeso();
+    c.viewedWeekId = 1;
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(res({ status: 201, body: planData({ viewing: 2 }) }));
+    await c.addWeek();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch.mock.calls[0][0]).toBe("/meso/api/plan/7/week/");
+    expect(global.fetch.mock.calls[0][1].method).toBe("POST");
+    expect(c.viewedWeekId).toBe(2);
+    expect(c.weeks).toHaveLength(2);
+  });
+
+  it("setCurrentWeek POSTs to the current endpoint and applies the result", async () => {
+    const c = makeMeso();
+    // The server flips week 2 to current and returns the re-serialized plan.
+    const data = planData({ viewing: 2 });
+    data.weeks = [
+      { id: 1, index: 1, label: "Wk 1", current: false },
+      { id: 2, index: 2, label: "Wk 2", current: true },
+    ];
+    global.fetch = vi.fn().mockResolvedValue(res({ body: data }));
+    await c.setCurrentWeek(2);
+    expect(global.fetch.mock.calls[0][0]).toBe("/meso/api/plan/7/week/2/current/");
+    expect(global.fetch.mock.calls[0][1].method).toBe("POST");
+    expect(c.viewedIsCurrent).toBe(true);
+  });
+
+  it("week methods no-op without a network call when not live", async () => {
+    const c = makeMeso();
+    c.live = false;
+    global.fetch = vi.fn();
+    await c.switchWeek(2);
+    await c.addWeek();
+    await c.setCurrentWeek(2);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What & why

Closes the long-deferred **add-week / week-switcher** gap. A plan was effectively **single-week** — `Plan.scaffold` materialized one `Week` (`is_current`) and the only growth verb was `session_add` (a day in *that* week) — so a coach could not build a multi-week mesocycle, review an earlier week, or aim delivery anywhere but the scaffold's first week.

## What's in it

**Model / serializer seam**
- `Mesocycle.append_week()` — materialize the next week by **copying the latest week's grid** (sessions + prescriptions, a real progression starting point; loads carried forward to tweak, not a blank). For a **group** shared plan it also carries each member's `PrescriptionOverride` forward, so a per-athlete swap/load-cut isn't silently dropped on the new week's delivery. The new week is a **non-current, undelivered draft**; `week_count` grows to track the highest materialized index.
- `serialize_week` gains `id`/`index`; `serialize_plan` gains **`viewing`** (the open week's pk) so the client distinguishes the *viewed* week from the *current* (deliver-target) one.

**Endpoints** (`api/plan/<id>/week/…`)
- `GET week/<id>/` — **view** any week (pure read, ownership-scoped, *not* billing-gated, so a suspended coach keeps read access).
- `POST week/` — **add** the next week (edit-gated, mesocycle row-locked against the `unique_week_index` race).
- `POST week/<id>/current/` — **set the live/deliver-target** week (edit-gated, plan row-locked, clears siblings).
- `session_add` ("+ Add day") is now **week-scoped** via an optional `week_id` so a day lands on the week the coach is viewing, not blindly on `current_week`.

**Designer UI**
- A **week-switcher strip** in the week view (chips → `switchWeek`, a live-week dot, "+ Add week" → `addWeek`, "Make current" → `setCurrentWeek` shown only off-target) and click-to-view periodization bars.
- `meso.js` tracks `viewedWeekId`; a shared `applyPlanData` keeps program / week strip / phases / viewed pointer in lockstep; headers follow the viewed week.

## Design call

**Viewing is a pure read; making a week the deliver target is the separate explicit `set-current` action.** Building weeks ahead never silently moves what delivery sends, and reviewing a past week never re-marks it live. Deliver code is unchanged (still sends `current_week`, now coach-controllable).

## Tests

Red→green: **+37 pytest** (`test_week_management.py`: `append_week` incl. group override carry-forward, the three endpoints incl. scoping/402/404/405, `session_add` week-scoping, serializer shape, render/JS wiring) + **+9 vitest** (`applyPlanData`, viewed-week getters, `switchWeek`/`addWeek`/`setCurrentWeek` incl. no-op + failure paths). Updated the exact-shape serializer test for `id`/`index`/`viewing`.

**1218 pytest + 112 vitest green**, ruff + format clean. **No migration.** Codex review loop CLEAN after 2 fix iterations (the two correctness gaps above).

## Follow-ups (noted)
- Deliver a chosen non-current week without first making it current.
- S6 billing Phase 5 annual prices (blocked on the owner's per-seat number + a Stripe annual Price).

https://claude.ai/code/session_019A9KdsVs33wipsGjSaFWXV