### PR TITLE
docs: sync .env.example/README/CLAUDE.md with dev ports + Meso vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,12 @@ DJANGO_ALLOWED_HOSTS=
 DOMAIN_URL=
 CORS_ALLOWED_ORIGINS=
 
+# --- Cache / sessions (Redis) --------------------------------------------
+# Production: docker-compose.production.yml sets REDIS_URL. Local dev: the dev
+# docker-compose runs Redis on :6334, and sessions live in the cache, so point
+# at it explicitly (the code default is :6379, which is wrong for dev).
+REDIS_URL=redis://localhost:6334/0
+
 # --- Stripe (payments) ---------------------------------------------------
 # https://dashboard.stripe.com/apikeys
 STRIPE_PUBLISHABLE_KEY=
@@ -82,6 +88,30 @@ GOOGLE_API_KEY=
 # --- Analytics / error monitoring ----------------------------------------
 GOOGLE_ANALYTICS_GTAG_PROPERTY_ID=
 SENTRY_DSN=
+
+# --- Meso (coaching app) -------------------------------------------------
+# All optional — each feature degrades to a no-op when its keys are blank.
+#
+# AI agent: key from https://console.anthropic.com/. Set MESO_AGENT_RUN_SYNC=true
+# locally to run proposal jobs inline (no qcluster worker needed); leave false in
+# production, where the qcluster process drains the queue.
+ANTHROPIC_API_KEY=
+MESO_AGENT_MODEL=claude-opus-4-8
+MESO_AGENT_RUN_SYNC=false
+#
+# Web push (PWA). Generate a VAPID keypair (`vapid --gen`, or py_vapid): PUBLIC is
+# the base64url uncompressed point, PRIVATE the base64url raw key. Blank => push is
+# a silent no-op. Use a fresh keypair per environment.
+MESO_VAPID_PUBLIC_KEY=
+MESO_VAPID_PRIVATE_KEY=
+MESO_VAPID_SUBJECT=mailto:you@example.com
+#
+# Stripe subscription billing (separate Product/webhook from the products keys
+# above). SEAT_PRICE_ID = a recurring monthly USD licensed Price id;
+# WEBHOOK_SECRET from the billing endpoint (`stripe listen --print-secret`).
+# Blank => billing stays dormant.
+MESO_SEAT_PRICE_ID=
+MESO_STRIPE_WEBHOOK_SECRET=
 
 # --- Scout APM ------------------------------------------------------------
 # Scout APM was removed (no `scout-apm` dependency). To bring it back, re-add

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,11 +141,14 @@ Uses django-allauth with email-only login, social authentication (Facebook, Goog
 - ruff for code formatting and linting
 
 ## Environment Variables
-Key variables needed in `.env.dev` for local development:
+Local dev loads `.env` (via `load_dotenv()`); copy `.env.example` to `.env` for the
+full, annotated list. Key variables needed for local development:
 - `STRIPE_PUBLISHABLE_KEY` and `STRIPE_SECRET_KEY` (test mode)
-- Database credentials for PostgreSQL
+- Database credentials for PostgreSQL (`SQL_PORT=5434` for the dev container)
+- `REDIS_URL=redis://localhost:6334/0` (dev Redis; sessions live in the cache)
 - Social auth keys for Facebook and Google
 - AWS credentials for S3 storage
+- Optional Meso features: `ANTHROPIC_API_KEY` and `MESO_*` (all no-ops when unset)
 
 ## Testing Strategy
 - Test files located in `tests/` subdirectories within each app

--- a/README.md
+++ b/README.md
@@ -86,54 +86,69 @@ python manage.py shell
 >>> me.save()
 ```
 
-...or in the Django admin at `http://localhost:8000/backside/users/user/`
+...or in the Django admin at `http://localhost:8034/backside/users/user/`
 
 ## Local Development
 
 ### Environment Variables
 
-Be sure to include [Stripe test mode publishable and secret keys](https://stripe.com/docs/test-mode) in `.env.dev`.
-AWS credentials are optional when running locally because `settings/local.py` now sets
+Copy `.env.example` to `.env` — it lists every variable with notes and safe dev
+defaults, and most can be left blank locally. At minimum, set [Stripe test mode
+keys](https://stripe.com/docs/test-mode), and point `SQL_PORT=5434` and
+`REDIS_URL=redis://localhost:6334/0` at the dev containers (see Docker Compose below).
+
+AWS credentials are optional when running locally because `settings/local.py` sets
 `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to dummy values if they are not
 provided.
-Set `GOOGLE_API_KEY` to enable Gemini-powered challenge summaries.
+Set `GOOGLE_API_KEY` to enable Gemini-powered challenge summaries. The optional
+Meso features (AI agent, web push, Stripe billing) have their own `ANTHROPIC_API_KEY`
+and `MESO_*` variables — all documented in `.env.example` and all no-ops when unset.
 
 ### Docker Compose
 
-To build the database and cache containers:
+To start the Postgres (`:5434`) and Redis (`:6334`) containers:
 
 ```
-cd fitness-store
-docker-compose up -d --build
+just services
 ```
 
 ### Python & Django
 
-To run the Django development server:
+To run the Django development server (on http://localhost:8034/):
 
 ```
-cd app
-python manage.py runserver
+just dev
 ```
 
 To update the database schema:
 
 ```
-cd app
-python manage.py migrate
+just migrate
+```
+
+The `django-q2` cluster that runs scheduled/background tasks (invite sweeps, the
+`reconcile_seats` billing sweep, async Meso agent jobs) is a separate process —
+start it in its own terminal when you need it (locally you can instead set
+`MESO_AGENT_RUN_SYNC=true` to run agent jobs inline):
+
+```
+just qcluster
 ```
 
 To see running container logs:
 
 ```
-docker-compose logs -f
+docker compose logs -f
 ```
 
 To test if a purchase gives a user the permission to view a purchased product, you'll need to [forward those events from Stripe to the local server](https://stripe.com/docs/webhooks/test) instead of the live server in production. Make sure to list the appropriate webhook URL for handling the triggered events.
 
 ```
 stripe login
-stripe listen --forward-to localhost:8000/payments/webhook/
+# One-time product purchases:
+stripe listen --forward-to localhost:8034/payments/webhook/
+# Meso subscription billing (separate endpoint + signing secret; run in its own terminal):
+stripe listen --forward-to localhost:8034/meso/billing/webhook/
 ```
 
 Once listening, you must trigger the event by performing the corresponding actions on your site or by using the Stripe CLI, e.g. `stripe trigger checkout.session.completed`.


### PR DESCRIPTION
## What

Brings the env/setup docs back in line with how local dev actually works after the dev-port and Meso changes.

- **`.env.example`**: add `REDIS_URL` and the full **Meso** block (AI agent, VAPID web push, Stripe billing) as blank, annotated placeholders — no secrets.
- **`README.md` / `CLAUDE.md`**: `.env.dev` → `.env` (the file actually loaded), `localhost:8000` → `localhost:8034` (the `just dev` port), bare `python manage.py`/`docker-compose` → `just` commands, document the new `meso/billing/webhook/` endpoint, and note `just qcluster` is a separate process.

## Why

Docs referenced a nonexistent `.env.dev`, the wrong port, and didn't mention the Meso agent/push/billing env vars, so a fresh setup pointed at the wrong DB/Redis.

Docs-only — no runtime code changes.