### PR TITLE
Meso — changes-since-last-delivery diff on the deliver screen

### DIFF
--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -22,14 +22,17 @@ from .models import LoadType
 from .models import Plan
 from .models import SessionLog
 from .models import Week
+from .models import WeekDelivery
 from .one_rm import one_rm_values
 from .serializers import _fmt_num
 from .serializers import _num
 from .serializers import current_week
+from .serializers import diff_week_snapshots
 from .serializers import initials
 from .serializers import latest_delivered_week
 from .serializers import serialize_prescription
 from .serializers import serialize_proposed_change
+from .serializers import serialize_week_snapshot
 
 
 def _age(user):
@@ -317,9 +320,11 @@ def deliver_screen(plan, week=None):
     lists every week (id / label / whether it's the live week / whether it's already
     been delivered) so the screen offers a per-week selector, and ``is_current``
     /``current_label`` let it warn when the coach is sending a week that isn't the
-    live one (delivering it won't move the live pointer). Scheduling and the full
-    "changes since last delivery" diff are later-slice concerns; we only surface
-    whether this is a first delivery or a re-delivery.
+    live one (delivering it won't move the live pointer). On a re-delivery,
+    ``deliver["changes"]`` is the diff of the target week's live grid against the
+    snapshot last delivered (``diff_week_snapshots``) so the coach reviews exactly
+    what's about to change for the athlete; it's ``None`` on a first delivery.
+    Scheduling stays a later-slice concern.
     """
     live = current_week(plan)
     target = week or live
@@ -332,6 +337,20 @@ def deliver_screen(plan, week=None):
     mesocycle = target.mesocycle if target else None
     session_count = target.sessions.count() if target else 0
     is_redelivery = target is not None and target.deliveries.exists()
+
+    # On a re-delivery, diff the live grid against the snapshot last delivered so
+    # the coach sees what's about to change for the athlete. A first delivery (no
+    # prior snapshot) has nothing to diff → None.
+    changes = None
+    if is_redelivery:
+        last_payload = (
+            WeekDelivery.objects.filter(week=target)
+            .order_by("-delivered_at")
+            .values_list("payload", flat=True)
+            .first()
+        )
+        if last_payload:
+            changes = diff_week_snapshots(serialize_week_snapshot(target), last_payload)
 
     weeks = [
         {
@@ -357,6 +376,7 @@ def deliver_screen(plan, week=None):
             "what": plan.title,
             "sessions": session_count,
             "is_redelivery": is_redelivery,
+            "changes": changes,
             "week_id": target.pk if target else None,
             "week_label": f"Wk {target.index}" if target else "",
             "is_current": target is not None and target.pk == live_id,

--- a/app/store_project/meso/serializers.py
+++ b/app/store_project/meso/serializers.py
@@ -223,6 +223,143 @@ def serialize_week_snapshot(week):
     }
 
 
+# Prescription fields a coach cares about when reviewing "what changed", with the
+# label the deliver screen shows. ``name`` first so a swap reads as the headline
+# change; ``tag`` last (it's only present when the row carries one).
+_PRESCRIPTION_DIFF_FIELDS = (
+    ("name", "Exercise"),
+    ("sets", "Sets"),
+    ("reps", "Reps"),
+    ("load", "Load"),
+    ("load_type", "Load type"),
+    ("rpe", "RPE"),
+    ("note", "Note"),
+    ("tag", "Tag"),
+)
+
+# Week-level meta the snapshot captures alongside the grid.
+_WEEK_DIFF_FIELDS = (
+    ("phase", "Phase"),
+    ("volume", "Volume"),
+    ("intensity", "Intensity"),
+    ("is_deload", "Deload"),
+)
+
+
+def _prescription_label(presc):
+    """A compact one-line label for an added/removed exercise row."""
+    name = presc.get("name") or "Exercise"
+    sets = presc.get("sets")
+    reps = presc.get("reps")
+    if sets and reps:
+        return f"{name} {sets}×{reps}"
+    return name
+
+
+def _diff_fields(before, after, fields):
+    """Per-field before/after for two dicts over ``fields`` (key, label) pairs."""
+    out = []
+    for key, label in fields:
+        old = before.get(key)
+        new = after.get(key)
+        if old != new:
+            out.append({"field": key, "label": label, "before": old, "after": new})
+    return out
+
+
+def _diff_exercises(current, previous):
+    """Added / removed / changed exercise rows between two session grids.
+
+    Rows match by pk (``id``) — a stable DB identity across edits — so an edited
+    row reads as *changed* (with per-field before/after), a brand-new row as
+    *added*, and a deleted one as *removed*. (A delete-then-re-add of the same
+    movement honestly shows as remove + add, since it's a different row.)
+    """
+    prev_by_id = {e.get("id"): e for e in previous}
+    cur_by_id = {e.get("id"): e for e in current}
+    added = [
+        {"label": _prescription_label(e)}
+        for e in current
+        if e.get("id") not in prev_by_id
+    ]
+    removed = [
+        {"label": _prescription_label(e)}
+        for e in previous
+        if e.get("id") not in cur_by_id
+    ]
+    changed = []
+    for e in current:
+        prev_e = prev_by_id.get(e.get("id"))
+        if prev_e is None:
+            continue
+        fields = _diff_fields(prev_e, e, _PRESCRIPTION_DIFF_FIELDS)
+        if fields:
+            changed.append({"name": e.get("name") or "Exercise", "fields": fields})
+    return {"added": added, "removed": removed, "changed": changed}
+
+
+def _session_label(session):
+    return session.get("name") or f"Day {session.get('n')}"
+
+
+def diff_week_snapshots(current, previous):
+    """Diff a week's live snapshot against the one last delivered.
+
+    Both args are ``serialize_week_snapshot`` payloads. Sessions match by pk;
+    a session in ``current`` but not ``previous`` is wholly *added* (and not
+    double-counted as per-row diffs), the reverse is *removed*, and a session in
+    both yields its added/removed/changed exercise rows. Week-meta differences
+    (phase/volume/intensity/deload) are surfaced separately. Returns ``None``
+    when there's nothing to diff against (no/blank prior payload); otherwise a
+    dict whose ``has_changes`` is ``False`` when the week is unchanged since its
+    last delivery.
+    """
+    if not previous or "sessions" not in previous:
+        return None
+
+    cur_sessions = current.get("sessions", [])
+    prev_sessions = previous.get("sessions", [])
+    prev_by_id = {s.get("id"): s for s in prev_sessions}
+    cur_ids = {s.get("id") for s in cur_sessions}
+
+    session_diffs = []
+    added_sessions = []
+    for s in cur_sessions:
+        prev_s = prev_by_id.get(s.get("id"))
+        if prev_s is None:
+            added_sessions.append(
+                {
+                    "name": _session_label(s),
+                    "day": s.get("n"),
+                    "count": len(s.get("exercises", [])),
+                }
+            )
+            continue
+        ex = _diff_exercises(s.get("exercises", []), prev_s.get("exercises", []))
+        if ex["added"] or ex["removed"] or ex["changed"]:
+            session_diffs.append({"name": _session_label(s), "day": s.get("n"), **ex})
+
+    removed_sessions = [
+        {"name": _session_label(s), "day": s.get("n")}
+        for s in prev_sessions
+        if s.get("id") not in cur_ids
+    ]
+
+    week_changes = _diff_fields(
+        previous.get("week", {}), current.get("week", {}), _WEEK_DIFF_FIELDS
+    )
+
+    return {
+        "has_changes": bool(
+            session_diffs or added_sessions or removed_sessions or week_changes
+        ),
+        "sessions": session_diffs,
+        "added_sessions": added_sessions,
+        "removed_sessions": removed_sessions,
+        "week": week_changes,
+    }
+
+
 def serialize_session_log(log):
     """The athlete's saved log for a session, in the shape the log endpoint returns.
 

--- a/app/store_project/meso/tests/test_delivery_diff.py
+++ b/app/store_project/meso/tests/test_delivery_diff.py
@@ -301,3 +301,18 @@ class TestDeliverScreenRendersDiff:
         body = self._screen(client, plan).content.decode()
 
         assert "No changes" in body
+
+    def test_redelivery_screen_renders_a_zero_week_value(self, client):
+        # 0 is a valid volume/intensity (the model default), so a change *to* 0
+        # must render the number — not get swallowed by an em-dash placeholder.
+        plan, week, _, _ = seed_plan()
+        record_delivery(week)  # snapshot at the factory's volume=70
+        week.volume = 0
+        week.save(update_fields=["volume"])
+        client.force_login(plan.relationship.coach)
+
+        body = self._screen(client, plan).content.decode()
+
+        assert "Volume" in body
+        # The new value 0 is rendered, not the em-dash fallback.
+        assert ">0</span>" in body

--- a/app/store_project/meso/tests/test_delivery_diff.py
+++ b/app/store_project/meso/tests/test_delivery_diff.py
@@ -1,0 +1,303 @@
+"""Changes-since-last-delivery diff (the deferred "full diff UI").
+
+Delivering a week records a ``WeekDelivery`` snapshot (``serialize_week_snapshot``).
+When a coach comes back to re-deliver, the deliver screen should show **what
+changed since the last delivery** — a diff of the week's live grid against the
+most recent delivered snapshot. The snapshot data was always captured; this is
+the UI that finally reads it (persistence-plan open assumption #3).
+
+Three seams, mirroring the slice discipline:
+
+- ``diff_week_snapshots`` — the pure diff over two snapshot payloads (matched by
+  stable pks): added / removed / changed exercise rows grouped by session, whole
+  sessions added/removed, and week-meta changes;
+- ``presenters.deliver_screen`` — surfaces ``deliver["changes"]`` (``None`` on a
+  first delivery; the diff on a re-delivery);
+- ``DeliverView`` — the screen renders the diff on a re-delivery.
+"""
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+
+from store_project.meso import presenters
+from store_project.meso.factories import CoachAthleteFactory
+from store_project.meso.factories import ExercisePrescriptionFactory
+from store_project.meso.factories import MesocycleFactory
+from store_project.meso.factories import PlanFactory
+from store_project.meso.factories import SessionFactory
+from store_project.meso.factories import WeekFactory
+from store_project.meso.models import Plan
+from store_project.meso.models import WeekDelivery
+from store_project.meso.serializers import diff_week_snapshots
+from store_project.meso.serializers import serialize_week_snapshot
+from store_project.users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+# --------------------------------------------------------------------------- #
+# Pure diff over two snapshot payloads (no DB)                                 #
+# --------------------------------------------------------------------------- #
+
+
+def _presc(pk, name, **over):
+    row = {
+        "id": pk,
+        "name": name,
+        "sets": "3",
+        "reps": "10",
+        "load": "60",
+        "load_type": "abs",
+        "rpe": "7",
+        "note": "",
+    }
+    row.update(over)
+    return row
+
+
+def _session(pk, n, name, exercises, bias=""):
+    return {"id": pk, "n": n, "name": name, "bias": bias, "exercises": exercises}
+
+
+def _snap(sessions, **week_over):
+    week = {
+        "id": 1,
+        "index": 1,
+        "phase": "Accum",
+        "volume": 70,
+        "intensity": 65,
+        "is_deload": False,
+    }
+    week.update(week_over)
+    return {"week": week, "sessions": sessions}
+
+
+class TestDiffWeekSnapshots:
+    def test_no_prior_payload_returns_none(self):
+        cur = _snap([_session(1, 1, "Lower", [_presc(10, "Squat")])])
+        assert diff_week_snapshots(cur, None) is None
+        assert diff_week_snapshots(cur, {}) is None
+
+    def test_identical_snapshots_have_no_changes(self):
+        cur = _snap([_session(1, 1, "Lower", [_presc(10, "Squat")])])
+        prev = _snap([_session(1, 1, "Lower", [_presc(10, "Squat")])])
+        diff = diff_week_snapshots(cur, prev)
+        assert diff["has_changes"] is False
+        assert diff["sessions"] == []
+        assert diff["added_sessions"] == []
+        assert diff["removed_sessions"] == []
+        assert diff["week"] == []
+
+    def test_changed_load_is_a_changed_row(self):
+        prev = _snap([_session(1, 1, "Lower", [_presc(10, "Squat", load="100")])])
+        cur = _snap([_session(1, 1, "Lower", [_presc(10, "Squat", load="105")])])
+        diff = diff_week_snapshots(cur, prev)
+        assert diff["has_changes"] is True
+        (sess,) = diff["sessions"]
+        assert sess["name"] == "Lower"
+        (changed,) = sess["changed"]
+        assert changed["name"] == "Squat"
+        (field,) = changed["fields"]
+        assert field["field"] == "load"
+        assert field["before"] == "100"
+        assert field["after"] == "105"
+
+    def test_swap_is_a_changed_name(self):
+        prev = _snap([_session(1, 1, "Lower", [_presc(10, "Back Squat")])])
+        cur = _snap([_session(1, 1, "Lower", [_presc(10, "Front Squat")])])
+        diff = diff_week_snapshots(cur, prev)
+        (sess,) = diff["sessions"]
+        (changed,) = sess["changed"]
+        fields = {f["field"]: (f["before"], f["after"]) for f in changed["fields"]}
+        assert fields["name"] == ("Back Squat", "Front Squat")
+
+    def test_added_row(self):
+        prev = _snap([_session(1, 1, "Lower", [_presc(10, "Squat")])])
+        cur = _snap(
+            [
+                _session(
+                    1,
+                    1,
+                    "Lower",
+                    [_presc(10, "Squat"), _presc(11, "RDL", sets="3", reps="8")],
+                )
+            ]
+        )
+        diff = diff_week_snapshots(cur, prev)
+        (sess,) = diff["sessions"]
+        assert sess["changed"] == []
+        (added,) = sess["added"]
+        assert "RDL" in added["label"]
+        assert "3" in added["label"] and "8" in added["label"]
+
+    def test_removed_row(self):
+        prev = _snap(
+            [_session(1, 1, "Lower", [_presc(10, "Squat"), _presc(11, "Leg Press")])]
+        )
+        cur = _snap([_session(1, 1, "Lower", [_presc(10, "Squat")])])
+        diff = diff_week_snapshots(cur, prev)
+        (sess,) = diff["sessions"]
+        (removed,) = sess["removed"]
+        assert "Leg Press" in removed["label"]
+
+    def test_added_session(self):
+        prev = _snap([_session(1, 1, "Lower", [_presc(10, "Squat")])])
+        cur = _snap(
+            [
+                _session(1, 1, "Lower", [_presc(10, "Squat")]),
+                _session(2, 2, "Upper", [_presc(20, "Bench"), _presc(21, "Row")]),
+            ]
+        )
+        diff = diff_week_snapshots(cur, prev)
+        assert diff["has_changes"] is True
+        (added,) = diff["added_sessions"]
+        assert added["name"] == "Upper"
+        assert added["count"] == 2
+        # A wholly-new session isn't double-counted as a per-session row diff.
+        assert diff["sessions"] == []
+
+    def test_removed_session(self):
+        prev = _snap(
+            [
+                _session(1, 1, "Lower", [_presc(10, "Squat")]),
+                _session(2, 2, "Upper", [_presc(20, "Bench")]),
+            ]
+        )
+        cur = _snap([_session(1, 1, "Lower", [_presc(10, "Squat")])])
+        diff = diff_week_snapshots(cur, prev)
+        (removed,) = diff["removed_sessions"]
+        assert removed["name"] == "Upper"
+
+    def test_week_meta_change(self):
+        prev = _snap([_session(1, 1, "Lower", [_presc(10, "Squat")])], is_deload=False)
+        cur = _snap([_session(1, 1, "Lower", [_presc(10, "Squat")])], is_deload=True)
+        diff = diff_week_snapshots(cur, prev)
+        assert diff["has_changes"] is True
+        (field,) = diff["week"]
+        assert field["field"] == "is_deload"
+        assert field["before"] is False
+        assert field["after"] is True
+
+
+# --------------------------------------------------------------------------- #
+# Presenter + view (DB-backed)                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def seed_plan(coach=None, athlete=None, load="111"):
+    """A minimal owned plan with one current week → session → prescription."""
+    rel = CoachAthleteFactory(
+        coach=coach or UserFactory(), athlete=athlete or UserFactory()
+    )
+    plan = PlanFactory(
+        relationship=rel, title="Hypertrophy Block", status=Plan.Status.ACTIVE
+    )
+    meso = MesocycleFactory(plan=plan, name="Hypertrophy", order=0)
+    week = WeekFactory(mesocycle=meso, index=1, is_current=True)
+    session = SessionFactory(week=week, day_number=1, name="Lower")
+    presc = ExercisePrescriptionFactory(
+        session=session, name="Box Squat", sets="4", reps="6", load=load, rpe="7"
+    )
+    return plan, week, session, presc
+
+
+def record_delivery(week):
+    """Snapshot ``week`` as a delivery, exactly as ``plan_deliver`` does."""
+    now = timezone.now()
+    week.delivered_at = now
+    week.save(update_fields=["delivered_at"])
+    return WeekDelivery.objects.create(
+        week=week, delivered_at=now, payload=serialize_week_snapshot(week)
+    )
+
+
+class TestDeliverScreenChanges:
+    def test_first_delivery_has_no_diff(self):
+        plan, _, _, _ = seed_plan()
+        deliver = presenters.deliver_screen(plan)["deliver"]
+        assert deliver["is_redelivery"] is False
+        assert deliver["changes"] is None
+
+    def test_redelivery_after_edit_surfaces_the_change(self):
+        plan, week, _, presc = seed_plan(load="111")
+        record_delivery(week)
+        presc.load = "222"
+        presc.save(update_fields=["load"])
+
+        deliver = presenters.deliver_screen(plan)["deliver"]
+
+        assert deliver["is_redelivery"] is True
+        changes = deliver["changes"]
+        assert changes is not None
+        assert changes["has_changes"] is True
+        (sess,) = changes["sessions"]
+        (changed,) = sess["changed"]
+        assert changed["name"] == "Box Squat"
+        fields = {f["field"]: (f["before"], f["after"]) for f in changed["fields"]}
+        assert fields["load"] == ("111", "222")
+
+    def test_redelivery_with_no_edits_reports_no_changes(self):
+        plan, week, _, _ = seed_plan()
+        record_delivery(week)
+
+        deliver = presenters.deliver_screen(plan)["deliver"]
+
+        assert deliver["is_redelivery"] is True
+        assert deliver["changes"] is not None
+        assert deliver["changes"]["has_changes"] is False
+
+    def test_diff_targets_the_chosen_week(self):
+        # A coach can deliver a built-ahead week; the diff must compare *that*
+        # week's snapshot, not the live week's.
+        plan, week1, _, _ = seed_plan()
+        meso = plan.mesocycles.first()
+        week2 = WeekFactory(mesocycle=meso, index=2, is_current=False)
+        session2 = SessionFactory(week=week2, day_number=1, name="Upper")
+        presc2 = ExercisePrescriptionFactory(
+            session=session2, name="Bench", sets="3", reps="5", load="80"
+        )
+        record_delivery(week2)
+        presc2.load = "90"
+        presc2.save(update_fields=["load"])
+
+        deliver = presenters.deliver_screen(plan, week=week2)["deliver"]
+
+        assert deliver["week_id"] == week2.pk
+        (sess,) = deliver["changes"]["sessions"]
+        (changed,) = sess["changed"]
+        assert changed["name"] == "Bench"
+
+
+class TestDeliverScreenRendersDiff:
+    def _screen(self, client, plan):
+        return client.get(reverse("meso:deliver_plan", kwargs={"plan_id": plan.pk}))
+
+    def test_first_delivery_screen_says_first_delivery(self, client):
+        plan, _, _, _ = seed_plan()
+        client.force_login(plan.relationship.coach)
+        body = self._screen(client, plan).content.decode()
+        assert "First delivery" in body
+
+    def test_redelivery_screen_renders_the_diff(self, client):
+        plan, week, _, presc = seed_plan(load="111")
+        record_delivery(week)
+        presc.load = "222"
+        presc.save(update_fields=["load"])
+        client.force_login(plan.relationship.coach)
+
+        body = self._screen(client, plan).content.decode()
+
+        # The changed exercise and its before/after load are both surfaced.
+        assert "Box Squat" in body
+        assert "111" in body
+        assert "222" in body
+
+    def test_redelivery_screen_with_no_edits_says_no_changes(self, client):
+        plan, week, _, _ = seed_plan()
+        record_delivery(week)
+        client.force_login(plan.relationship.coach)
+
+        body = self._screen(client, plan).content.decode()
+
+        assert "No changes" in body

--- a/app/store_project/templates/meso/deliver.html
+++ b/app/store_project/templates/meso/deliver.html
@@ -70,11 +70,55 @@
 
       <div class="meso-card meso-card--pad">
         <p class="meso-eyebrow">Changes since last delivery</p>
-        <div style="display:flex;flex-direction:column;gap:7px;">
-          <span style="font-size:12.5px;line-height:1.35;color:var(--dim);">
-            {% if deliver.is_redelivery %}Re-delivering {{ athlete.week }} with your latest edits.{% else %}First delivery — {{ athlete.week }} ({{ deliver.sessions }} session{{ deliver.sessions|pluralize }}) is sent to {{ athlete.name }}.{% endif %}
-          </span>
-        </div>
+        {% if not deliver.is_redelivery %}
+        <!-- First delivery: nothing to diff against. -->
+          <span style="font-size:12.5px;line-height:1.35;color:var(--dim);">First delivery — {{ athlete.week }} ({{ deliver.sessions }} session{{ deliver.sessions|pluralize }}) is sent to {{ athlete.name }}.</span>
+        {% elif not deliver.changes.has_changes %}
+        <!-- Re-delivering the same week with no edits since it last went out. -->
+          <span style="font-size:12.5px;line-height:1.35;color:var(--dim);">No changes since you last delivered {{ athlete.week }} — re-delivering it as-is.</span>
+        {% else %}
+        <!-- The week's live grid diffed against the snapshot last delivered: per
+             session, each edited row's fields (before &#8594; after), rows added
+             (+) or removed (&#8722;), then whole days and week-meta changes. -->
+          <div style="display:flex;flex-direction:column;gap:12px;">
+            {% for s in deliver.changes.sessions %}
+              <div>
+                <div style="font-size:10.5px;font-weight:700;letter-spacing:0.05em;text-transform:uppercase;color:var(--dim);margin-bottom:4px;">{{ s.name }}</div>
+                <div style="display:flex;flex-direction:column;gap:3px;">
+                  {% for c in s.changed %}
+                    <div style="font-size:12.5px;line-height:1.45;">
+                      <span style="font-weight:650;">{{ c.name }}</span><span style="color:var(--dim);"> &#183; </span>{% for f in c.fields %}{% if not forloop.first %}<span style="color:var(--dim);">, </span>{% endif %}<span style="color:var(--dim);">{{ f.label }}</span> {% if f.field == 'is_deload' %}{{ f.before|yesno:"on,off" }} &#8594; <span style="font-weight:650;">{{ f.after|yesno:"on,off" }}</span>{% else %}<span style="text-decoration:line-through;opacity:0.6;">{{ f.before|default:"&#8212;" }}</span> &#8594; <span style="font-weight:650;">{{ f.after|default:"&#8212;" }}</span>{% endif %}{% endfor %}
+                    </div>
+                  {% endfor %}
+                  {% for a in s.added %}
+                    <div style="font-size:12.5px;line-height:1.45;color:var(--ok);"><span style="font-weight:700;">+</span> {{ a.label }}</div>
+                  {% endfor %}
+                  {% for r in s.removed %}
+                    <div style="font-size:12.5px;line-height:1.45;color:var(--warn);"><span style="font-weight:700;">&#8722;</span> <span style="text-decoration:line-through;opacity:0.8;">{{ r.label }}</span></div>
+                  {% endfor %}
+                </div>
+              </div>
+            {% endfor %}
+
+            {% for a in deliver.changes.added_sessions %}
+              <div style="font-size:12.5px;line-height:1.45;color:var(--ok);"><span style="font-weight:700;">+</span> New day &#183; {{ a.name }} ({{ a.count }} exercise{{ a.count|pluralize }})</div>
+            {% endfor %}
+            {% for r in deliver.changes.removed_sessions %}
+              <div style="font-size:12.5px;line-height:1.45;color:var(--warn);"><span style="font-weight:700;">&#8722;</span> Removed day &#183; {{ r.name }}</div>
+            {% endfor %}
+
+            {% if deliver.changes.week %}
+              <div>
+                <div style="font-size:10.5px;font-weight:700;letter-spacing:0.05em;text-transform:uppercase;color:var(--dim);margin-bottom:4px;">Week</div>
+                <div style="display:flex;flex-direction:column;gap:3px;">
+                  {% for f in deliver.changes.week %}
+                    <div style="font-size:12.5px;line-height:1.45;"><span style="color:var(--dim);">{{ f.label }}</span> {% if f.field == 'is_deload' %}{{ f.before|yesno:"on,off" }} &#8594; <span style="font-weight:650;">{{ f.after|yesno:"on,off" }}</span>{% else %}<span style="text-decoration:line-through;opacity:0.6;">{{ f.before|default:"&#8212;" }}</span> &#8594; <span style="font-weight:650;">{{ f.after|default:"&#8212;" }}</span>{% endif %}</div>
+                  {% endfor %}
+                </div>
+              </div>
+            {% endif %}
+          </div>
+        {% endif %}
       </div>
 
       <div class="meso-card meso-card--pad">

--- a/app/store_project/templates/meso/deliver.html
+++ b/app/store_project/templates/meso/deliver.html
@@ -112,7 +112,9 @@
                 <div style="font-size:10.5px;font-weight:700;letter-spacing:0.05em;text-transform:uppercase;color:var(--dim);margin-bottom:4px;">Week</div>
                 <div style="display:flex;flex-direction:column;gap:3px;">
                   {% for f in deliver.changes.week %}
-                    <div style="font-size:12.5px;line-height:1.45;"><span style="color:var(--dim);">{{ f.label }}</span> {% if f.field == 'is_deload' %}{{ f.before|yesno:"on,off" }} &#8594; <span style="font-weight:650;">{{ f.after|yesno:"on,off" }}</span>{% else %}<span style="text-decoration:line-through;opacity:0.6;">{{ f.before|default:"&#8212;" }}</span> &#8594; <span style="font-weight:650;">{{ f.after|default:"&#8212;" }}</span>{% endif %}</div>
+                    <!-- volume/intensity are ints where 0 is valid — default_if_none
+                         (not default) so a real 0 isn't shown as the em-dash. -->
+                    <div style="font-size:12.5px;line-height:1.45;"><span style="color:var(--dim);">{{ f.label }}</span> {% if f.field == 'is_deload' %}{{ f.before|yesno:"on,off" }} &#8594; <span style="font-weight:650;">{{ f.after|yesno:"on,off" }}</span>{% else %}<span style="text-decoration:line-through;opacity:0.6;">{{ f.before|default_if_none:"&#8212;" }}</span> &#8594; <span style="font-weight:650;">{{ f.after|default_if_none:"&#8212;" }}</span>{% endif %}</div>
                   {% endfor %}
                 </div>
               </div>


### PR DESCRIPTION
## What

The deliver screen's **"Changes since last delivery"** card now shows a real diff of what's about to change for the athlete, instead of the static "re-delivering with your latest edits" placeholder.

Delivering a week has always recorded a `WeekDelivery` snapshot (`serialize_week_snapshot`), but nothing read it back. This ships the long-deferred **full diff UI** — *persistence-plan open assumption #3*, cited as deferred across the persistence / agent / athlete / first-time-UX plans.

## How

- **`serializers.diff_week_snapshots(current, previous)`** — a pure diff over two snapshot payloads, matched by stable pks:
  - per-session **changed** rows (with per-field before/after: exercise/sets/reps/load/load_type/rpe/note/tag),
  - rows **added** / **removed**,
  - whole **sessions** added/removed,
  - **week-meta** changes (phase/volume/intensity/deload).
  - Returns `None` when there's no prior payload; `has_changes` is `False` when the week is unchanged since its last delivery.
- **`presenters.deliver_screen`** — on a re-delivery, diffs the **target** week's live grid against its most recent delivered snapshot → `deliver["changes"]` (`None` on a first delivery). Because it targets the chosen week, a built-ahead week diffs against *its own* last delivery.
- **`deliver.html`** — renders the diff (first-delivery / no-changes / per-session edits + added/removed days + week meta), styled with the existing design tokens (`var(--ok)` for additions, `var(--warn)` for removals).

**No model change, no migration** — a pure read over data already captured at delivery time. No JS change — fully server-rendered.

## Tests

Red→green: **+16 pytest** in `test_delivery_diff.py` — the pure diff (added/removed/changed/swap/sessions/week-meta/no-prior/identical), the presenter context (first vs re-delivery, chosen-week targeting), and the screen render (diff appears, "No changes", "First delivery").

Full project suite **1280 green**; ruff + format + djhtml + `makemigrations --check` clean.

https://claude.ai/code/session_019A9KdsVs33wipsGjSaFWXV