### PR TITLE
docs(meso): record changes-since-last-delivery diff UI (#337)

### DIFF
--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -914,3 +914,38 @@ _(Append dated entries here as decisions land.)_
   Remaining Meso backlog unchanged: **S6 billing Phase 5 annual prices** (blocked
   on the owner's per-seat number + a Stripe annual Price) — no other autonomous
   slice outstanding.
+- 2026-06-30 — **Changes-since-last-delivery diff UI built, merged & deployed**
+  (PR #337, squash `3224d30`, **no migration**): ships the long-deferred **full
+  diff UI** (persistence-plan open assumption #3, cited across the
+  persistence/agent/athlete/first-time-UX plans). Delivering a week always
+  recorded a `WeekDelivery` snapshot (`serialize_week_snapshot`), but nothing
+  read it back — the deliver screen's "Changes since last delivery" card just
+  said "re-delivering with your latest edits". Now, on a **re-delivery**, the
+  deliver confirm screen diffs the **target** week's live grid against the
+  snapshot last delivered so the coach reviews exactly what's about to change for
+  the athlete. Three seams: **(1)** `serializers.diff_week_snapshots(current,
+  previous)` — a **pure** diff over two snapshot payloads matched by **stable
+  pks** (a row in both with differing fields is *changed*, with per-field
+  before/after over name/sets/reps/load/load_type/rpe/note/tag; a new pk is
+  *added*, a missing one *removed*; whole sessions added/removed are surfaced
+  separately and not double-counted as row diffs; week-meta
+  phase/volume/intensity/deload diffed too). Returns `None` when there's no prior
+  payload; `has_changes` is `False` when the week is unchanged since its last
+  delivery. **(2)** `presenters.deliver_screen` computes `deliver["changes"]`
+  (the last `WeekDelivery.payload` for the **target** week vs its live snapshot)
+  — `None` on a first delivery; because it keys on the *target* week, a
+  built-ahead week diffs against *its own* last delivery. **(3)** `deliver.html`
+  renders first-delivery / no-changes / the grouped diff, styled with the
+  existing tokens (`var(--ok)` add, `var(--warn)` remove). **No model change, no
+  migration; no JS — fully server-rendered.** Built red→green: **+17 pytest**
+  (`test_delivery_diff.py` — pure diff, presenter context incl. chosen-week
+  targeting, screen render). 1280 project pytest green; ruff + format + DjHTML +
+  `makemigrations --check` clean. **Codex review loop CLEAN after 1 fix
+  iteration** — a P2: Django's `default` filter treats a valid `0`
+  (volume/intensity) as falsy and rendered the em-dash, fixed with
+  `default_if_none` for the week-meta line (prescription string fields keep
+  `default`, where blank → dash is intended) + a regression test. **Prod-verified:**
+  deploy succeeded (no migration), `https://mastering.fitness/meso/` serves 200
+  after restart. Remaining Meso backlog unchanged: **S6 billing Phase 5 annual
+  prices** (blocked on the owner's per-seat number + a Stripe annual Price) — no
+  other autonomous slice outstanding.

--- a/docs/meso/persistence-plan.md
+++ b/docs/meso/persistence-plan.md
@@ -232,7 +232,11 @@ plans; athlete sees all their coaches'), the **invite state machine**, and **aut
 1. ~~**D-a/D-b/D-c** as recorded in `decisions.md`.~~ — **locked** (decisions log, 2026-06-26).
 2. ~~Roles live in the **`meso`** app (not `users`).~~ — **confirmed**; built there in Phase 1.
 3. ~~"Changes since last delivery" = **snapshot-per-delivery now**, full diff UI deferred.~~ —
-   **snapshot done** in Phase 4 (`WeekDelivery.payload`); the full diff *UI* is still deferred to
-   the agent/athlete slice.
+   **DONE** (2026-06-30, PR #337): snapshot captured in Phase 4 (`WeekDelivery.payload`); the
+   full diff **UI** now ships on the **deliver confirm screen** — `serializers.diff_week_snapshots`
+   diffs the target week's live grid against the snapshot last delivered (matched by stable pks:
+   added / removed / changed rows per session, whole days, week-meta), surfaced by
+   `presenters.deliver_screen` (`deliver["changes"]`) and rendered in `deliver.html`. No model
+   change, no migration.
 4. ~~**Logging models defined now**, UI later.~~ — **done**: `SessionLog`/`LoggedSet` built in
    Phase 2 (models + admin + factories only; athlete-facing logging UI lands with the athlete slice).


### PR DESCRIPTION
Records the changes-since-last-delivery diff UI shipped in #337:
- `decisions.md` changelog entry,
- resolves `persistence-plan.md` open assumption #3 (the "full diff UI" deferred since Phase 4 is now shipped).

Docs only.

https://claude.ai/code/session_019A9KdsVs33wipsGjSaFWXV