### PR TITLE
Meso — deliver any week: send a chosen non-current week

### DIFF
--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -320,6 +320,12 @@ def deliver_screen(plan, week=None):
     """
     live = current_week(plan)
     target = week or live
+    # "Live" everywhere = the week ``current_week`` *resolves* to, not the raw
+    # ``is_current`` flag: a plan with no flagged week falls back to its earliest
+    # week as the live target, and the chip marker + the "not the live week"
+    # warning must agree with that fallback (else the screen contradicts itself —
+    # "sending Wk 1, not the live week (Wk 1)").
+    live_id = live.pk if live else None
     mesocycle = target.mesocycle if target else None
     session_count = target.sessions.count() if target else 0
     is_redelivery = target is not None and target.deliveries.exists()
@@ -328,7 +334,7 @@ def deliver_screen(plan, week=None):
         {
             "id": w.pk,
             "label": f"Wk {w.index}",
-            "is_current": w.is_current,
+            "is_current": w.pk == live_id,
             "is_delivered": w.delivered_at is not None,
             "is_target": target is not None and w.pk == target.pk,
         }
@@ -350,7 +356,7 @@ def deliver_screen(plan, week=None):
             "is_redelivery": is_redelivery,
             "week_id": target.pk if target else None,
             "week_label": f"Wk {target.index}" if target else "",
-            "is_current": target is not None and target.is_current,
+            "is_current": target is not None and target.pk == live_id,
             "current_label": f"Wk {live.index}" if live else "",
             "weeks": weeks,
         },

--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -21,6 +21,7 @@ from .models import CoachSubscription
 from .models import LoadType
 from .models import Plan
 from .models import SessionLog
+from .models import Week
 from .one_rm import one_rm_values
 from .serializers import _fmt_num
 from .serializers import _num
@@ -305,28 +306,53 @@ def group_detail(group):
     }
 
 
-def deliver_screen(plan):
-    """Context for the plan-bound deliver screen (Phase 4).
+def deliver_screen(plan, week=None):
+    """Context for the plan-bound deliver screen (Phase 4; per-week, multi-week).
 
-    Real athlete + current-week summary. Scheduling and the full "changes since
-    last delivery" diff are later-slice concerns (notifications / agent), so the
-    template hides those controls in plan mode; we only surface whether this is
-    a first delivery or a re-delivery.
+    Summarizes the **target** week — the plan's current (live) week by default, or
+    an explicit ``week`` the coach chose in the designer's switcher. ``deliver.weeks``
+    lists every week (id / label / whether it's the live week / whether it's already
+    been delivered) so the screen offers a per-week selector, and ``is_current``
+    /``current_label`` let it warn when the coach is sending a week that isn't the
+    live one (delivering it won't move the live pointer). Scheduling and the full
+    "changes since last delivery" diff are later-slice concerns; we only surface
+    whether this is a first delivery or a re-delivery.
     """
-    week = current_week(plan)
-    mesocycle = week.mesocycle if week else None
-    session_count = week.sessions.count() if week else 0
-    is_redelivery = week is not None and week.deliveries.exists()
+    live = current_week(plan)
+    target = week or live
+    mesocycle = target.mesocycle if target else None
+    session_count = target.sessions.count() if target else 0
+    is_redelivery = target is not None and target.deliveries.exists()
+
+    weeks = [
+        {
+            "id": w.pk,
+            "label": f"Wk {w.index}",
+            "is_current": w.is_current,
+            "is_delivered": w.delivered_at is not None,
+            "is_target": target is not None and w.pk == target.pk,
+        }
+        for w in (
+            Week.objects.filter(mesocycle__plan=plan)
+            .select_related("mesocycle")
+            .order_by("mesocycle__order", "index")
+        )
+    ]
 
     athlete = profile_athlete(plan.athlete)
     athlete["block"] = mesocycle.name if mesocycle else ""
-    athlete["week"] = f"Wk {week.index}" if week else ""
+    athlete["week"] = f"Wk {target.index}" if target else ""
     return {
         "athlete": athlete,
         "deliver": {
             "what": plan.title,
             "sessions": session_count,
             "is_redelivery": is_redelivery,
+            "week_id": target.pk if target else None,
+            "week_label": f"Wk {target.index}" if target else "",
+            "is_current": target is not None and target.is_current,
+            "current_label": f"Wk {live.index}" if live else "",
+            "weeks": weeks,
         },
     }
 

--- a/app/store_project/meso/tests/test_deliver.py
+++ b/app/store_project/meso/tests/test_deliver.py
@@ -265,15 +265,27 @@ class TestDeliverChosenWeek:
         assert other_week.delivered_at is None
         assert not WeekDelivery.objects.exists()
 
-    def test_malformed_week_id_is_a_clean_400_not_500(self, client):
-        # ``week_id`` arrives from JSON, so a tampered non-integer must answer a
-        # clean 400 — not crash the int-pk query with a 500.
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            "not-a-number",  # string → not an int-pk
+            1.9,  # float → must not coerce to 1
+            True,  # bool → must not coerce to 1
+            [1],  # wrong type entirely
+        ],
+    )
+    def test_non_integer_week_id_is_a_clean_400(self, client, bad_value):
+        # ``week_id`` arrives from JSON; only a genuine integer is honored. A
+        # string would 500 the int-pk query; a float/bool would silently coerce
+        # onto a valid pk and act on the wrong week — both must answer 400.
         plan, week, _, _ = seed_plan()
+        # A week whose pk could be the coercion target (1) of 1.9 / True.
+        add_week(plan, index=2, is_current=False)
         client.force_login(plan.relationship.coach)
 
         resp = client.post(
             deliver_url(plan),
-            data=json.dumps({"week_id": "not-a-number"}),
+            data=json.dumps({"week_id": bad_value}),
             content_type="application/json",
         )
 

--- a/app/store_project/meso/tests/test_deliver.py
+++ b/app/store_project/meso/tests/test_deliver.py
@@ -16,6 +16,8 @@ These tests cover the server seam:
 - the plan-bound deliver screen renders real data and 404s a non-owned plan.
 """
 
+import json
+
 import pytest
 from django.urls import reverse
 
@@ -49,8 +51,25 @@ def seed_plan(coach=None, athlete=None):
     return plan, week, session, presc
 
 
+def add_week(plan, *, index, is_current=False):
+    """Append another week (with one session) to the plan's first block."""
+    meso = plan.mesocycles.order_by("order").first()
+    week = WeekFactory(mesocycle=meso, index=index, is_current=is_current)
+    SessionFactory(week=week, day_number=1, name=f"Day {index}")
+    return week
+
+
 def deliver_url(plan):
     return reverse("meso:api_plan_deliver", kwargs={"plan_id": plan.pk})
+
+
+def post_week(client, plan, week_id):
+    """POST the deliver endpoint with an explicit ``week_id`` JSON body."""
+    return client.post(
+        deliver_url(plan),
+        data=json.dumps({"week_id": week_id}),
+        content_type="application/json",
+    )
 
 
 class TestDeliver:
@@ -119,6 +138,18 @@ class TestDeliver:
         assert data["week"]["id"] == week.pk
         assert data["delivered_at"]
 
+    def test_empty_json_body_delivers_current_week(self, client):
+        # The bare deliver button posts no useful body; an explicit ``{}`` (or no
+        # body) must still mean "deliver the live week", not a 400.
+        plan, week, _, _ = seed_plan()
+        client.force_login(plan.relationship.coach)
+
+        resp = post_week(client, plan, None)
+
+        assert resp.status_code == 201
+        week.refresh_from_db()
+        assert week.delivered_at is not None
+
     def test_non_owner_deliver_forbidden(self, client):
         plan, week, _, _ = seed_plan()
         client.force_login(UserFactory())  # a stranger
@@ -171,6 +202,88 @@ class TestDeliver:
         assert resp.status_code == 405
 
 
+class TestDeliverChosenWeek:
+    """Deliver a chosen (non-current) week via an explicit ``week_id``.
+
+    The multi-week designer lets a coach build weeks ahead; this lets them
+    *send* a built-ahead week directly — without first flipping it to the live
+    (current) week. The athlete sees the newest-delivered week, the coach's live
+    pointer is left untouched, and a foreign week is rejected.
+    """
+
+    def test_delivers_the_chosen_non_current_week(self, client):
+        plan, week1, _, _ = seed_plan()
+        week2 = add_week(plan, index=2, is_current=False)
+        client.force_login(plan.relationship.coach)
+
+        resp = post_week(client, plan, week2.pk)
+
+        assert resp.status_code == 201
+        assert resp.json()["week"]["id"] == week2.pk
+        week1.refresh_from_db()
+        week2.refresh_from_db()
+        # Only the chosen week is delivered + snapshotted; the live week is not.
+        assert week2.delivered_at is not None
+        assert week1.delivered_at is None
+        assert WeekDelivery.objects.filter(week=week2).count() == 1
+        assert WeekDelivery.objects.filter(week=week1).count() == 0
+
+    def test_delivering_a_week_does_not_change_the_current_pointer(self, client):
+        plan, week1, _, _ = seed_plan()
+        week2 = add_week(plan, index=2, is_current=False)
+        client.force_login(plan.relationship.coach)
+
+        post_week(client, plan, week2.pk)
+
+        week1.refresh_from_db()
+        week2.refresh_from_db()
+        # Delivering never flips ``is_current`` — week1 stays the live target.
+        assert week1.is_current is True
+        assert week2.is_current is False
+
+    def test_chosen_week_becomes_the_athletes_visible_week(self, client):
+        from store_project.meso.serializers import latest_delivered_week
+
+        plan, _, _, _ = seed_plan()
+        week2 = add_week(plan, index=2, is_current=False)
+        client.force_login(plan.relationship.coach)
+
+        post_week(client, plan, week2.pk)
+
+        # Newest delivery wins → the athlete lands on the week just sent.
+        assert latest_delivered_week(plan).pk == week2.pk
+
+    def test_foreign_week_id_is_404_and_delivers_nothing(self, client):
+        plan, _, _, _ = seed_plan()
+        other_plan, other_week, _, _ = seed_plan()
+        client.force_login(plan.relationship.coach)
+
+        resp = post_week(client, plan, other_week.pk)
+
+        assert resp.status_code == 404
+        other_week.refresh_from_db()
+        assert other_week.delivered_at is None
+        assert not WeekDelivery.objects.exists()
+
+    def test_over_limit_coach_cannot_deliver_a_chosen_week(self, client):
+        # The D6 freeze guards the endpoint before the body is read, so a
+        # per-week deliver is gated exactly like the current-week deliver. A free
+        # coach with a kept link + a newer (suspended) one is over the seat cap.
+        from store_project.meso.models import CoachAthlete
+
+        coach = UserFactory()
+        CoachAthleteFactory(coach=coach, status=CoachAthlete.Status.ACTIVE)  # kept
+        plan, _, _, _ = seed_plan(coach=coach)  # newer link → suspended → over
+        week2 = add_week(plan, index=2, is_current=False)
+        client.force_login(coach)
+
+        resp = post_week(client, plan, week2.pk)
+
+        assert resp.status_code == 402
+        week2.refresh_from_db()
+        assert week2.delivered_at is None
+
+
 class TestDeliverScreen:
     def test_plan_screen_renders_real_plan(self, client):
         plan, _, _, _ = seed_plan(athlete=UserFactory(name="Maya Okonkwo"))
@@ -198,3 +311,76 @@ class TestDeliverScreen:
         client.force_login(coach)
         resp = client.get(reverse("meso:deliver_plan", kwargs={"plan_id": plan.pk}))
         assert resp.status_code == 404
+
+    def _screen(self, client, plan, **params):
+        url = reverse("meso:deliver_plan", kwargs={"plan_id": plan.pk})
+        return client.get(url, params)
+
+    def test_screen_defaults_to_current_week(self, client):
+        plan, week1, _, _ = seed_plan()
+        add_week(plan, index=2, is_current=False)
+        client.force_login(plan.relationship.coach)
+
+        ctx = self._screen(client, plan).context["deliver"]
+
+        assert ctx["week_id"] == week1.pk
+        assert ctx["is_current"] is True
+
+    def test_screen_targets_the_week_query_param(self, client):
+        plan, _, _, _ = seed_plan()
+        week2 = add_week(plan, index=2, is_current=False)
+        client.force_login(plan.relationship.coach)
+
+        resp = self._screen(client, plan, week=week2.pk)
+
+        ctx = resp.context["deliver"]
+        assert ctx["week_id"] == week2.pk
+        # Targeting a non-current week flags it so the screen can warn the coach.
+        assert ctx["is_current"] is False
+        assert "Wk 2" in resp.content.decode()
+
+    def test_screen_lists_every_week_for_the_selector(self, client):
+        plan, week1, _, _ = seed_plan()
+        week2 = add_week(plan, index=2, is_current=False)
+        client.force_login(plan.relationship.coach)
+
+        resp = self._screen(client, plan)
+
+        weeks = resp.context["deliver"]["weeks"]
+        ids = {w["id"] for w in weeks}
+        assert ids == {week1.pk, week2.pk}
+        body = resp.content.decode()
+        # Each week is a link that re-targets the screen at that week.
+        assert f"?week={week1.pk}" in body
+        assert f"?week={week2.pk}" in body
+
+    def test_screen_warns_when_target_is_not_the_live_week(self, client):
+        plan, _, _, _ = seed_plan()
+        week2 = add_week(plan, index=2, is_current=False)
+        client.force_login(plan.relationship.coach)
+
+        on_current = self._screen(client, plan).content.decode()
+        on_other = self._screen(client, plan, week=week2.pk).content.decode()
+
+        # The "not the live week" notice shows only when sending a non-live week.
+        assert "live week" not in on_current.lower()
+        assert "live week" in on_other.lower()
+
+    def test_screen_foreign_week_param_falls_back_to_current(self, client):
+        plan, week1, _, _ = seed_plan()
+        _, other_week, _, _ = seed_plan()
+        client.force_login(plan.relationship.coach)
+
+        ctx = self._screen(client, plan, week=other_week.pk).context["deliver"]
+
+        # A foreign / stale ?week= silently falls back to the live week (the
+        # confirm screen always renders something deliverable); the POST is strict.
+        assert ctx["week_id"] == week1.pk
+
+    def test_screen_non_numeric_week_param_falls_back_to_current(self, client):
+        plan, week1, _, _ = seed_plan()
+        client.force_login(plan.relationship.coach)
+
+        ctx = self._screen(client, plan, week="nope").context["deliver"]
+
+        assert ctx["week_id"] == week1.pk

--- a/app/store_project/meso/tests/test_deliver.py
+++ b/app/store_project/meso/tests/test_deliver.py
@@ -282,6 +282,23 @@ class TestDeliverChosenWeek:
         assert week.delivered_at is None
         assert not WeekDelivery.objects.exists()
 
+    def test_malformed_json_body_is_a_400_not_a_silent_current_delivery(self, client):
+        # A truncated / tampered body that meant to pin a week must fail loudly,
+        # not silently stamp + email/push the live week.
+        plan, week, _, _ = seed_plan()
+        client.force_login(plan.relationship.coach)
+
+        resp = client.post(
+            deliver_url(plan),
+            data="{not valid json",
+            content_type="application/json",
+        )
+
+        assert resp.status_code == 400
+        week.refresh_from_db()
+        assert week.delivered_at is None
+        assert not WeekDelivery.objects.exists()
+
     def test_over_limit_coach_cannot_deliver_a_chosen_week(self, client):
         # The D6 freeze guards the endpoint before the body is read, so a
         # per-week deliver is gated exactly like the current-week deliver. A free

--- a/app/store_project/meso/tests/test_deliver.py
+++ b/app/store_project/meso/tests/test_deliver.py
@@ -418,3 +418,23 @@ class TestDeliverScreen:
         ctx = self._screen(client, plan, week="nope").context["deliver"]
 
         assert ctx["week_id"] == week1.pk
+
+    def test_screen_no_flagged_week_treats_the_fallback_as_live(self, client):
+        # When no week is flagged ``is_current``, ``current_week`` falls back to the
+        # earliest week as the live target. The screen must agree: default target ==
+        # that fallback, marked live, with no contradictory "not the live week" notice.
+        plan, week1, _, _ = seed_plan()
+        week1.is_current = False
+        week1.save(update_fields=["is_current"])
+        add_week(plan, index=2, is_current=False)
+        client.force_login(plan.relationship.coach)
+
+        resp = self._screen(client, plan)
+
+        ctx = resp.context["deliver"]
+        assert ctx["week_id"] == week1.pk
+        assert ctx["is_current"] is True
+        assert "live week" not in resp.content.decode().lower()
+        # The fallback week is the one marked live in the selector.
+        live_chip = next(w for w in ctx["weeks"] if w["id"] == week1.pk)
+        assert live_chip["is_current"] is True

--- a/app/store_project/meso/tests/test_deliver.py
+++ b/app/store_project/meso/tests/test_deliver.py
@@ -265,6 +265,23 @@ class TestDeliverChosenWeek:
         assert other_week.delivered_at is None
         assert not WeekDelivery.objects.exists()
 
+    def test_malformed_week_id_is_a_clean_400_not_500(self, client):
+        # ``week_id`` arrives from JSON, so a tampered non-integer must answer a
+        # clean 400 — not crash the int-pk query with a 500.
+        plan, week, _, _ = seed_plan()
+        client.force_login(plan.relationship.coach)
+
+        resp = client.post(
+            deliver_url(plan),
+            data=json.dumps({"week_id": "not-a-number"}),
+            content_type="application/json",
+        )
+
+        assert resp.status_code == 400
+        week.refresh_from_db()
+        assert week.delivered_at is None
+        assert not WeekDelivery.objects.exists()
+
     def test_over_limit_coach_cannot_deliver_a_chosen_week(self, client):
         # The D6 freeze guards the endpoint before the body is read, so a
         # per-week deliver is gated exactly like the current-week deliver. A free

--- a/app/store_project/meso/tests/test_group_deliver.py
+++ b/app/store_project/meso/tests/test_group_deliver.py
@@ -333,6 +333,25 @@ class TestPlanDeliverGroup:
         assert data["delivered_at"]
         assert Plan.objects.filter(source_group=group).count() == 2
 
+    def test_group_ignores_a_week_id_and_fans_out_current(self, client):
+        # Per-week delivery is an individual-designer affordance; a group plan
+        # always fans out its current week, so a stray ``week_id`` in the body is
+        # ignored (the group branch short-circuits before the body is read).
+        import json
+
+        group, plan, memberships = seed_group(member_count=2)
+        client.force_login(group.coach)
+
+        resp = client.post(
+            deliver_url(plan),
+            data=json.dumps({"week_id": 999999}),
+            content_type="application/json",
+        )
+
+        assert resp.status_code == 201
+        assert resp.json()["members"] == 2
+        assert Plan.objects.filter(source_group=group).count() == 2
+
     def test_notifies_each_member_once(
         self, client, mailoutbox, django_capture_on_commit_callbacks
     ):

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -1503,16 +1503,29 @@ def _editable_plan_or_response(request, plan_id):
     return plan, None
 
 
-def _coerce_week_id(payload):
-    """A JSON body's ``week_id`` as an int, or an error response if malformed.
+def _body_week_id(request):
+    """A designer write's optional ``week_id``, parsed from the JSON request body.
 
-    Returns ``(week_id, None)`` — ``week_id`` is None when absent (the caller
-    falls back to the live week) — or ``(None, HttpResponseBadRequest)`` when the
-    value is present but not integer-coercible. ``week_id`` arrives from JSON (not
-    an ``<int:...>`` URL segment), so a tampered value ("abc", "") must answer a
-    clean 400 rather than letting a non-int pk reach the query and 500.
+    The real callers post ``application/json`` (``apiPost`` and the deliver
+    ``fetch`` always set it, even for an empty ``body: null``); a bodyless / form /
+    multipart post carries no ``week_id`` → fall back to the live week. A declared
+    JSON body, though, is validated strictly: returns ``(None, HttpResponseBadRequest)``
+    when it's malformed (bad JSON, not an object, or a non-integer ``week_id``) so a
+    truncated / tampered request that meant to pin a week fails loudly rather than
+    silently acting on the live week (which, for deliver, would email/push the wrong
+    week). On success returns ``(week_id, None)`` — ``week_id`` is None when absent.
+    ``week_id`` arrives from JSON, not an ``<int:...>`` URL segment, so the int
+    coercion also guards the pk query against a 500.
     """
-    week_id = payload.get("week_id") if isinstance(payload, dict) else None
+    if request.content_type != "application/json" or not request.body:
+        return None, None
+    try:
+        payload = json.loads(request.body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None, HttpResponseBadRequest("Expected a JSON object.")
+    if not isinstance(payload, dict):
+        return None, HttpResponseBadRequest("Expected a JSON object.")
+    week_id = payload.get("week_id")
     if week_id is None:
         return None, None
     try:
@@ -1620,13 +1633,9 @@ def session_add(request, plan_id):
     plan, forbidden = _editable_plan_or_response(request, plan_id)
     if forbidden is not None:
         return forbidden
-    # An empty / non-JSON body (the pre-switcher callers post no body) means
-    # "no week_id" — fall back to the live week — rather than a 400.
-    try:
-        payload = json.loads(request.body or "{}")
-    except (json.JSONDecodeError, UnicodeDecodeError):
-        payload = {}
-    week_id, bad = _coerce_week_id(payload)
+    # An empty body (the pre-switcher callers post none) means "no week_id" —
+    # fall back to the live week; a present-but-malformed body is a 400.
+    week_id, bad = _body_week_id(request)
     if bad is not None:
         return bad
     if week_id is not None:
@@ -1972,13 +1981,10 @@ def plan_deliver(request, plan_id):
         if error is not None:
             return HttpResponseBadRequest(error)
         return JsonResponse({"ok": True, **summary}, status=201)
-    # An empty / non-JSON body (the bare deliver button posts none) means "no
-    # week_id" — deliver the live week, as before — rather than a 400.
-    try:
-        payload = json.loads(request.body or "{}")
-    except (json.JSONDecodeError, UnicodeDecodeError):
-        payload = {}
-    week_id, bad = _coerce_week_id(payload)
+    # An empty body (the bare deliver button) means "no week_id" — deliver the
+    # live week, as before; a present-but-malformed body is a 400, not a silent
+    # delivery of the wrong week.
+    week_id, bad = _body_week_id(request)
     if bad is not None:
         return bad
     if week_id is not None:

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -1929,18 +1929,40 @@ def _fan_out_group_delivery(request, plan):
 @login_required
 @require_POST
 def plan_deliver(request, plan_id):
-    """Deliver the plan's current week: stamp ``delivered_at`` + snapshot it (Phase 4)."""
+    """Deliver a week of the plan: stamp ``delivered_at`` + snapshot it (Phase 4).
+
+    Delivers the plan's **current** (live) week by default, or a specific week
+    when the body carries a ``week_id`` — the multi-week designer's "send the week
+    I'm viewing". A coach can deliver a built-ahead week directly: delivering never
+    changes ``is_current``, so sending a future week doesn't move the live pointer.
+    Visibility is by newest ``delivered_at`` (``latest_delivered_week``), so the
+    athlete lands on the week just sent while the live pointer stays put. The chosen
+    week must belong to the plan (a foreign week is a 404). A group plan ignores
+    ``week_id`` and fans out its current week (per-week delivery is an
+    individual-designer affordance).
+    """
     plan, forbidden = _editable_plan_or_response(request, plan_id)
     if forbidden is not None:
         return forbidden
     if plan.is_group:
         # A group plan fans its current week out to every active member (each
-        # member's *resolved* program), groups Phase 4.
+        # member's *resolved* program), groups Phase 4. ``week_id`` is ignored —
+        # the group always sends its current week.
         summary, error = _fan_out_group_delivery(request, plan)
         if error is not None:
             return HttpResponseBadRequest(error)
         return JsonResponse({"ok": True, **summary}, status=201)
-    week = current_week(plan)
+    # An empty / non-JSON body (the bare deliver button posts none) means "no
+    # week_id" — deliver the live week, as before — rather than a 400.
+    try:
+        payload = json.loads(request.body or "{}")
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        payload = {}
+    week_id = payload.get("week_id") if isinstance(payload, dict) else None
+    if week_id is not None:
+        week = get_object_or_404(Week, pk=week_id, mesocycle__plan=plan)
+    else:
+        week = current_week(plan)
     if week is None:
         return HttpResponseBadRequest("This plan has no week to deliver.")
     now = timezone.now()
@@ -2538,8 +2560,25 @@ class DeliverView(LoginRequiredMixin, TemplateView):
         if plan is None:
             raise Http404("Unknown plan")
         ctx["plan_id"] = plan.pk
-        ctx.update(presenters.deliver_screen(plan))
+        ctx.update(presenters.deliver_screen(plan, week=self._target_week(plan)))
         return ctx
+
+    def _target_week(self, plan):
+        """The week the deliver screen targets, from the ``?week=`` query param.
+
+        Resolves ``?week=`` to a week of this plan, or None (the presenter falls
+        back to the live week). A missing / foreign / non-numeric ``week`` is
+        ignored rather than a 404: the confirm screen always renders something
+        deliverable, and the deliver POST itself validates the chosen week strictly.
+        """
+        raw = self.request.GET.get("week")
+        if not raw:
+            return None
+        try:
+            week_id = int(raw)
+        except (TypeError, ValueError):
+            return None
+        return Week.objects.filter(pk=week_id, mesocycle__plan=plan).first()
 
 
 class ResultsView(LoginRequiredMixin, TemplateView):

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -1528,10 +1528,13 @@ def _body_week_id(request):
     week_id = payload.get("week_id")
     if week_id is None:
         return None, None
-    try:
-        return int(week_id), None
-    except (TypeError, ValueError):
+    # A real client sends a JSON integer; accept only that. ``int()`` would
+    # silently coerce ``1.9``→1 or ``True``→1 onto a valid pk — the exact
+    # wrong-week action this strict path exists to reject. ``bool`` is an ``int``
+    # subclass, so exclude it explicitly.
+    if not isinstance(week_id, int) or isinstance(week_id, bool):
         return None, HttpResponseBadRequest("week_id must be an integer.")
+    return week_id, None
 
 
 def _touch_plan(plan):

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -1503,6 +1503,24 @@ def _editable_plan_or_response(request, plan_id):
     return plan, None
 
 
+def _coerce_week_id(payload):
+    """A JSON body's ``week_id`` as an int, or an error response if malformed.
+
+    Returns ``(week_id, None)`` — ``week_id`` is None when absent (the caller
+    falls back to the live week) — or ``(None, HttpResponseBadRequest)`` when the
+    value is present but not integer-coercible. ``week_id`` arrives from JSON (not
+    an ``<int:...>`` URL segment), so a tampered value ("abc", "") must answer a
+    clean 400 rather than letting a non-int pk reach the query and 500.
+    """
+    week_id = payload.get("week_id") if isinstance(payload, dict) else None
+    if week_id is None:
+        return None, None
+    try:
+        return int(week_id), None
+    except (TypeError, ValueError):
+        return None, HttpResponseBadRequest("week_id must be an integer.")
+
+
 def _touch_plan(plan):
     """Bump the plan's ``modified`` so it reads as the coach's working plan.
 
@@ -1608,7 +1626,9 @@ def session_add(request, plan_id):
         payload = json.loads(request.body or "{}")
     except (json.JSONDecodeError, UnicodeDecodeError):
         payload = {}
-    week_id = payload.get("week_id") if isinstance(payload, dict) else None
+    week_id, bad = _coerce_week_id(payload)
+    if bad is not None:
+        return bad
     if week_id is not None:
         week = get_object_or_404(Week, pk=week_id, mesocycle__plan=plan)
     else:
@@ -1958,7 +1978,9 @@ def plan_deliver(request, plan_id):
         payload = json.loads(request.body or "{}")
     except (json.JSONDecodeError, UnicodeDecodeError):
         payload = {}
-    week_id = payload.get("week_id") if isinstance(payload, dict) else None
+    week_id, bad = _coerce_week_id(payload)
+    if bad is not None:
+        return bad
     if week_id is not None:
         week = get_object_or_404(Week, pk=week_id, mesocycle__plan=plan)
     else:

--- a/app/store_project/static/js/meso.js
+++ b/app/store_project/static/js/meso.js
@@ -163,6 +163,20 @@ function createMeso() {
       return p.name + " — " + p.weeks + " mesocycle";
     },
 
+    // The top-bar "Deliver" link target — the deliver/confirm screen for this
+    // plan, pinned to the week the coach is *viewing* (?week=) so "Deliver" sends
+    // the week on screen rather than always the live one (the deliver screen lets
+    // a coach send a built-ahead week without first making it current). Falls back
+    // to the bare deliver URL with no plan (the bare designer redirects to a real
+    // plan anyway).
+    get deliverHref() {
+      if (this.planId == null) return "/meso/deliver/";
+      const base = `/meso/deliver/${this.planId}/`;
+      return this.viewedWeekId != null
+        ? `${base}?week=${this.viewedWeekId}`
+        : base;
+    },
+
     // ---- backend hydration + autosave (Phase 3) ----
     init() {
       // Hydrate dismissed coachmarks first, so it works even without a plan.

--- a/app/store_project/templates/meso/deliver.html
+++ b/app/store_project/templates/meso/deliver.html
@@ -9,7 +9,7 @@
 
 {% block content %}
   <div class="meso-page meso-page--narrow"
-       x-data="mesoDeliver({{ plan_id|default:'null' }}, '{{ csrf_token }}')">
+       x-data="mesoDeliver({{ plan_id|default:'null' }}, '{{ csrf_token }}', {{ deliver.week_id|default:'null' }})">
     <div class="meso-crumbs">
       <a href="{% url 'meso:roster' %}">Roster</a> <span>/</span>
       <span>{{ athlete.name }}</span> <span>/</span> <span>Deliver</span>
@@ -36,6 +36,37 @@
           <span class="meso-badge meso-badge--accent"><i></i>{{ deliver.what }}</span>
         </div>
       </div>
+
+      {% if deliver.weeks|length > 1 %}
+      <!-- Multi-week designer: pick which week to send. Each chip re-targets the
+           screen at that week (?week=) — server-rendered so the summary stays
+           consistent — and the "Deliver" button sends the highlighted one. -->
+        <div class="meso-card meso-card--pad">
+          <p class="meso-eyebrow">Which week</p>
+          <div style="display:flex;gap:7px;flex-wrap:wrap;">
+            {% for w in deliver.weeks %}
+              <a href="?week={{ w.id }}"
+                 title="{% if w.is_current %}Live · the deliver target{% else %}Deliver {{ w.label }}{% endif %}"
+                 style="text-decoration:none;font:inherit;display:inline-flex;align-items:center;gap:5px;font-size:11.5px;font-weight:650;padding:6px 11px;border-radius:999px;border:1px solid {% if w.is_target %}var(--accent){% else %}var(--line){% endif %};background:{% if w.is_target %}var(--accent){% else %}var(--surface){% endif %};color:{% if w.is_target %}var(--accent-ink){% else %}var(--ink){% endif %};">
+                <span>{{ w.label }}</span>
+                {% if w.is_current %}<span style="opacity:0.8;">&#183; live</span>{% endif %}
+                {% if w.is_delivered %}<span title="Already delivered" aria-label="already delivered" style="opacity:0.8;">&#10003;</span>{% endif %}
+              </a>
+            {% endfor %}
+          </div>
+        </div>
+      {% endif %}
+
+      {% if not deliver.is_current %}
+      <!-- The coach chose a week that isn't the live one. Delivering it makes it
+           visible to the athlete (newest delivery wins) without moving the live
+           pointer — make that explicit so it's never a surprise. -->
+        <div class="meso-card meso-card--pad" style="border-color:var(--warn);">
+          <p class="meso-sub" style="margin:0;font-size:12.5px;line-height:1.4;">
+            You&#8217;re sending <strong>{{ deliver.week_label }}</strong> — not {{ athlete.name }}&#8217;s live week ({{ deliver.current_label }}). Delivering this week makes it visible to her without changing which week is current.
+          </p>
+        </div>
+      {% endif %}
 
       <div class="meso-card meso-card--pad">
         <p class="meso-eyebrow">Changes since last delivery</p>
@@ -77,12 +108,15 @@
   <style>[x-cloak]{display:none !important;}</style>
   <script>
     // Deliver screen state. The "Deliver" button POSTs the real action (stamp
-    // the current week + snapshot). Scheduling and push/email notifications
-    // arrive with the athlete app.
+    // the target week + snapshot). `weekId` is the week the screen targets (the
+    // current week, or the ?week= the coach picked); sending it lets a coach
+    // deliver a built-ahead week without first making it current. Scheduling and
+    // push/email notifications arrive with the athlete app.
     document.addEventListener("alpine:init", () => {
-      Alpine.data("mesoDeliver", (planId, csrf) => ({
+      Alpine.data("mesoDeliver", (planId, csrf, weekId) => ({
         planId: planId,
         csrf: csrf,
+        weekId: weekId,
         delivered: false,
         sending: false,
         error: false,
@@ -92,7 +126,13 @@
           try {
             const res = await fetch(`/meso/api/plan/${this.planId}/deliver/`, {
               method: "POST",
-              headers: { "X-CSRFToken": this.csrf },
+              headers: {
+                "X-CSRFToken": this.csrf,
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify(
+                this.weekId != null ? { week_id: this.weekId } : {},
+              ),
             });
             if (!res.ok) throw new Error("Request failed: " + res.status);
             this.delivered = true;

--- a/app/store_project/templates/meso/designer.html
+++ b/app/store_project/templates/meso/designer.html
@@ -92,7 +92,7 @@
         <!-- Review + Deliver are individual-only flows; group review + deliver-to-all
              are groups Phase 3/4, so a group plan shows a "soon" chip instead. -->
         <a x-show="isIndividual" href="{% url 'meso:review' %}" data-hover="rail" style="text-decoration:none;font:inherit;font-size:12.5px;font-weight:600;color:var(--ink);background:var(--surface);border:1px solid var(--line);border-radius:8px;padding:7px 13px;">Review changes</a>
-        <a x-show="isIndividual" href="{% if plan_data %}{% url 'meso:deliver_plan' plan_data.plan.id %}{% else %}{% url 'meso:deliver' %}{% endif %}" data-hover="brighten" style="text-decoration:none;font:inherit;font-size:12.5px;font-weight:650;color:var(--accent-ink);background:var(--accent);border-radius:8px;padding:8px 15px;box-shadow:0 1px 2px rgba(16,18,22,0.12);">Deliver</a>
+        <a x-show="isIndividual" href="{% if plan_data %}{% url 'meso:deliver_plan' plan_data.plan.id %}{% else %}{% url 'meso:deliver' %}{% endif %}" :href="deliverHref" data-hover="brighten" style="text-decoration:none;font:inherit;font-size:12.5px;font-weight:650;color:var(--accent-ink);background:var(--accent);border-radius:8px;padding:8px 15px;box-shadow:0 1px 2px rgba(16,18,22,0.12);">Deliver</a>
         <span x-show="isGroup" style="font-size:12.5px;font-weight:600;color:var(--dim);background:var(--rail);border:1px solid var(--line);border-radius:8px;padding:7px 13px;">Deliver to all &#183; soon</span>
       </div>
 

--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -834,3 +834,49 @@ _(Append dated entries here as decisions land.)_
   vitest green, ruff + format clean. Remaining Meso backlog: **deliver a chosen non-current
   week without first making it current** (a natural follow-up) and **S6 billing Phase
   5 annual prices** (blocked on the owner's per-seat number + a Stripe annual Price).
+- 2026-06-30 — **Deliver any week built** (branch `meso-deliver-any-week`,
+  **no migration**): closes the multi-week designer's follow-up — **deliver a
+  chosen, non-current week without first making it current**. After the
+  multi-week designer, a coach could build weeks ahead and switch which is live,
+  but `plan_deliver` only ever sent `current_week`, so sending a built-ahead week
+  meant first flipping it current (moving the live pointer as a side effect).
+  Now: **(1)** `plan_deliver` takes an optional `week_id` (individual plans) and
+  delivers *that* week — stamp `delivered_at` + `WeekDelivery` snapshot —
+  **without touching `is_current`**; a foreign week is a 404, absent → the live
+  week (unchanged), and a **group plan ignores `week_id`** (still fans out its
+  current week — per-week delivery is an individual-designer affordance). **(2)**
+  `deliver_screen(plan, week=None)` targets a chosen week, lists every week for a
+  selector, and flags whether the target is the live week. **(3)** `DeliverView`
+  resolves `?week=` (foreign / non-numeric → silently falls back to live; the
+  confirm screen always renders something deliverable, the POST validates
+  strictly). The deliver screen gains a **per-week selector** (chips link
+  `?week=<id>`, server-rendered so the summary stays consistent) + a **"not the
+  live week" notice**; the designer's "Deliver" link carries the **viewed** week
+  (`:href="deliverHref"` → `?week=<viewedWeekId>`) so "Deliver" sends the week on
+  screen. **Design call:** *delivery never moves the live pointer* — visibility
+  stays "newest delivery wins" (`latest_delivered_week`), so the athlete lands on
+  the week just sent while the coach's `is_current`/deliver-default holds (the
+  multi-week "no footgun" stance, extended to delivery). Built red→green:
+  `test_deliver.py` (**+~20 pytest**: per-week deliver + leaves-current,
+  athlete-visible week, foreign-404, over-limit 402, screen `?week=` targeting /
+  selector / notice / fallback) + `test_group_deliver.py` (**+1**: group ignores
+  `week_id`) + `frontend/meso.test.js` (**+3 vitest**: `deliverHref`). 1097 meso
+  pytest + 54 vitest green; ruff + format + djhtml + `makemigrations --check`
+  clean. **Codex review loop:** 4 fix iterations then CLEAN — all four were the
+  same class of **strict-input** nit on the new JSON `week_id` path (P2 non-int pk
+  → 500 → coerce; P2 malformed-body → silent live-week delivery → 400, gated on
+  `content_type == "application/json"` so bodyless/multipart callers still mean
+  "live week"; **shared `_body_week_id` helper** wired into `plan_deliver` *and*
+  the adjacent pre-existing `session_add`, which carried the identical latent
+  vector; P3 the live-week warning read the raw `is_current` flag, contradicting
+  `current_week`'s earliest-week fallback → resolve one `live_id` for both the
+  chip marker and the notice; P2 `int()` coerced `1.9`→1 / `True`→1 → accept only
+  a genuine JSON integer, `bool` excluded). **GOTCHA (reusable):** Django's test
+  client `client.post(url)` with **no data still sends a non-empty multipart
+  body** (boundary bytes), so a `if not request.body` guard won't see it as empty
+  — gate strict JSON parsing on `request.content_type` instead. Plus the
+  recurring render-test gotcha (a `// live week` comment in the deliver
+  `<script>` tripped the "no 'live week' on the current screen" assert — scrub
+  dev-facing comments of asserted tokens). Remaining Meso backlog: **S6 billing
+  Phase 5 annual prices** (blocked on the owner's per-seat number + a Stripe
+  annual Price) — no other autonomous slice outstanding.

--- a/frontend/meso.test.js
+++ b/frontend/meso.test.js
@@ -715,3 +715,28 @@ describe("week switcher", () => {
     expect(global.fetch).not.toHaveBeenCalled();
   });
 });
+
+// The top-bar "Deliver" link target. The multi-week designer can view a week
+// other than the live one; "Deliver" should send the week on screen, so the
+// link carries the viewed week as ?week=. Falls back to the bare deliver URL
+// with no plan (the bare designer redirects to a real plan anyway).
+describe("deliver link (deliverHref)", () => {
+  it("carries the viewed week as a ?week= query param", () => {
+    const c = makeMeso();
+    c.viewedWeekId = 2;
+    expect(c.deliverHref).toBe("/meso/deliver/7/?week=2");
+  });
+
+  it("omits ?week= when no week is viewed yet", () => {
+    const c = makeMeso();
+    c.viewedWeekId = null;
+    expect(c.deliverHref).toBe("/meso/deliver/7/");
+  });
+
+  it("falls back to the bare deliver URL without a plan", () => {
+    const c = makeMeso();
+    c.planId = null;
+    c.viewedWeekId = 2;
+    expect(c.deliverHref).toBe("/meso/deliver/");
+  });
+});


### PR DESCRIPTION
## What

Closes the multi-week designer's (#333) follow-up: **deliver a chosen, non-current week without first making it current.**

After the multi-week designer landed, a coach could build weeks ahead and switch which week is live — but `plan_deliver` only ever sent the **current** week, so sending a built-ahead week meant first flipping it current (which moves the live/deliver-default pointer as a side effect). Now a coach can deliver the week they're viewing directly.

## Changes

- **`plan_deliver`** takes an optional `week_id` (individual plans): delivers *that* week — stamp `delivered_at` + `WeekDelivery` snapshot — **without touching `is_current`**. A foreign week is a 404; absent → the live week (unchanged). A **group plan ignores `week_id`** and still fans out its current week (per-week delivery is an individual-designer affordance).
- **`deliver_screen(plan, week=None)`** targets a chosen week, lists every week for a selector, and flags whether the target is the live week (resolved via `current_week`, so it agrees with the earliest-week fallback).
- **`DeliverView`** resolves `?week=` (foreign / non-numeric → silently falls back to live; the confirm screen always renders something deliverable, the POST validates strictly).
- **Deliver screen UI:** a per-week **selector** (chips link `?week=<id>`, server-rendered so the summary stays consistent) + a **"not the live week" notice**.
- **Designer:** the "Deliver" link carries the **viewed** week (`:href="deliverHref"` → `?week=<viewedWeekId>`) so "Deliver" sends the week on screen.

**Design call:** *delivery never moves the live pointer.* Visibility stays "newest delivery wins" (`latest_delivered_week`), so the athlete lands on the week just sent while the coach's `is_current` deliver-default holds — the multi-week "no footgun" stance, extended to delivery.

## Hardening (Codex review loop)

A shared **`_body_week_id`** helper validates the new JSON `week_id` path strictly: non-int pk would 500 → coerced; a malformed (non-empty) JSON body would silently deliver the live week → now 400 (gated on `content_type == "application/json"` so bodyless/multipart callers still mean "live week"); `int()` would coerce `1.9`→1 / `True`→1 → accept only a genuine JSON integer. The helper is wired into `plan_deliver` **and** the adjacent pre-existing `session_add`, which carried the identical latent vector.

## Tests

Red→green. `test_deliver.py` (~20 new: per-week deliver + leaves-current, athlete-visible week, foreign-404, over-limit 402, screen `?week=` targeting / selector / notice / fallback / unflagged-plan, parametrized non-integer → 400) + `test_group_deliver.py` (+1: group ignores `week_id`) + `frontend/meso.test.js` (+3 vitest: `deliverHref`).

**1097 meso pytest + 54 vitest green; ruff + format + djhtml + `makemigrations --check` clean. No migration. Codex review loop CLEAN after 4 fix iterations.**

https://claude.ai/code/session_019A9KdsVs33wipsGjSaFWXV
