### PR TITLE
Meso agent usage & cost tracking — Phase 2 (report)

### DIFF
--- a/app/store_project/meso/billing/agent_usage_report.py
+++ b/app/store_project/meso/billing/agent_usage_report.py
@@ -78,8 +78,14 @@ def month_bounds(year, month):
 
 
 def current_month_bounds():
-    """``month_bounds`` for the month containing ``now`` — the report's default."""
-    now = timezone.now()
+    """``month_bounds`` for the *local* month containing now — the report's default.
+
+    ``month_bounds`` builds its window in the current timezone, so the default
+    month must come from the localized now: a bare UTC ``timezone.now()`` can
+    already read as next month during the last local evening of the month when the
+    app timezone is behind UTC, mismatching the window it then builds.
+    """
+    now = timezone.localtime(timezone.now())
     return month_bounds(now.year, now.month)
 
 
@@ -107,9 +113,15 @@ def monthly_revenue(status, seats):
     comped, canceled, or no row at all yield $0 (revenue we collect, not list
     price). ``seats`` is the coach's *current* billable active-athlete count — an
     approximation of the report month, since historical seat counts aren't stored.
+
+    The seat line is **floored at one** to mirror Stripe billing
+    (``stripe_gateway._seat_quantity`` rejects a quantity of 0): a paid coach with
+    zero active athletes still pays for one seat, so revenue is ``$9.99 + $1``, not
+    just the base — otherwise the report could under-report revenue and wrongly
+    flag a zero-seat paid coach as negative-margin.
     """
     if status in CoachSubscription.LIVE_STRIPE_STATUSES:
-        return BASE_PRICE_USD + SEAT_PRICE_USD * seats
+        return BASE_PRICE_USD + SEAT_PRICE_USD * max(seats, 1)
     return _ZERO
 
 

--- a/app/store_project/meso/billing/agent_usage_report.py
+++ b/app/store_project/meso/billing/agent_usage_report.py
@@ -1,0 +1,330 @@
+"""Roll captured agent-run usage up into a per-coach margin report (agent-usage v2).
+
+Phase 1 (``agent_costs.py`` + the ``AgentProposalBatch`` usage columns) captured
+per-run token usage and an estimated cost on the run ledger. This is the **read
+side**: aggregate those rows for a calendar month into
+
+* per-coach **cost vs revenue → margin** (and a flag when a *paying* coach's agent
+  cost outruns what they pay — the $1/seat tail risk D13 called out),
+* a per-(coach, client) breakdown to find the **heavy seats** (a client is the
+  athlete on an individual plan, or the group on a group plan), and
+* roll-ups by **model**, by **trigger**, and by **billing tier** (the COGS-vs-CAC
+  split off each run's snapshotted ``billing_status``).
+
+``eval`` runs are excluded everywhere — they're a golden-corpus quality check, not
+coach usage (the count is surfaced as a footnote). The cost is the **internal
+estimate** stored at write time (the Anthropic invoice stays authoritative);
+revenue is the coach's *current* plan price (base + per active seat), an
+approximation since per-month historical seat counts aren't stored. See
+``docs/meso/agent-usage-plan.md``.
+"""
+
+from dataclasses import dataclass
+from dataclasses import field
+from datetime import datetime
+from decimal import Decimal
+
+from django.db.models import Count
+from django.utils import timezone
+
+from store_project.meso.models import AgentProposalBatch
+from store_project.meso.models import CoachAthlete
+from store_project.meso.models import CoachSubscription
+
+# Plan price (S6 Phase 6, D13) — the numeric source for the revenue math, mirroring
+# the ``presenters.PRICE_SUMMARY`` marketing copy ("$9.99/mo + $1 per active
+# athlete"). Strings so the Decimals are exact. Update alongside that copy.
+BASE_PRICE_USD = Decimal("9.99")
+SEAT_PRICE_USD = Decimal("1.00")
+
+_ZERO = Decimal("0")
+
+# Billing-tier buckets for the COGS-vs-CAC split (off each run's snapshot status).
+PAID = "paid"  # a real Stripe subscription — agent cost is COGS against revenue
+COMPED = "comped"  # owner / demo coaches — real cost, no revenue, never flagged
+FREE_TRIAL = "free_trial"  # free / trial / churned — cost is CAC (acquisition)
+TIERS = (PAID, COMPED, FREE_TRIAL)
+
+
+def parse_month(value):
+    """Parse a ``YYYY-MM`` string into a ``(year, month)`` tuple.
+
+    Raises ``ValueError`` (with a friendly message) on anything malformed so the
+    management command can surface a ``CommandError`` rather than a stack trace.
+    """
+    try:
+        parsed = datetime.strptime(value, "%Y-%m")
+    except ValueError as exc:
+        raise ValueError(
+            f"Month must be YYYY-MM (e.g. 2026-06), got {value!r}."
+        ) from exc
+    return parsed.year, parsed.month
+
+
+def month_bounds(year, month):
+    """The ``[start, end)`` tz-aware datetimes spanning one calendar month.
+
+    Half-open so a batch is counted in exactly one month (``created_at >= start``
+    and ``< end``). Made aware in the current timezone, matching how the rest of
+    the app reasons about month windows (``billing/access.py``).
+    """
+    start_naive = datetime(year, month, 1)
+    if month == 12:
+        end_naive = datetime(year + 1, 1, 1)
+    else:
+        end_naive = datetime(year, month + 1, 1)
+    tz = timezone.get_current_timezone()
+    return timezone.make_aware(start_naive, tz), timezone.make_aware(end_naive, tz)
+
+
+def current_month_bounds():
+    """``month_bounds`` for the month containing ``now`` — the report's default."""
+    now = timezone.now()
+    return month_bounds(now.year, now.month)
+
+
+def cost_bucket(billing_status):
+    """Map a run's snapshot ``billing_status`` to a COGS-vs-CAC tier.
+
+    ``active``/``past_due`` → paid (cost is COGS); ``comped`` → comped (owner/demo,
+    real cost but no revenue); everything else — ``free``/``trialing``,
+    ``canceled``, or a blank legacy snapshot — → free/trial (the cost is CAC).
+    """
+    if billing_status in (
+        CoachSubscription.Status.ACTIVE,
+        CoachSubscription.Status.PAST_DUE,
+    ):
+        return PAID
+    if billing_status == CoachSubscription.Status.COMPED:
+        return COMPED
+    return FREE_TRIAL
+
+
+def monthly_revenue(status, seats):
+    """The coach's current monthly plan price: base + per-seat, or $0 when unpaid.
+
+    Only a live Stripe subscription (``active``/``past_due``) bills; free, trial,
+    comped, canceled, or no row at all yield $0 (revenue we collect, not list
+    price). ``seats`` is the coach's *current* billable active-athlete count — an
+    approximation of the report month, since historical seat counts aren't stored.
+    """
+    if status in CoachSubscription.LIVE_STRIPE_STATUSES:
+        return BASE_PRICE_USD + SEAT_PRICE_USD * seats
+    return _ZERO
+
+
+class Totals:
+    """A mutable usage accumulator — runs, the four token buckets, and cost.
+
+    ``cost`` sums only runs whose model was in the rate table; a run with an
+    unknown model (cost ``None``) is counted in ``unknown_cost_runs`` instead of
+    silently pricing as $0, so the report can flag it.
+    """
+
+    __slots__ = (
+        "runs",
+        "input_tokens",
+        "output_tokens",
+        "cache_creation_input_tokens",
+        "cache_read_input_tokens",
+        "cost",
+        "unknown_cost_runs",
+    )
+
+    def __init__(self):
+        self.runs = 0
+        self.input_tokens = 0
+        self.output_tokens = 0
+        self.cache_creation_input_tokens = 0
+        self.cache_read_input_tokens = 0
+        self.cost = _ZERO
+        self.unknown_cost_runs = 0
+
+    def add(self, batch):
+        self.runs += 1
+        self.input_tokens += batch.input_tokens
+        self.output_tokens += batch.output_tokens
+        self.cache_creation_input_tokens += batch.cache_creation_input_tokens
+        self.cache_read_input_tokens += batch.cache_read_input_tokens
+        if batch.estimated_cost_usd is None:
+            self.unknown_cost_runs += 1
+        else:
+            self.cost += batch.estimated_cost_usd
+
+    @property
+    def total_tokens(self):
+        return (
+            self.input_tokens
+            + self.output_tokens
+            + self.cache_creation_input_tokens
+            + self.cache_read_input_tokens
+        )
+
+
+@dataclass
+class ClientUsage:
+    """One coach's spend on a single client — an athlete, or a group."""
+
+    label: str
+    is_group: bool
+    totals: Totals
+
+
+@dataclass
+class CoachUsage:
+    """One coach's month: cost vs revenue, the margin, and a per-client breakdown."""
+
+    coach_id: object
+    label: str
+    billing_status: str  # the coach's *current* subscription status
+    is_paid: bool
+    billable_seats: int
+    revenue: Decimal
+    totals: Totals
+    clients: list = field(default_factory=list)
+
+    @property
+    def margin(self):
+        """Revenue minus estimated agent cost — negative means the run cost won."""
+        return self.revenue - self.totals.cost
+
+    @property
+    def flagged(self):
+        """A *paying* coach whose agent cost outran their revenue (the tail risk).
+
+        Only paid coaches flag: a free/trial coach has $0 revenue by design, so any
+        cost would trivially "exceed" it — that's CAC, not a margin problem.
+        """
+        return self.is_paid and self.totals.cost > self.revenue
+
+
+@dataclass
+class Report:
+    start: datetime
+    end: datetime
+    coaches: list
+    by_model: dict
+    by_trigger: dict
+    by_tier: dict
+    totals: Totals
+    eval_runs_excluded: int
+
+
+def _attribution(plan):
+    """``(key, label, is_group)`` for the client a batch's plan serves.
+
+    A group plan attributes to the group (no single athlete); an individual plan to
+    its athlete. ``key`` namespaces the two so an athlete and a group can't collide.
+    """
+    if plan.group_id is not None:
+        return ("group", plan.group_id), f"Group: {plan.group.name}", True
+    athlete = plan.relationship.athlete
+    return ("athlete", athlete.id), athlete.display_name(), False
+
+
+def build_report(*, start, end):
+    """Aggregate the month's non-eval agent runs into a :class:`Report`.
+
+    Coaches and their clients are sorted by estimated cost (then run count)
+    descending, so the heaviest spenders surface first. Revenue and billable-seat
+    counts are read from each coach's *current* subscription.
+    """
+    in_window = AgentProposalBatch.objects.filter(
+        created_at__gte=start, created_at__lt=end
+    )
+    eval_runs_excluded = in_window.filter(
+        trigger=AgentProposalBatch.Trigger.EVAL
+    ).count()
+    batches = in_window.exclude(trigger=AgentProposalBatch.Trigger.EVAL).select_related(
+        "coach",
+        "plan",
+        "plan__relationship__athlete",
+        "plan__group",
+    )
+
+    totals = Totals()
+    by_model = {}
+    by_trigger = {}
+    by_tier = {tier: Totals() for tier in TIERS}
+    # coach_id -> {"label", "totals", "clients": {key: ClientUsage}}
+    coaches = {}
+
+    for batch in batches:
+        totals.add(batch)
+        _bucket(by_model, batch.model or "(unset)").add(batch)
+        _bucket(by_trigger, batch.get_trigger_display()).add(batch)
+        by_tier[cost_bucket(batch.billing_status)].add(batch)
+
+        acc = coaches.get(batch.coach_id)
+        if acc is None:
+            acc = {
+                "label": batch.coach.display_name(),
+                "totals": Totals(),
+                "clients": {},
+            }
+            coaches[batch.coach_id] = acc
+        acc["totals"].add(batch)
+
+        key, label, is_group = _attribution(batch.plan)
+        client = acc["clients"].get(key)
+        if client is None:
+            client = ClientUsage(label=label, is_group=is_group, totals=Totals())
+            acc["clients"][key] = client
+        client.totals.add(batch)
+
+    coach_ids = list(coaches)
+    subs = {
+        sub.coach_id: sub
+        for sub in CoachSubscription.objects.filter(coach_id__in=coach_ids)
+    }
+    seat_counts = {
+        row["coach_id"]: row["n"]
+        for row in CoachAthlete.objects.billable()
+        .filter(coach_id__in=coach_ids)
+        .values("coach_id")
+        .annotate(n=Count("id"))
+    }
+
+    coach_usages = []
+    for coach_id, acc in coaches.items():
+        sub = subs.get(coach_id)
+        status = sub.status if sub else CoachSubscription.Status.FREE
+        seats = seat_counts.get(coach_id, 0)
+        clients = sorted(
+            acc["clients"].values(),
+            key=lambda c: (c.totals.cost, c.totals.runs),
+            reverse=True,
+        )
+        coach_usages.append(
+            CoachUsage(
+                coach_id=coach_id,
+                label=acc["label"],
+                billing_status=status,
+                is_paid=status in CoachSubscription.LIVE_STRIPE_STATUSES,
+                billable_seats=seats,
+                revenue=monthly_revenue(status, seats),
+                totals=acc["totals"],
+                clients=clients,
+            )
+        )
+    coach_usages.sort(key=lambda c: (c.totals.cost, c.totals.runs), reverse=True)
+
+    return Report(
+        start=start,
+        end=end,
+        coaches=coach_usages,
+        by_model=by_model,
+        by_trigger=by_trigger,
+        by_tier=by_tier,
+        totals=totals,
+        eval_runs_excluded=eval_runs_excluded,
+    )
+
+
+def _bucket(mapping, key):
+    """Return ``mapping[key]``, creating a fresh :class:`Totals` on first sight."""
+    totals = mapping.get(key)
+    if totals is None:
+        totals = Totals()
+        mapping[key] = totals
+    return totals

--- a/app/store_project/meso/management/commands/meso_agent_usage_report.py
+++ b/app/store_project/meso/management/commands/meso_agent_usage_report.py
@@ -1,0 +1,181 @@
+"""Report Meso agent usage + estimated cost vs revenue for a calendar month.
+
+Phase 1 captured per-run token usage and an estimated cost on the
+``AgentProposalBatch`` ledger; this command is the owner-facing read-out
+(agent-usage v2). For a month it prints per-coach **cost vs revenue → margin**
+(flagging any *paying* coach whose agent cost outran their plan — the $1/seat tail
+risk D13 called out), a per-(coach, client) breakdown to find the heavy seats, and
+roll-ups by model / trigger / billing tier (the COGS-vs-CAC split). ``eval`` runs
+are excluded (a quality check, not coach usage).
+
+The cost is the **internal estimate** stored at write time — the Anthropic invoice
+is authoritative; this exists to attribute that org-level total per coach/seat and
+watch the margin. See ``docs/meso/agent-usage-plan.md``.
+
+    manage.py meso_agent_usage_report                # the current month
+    manage.py meso_agent_usage_report --month 2026-06
+    manage.py meso_agent_usage_report --month 2026-06 --json
+"""
+
+import json
+
+from django.core.management.base import BaseCommand
+from django.core.management.base import CommandError
+
+from store_project.meso.billing import agent_usage_report as report_mod
+
+
+def _usd(value, places=4):
+    """Format a Decimal as USD; an em-dash for a None (unknown-model) cost."""
+    if value is None:
+        return "—"
+    return f"${value:.{places}f}"
+
+
+def _serialize_totals(totals):
+    return {
+        "runs": totals.runs,
+        "input_tokens": totals.input_tokens,
+        "output_tokens": totals.output_tokens,
+        "cache_creation_input_tokens": totals.cache_creation_input_tokens,
+        "cache_read_input_tokens": totals.cache_read_input_tokens,
+        "total_tokens": totals.total_tokens,
+        "cost": str(totals.cost),
+        "unknown_cost_runs": totals.unknown_cost_runs,
+    }
+
+
+def _serialize(report):
+    """A JSON-safe dict of the report (Decimals → strings) for ``--json``."""
+    return {
+        "start": report.start.isoformat(),
+        "end": report.end.isoformat(),
+        "eval_runs_excluded": report.eval_runs_excluded,
+        "totals": _serialize_totals(report.totals),
+        "by_model": {k: _serialize_totals(v) for k, v in report.by_model.items()},
+        "by_trigger": {k: _serialize_totals(v) for k, v in report.by_trigger.items()},
+        "by_tier": {k: _serialize_totals(v) for k, v in report.by_tier.items()},
+        "coaches": [
+            {
+                "coach_id": str(c.coach_id),
+                "label": c.label,
+                "billing_status": c.billing_status,
+                "is_paid": c.is_paid,
+                "flagged": c.flagged,
+                "billable_seats": c.billable_seats,
+                "revenue": str(c.revenue),
+                "margin": str(c.margin),
+                "totals": _serialize_totals(c.totals),
+                "clients": [
+                    {
+                        "label": cl.label,
+                        "is_group": cl.is_group,
+                        "totals": _serialize_totals(cl.totals),
+                    }
+                    for cl in c.clients
+                ],
+            }
+            for c in report.coaches
+        ],
+    }
+
+
+class Command(BaseCommand):
+    help = (
+        "Per-coach Meso agent usage, estimated cost, and margin for a calendar month."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--month",
+            help="Calendar month as YYYY-MM (defaults to the current month).",
+        )
+        parser.add_argument(
+            "--json",
+            action="store_true",
+            help="Emit the report as JSON instead of a text table.",
+        )
+
+    def handle(self, *args, **options):
+        if options["month"]:
+            try:
+                year, month = report_mod.parse_month(options["month"])
+            except ValueError as exc:
+                raise CommandError(str(exc)) from exc
+            start, end = report_mod.month_bounds(year, month)
+        else:
+            start, end = report_mod.current_month_bounds()
+
+        report = report_mod.build_report(start=start, end=end)
+
+        if options["json"]:
+            self.stdout.write(json.dumps(_serialize(report), indent=2))
+            return
+
+        self._render(report)
+
+    def _render(self, report):
+        w = self.stdout.write
+        label = report.start.strftime("%Y-%m")
+        w(f"Meso agent usage — {label} ({report.start.date()} → {report.end.date()})")
+        w("Estimated cost is internal; the Anthropic invoice is authoritative.")
+        w("")
+
+        t = report.totals
+        suffix = ""
+        if t.unknown_cost_runs:
+            suffix = f" · {t.unknown_cost_runs} run(s) with an unpriced model"
+        excluded = ""
+        if report.eval_runs_excluded:
+            excluded = f"   ({report.eval_runs_excluded} eval run(s) excluded)"
+        w(
+            f"Totals: {t.runs} run(s) · {t.total_tokens:,} tokens · "
+            f"est. {_usd(t.cost)}{suffix}{excluded}"
+        )
+
+        if not report.coaches:
+            w("")
+            w("No agent runs in this month.")
+            return
+
+        self._render_rollup(w, "By billing tier", report.by_tier)
+        self._render_rollup(w, "By model", report.by_model)
+        self._render_rollup(w, "By trigger", report.by_trigger)
+
+        w("")
+        w("Per coach (highest cost first):")
+        for coach in report.coaches:
+            flag = "[FLAG] " if coach.flagged else ""
+            w(
+                f"  {flag}{coach.label} "
+                f"({coach.billing_status}, {coach.billable_seats} seat(s))"
+            )
+            w(
+                f"      {coach.totals.runs} run(s) · "
+                f"{coach.totals.total_tokens:,} tokens · "
+                f"cost {_usd(coach.totals.cost)} · "
+                f"revenue {_usd(coach.revenue, 2)} · "
+                f"margin {_usd(coach.margin)}"
+            )
+            for client in coach.clients:
+                w(
+                    f"        {client.label}: {client.totals.runs} run(s), "
+                    f"{_usd(client.totals.cost)}"
+                )
+
+    def _render_rollup(self, w, title, mapping):
+        if not mapping:
+            return
+        w("")
+        w(f"{title} (cost):")
+        rows = sorted(
+            mapping.items(), key=lambda kv: (kv[1].cost, kv[1].runs), reverse=True
+        )
+        for key, totals in rows:
+            note = ""
+            if totals.unknown_cost_runs:
+                note = f" ({totals.unknown_cost_runs} unpriced)"
+            w(
+                f"  {key}: {totals.runs} run(s), "
+                f"{totals.total_tokens:,} tokens, {_usd(totals.cost)}{note}"
+            )

--- a/app/store_project/meso/tests/test_agent_usage_report.py
+++ b/app/store_project/meso/tests/test_agent_usage_report.py
@@ -81,6 +81,13 @@ class TestPureHelpers:
         rev = report_mod.monthly_revenue(CoachSubscription.Status.PAST_DUE, 2)
         assert rev == Decimal("11.99")
 
+    def test_monthly_revenue_paid_floors_seats_at_one(self):
+        # Stripe bills at least one seat (``_seat_quantity`` floors at 1), so a paid
+        # coach with zero active athletes still owes base + one seat = $10.99.
+        assert report_mod.monthly_revenue(
+            CoachSubscription.Status.ACTIVE, 0
+        ) == Decimal("10.99")
+
     @pytest.mark.parametrize(
         "status",
         [
@@ -92,6 +99,14 @@ class TestPureHelpers:
     )
     def test_monthly_revenue_unpaid_is_zero(self, status):
         assert report_mod.monthly_revenue(status, 10) == Decimal("0")
+
+    def test_current_month_bounds_uses_local_month(self):
+        # The default month must match the localized now, not a bare UTC now —
+        # otherwise the window and its month label can disagree near a boundary.
+        local = timezone.localtime(timezone.now())
+        assert report_mod.current_month_bounds() == report_mod.month_bounds(
+            local.year, local.month
+        )
 
 
 # --- month windowing ------------------------------------------------------

--- a/app/store_project/meso/tests/test_agent_usage_report.py
+++ b/app/store_project/meso/tests/test_agent_usage_report.py
@@ -1,0 +1,471 @@
+"""The agent usage + margin report (agent-usage tracking v2, Phase 2 — report).
+
+Phase 1 captured per-run usage/cost on ``AgentProposalBatch`` (the per-run ledger);
+this is the read side. ``billing/agent_usage_report.build_report`` rolls a calendar
+month's non-eval runs up into per-coach cost-vs-revenue margins, a per-client
+breakdown, and roll-ups by model / trigger / billing tier; the
+``meso_agent_usage_report`` command renders it. Covers the month window, the
+margin math, the COGS-vs-CAC tier split, group-vs-athlete attribution, the
+eval-exclusion, and the unknown-model (unpriced) path. See
+``docs/meso/agent-usage-plan.md``.
+"""
+
+import json
+from datetime import timedelta
+from decimal import Decimal
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.utils import timezone
+
+from store_project.meso.billing import agent_usage_report as report_mod
+from store_project.meso.factories import AgentProposalBatchFactory
+from store_project.meso.factories import CoachAthleteFactory
+from store_project.meso.factories import CoachSubscriptionFactory
+from store_project.meso.factories import GroupPlanFactory
+from store_project.meso.factories import PlanFactory
+from store_project.meso.models import AgentProposalBatch
+from store_project.meso.models import CoachSubscription
+
+pytestmark = pytest.mark.django_db
+
+
+def _at(when, **kw):
+    """Build a batch then stamp its auto-add ``created_at`` to ``when``."""
+    batch = AgentProposalBatchFactory(**kw)
+    AgentProposalBatch.objects.filter(pk=batch.pk).update(created_at=when)
+    batch.refresh_from_db()
+    return batch
+
+
+# --- pure helpers ---------------------------------------------------------
+
+
+class TestPureHelpers:
+    def test_parse_month_ok(self):
+        assert report_mod.parse_month("2026-06") == (2026, 6)
+
+    @pytest.mark.parametrize("bad", ["2026", "2026/06", "June", "2026-13", ""])
+    def test_parse_month_rejects_malformed(self, bad):
+        with pytest.raises(ValueError):
+            report_mod.parse_month(bad)
+
+    def test_month_bounds_is_half_open_and_tz_aware(self):
+        start, end = report_mod.month_bounds(2026, 6)
+        assert (start.year, start.month, start.day) == (2026, 6, 1)
+        assert (end.year, end.month, end.day) == (2026, 7, 1)
+        assert timezone.is_aware(start) and timezone.is_aware(end)
+
+    def test_month_bounds_rolls_over_december(self):
+        _, end = report_mod.month_bounds(2026, 12)
+        assert (end.year, end.month, end.day) == (2027, 1, 1)
+
+    def test_cost_bucket_maps_each_status(self):
+        S = CoachSubscription.Status
+        assert report_mod.cost_bucket(S.ACTIVE) == report_mod.PAID
+        assert report_mod.cost_bucket(S.PAST_DUE) == report_mod.PAID
+        assert report_mod.cost_bucket(S.COMPED) == report_mod.COMPED
+        assert report_mod.cost_bucket(S.FREE) == report_mod.FREE_TRIAL
+        assert report_mod.cost_bucket(S.TRIALING) == report_mod.FREE_TRIAL
+        assert report_mod.cost_bucket(S.CANCELED) == report_mod.FREE_TRIAL
+        assert report_mod.cost_bucket("") == report_mod.FREE_TRIAL  # legacy blank
+
+    def test_monthly_revenue_paid_is_base_plus_seats(self):
+        rev = report_mod.monthly_revenue(CoachSubscription.Status.ACTIVE, 3)
+        assert rev == report_mod.BASE_PRICE_USD + report_mod.SEAT_PRICE_USD * 3
+        assert rev == Decimal("12.99")
+
+    def test_monthly_revenue_past_due_still_bills(self):
+        rev = report_mod.monthly_revenue(CoachSubscription.Status.PAST_DUE, 2)
+        assert rev == Decimal("11.99")
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            CoachSubscription.Status.FREE,
+            CoachSubscription.Status.TRIALING,
+            CoachSubscription.Status.COMPED,
+            CoachSubscription.Status.CANCELED,
+        ],
+    )
+    def test_monthly_revenue_unpaid_is_zero(self, status):
+        assert report_mod.monthly_revenue(status, 10) == Decimal("0")
+
+
+# --- month windowing ------------------------------------------------------
+
+
+class TestMonthWindow:
+    def test_only_runs_inside_the_window_count(self):
+        start, end = report_mod.month_bounds(2026, 6)
+        inside = _at(start + timedelta(days=5))
+        _at(start - timedelta(seconds=1))  # last instant of May
+        _at(end)  # first instant of July (end is exclusive)
+
+        report = report_mod.build_report(start=start, end=end)
+        assert report.totals.runs == 1
+        assert report.coaches[0].coach_id == inside.coach_id
+
+
+# --- attribution ----------------------------------------------------------
+
+
+class TestAttribution:
+    def test_individual_run_attributes_to_the_athlete(self):
+        start, end = report_mod.month_bounds(2026, 6)
+        plan = PlanFactory()
+        _at(start + timedelta(days=1), plan=plan, coach=plan.relationship.coach)
+
+        report = report_mod.build_report(start=start, end=end)
+        (coach,) = report.coaches
+        (client,) = coach.clients
+        assert client.is_group is False
+        assert client.label == plan.relationship.athlete.display_name()
+
+    def test_group_run_attributes_to_the_group(self):
+        start, end = report_mod.month_bounds(2026, 6)
+        plan = GroupPlanFactory()
+        _at(
+            start + timedelta(days=1),
+            plan=plan,
+            coach=plan.group.coach,
+            trigger=AgentProposalBatch.Trigger.GROUP,
+        )
+
+        report = report_mod.build_report(start=start, end=end)
+        (coach,) = report.coaches
+        (client,) = coach.clients
+        assert client.is_group is True
+        assert client.label == f"Group: {plan.group.name}"
+
+    def test_two_runs_for_one_athlete_collapse_to_one_client(self):
+        start, end = report_mod.month_bounds(2026, 6)
+        plan = PlanFactory()
+        coach = plan.relationship.coach
+        _at(
+            start + timedelta(days=1),
+            plan=plan,
+            coach=coach,
+            estimated_cost_usd=Decimal("0.01"),
+        )
+        _at(
+            start + timedelta(days=2),
+            plan=plan,
+            coach=coach,
+            estimated_cost_usd=Decimal("0.02"),
+        )
+
+        report = report_mod.build_report(start=start, end=end)
+        (c,) = report.coaches
+        assert len(c.clients) == 1
+        assert c.clients[0].totals.runs == 2
+        assert c.clients[0].totals.cost == Decimal("0.03")
+
+
+# --- eval exclusion -------------------------------------------------------
+
+
+class TestEvalExclusion:
+    def test_eval_runs_are_excluded_but_counted(self):
+        start, end = report_mod.month_bounds(2026, 6)
+        plan = PlanFactory()
+        coach = plan.relationship.coach
+        _at(
+            start + timedelta(days=1),
+            plan=plan,
+            coach=coach,
+            trigger=AgentProposalBatch.Trigger.MANUAL,
+            estimated_cost_usd=Decimal("0.05"),
+        )
+        _at(
+            start + timedelta(days=2),
+            plan=plan,
+            coach=coach,
+            trigger=AgentProposalBatch.Trigger.EVAL,
+            estimated_cost_usd=Decimal("9.99"),
+        )
+
+        report = report_mod.build_report(start=start, end=end)
+        assert report.totals.runs == 1
+        assert report.totals.cost == Decimal("0.05")
+        assert report.eval_runs_excluded == 1
+
+
+# --- token + cost aggregation + unknown model -----------------------------
+
+
+class TestAggregation:
+    def test_token_buckets_and_total_sum(self):
+        start, end = report_mod.month_bounds(2026, 6)
+        plan = PlanFactory()
+        coach = plan.relationship.coach
+        _at(
+            start + timedelta(days=1),
+            plan=plan,
+            coach=coach,
+            input_tokens=100,
+            output_tokens=50,
+            cache_creation_input_tokens=20,
+            cache_read_input_tokens=300,
+            estimated_cost_usd=Decimal("0.01"),
+        )
+        _at(
+            start + timedelta(days=2),
+            plan=plan,
+            coach=coach,
+            input_tokens=10,
+            output_tokens=5,
+            estimated_cost_usd=Decimal("0.02"),
+        )
+
+        t = report_mod.build_report(start=start, end=end).totals
+        assert t.input_tokens == 110
+        assert t.output_tokens == 55
+        assert t.cache_creation_input_tokens == 20
+        assert t.cache_read_input_tokens == 300
+        assert t.total_tokens == 110 + 55 + 20 + 300
+        assert t.cost == Decimal("0.03")
+
+    def test_unknown_model_cost_is_not_counted_as_zero(self):
+        start, end = report_mod.month_bounds(2026, 6)
+        plan = PlanFactory()
+        coach = plan.relationship.coach
+        _at(
+            start + timedelta(days=1),
+            plan=plan,
+            coach=coach,
+            estimated_cost_usd=None,
+            model="some-unpriced-model",
+        )
+        _at(
+            start + timedelta(days=2),
+            plan=plan,
+            coach=coach,
+            estimated_cost_usd=Decimal("0.04"),
+        )
+
+        t = report_mod.build_report(start=start, end=end).totals
+        assert t.runs == 2
+        assert t.cost == Decimal("0.04")
+        assert t.unknown_cost_runs == 1
+
+
+# --- margin + flagging + revenue ------------------------------------------
+
+
+class TestMargin:
+    def test_paid_coach_with_cost_under_revenue_is_not_flagged(self):
+        start, end = report_mod.month_bounds(2026, 6)
+        sub = CoachSubscriptionFactory(status=CoachSubscription.Status.ACTIVE)
+        coach = sub.coach
+        plan = PlanFactory(relationship__coach=coach)
+        CoachAthleteFactory(coach=coach)  # one extra billable seat → revenue 10.99+...
+        _at(
+            start + timedelta(days=1),
+            plan=plan,
+            coach=coach,
+            billing_status=CoachSubscription.Status.ACTIVE,
+            estimated_cost_usd=Decimal("0.50"),
+        )
+
+        (c,) = report_mod.build_report(start=start, end=end).coaches
+        assert c.is_paid is True
+        assert c.revenue > c.totals.cost
+        assert c.margin == c.revenue - Decimal("0.50")
+        assert c.flagged is False
+
+    def test_paid_coach_whose_cost_exceeds_revenue_is_flagged(self):
+        start, end = report_mod.month_bounds(2026, 6)
+        sub = CoachSubscriptionFactory(status=CoachSubscription.Status.ACTIVE)
+        coach = sub.coach
+        plan = PlanFactory(relationship__coach=coach)
+        _at(
+            start + timedelta(days=1),
+            plan=plan,
+            coach=coach,
+            billing_status=CoachSubscription.Status.ACTIVE,
+            estimated_cost_usd=Decimal("99.00"),
+        )
+
+        (c,) = report_mod.build_report(start=start, end=end).coaches
+        assert c.flagged is True
+        assert c.margin < 0
+
+    def test_free_coach_is_never_flagged_even_with_cost(self):
+        start, end = report_mod.month_bounds(2026, 6)
+        plan = PlanFactory()  # coach has no subscription row → free
+        _at(
+            start + timedelta(days=1),
+            plan=plan,
+            coach=plan.relationship.coach,
+            billing_status=CoachSubscription.Status.FREE,
+            estimated_cost_usd=Decimal("5.00"),
+        )
+
+        (c,) = report_mod.build_report(start=start, end=end).coaches
+        assert c.is_paid is False
+        assert c.revenue == Decimal("0")
+        assert c.flagged is False
+
+    def test_revenue_reflects_current_billable_seats(self):
+        start, end = report_mod.month_bounds(2026, 6)
+        sub = CoachSubscriptionFactory(status=CoachSubscription.Status.ACTIVE)
+        coach = sub.coach
+        plan = PlanFactory(relationship__coach=coach)
+        # The plan's own relationship is one billable seat; add two more.
+        CoachAthleteFactory(coach=coach)
+        CoachAthleteFactory(coach=coach)
+        _at(
+            start + timedelta(days=1),
+            plan=plan,
+            coach=coach,
+            estimated_cost_usd=Decimal("0.10"),
+        )
+
+        (c,) = report_mod.build_report(start=start, end=end).coaches
+        assert c.billable_seats == 3
+        assert c.revenue == Decimal("9.99") + Decimal("3")
+
+
+# --- tier / model / trigger roll-ups --------------------------------------
+
+
+class TestRollups:
+    def test_tier_split_cogs_vs_cac_vs_comped(self):
+        start, end = report_mod.month_bounds(2026, 6)
+        plan = PlanFactory()
+        coach = plan.relationship.coach
+        _at(
+            start + timedelta(days=1),
+            plan=plan,
+            coach=coach,
+            billing_status=CoachSubscription.Status.ACTIVE,
+            estimated_cost_usd=Decimal("0.10"),
+        )
+        _at(
+            start + timedelta(days=2),
+            plan=plan,
+            coach=coach,
+            billing_status=CoachSubscription.Status.FREE,
+            estimated_cost_usd=Decimal("0.20"),
+        )
+        _at(
+            start + timedelta(days=3),
+            plan=plan,
+            coach=coach,
+            billing_status=CoachSubscription.Status.COMPED,
+            estimated_cost_usd=Decimal("0.30"),
+        )
+
+        tiers = report_mod.build_report(start=start, end=end).by_tier
+        assert tiers[report_mod.PAID].cost == Decimal("0.10")
+        assert tiers[report_mod.FREE_TRIAL].cost == Decimal("0.20")
+        assert tiers[report_mod.COMPED].cost == Decimal("0.30")
+
+    def test_model_and_trigger_rollups(self):
+        start, end = report_mod.month_bounds(2026, 6)
+        plan = PlanFactory()
+        coach = plan.relationship.coach
+        _at(
+            start + timedelta(days=1),
+            plan=plan,
+            coach=coach,
+            model="claude-opus-4-8",
+            trigger=AgentProposalBatch.Trigger.MANUAL,
+            estimated_cost_usd=Decimal("0.10"),
+        )
+        _at(
+            start + timedelta(days=2),
+            plan=plan,
+            coach=coach,
+            model="claude-sonnet-4-6",
+            trigger=AgentProposalBatch.Trigger.DRAFT,
+            estimated_cost_usd=Decimal("0.20"),
+        )
+
+        report = report_mod.build_report(start=start, end=end)
+        assert report.by_model["claude-opus-4-8"].cost == Decimal("0.10")
+        assert report.by_model["claude-sonnet-4-6"].cost == Decimal("0.20")
+        assert report.by_trigger["Manual"].cost == Decimal("0.10")
+        assert report.by_trigger["Draft with AI"].cost == Decimal("0.20")
+
+
+# --- ordering -------------------------------------------------------------
+
+
+def test_coaches_sorted_by_cost_descending():
+    start, end = report_mod.month_bounds(2026, 6)
+    cheap_plan = PlanFactory()
+    dear_plan = PlanFactory()
+    _at(
+        start + timedelta(days=1),
+        plan=cheap_plan,
+        coach=cheap_plan.relationship.coach,
+        estimated_cost_usd=Decimal("0.01"),
+    )
+    _at(
+        start + timedelta(days=1),
+        plan=dear_plan,
+        coach=dear_plan.relationship.coach,
+        estimated_cost_usd=Decimal("9.00"),
+    )
+
+    report = report_mod.build_report(start=start, end=end)
+    assert report.coaches[0].coach_id == dear_plan.relationship.coach_id
+    assert report.coaches[1].coach_id == cheap_plan.relationship.coach_id
+
+
+# --- management command ---------------------------------------------------
+
+
+class TestCommand:
+    def test_text_report_renders_coach_and_flag(self):
+        start, end = report_mod.month_bounds(2026, 6)
+        sub = CoachSubscriptionFactory(status=CoachSubscription.Status.ACTIVE)
+        coach = sub.coach
+        plan = PlanFactory(relationship__coach=coach)
+        _at(
+            start + timedelta(days=1),
+            plan=plan,
+            coach=coach,
+            billing_status=CoachSubscription.Status.ACTIVE,
+            estimated_cost_usd=Decimal("99.00"),
+        )
+
+        out = StringIO()
+        call_command("meso_agent_usage_report", "--month", "2026-06", stdout=out)
+        body = out.getvalue()
+        assert "2026-06" in body
+        assert coach.display_name() in body
+        assert "[FLAG]" in body
+
+    def test_empty_month_reports_no_runs(self):
+        out = StringIO()
+        call_command("meso_agent_usage_report", "--month", "2020-01", stdout=out)
+        assert "No agent runs in this month." in out.getvalue()
+
+    def test_json_output_is_machine_readable(self):
+        start, end = report_mod.month_bounds(2026, 6)
+        plan = PlanFactory()
+        _at(
+            start + timedelta(days=1),
+            plan=plan,
+            coach=plan.relationship.coach,
+            estimated_cost_usd=Decimal("0.10"),
+        )
+
+        out = StringIO()
+        call_command(
+            "meso_agent_usage_report", "--month", "2026-06", "--json", stdout=out
+        )
+        data = json.loads(out.getvalue())
+        assert data["totals"]["runs"] == 1
+        # Cost rides as a string (Decimal-safe); the DB field keeps 6 places.
+        assert Decimal(data["totals"]["cost"]) == Decimal("0.10")
+        assert len(data["coaches"]) == 1
+
+    def test_bad_month_raises_command_error(self):
+        with pytest.raises(CommandError):
+            call_command("meso_agent_usage_report", "--month", "nonsense")

--- a/docs/meso/agent-usage-plan.md
+++ b/docs/meso/agent-usage-plan.md
@@ -1,6 +1,6 @@
 # Meso — agent usage & cost tracking
 
-**Status:** 🟢 Phase 1 (capture) shipped · 🟡 Phase 2 (report) pending · started 2026-06-30
+**Status:** 🟢 Phase 1 (capture) shipped · 🟢 Phase 2 (report) shipped · started 2026-06-30
 **Context:** Billing launches at **$9.99/mo base + $1/mo per active seat** (D13 in
 [`billing-plan.md`](./billing-plan.md)). The **AI agent is the cost-bearing
 feature** — every proposal run is a Claude API call. To confirm the $1/seat
@@ -140,7 +140,22 @@ def estimate_cost(model, usage) -> Decimal:
    helper) + `test_agent_usage.py` (client capture, persist on success+failure,
    trigger/billing snapshots). Existing fakes returning a bare dict normalize to
    zero usage, so they stayed green.
-2. **Report (NEXT).** The `meso_agent_usage_report` command + the admin readout.
+2. **Report — ✅ DONE (no migration).** `meso/billing/agent_usage_report.py`
+   `build_report(start, end)` aggregates a calendar month's **non-eval** runs into
+   per-coach **cost vs revenue → margin** (a `flagged` flag fires only for a
+   *paying* coach whose summed cost beats revenue — a free/trial coach's $0-revenue
+   cost is CAC by design, never a flag), a per-(coach, client) breakdown sorted by
+   cost (client = athlete on an individual plan, or the **group** on a group plan),
+   and roll-ups by `model`, `trigger`, and **billing tier** (`cost_bucket` → paid /
+   comped / free-trial off each run's snapshot `billing_status`). Revenue =
+   `BASE_PRICE_USD + SEAT_PRICE_USD × current billable seats` (the constants mirror
+   `presenters.PRICE_SUMMARY`; only `active`/`past_due` coaches bill, all else $0) —
+   an approximation, since per-month historical seat counts aren't stored. The
+   `meso_agent_usage_report` command renders a text table (`--month YYYY-MM`,
+   default current month) or `--json`. Unknown-model runs (cost `None`) are counted
+   as `unknown_cost_runs`, never summed as $0. The admin readout shipped in Phase 1.
+   Tests: `test_agent_usage_report.py` (helpers, month window, attribution, eval
+   exclusion, aggregation, margin/flagging, tier/model/trigger roll-ups, the command).
 3. *(Deferred)* dashboard; a margin-threshold alert (e.g. flag when a coach's
    monthly agent cost exceeds a set fraction of their revenue); a reconciliation
    job against the Anthropic Admin/Usage API.

--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -1003,3 +1003,33 @@ _(Append dated entries here as decisions land.)_
   mocked. Ships **dormant** until the owner creates both Prices + registers the
   webhook. **Annual prices** (a `*_ANNUAL` Price per line + a Checkout toggle) are
   the remaining ride-along, still blocked on the annual numbers.
+- 2026-06-30 — **Agent usage tracking Phase 1 (capture) built** (migration `0025`,
+  PR #344). Extended `AgentProposalBatch` (the per-run ledger) with the token/cost/
+  dimension columns: `input_tokens`/`output_tokens`/`cache_creation_input_tokens`/
+  `cache_read_input_tokens`/`api_calls`/`request_id`/`stop_reason`/`duration_ms`,
+  a computed `estimated_cost_usd` (Decimal, from `meso/billing/agent_costs.py`'s
+  per-model rate table — unknown model → `None`, never a wrong $0), plus the
+  `trigger` (manual/draft/eval/group) and `billing_status` snapshots. `client.propose`
+  now returns a `ProposalResult(data, usage)` carrying the Anthropic `usage` block +
+  `_request_id` + `stop_reason`; the service threads it (with the measured
+  `duration_ms`) onto the batch. A **failed** run still records model + duration (U5).
+  Admin surfaces the columns read-only. No Stripe — independent of go-live.
+- 2026-06-30 — **Agent usage tracking Phase 2 (report) built** (no migration). The
+  read side of the captured data: `meso/billing/agent_usage_report.py`
+  `build_report(start, end)` rolls a calendar month's **non-eval** runs up into
+  per-coach **cost vs revenue → margin** (flagging any *paying* coach whose agent
+  cost outran their plan — the $1/seat tail risk D13 called out), a per-(coach,
+  client) breakdown to surface the heavy seats (a client = the athlete on an
+  individual plan, or the **group** on a group plan, athlete null), and roll-ups by
+  **model**, **trigger**, and **billing tier** (the COGS-vs-CAC split off each run's
+  snapshot `billing_status`: active/past_due = paid, comped = owner/demo, else
+  free/trial = CAC). Revenue = the coach's *current* plan price (`$9.99 base + $1 ×
+  current billable seats` — `BASE_PRICE_USD`/`SEAT_PRICE_USD` mirror
+  `presenters.PRICE_SUMMARY`), an approximation since per-month historical seat
+  counts aren't stored. The `meso_agent_usage_report` management command renders it
+  (`--month YYYY-MM`, default current; `--json` for machine output). Estimated cost
+  stays the internal number; the Anthropic invoice is authoritative. Eval runs are
+  excluded everywhere (a quality check, not coach usage) but counted as a footnote.
+  Red→green; `test_agent_usage_report.py`. **Deferred** (Phase 3): an owner
+  dashboard, a margin-threshold alert, and reconciliation against the Anthropic
+  Admin/Usage API.


### PR DESCRIPTION
## Meso agent usage & cost tracking — Phase 2 (report)

The **read side** of the per-run usage captured in Phase 1 (PR #344). Phase 1
extended `AgentProposalBatch` (the per-run ledger) with token usage + an estimated
cost; this turns that data into an owner-facing margin report.

### What's new

**`meso/billing/agent_usage_report.py`** — `build_report(start, end)` rolls a
calendar month's **non-eval** agent runs up into:

- **Per-coach cost vs revenue → margin**, flagging any *paying* coach whose
  estimated agent cost outran their plan price (the $1/seat tail risk D13 called
  out). Free/trial coaches have $0 revenue by design, so their cost is CAC — never
  flagged.
- **Per-(coach, client) breakdown** to surface the heavy seats — a client is the
  athlete on an individual plan, or the **group** on a group plan (athlete null).
- **Roll-ups** by `model`, by `trigger`, and by **billing tier** — the COGS-vs-CAC
  split off each run's snapshot `billing_status` (active/past_due = paid, comped =
  owner/demo, else free/trial).

**`meso_agent_usage_report` management command** renders it:

```
manage.py meso_agent_usage_report                # current (local) month
manage.py meso_agent_usage_report --month 2026-06
manage.py meso_agent_usage_report --month 2026-06 --json
```

### Notes

- **Revenue** = the coach's *current* plan price (`$9.99 base + $1 × current
  billable seats`, seat line floored at 1 to mirror `stripe_gateway._seat_quantity`)
  — an approximation, since per-month historical seat counts aren't stored.
- **Estimated cost** stays the internal number; the Anthropic invoice is
  authoritative. Eval runs are excluded everywhere (a quality check, not coach
  usage) but counted as a footnote; unknown-model runs (cost `None`) are tracked
  separately, never summed as $0.
- **No model change / no migration.** The admin readout shipped in Phase 1.

### Testing

`test_agent_usage_report.py` — pure helpers (month parse/bounds, cost buckets,
revenue + seat floor), month windowing, athlete-vs-group attribution, eval
exclusion, token/cost aggregation, the unknown-model path, margin + flagging, the
tier/model/trigger roll-ups, and the command (text + `--json` + bad-month error).
Full meso suite green (1208 passing). Codex review loop: CLEAN after one fix
iteration (seat-floor revenue + local-tz default month).

Docs synced: `docs/meso/agent-usage-plan.md` (Phase 2 ✅) + `docs/meso/decisions.md`.

https://claude.ai/code/session_019A9KdsVs33wipsGjSaFWXV
