### PR TITLE
fix(css): remove unexpected border radius from header navbar

### DIFF
--- a/app/store_project/static/css/base.css
+++ b/app/store_project/static/css/base.css
@@ -1609,6 +1609,9 @@ ul.grid {
   background-color: var(--main-color-dark);
   color: var(--main-color-light-gray);
   padding: clamp(1rem, 4vw, var(--s2));
+  /* The navbar is a full-bleed top bar, so it overrides the rounded corners it
+     would otherwise inherit from `.box` (see issue #327). */
+  border-radius: 0;
 }
 
 .nav-menu ul {


### PR DESCRIPTION
## What

The header navbar carries the `.box` class, which applies `border-radius: 12px` (added in #232/#243's "consistent rounded corners" pass). The `.navbar` rule overrode the box's background and padding but **not** its border-radius, so the full-bleed top bar inherited rounded corners.

This pins `.navbar` to `border-radius: 0`. Equal specificity (single class) but later in source order than `.box`, so it wins cleanly.

## Why

Closes #327. A full-width top navigation bar shouldn't have rounded corners — the radius reads as an accidental artifact of the box-rounding change.

## Scope

Deliberately surgical — one rule, navbar only. This is the quick-win extracted from a larger styling-consistency investigation (competing `base.css` / dead-Bulma / `crispy_bulma` / Meso systems); the broader rework is being scoped separately.

## Testing

CSS-only change. Specificity reasoning: `.box` sets `border-radius: var(--border-radius)` at line ~499; `.navbar` now sets `border-radius: 0` at line ~1608. The nav element has both classes (`class="box invert navbar"`), so the later equal-specificity rule overrides.