### PR TITLE
Meso agent usage Phase 3 — margin-threshold alert

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,6 +115,10 @@ MESO_VAPID_SUBJECT=mailto:you@example.com
 MESO_BASE_PRICE_ID=
 MESO_SEAT_PRICE_ID=
 MESO_STRIPE_WEBHOOK_SECRET=
+# Agent margin-alert threshold (fraction of revenue). A paying coach whose monthly
+# agent cost tops this share of their plan triggers the monthly owner email.
+# Default 0.5 (50%); blank uses the default.
+MESO_MARGIN_ALERT_THRESHOLD=0.5
 
 # --- Scout APM ------------------------------------------------------------
 # Scout APM was removed (no `scout-apm` dependency). To bring it back, re-add

--- a/app/config/settings/base.py
+++ b/app/config/settings/base.py
@@ -326,7 +326,7 @@ MESO_STRIPE_WEBHOOK_SECRET = os.environ.get("MESO_STRIPE_WEBHOOK_SECRET", "")
 # early-warning "at risk" — the monthly ``meso-agent-margin-alert`` sweep emails the
 # owner. Default 0.5 (50%); the ``meso_agent_margin_alert`` command's ``--threshold``
 # overrides it. See ``docs/meso/agent-usage-plan.md``.
-MESO_MARGIN_ALERT_THRESHOLD = os.environ.get("MESO_MARGIN_ALERT_THRESHOLD", "0.5")
+MESO_MARGIN_ALERT_THRESHOLD = os.environ.get("MESO_MARGIN_ALERT_THRESHOLD") or "0.5"
 
 # Crispy Forms
 CRISPY_ALLOWED_TEMPLATE_PACKS = ("bulma",)

--- a/app/config/settings/base.py
+++ b/app/config/settings/base.py
@@ -321,6 +321,12 @@ MESO_BASE_PRICE_ID = os.environ.get("MESO_BASE_PRICE_ID", "")
 # endpoint is registered in Stripe; the webhook view rejects unsigned/unverifiable
 # requests, so billing stays dormant (not broken) until this is set.
 MESO_STRIPE_WEBHOOK_SECRET = os.environ.get("MESO_STRIPE_WEBHOOK_SECRET", "")
+# Agent margin-alert threshold (agent-usage tracking Phase 3). A paying coach whose
+# estimated monthly agent cost exceeds this fraction of their plan revenue is an
+# early-warning "at risk" — the monthly ``meso-agent-margin-alert`` sweep emails the
+# owner. Default 0.5 (50%); the ``meso_agent_margin_alert`` command's ``--threshold``
+# overrides it. See ``docs/meso/agent-usage-plan.md``.
+MESO_MARGIN_ALERT_THRESHOLD = os.environ.get("MESO_MARGIN_ALERT_THRESHOLD", "0.5")
 
 # Crispy Forms
 CRISPY_ALLOWED_TEMPLATE_PACKS = ("bulma",)

--- a/app/store_project/meso/billing/agent_usage_report.py
+++ b/app/store_project/meso/billing/agent_usage_report.py
@@ -89,6 +89,22 @@ def current_month_bounds():
     return month_bounds(now.year, now.month)
 
 
+def previous_month_bounds():
+    """``month_bounds`` for the calendar month *before* the local current one.
+
+    The default window for the scheduled margin sweep: a monthly cron fires after a
+    month has fully closed, so it should report that closed month, not the partial
+    current one. Built off the localized now for the same boundary safety as
+    ``current_month_bounds``.
+    """
+    now = timezone.localtime(timezone.now())
+    if now.month == 1:
+        year, month = now.year - 1, 12
+    else:
+        year, month = now.year, now.month - 1
+    return month_bounds(year, month)
+
+
 def cost_bucket(billing_status):
     """Map a run's snapshot ``billing_status`` to a COGS-vs-CAC tier.
 
@@ -201,6 +217,17 @@ class CoachUsage:
         return self.revenue - self.totals.cost
 
     @property
+    def cost_to_revenue_ratio(self):
+        """Estimated agent cost as a fraction of revenue, or ``None`` when unpaid.
+
+        ``None`` (not zero/infinity) when ``revenue`` is $0 — a free/trial coach has
+        no revenue to compare against, so the ratio is undefined by design.
+        """
+        if self.revenue <= _ZERO:
+            return None
+        return self.totals.cost / self.revenue
+
+    @property
     def flagged(self):
         """A *paying* coach whose agent cost outran their revenue (the tail risk).
 
@@ -208,6 +235,17 @@ class CoachUsage:
         cost would trivially "exceed" it — that's CAC, not a margin problem.
         """
         return self.is_paid and self.totals.cost > self.revenue
+
+    def at_risk(self, threshold):
+        """Is a *paying* coach's agent cost over ``threshold`` × their revenue?
+
+        The tunable early-warning generalization of :attr:`flagged` (which is the
+        ``threshold == 1`` case — cost already past revenue). ``threshold`` is a
+        fraction (``Decimal("0.5")`` = 50%); the comparison is strict, so a coach
+        exactly at the threshold is not yet over it. Only paid coaches qualify, for
+        the same reason ``flagged`` does — $0 revenue is CAC, not a margin problem.
+        """
+        return self.is_paid and self.totals.cost > threshold * self.revenue
 
 
 @dataclass
@@ -340,3 +378,18 @@ def _bucket(mapping, key):
         totals = Totals()
         mapping[key] = totals
     return totals
+
+
+def margin_alerts(report, threshold):
+    """The report's at-risk coaches — cost over ``threshold`` × revenue, worst first.
+
+    The owner-facing early-warning subset (Phase 3): paying coaches whose estimated
+    agent cost has crossed ``threshold`` of their revenue, sorted by
+    cost-to-revenue ratio descending so the deepest margin compression leads. A
+    ``threshold`` of ``Decimal("0.5")`` flags any paying coach spending more than
+    half their plan on the agent. Free/trial coaches never appear (see
+    :meth:`CoachUsage.at_risk`).
+    """
+    alerts = [coach for coach in report.coaches if coach.at_risk(threshold)]
+    alerts.sort(key=lambda c: c.cost_to_revenue_ratio, reverse=True)
+    return alerts

--- a/app/store_project/meso/management/commands/meso_agent_margin_alert.py
+++ b/app/store_project/meso/management/commands/meso_agent_margin_alert.py
@@ -33,6 +33,10 @@ from store_project.notifications.emails import send_margin_alert_email
 
 logger = logging.getLogger(__name__)
 
+# The documented default when neither --threshold nor the setting supplies one (a
+# blank ``MESO_MARGIN_ALERT_THRESHOLD=`` env value), mirroring the settings default.
+DEFAULT_THRESHOLD = Decimal("0.5")
+
 
 class Command(BaseCommand):
     help = "Email the owner about paying coaches whose agent cost outpaces revenue."
@@ -115,11 +119,20 @@ class Command(BaseCommand):
         return start, end, start.strftime("%Y-%m")
 
     def _threshold(self, raw):
-        """Resolve the alert fraction from the flag or the setting; validate it."""
+        """Resolve the alert fraction from the flag or the setting; validate it.
+
+        A blank source — an unset flag *and* a blank ``MESO_MARGIN_ALERT_THRESHOLD``
+        env value — falls back to :data:`DEFAULT_THRESHOLD`, so a deployment that
+        leaves the env var empty still runs the sweep (honoring the documented
+        "blank uses the default") instead of erroring out of the scheduled run.
+        """
         if raw is None:
             raw = settings.MESO_MARGIN_ALERT_THRESHOLD
+        raw = str(raw).strip()
+        if not raw:
+            return DEFAULT_THRESHOLD
         try:
-            threshold = Decimal(str(raw))
+            threshold = Decimal(raw)
         except InvalidOperation as exc:
             raise CommandError(f"--threshold must be a number, got {raw!r}.") from exc
         if threshold <= 0:

--- a/app/store_project/meso/management/commands/meso_agent_margin_alert.py
+++ b/app/store_project/meso/management/commands/meso_agent_margin_alert.py
@@ -1,0 +1,127 @@
+"""Email the owner when a paying coach's agent cost is eating their margin.
+
+Agent-usage tracking Phase 3 (early warning). Phase 2's report computes each
+paying coach's cost vs revenue and a binary ``flagged`` (cost already past
+revenue). This command generalizes that to a tunable threshold (default 50% of
+revenue, ``MESO_MARGIN_ALERT_THRESHOLD``) and *pushes* the result: it builds the
+month's report, finds the at-risk paying coaches
+(``agent_usage_report.margin_alerts``), and emails the owner a summary — so a
+$1/seat tail-risk coach surfaces without anyone remembering to run a report.
+
+Free/trial coaches never alert ($0 revenue is CAC by design, not a margin
+problem). The estimated cost is the internal per-run number; the Anthropic invoice
+stays authoritative. The monthly ``meso-agent-margin-alert`` schedule runs this
+over the *previous* (closed) month via ``store_project.meso.tasks``.
+
+    manage.py meso_agent_margin_alert                       # current month
+    manage.py meso_agent_margin_alert --last-month          # the closed month (cron)
+    manage.py meso_agent_margin_alert --month 2026-06
+    manage.py meso_agent_margin_alert --threshold 0.75
+    manage.py meso_agent_margin_alert --dry-run             # report, send nothing
+"""
+
+import logging
+from decimal import Decimal
+from decimal import InvalidOperation
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.core.management.base import CommandError
+
+from store_project.meso.billing import agent_usage_report as report_mod
+from store_project.notifications.emails import send_margin_alert_email
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Email the owner about paying coaches whose agent cost outpaces revenue."
+
+    def add_arguments(self, parser):
+        window = parser.add_mutually_exclusive_group()
+        window.add_argument(
+            "--month",
+            help="Calendar month as YYYY-MM (defaults to the current month).",
+        )
+        window.add_argument(
+            "--last-month",
+            action="store_true",
+            help="Use the previous (closed) calendar month — the scheduled default.",
+        )
+        parser.add_argument(
+            "--threshold",
+            help=(
+                "Alert fraction of revenue, e.g. 0.5 for 50% "
+                "(defaults to MESO_MARGIN_ALERT_THRESHOLD)."
+            ),
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report the at-risk coaches without sending the email.",
+        )
+
+    def handle(self, *args, **options):
+        start, end, label = self._window(options)
+        threshold = self._threshold(options["threshold"])
+
+        report = report_mod.build_report(start=start, end=end)
+        alerts = report_mod.margin_alerts(report, threshold)
+
+        pct = f"{threshold * 100:.0f}"
+        self.stdout.write(
+            f"Margin alert — {label}: {len(alerts)} paying coach(es) over {pct}% "
+            f"of revenue on the agent."
+        )
+        for coach in alerts:
+            ratio_pct = f"{coach.cost_to_revenue_ratio * 100:.0f}"
+            self.stdout.write(
+                f"  {coach.label} ({coach.billing_status}): "
+                f"cost ${coach.totals.cost:.2f} of ${coach.revenue:.2f} revenue "
+                f"({ratio_pct}%) · margin ${coach.margin:.2f}"
+            )
+
+        if not alerts:
+            return
+        if options["dry_run"]:
+            self.stdout.write("Dry run — no email sent.")
+            return
+
+        try:
+            sent = send_margin_alert_email(
+                alerts=alerts, month_label=label, threshold=threshold
+            )
+        except Exception:  # best-effort: a mail failure must not fail the sweep
+            logger.exception("Margin-alert email failed for %s", label)
+            self.stderr.write(self.style.WARNING("Margin-alert email failed (logged)."))
+            return
+        if sent:
+            self.stdout.write(self.style.SUCCESS("Alert email sent to the owner."))
+        else:
+            self.stdout.write("No admin address configured — email skipped.")
+
+    def _window(self, options):
+        """Resolve the ``(start, end, label)`` window from the mutually-exclusive opts."""
+        if options["last_month"]:
+            start, end = report_mod.previous_month_bounds()
+        elif options["month"]:
+            try:
+                year, month = report_mod.parse_month(options["month"])
+            except ValueError as exc:
+                raise CommandError(str(exc)) from exc
+            start, end = report_mod.month_bounds(year, month)
+        else:
+            start, end = report_mod.current_month_bounds()
+        return start, end, start.strftime("%Y-%m")
+
+    def _threshold(self, raw):
+        """Resolve the alert fraction from the flag or the setting; validate it."""
+        if raw is None:
+            raw = settings.MESO_MARGIN_ALERT_THRESHOLD
+        try:
+            threshold = Decimal(str(raw))
+        except InvalidOperation as exc:
+            raise CommandError(f"--threshold must be a number, got {raw!r}.") from exc
+        if threshold <= 0:
+            raise CommandError("--threshold must be greater than zero.")
+        return threshold

--- a/app/store_project/meso/management/commands/meso_agent_margin_alert.py
+++ b/app/store_project/meso/management/commands/meso_agent_margin_alert.py
@@ -135,6 +135,8 @@ class Command(BaseCommand):
             threshold = Decimal(raw)
         except InvalidOperation as exc:
             raise CommandError(f"--threshold must be a number, got {raw!r}.") from exc
-        if threshold <= 0:
-            raise CommandError("--threshold must be greater than zero.")
+        # is_finite() first: it rejects Infinity/NaN, and guards the comparison
+        # below — ``Decimal("NaN") <= 0`` itself raises InvalidOperation.
+        if not threshold.is_finite() or threshold <= 0:
+            raise CommandError(f"--threshold must be a positive number, got {raw!r}.")
         return threshold

--- a/app/store_project/meso/migrations/0026_register_margin_alert_schedule.py
+++ b/app/store_project/meso/migrations/0026_register_margin_alert_schedule.py
@@ -1,0 +1,39 @@
+"""Register the monthly ``agent_margin_alert`` schedule (django-q2).
+
+The agent margin-alert sweep (agent-usage tracking Phase 3) runs **monthly** on
+the ``qcluster`` — unlike the daily invite/seat sweeps — because it summarizes a
+full closed month of agent cost vs revenue (the task reports the *previous*
+month). A versioned ``django_q.Schedule`` row that deploys with the code, like
+``0018_register_invite_schedules`` and ``0021_register_reconcile_seats_schedule``:
+no manual admin step, no box cron. Idempotent (keyed on ``name``) and reversible;
+points at the stable wrapper in ``store_project.meso.tasks``.
+"""
+
+from django.db import migrations
+
+NAME = "meso-agent-margin-alert"
+FUNC = "store_project.meso.tasks.agent_margin_alert"
+
+
+def create_schedule(apps, schema_editor):
+    Schedule = apps.get_model("django_q", "Schedule")
+    Schedule.objects.update_or_create(
+        name=NAME,
+        defaults={"func": FUNC, "schedule_type": "M"},  # Schedule.MONTHLY
+    )
+
+
+def remove_schedule(apps, schema_editor):
+    Schedule = apps.get_model("django_q", "Schedule")
+    Schedule.objects.filter(name=NAME).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("meso", "0025_agentproposalbatch_api_calls_and_more"),
+        ("django_q", "__latest__"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_schedule, remove_schedule),
+    ]

--- a/app/store_project/meso/migrations/0026_register_margin_alert_schedule.py
+++ b/app/store_project/meso/migrations/0026_register_margin_alert_schedule.py
@@ -7,19 +7,41 @@ month). A versioned ``django_q.Schedule`` row that deploys with the code, like
 ``0018_register_invite_schedules`` and ``0021_register_reconcile_seats_schedule``:
 no manual admin step, no box cron. Idempotent (keyed on ``name``) and reversible;
 points at the stable wrapper in ``store_project.meso.tasks``.
+
+Unlike the daily sweeps, this one **anchors ``next_run`` to the 1st of next
+month**. django-q defaults an unset ``next_run`` to row-creation time, which for a
+daily sweep just means "run on deploy then daily" (harmless, idempotent). For a
+*monthly* sweep that would fire mid-deploy (an unexpected owner email) and then on
+the deploy day-of-month — so a month's report could lag ~30 days. Anchoring to the
+month boundary makes each just-closed month report land at the start of the next.
 """
 
+from datetime import datetime
+
 from django.db import migrations
+from django.utils import timezone
 
 NAME = "meso-agent-margin-alert"
 FUNC = "store_project.meso.tasks.agent_margin_alert"
+
+
+def _first_of_next_month():
+    """The 1st of next month at 08:00 in the current timezone (the first fire)."""
+    now = timezone.localtime(timezone.now())
+    year, month = (now.year + 1, 1) if now.month == 12 else (now.year, now.month + 1)
+    naive = datetime(year, month, 1, 8, 0)
+    return timezone.make_aware(naive, timezone.get_current_timezone())
 
 
 def create_schedule(apps, schema_editor):
     Schedule = apps.get_model("django_q", "Schedule")
     Schedule.objects.update_or_create(
         name=NAME,
-        defaults={"func": FUNC, "schedule_type": "M"},  # Schedule.MONTHLY
+        defaults={
+            "func": FUNC,
+            "schedule_type": "M",  # Schedule.MONTHLY
+            "next_run": _first_of_next_month(),
+        },
     )
 
 

--- a/app/store_project/meso/tasks.py
+++ b/app/store_project/meso/tasks.py
@@ -30,3 +30,13 @@ def reconcile_seats():
     The daily backstop behind the inline best-effort seat sync (S6 billing Phase 2).
     """
     call_command("meso_reconcile_seats")
+
+
+def agent_margin_alert():
+    """Email the owner about paying coaches over the agent margin threshold.
+
+    The monthly margin-alert sweep (agent-usage tracking Phase 3). Runs over the
+    *previous* (closed) calendar month so the report covers a full month, not the
+    partial current one (``meso_agent_margin_alert --last-month``).
+    """
+    call_command("meso_agent_margin_alert", "--last-month")

--- a/app/store_project/meso/tests/test_agent_margin_alert.py
+++ b/app/store_project/meso/tests/test_agent_margin_alert.py
@@ -257,6 +257,17 @@ class TestCommand:
             call_command("meso_agent_margin_alert", "--month", "2026-06")
         assert mail.outbox == []  # default raised above the run's ratio
 
+    def test_blank_setting_falls_back_to_default_not_error(self):
+        # A blank MESO_MARGIN_ALERT_THRESHOLD= env value must not crash the
+        # scheduled run — it falls back to the documented 0.5 default.
+        start, _ = report_mod.month_bounds(2026, 6)
+        coach = _paid_at_risk_run(start, cost="6.00")  # ratio ~0.55 > 0.5
+
+        with override_settings(MESO_MARGIN_ALERT_THRESHOLD=""):
+            call_command("meso_agent_margin_alert", "--month", "2026-06")
+        assert len(mail.outbox) == 1
+        assert coach.display_name() in mail.outbox[0].body
+
     def test_last_month_window(self):
         prev_start, _ = report_mod.previous_month_bounds()
         coach = _paid_at_risk_run(prev_start)

--- a/app/store_project/meso/tests/test_agent_margin_alert.py
+++ b/app/store_project/meso/tests/test_agent_margin_alert.py
@@ -1,0 +1,278 @@
+"""The agent margin-threshold alert (agent-usage tracking v2, Phase 3).
+
+Phase 2 (``build_report``) computes each paying coach's cost vs revenue and a
+binary ``flagged`` (cost already exceeds revenue — margin gone negative). This is
+the **early-warning** layer: a tunable threshold (default 50% of revenue) plus a
+proactive owner email and a monthly ``qcluster`` sweep, so a coach whose agent
+cost is *eating into* — not yet exceeding — their plan surfaces before the month
+closes. Covers the pure ``at_risk`` / ``cost_to_revenue_ratio`` / ``margin_alerts``
+logic, the previous-month window, the owner email, and the management command.
+See ``docs/meso/agent-usage-plan.md``.
+"""
+
+from datetime import timedelta
+from decimal import Decimal
+from io import StringIO
+
+import pytest
+from django.core import mail
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import override_settings
+
+from store_project.meso.billing import agent_usage_report as report_mod
+from store_project.meso.factories import AgentProposalBatchFactory
+from store_project.meso.factories import CoachSubscriptionFactory
+from store_project.meso.factories import PlanFactory
+from store_project.meso.models import AgentProposalBatch
+from store_project.meso.models import CoachSubscription
+from store_project.notifications import emails
+
+pytestmark = pytest.mark.django_db
+
+
+def _at(when, **kw):
+    """Build a batch then stamp its auto-add ``created_at`` to ``when``."""
+    batch = AgentProposalBatchFactory(**kw)
+    AgentProposalBatch.objects.filter(pk=batch.pk).update(created_at=when)
+    batch.refresh_from_db()
+    return batch
+
+
+def _coach_usage(*, cost, revenue, is_paid=True, label="Coach", runs=1):
+    """A bare :class:`CoachUsage` for the pure-logic and email tests (no DB)."""
+    totals = report_mod.Totals()
+    totals.runs = runs
+    totals.cost = Decimal(cost)
+    return report_mod.CoachUsage(
+        coach_id="x",
+        label=label,
+        billing_status=CoachSubscription.Status.ACTIVE if is_paid else "free",
+        is_paid=is_paid,
+        billable_seats=1,
+        revenue=Decimal(revenue),
+        totals=totals,
+        clients=[],
+    )
+
+
+def _paid_at_risk_run(start, *, cost="6.00"):
+    """An active paid coach with one in-window run whose cost is >50% of revenue.
+
+    Revenue is base $9.99 + one seat = $10.99, so a $6.00 run trips the default
+    50% threshold (ratio ~0.55) without yet exceeding revenue (so it is *at risk*
+    but not ``flagged``).
+    """
+    sub = CoachSubscriptionFactory(status=CoachSubscription.Status.ACTIVE)
+    coach = sub.coach
+    plan = PlanFactory(relationship__coach=coach)
+    _at(
+        start + timedelta(days=1),
+        plan=plan,
+        coach=coach,
+        billing_status=CoachSubscription.Status.ACTIVE,
+        estimated_cost_usd=Decimal(cost),
+    )
+    return coach
+
+
+# --- pure logic: ratio / at_risk / margin_alerts --------------------------
+
+
+class TestRatioAndAtRisk:
+    def test_ratio_is_cost_over_revenue(self):
+        c = _coach_usage(cost="5.00", revenue="10.00")
+        assert c.cost_to_revenue_ratio == Decimal("0.5")
+
+    def test_ratio_is_none_when_no_revenue(self):
+        c = _coach_usage(cost="5.00", revenue="0", is_paid=False)
+        assert c.cost_to_revenue_ratio is None
+
+    def test_at_risk_when_cost_exceeds_threshold_fraction(self):
+        c = _coach_usage(cost="6.00", revenue="10.00")
+        assert c.at_risk(Decimal("0.5")) is True
+
+    def test_not_at_risk_below_threshold(self):
+        c = _coach_usage(cost="4.00", revenue="10.00")
+        assert c.at_risk(Decimal("0.5")) is False
+
+    def test_threshold_boundary_is_strict(self):
+        # Exactly at the threshold is not "over" it.
+        c = _coach_usage(cost="5.00", revenue="10.00")
+        assert c.at_risk(Decimal("0.5")) is False
+
+    def test_free_coach_is_never_at_risk(self):
+        # $0 revenue by design — cost is CAC, not a margin problem (mirrors flagged).
+        c = _coach_usage(cost="100.00", revenue="0", is_paid=False)
+        assert c.at_risk(Decimal("0.5")) is False
+
+    def test_at_risk_generalizes_flagged_at_one(self):
+        # flagged == cost > revenue == at_risk(1).
+        c = _coach_usage(cost="11.00", revenue="10.00")
+        assert c.flagged is True
+        assert c.at_risk(Decimal("1")) is True
+
+
+class TestMarginAlerts:
+    def test_collects_only_at_risk_coaches_sorted_by_ratio(self):
+        worst = _coach_usage(cost="9.00", revenue="10.00", label="Worst")  # 0.90
+        mild = _coach_usage(cost="6.00", revenue="10.00", label="Mild")  # 0.60
+        safe = _coach_usage(cost="1.00", revenue="10.00", label="Safe")  # 0.10
+        report = report_mod.Report(
+            start=None,
+            end=None,
+            coaches=[mild, safe, worst],
+            by_model={},
+            by_trigger={},
+            by_tier={},
+            totals=report_mod.Totals(),
+            eval_runs_excluded=0,
+        )
+        alerts = report_mod.margin_alerts(report, Decimal("0.5"))
+        assert [c.label for c in alerts] == ["Worst", "Mild"]
+
+    def test_higher_threshold_shrinks_the_set(self):
+        coach = _coach_usage(cost="7.00", revenue="10.00")  # 0.70
+        report = report_mod.Report(
+            start=None,
+            end=None,
+            coaches=[coach],
+            by_model={},
+            by_trigger={},
+            by_tier={},
+            totals=report_mod.Totals(),
+            eval_runs_excluded=0,
+        )
+        assert report_mod.margin_alerts(report, Decimal("0.5")) == [coach]
+        assert report_mod.margin_alerts(report, Decimal("0.9")) == []
+
+
+# --- previous-month window ------------------------------------------------
+
+
+class TestPreviousMonthBounds:
+    def test_previous_month_is_the_month_before_current(self):
+        from django.utils import timezone
+
+        now = timezone.localtime(timezone.now())
+        year, month = (
+            (now.year - 1, 12) if now.month == 1 else (now.year, now.month - 1)
+        )
+        assert report_mod.previous_month_bounds() == report_mod.month_bounds(
+            year, month
+        )
+
+    def test_previous_month_is_disjoint_and_earlier_than_current(self):
+        prev_start, prev_end = report_mod.previous_month_bounds()
+        cur_start, _ = report_mod.current_month_bounds()
+        assert prev_end == cur_start
+        assert prev_start < prev_end
+
+
+# --- the owner email ------------------------------------------------------
+
+
+class TestMarginAlertEmail:
+    def test_emails_admins_with_coach_and_threshold(self):
+        alerts = [_coach_usage(cost="6.00", revenue="10.99", label="Risky Rita")]
+        sent = emails.send_margin_alert_email(
+            alerts=alerts, month_label="2026-06", threshold=Decimal("0.5")
+        )
+        assert sent is True
+        assert len(mail.outbox) == 1
+        msg = mail.outbox[0]
+        assert msg.to == ["lance@lancegoyke.com"]  # settings.ADMINS
+        body = msg.body
+        assert "Risky Rita" in body
+        assert "2026-06" in body
+        assert "50%" in body
+
+    def test_no_email_when_no_alerts(self):
+        sent = emails.send_margin_alert_email(
+            alerts=[], month_label="2026-06", threshold=Decimal("0.5")
+        )
+        assert sent is False
+        assert mail.outbox == []
+
+
+# --- management command ---------------------------------------------------
+
+
+class TestCommand:
+    def test_sends_alert_for_at_risk_paid_coach(self):
+        start, _ = report_mod.month_bounds(2026, 6)
+        coach = _paid_at_risk_run(start)
+
+        out = StringIO()
+        call_command("meso_agent_margin_alert", "--month", "2026-06", stdout=out)
+
+        assert len(mail.outbox) == 1
+        assert mail.outbox[0].to == ["lance@lancegoyke.com"]
+        body = out.getvalue()
+        assert coach.display_name() in body
+        assert "1" in body  # one coach at risk
+
+    def test_dry_run_reports_but_sends_nothing(self):
+        start, _ = report_mod.month_bounds(2026, 6)
+        coach = _paid_at_risk_run(start)
+
+        out = StringIO()
+        call_command(
+            "meso_agent_margin_alert", "--month", "2026-06", "--dry-run", stdout=out
+        )
+
+        assert mail.outbox == []
+        assert coach.display_name() in out.getvalue()
+
+    def test_no_alert_when_all_within_threshold(self):
+        start, _ = report_mod.month_bounds(2026, 6)
+        _paid_at_risk_run(start, cost="0.10")  # ratio ~0.009 — safe
+
+        out = StringIO()
+        call_command("meso_agent_margin_alert", "--month", "2026-06", stdout=out)
+
+        assert mail.outbox == []
+        assert "0" in out.getvalue()
+
+    def test_threshold_override_changes_the_set(self):
+        start, _ = report_mod.month_bounds(2026, 6)
+        _paid_at_risk_run(start, cost="7.70")  # ratio ~0.70 of $10.99
+
+        out = StringIO()
+        call_command(
+            "meso_agent_margin_alert",
+            "--month",
+            "2026-06",
+            "--threshold",
+            "0.9",
+            stdout=out,
+        )
+        assert mail.outbox == []  # 0.70 < 0.90
+
+    def test_setting_supplies_the_default_threshold(self):
+        start, _ = report_mod.month_bounds(2026, 6)
+        _paid_at_risk_run(start, cost="6.00")  # ratio ~0.55
+
+        with override_settings(MESO_MARGIN_ALERT_THRESHOLD="0.9"):
+            call_command("meso_agent_margin_alert", "--month", "2026-06")
+        assert mail.outbox == []  # default raised above the run's ratio
+
+    def test_last_month_window(self):
+        prev_start, _ = report_mod.previous_month_bounds()
+        coach = _paid_at_risk_run(prev_start)
+
+        call_command("meso_agent_margin_alert", "--last-month")
+        assert len(mail.outbox) == 1
+        assert coach.display_name() in mail.outbox[0].body
+
+    def test_bad_month_raises_command_error(self):
+        with pytest.raises(CommandError):
+            call_command("meso_agent_margin_alert", "--month", "nonsense")
+
+    def test_bad_threshold_raises_command_error(self):
+        with pytest.raises(CommandError):
+            call_command("meso_agent_margin_alert", "--threshold", "abc")
+
+    def test_nonpositive_threshold_raises_command_error(self):
+        with pytest.raises(CommandError):
+            call_command("meso_agent_margin_alert", "--threshold", "0")

--- a/app/store_project/meso/tests/test_agent_margin_alert.py
+++ b/app/store_project/meso/tests/test_agent_margin_alert.py
@@ -287,3 +287,10 @@ class TestCommand:
     def test_nonpositive_threshold_raises_command_error(self):
         with pytest.raises(CommandError):
             call_command("meso_agent_margin_alert", "--threshold", "0")
+
+    @pytest.mark.parametrize("bad", ["Infinity", "NaN", "-1"])
+    def test_non_finite_or_negative_threshold_raises_command_error(self, bad):
+        # Decimal() accepts Infinity/NaN; a non-finite threshold would silently
+        # suppress every alert (cost > Infinity) or crash the <= comparison (NaN).
+        with pytest.raises(CommandError):
+            call_command("meso_agent_margin_alert", "--threshold", bad)

--- a/app/store_project/meso/tests/test_scheduler.py
+++ b/app/store_project/meso/tests/test_scheduler.py
@@ -122,6 +122,14 @@ class TestMarginAlertScheduleRegistration:
         assert sched.func == self.FUNC
         assert sched.schedule_type == Schedule.MONTHLY
 
+    def test_margin_alert_schedule_anchored_to_month_boundary(self):
+        # Anchored to the 1st of a month in the future, so it doesn't fire on
+        # deploy (a surprise owner email) or lag a month behind the deploy day.
+        sched = Schedule.objects.get(name=self.NAME)
+        assert sched.next_run is not None
+        assert timezone.localtime(sched.next_run).day == 1  # local month boundary
+        assert sched.next_run > timezone.now()
+
     def test_margin_alert_func_is_importable_callable(self):
         module_path, _, attr = self.FUNC.rpartition(".")
         resolved = getattr(importlib.import_module(module_path), attr)

--- a/app/store_project/meso/tests/test_scheduler.py
+++ b/app/store_project/meso/tests/test_scheduler.py
@@ -17,6 +17,7 @@ under ``Q_CLUSTER["sync"]``); we test the unit of work and its registration.
 
 import importlib
 from datetime import timedelta
+from decimal import Decimal
 
 import pytest
 from django.core import mail
@@ -24,7 +25,13 @@ from django.utils import timezone
 from django_q.models import Schedule
 
 from store_project.meso import tasks
+from store_project.meso.billing import agent_usage_report as report_mod
+from store_project.meso.factories import AgentProposalBatchFactory
+from store_project.meso.factories import CoachSubscriptionFactory
+from store_project.meso.factories import PlanFactory
+from store_project.meso.models import AgentProposalBatch
 from store_project.meso.models import CoachInvite
+from store_project.meso.models import CoachSubscription
 from store_project.users.factories import UserFactory
 
 pytestmark = pytest.mark.django_db
@@ -55,6 +62,33 @@ class TestInviteTasks:
         assert mail.outbox[0].to == ["ath@example.com"]
 
 
+# -- the margin-alert task runs over the previous month --------------------
+
+
+class TestMarginAlertTask:
+    def test_margin_alert_task_emails_owner_for_last_month_risk(self):
+        """The wrapper reports the *previous* month and alerts the owner."""
+        prev_start, _ = report_mod.previous_month_bounds()
+        sub = CoachSubscriptionFactory(status=CoachSubscription.Status.ACTIVE)
+        coach = sub.coach
+        plan = PlanFactory(relationship__coach=coach)
+        batch = AgentProposalBatchFactory(
+            plan=plan,
+            coach=coach,
+            billing_status=CoachSubscription.Status.ACTIVE,
+            estimated_cost_usd=Decimal("9.00"),  # > revenue ($10.99) fraction
+        )
+        AgentProposalBatch.objects.filter(pk=batch.pk).update(
+            created_at=prev_start + timedelta(days=1)
+        )
+
+        tasks.agent_margin_alert()
+
+        assert len(mail.outbox) == 1
+        assert mail.outbox[0].to == ["lance@lancegoyke.com"]
+        assert coach.display_name() in mail.outbox[0].body
+
+
 # -- the registered schedules ----------------------------------------------
 
 
@@ -77,3 +111,18 @@ class TestScheduleRegistration:
             module_path, _, attr = func.rpartition(".")
             resolved = getattr(importlib.import_module(module_path), attr)
             assert callable(resolved)
+
+
+class TestMarginAlertScheduleRegistration:
+    NAME = "meso-agent-margin-alert"
+    FUNC = "store_project.meso.tasks.agent_margin_alert"
+
+    def test_margin_alert_schedule_registered_monthly(self):
+        sched = Schedule.objects.get(name=self.NAME)
+        assert sched.func == self.FUNC
+        assert sched.schedule_type == Schedule.MONTHLY
+
+    def test_margin_alert_func_is_importable_callable(self):
+        module_path, _, attr = self.FUNC.rpartition(".")
+        resolved = getattr(importlib.import_module(module_path), attr)
+        assert callable(resolved)

--- a/app/store_project/notifications/emails.py
+++ b/app/store_project/notifications/emails.py
@@ -173,6 +173,67 @@ def send_coach_request_email(*, athlete, coach, roster_url) -> bool:
     return True
 
 
+def send_margin_alert_email(*, alerts, month_label, threshold) -> bool:
+    """Email the owner that paying coaches' agent cost is eating their margin.
+
+    Meso agent-usage tracking Phase 3: the monthly ``meso-agent-margin-alert``
+    sweep finds paying coaches whose estimated agent cost has crossed a fraction of
+    their plan revenue (``meso/billing/agent_usage_report.margin_alerts``) and
+    sends this internal, owner-facing summary so the $1/seat tail risk surfaces
+    before the month closes. The recipients are ``settings.ADMINS`` (the owner),
+    not a coach — this is operational, not customer-facing.
+
+    Args:
+        alerts: the at-risk ``CoachUsage`` rows (worst cost-to-revenue ratio
+            first), each carrying its label, revenue, totals, and margin.
+        month_label: the report month, e.g. ``"2026-06"`` (subject + body).
+        threshold: the alert fraction as a ``Decimal`` (``0.5`` renders "50%").
+
+    Returns:
+        ``True`` if a message was sent, ``False`` if skipped because there were no
+        alerts or no admin address to send to.
+
+    Raises a mail backend exception (``fail_silently=False``); callers that must
+    not fail a scheduled sweep on a bounced email should treat this as best-effort.
+    """
+    recipients = [email for _name, email in settings.ADMINS if email]
+    if not alerts or not recipients:
+        return False
+    rows = [
+        {
+            "label": coach.label,
+            "billing_status": coach.billing_status,
+            "seats": coach.billable_seats,
+            "runs": coach.totals.runs,
+            "cost": f"{coach.totals.cost:.2f}",
+            "revenue": f"{coach.revenue:.2f}",
+            "margin": f"{coach.margin:.2f}",
+            "ratio_pct": f"{coach.cost_to_revenue_ratio * 100:.0f}",
+        }
+        for coach in alerts
+    ]
+    context = {
+        "rows": rows,
+        "count": len(rows),
+        "month_label": month_label,
+        "threshold_pct": f"{threshold * 100:.0f}",
+    }
+    subject = render_to_string(
+        "notifications/margin_alert_subject.txt", context
+    ).strip()
+    msg_plain = render_to_string("notifications/margin_alert.md", context)
+    msg_html = render_to_string("notifications/margin_alert.html", context)
+    send_mail(
+        subject=subject,
+        message=msg_plain,
+        html_message=msg_html,
+        from_email=settings.SERVER_EMAIL,  # the robot, not the owner's own address
+        recipient_list=recipients,
+        fail_silently=False,
+    )
+    return True
+
+
 def send_week_delivered_email(
     *, athlete, coach, plan, week, home_url, unsubscribe_url=None
 ) -> bool:

--- a/app/store_project/templates/notifications/margin_alert.html
+++ b/app/store_project/templates/notifications/margin_alert.html
@@ -1,0 +1,24 @@
+<p>Heads up — for <strong>{{ month_label }}</strong>, {{ count }} paying
+  coach{{ count|pluralize:",es" }} spent more than {{ threshold_pct }}% of their
+  plan revenue on the AI agent:</p>
+
+<ul>
+  {% for row in rows %}
+    <li>
+      <strong>{{ row.label }}</strong> ({{ row.billing_status }},
+      {{ row.seats }} seat{{ row.seats|pluralize }}):
+      {{ row.runs }} run{{ row.runs|pluralize }} · cost ${{ row.cost }} of
+      ${{ row.revenue }} revenue ({{ row.ratio_pct }}%) · margin ${{ row.margin }}
+    </li>
+  {% endfor %}
+</ul>
+
+<p>Estimated cost is the internal per-run estimate; the Anthropic invoice is
+  authoritative. Run
+  <code>manage.py meso_agent_usage_report --month {{ month_label }}</code> for the
+  full per-coach and per-client breakdown.</p>
+
+<p>If margin keeps compressing, the two levers are dropping
+  <code>MESO_AGENT_MODEL</code> to a cheaper tier or metering paid agent runs.</p>
+
+<p>Mastering Fitness</p>

--- a/app/store_project/templates/notifications/margin_alert.md
+++ b/app/store_project/templates/notifications/margin_alert.md
@@ -1,0 +1,15 @@
+Heads up — for {{ month_label }}, {{ count }} paying coach{{ count|pluralize:",es" }}
+spent more than {{ threshold_pct }}% of their plan revenue on the AI agent:
+{% for row in rows %}
+  - {{ row.label }} ({{ row.billing_status }}, {{ row.seats }} seat{{ row.seats|pluralize }}):
+  {{ row.runs }} run{{ row.runs|pluralize }} · cost ${{ row.cost }} of ${{ row.revenue }} revenue
+  ({{ row.ratio_pct }}%) · margin ${{ row.margin }}
+{% endfor %}
+Estimated cost is the internal per-run estimate; the Anthropic invoice is
+authoritative. Run `manage.py meso_agent_usage_report --month {{ month_label }}` for
+the full per-coach and per-client breakdown.
+
+If margin keeps compressing, the two levers are dropping MESO_AGENT_MODEL to a
+cheaper tier or metering paid agent runs.
+
+Mastering Fitness

--- a/app/store_project/templates/notifications/margin_alert_subject.txt
+++ b/app/store_project/templates/notifications/margin_alert_subject.txt
@@ -1,0 +1,1 @@
+Meso margin alert: {{ count }} coach{{ count|pluralize:",es" }} over {{ threshold_pct }}% for {{ month_label }}

--- a/docs/meso/agent-usage-plan.md
+++ b/docs/meso/agent-usage-plan.md
@@ -1,6 +1,6 @@
 # Meso — agent usage & cost tracking
 
-**Status:** 🟢 Phase 1 (capture) shipped · 🟢 Phase 2 (report) shipped · started 2026-06-30
+**Status:** 🟢 Phase 1 (capture) shipped · 🟢 Phase 2 (report) shipped · 🟢 Phase 3 (margin alert) shipped · started 2026-06-30
 **Context:** Billing launches at **$9.99/mo base + $1/mo per active seat** (D13 in
 [`billing-plan.md`](./billing-plan.md)). The **AI agent is the cost-bearing
 feature** — every proposal run is a Claude API call. To confirm the $1/seat
@@ -156,9 +156,29 @@ def estimate_cost(model, usage) -> Decimal:
    as `unknown_cost_runs`, never summed as $0. The admin readout shipped in Phase 1.
    Tests: `test_agent_usage_report.py` (helpers, month window, attribution, eval
    exclusion, aggregation, margin/flagging, tier/model/trigger roll-ups, the command).
-3. *(Deferred)* dashboard; a margin-threshold alert (e.g. flag when a coach's
-   monthly agent cost exceeds a set fraction of their revenue); a reconciliation
-   job against the Anthropic Admin/Usage API.
+3. **Margin alert — ✅ DONE (migration `0026`, schedule-only; no Stripe).** The
+   early-warning push on top of Phase 2's passive report. `CoachUsage` gained
+   `cost_to_revenue_ratio` (`None` when revenue is $0) and `at_risk(threshold)` —
+   a *paying* coach whose estimated agent cost crossed `threshold × revenue`
+   (strict; `flagged` is the `threshold == 1` case it generalizes). A new
+   `agent_usage_report.margin_alerts(report, threshold)` collects the at-risk
+   coaches worst-ratio-first, and `previous_month_bounds()` gives the closed-month
+   window for the cron. `notifications/emails.send_margin_alert_email` emails the
+   owner (`settings.ADMINS`, from the `SERVER_EMAIL` robot) a summary; sent only
+   when there are alerts and an admin address. The `meso_agent_margin_alert`
+   command (`--month` / `--last-month` / `--threshold` / `--dry-run`) builds the
+   month, finds the at-risk coaches, prints them, and sends the email best-effort
+   (a mail failure is logged, never fails the run). The default threshold is
+   `MESO_MARGIN_ALERT_THRESHOLD` (0.5). `tasks.agent_margin_alert` wraps it with
+   `--last-month`; migration `0026` registers a **monthly** `django_q.Schedule`
+   (`schedule_type="M"`) pointing at it — the first non-daily Meso sweep. Free/
+   trial coaches never alert ($0 revenue is CAC by design). Tests:
+   `test_agent_margin_alert.py` (ratio/at-risk/margin_alerts pure logic, the
+   previous-month window, the owner email, the command across windows/thresholds/
+   dry-run/validation) + `test_scheduler.py` (the monthly registration + the task
+   wrapper over the previous month).
+4. *(Deferred)* an owner **dashboard**; a reconciliation job against the Anthropic
+   Admin/Usage API (sanity-check our estimate vs the invoice).
 
 This should land **before or with billing go-live** so the very first paid month
 produces real margin data — but it's independent of the Stripe wiring, so it can
@@ -184,8 +204,9 @@ this tracking is what tells us **whether** to pull either:
 ## Open values
 
 - **Rate table** — current Anthropic pricing (above); update on price changes.
-- **Margin-alert threshold** — e.g. flag a coach when monthly agent cost > 50%
-  of their revenue. (Phase 3, deferred.)
+- **Margin-alert threshold** — flag a coach when monthly agent cost > 50% of
+  their revenue. **Decided & shipped (Phase 3):** default `0.5` via
+  `MESO_MARGIN_ALERT_THRESHOLD`, per-run overridable with `--threshold`.
 
 ## Testing
 

--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -1033,3 +1033,33 @@ _(Append dated entries here as decisions land.)_
   Red→green; `test_agent_usage_report.py`. **Deferred** (Phase 3): an owner
   dashboard, a margin-threshold alert, and reconciliation against the Anthropic
   Admin/Usage API.
+- 2026-06-30 — **Agent usage tracking Phase 3 (margin alert) built** (migration
+  `0026`, schedule-only — no Stripe). The early-warning push on top of Phase 2's
+  passive report: instead of the owner remembering to run a report, the app
+  proactively emails them when a *paying* coach's estimated agent cost crosses a
+  fraction of their plan revenue. `CoachUsage` gained `cost_to_revenue_ratio`
+  (`None` at $0 revenue) and `at_risk(threshold)` — a paying coach with
+  `cost > threshold × revenue` (strict; it generalizes `flagged`, the
+  `threshold == 1` / cost-already-past-revenue case). `agent_usage_report`
+  gained `margin_alerts(report, threshold)` (at-risk coaches, worst ratio first)
+  and `previous_month_bounds()` (the closed-month window for the cron).
+  `notifications/emails.send_margin_alert_email` emails the owner
+  (`settings.ADMINS`, from the `SERVER_EMAIL` robot) — operational, not
+  customer-facing — only when there are alerts and an admin address. The
+  `meso_agent_margin_alert` command (`--month` / `--last-month` / `--threshold` /
+  `--dry-run`) builds the month, lists the at-risk coaches, and sends the email
+  best-effort (a mail failure is logged, never crashes the sweep). Default
+  threshold = `MESO_MARGIN_ALERT_THRESHOLD` (0.5, overridable per run).
+  `tasks.agent_margin_alert` wraps the command with `--last-month`; migration
+  `0026` registers a **monthly** `django_q.Schedule` (`schedule_type="M"`) at it —
+  the first non-daily Meso sweep (a monthly cron summarizes a full closed month,
+  not the partial current one). Free/trial coaches never alert ($0 revenue is CAC
+  by design — same rule as `flagged`). Red→green: `test_agent_margin_alert.py`
+  (pure ratio/at-risk/margin_alerts, previous-month window, owner email, command
+  across windows/thresholds/dry-run/validation) + `test_scheduler.py` (monthly
+  registration + the task wrapper over the previous month). The two billing
+  pressure valves it informs (drop `MESO_AGENT_MODEL` / meter paid runs) stay
+  deferred — gated on what the data shows. **Remaining agent-usage backlog:** an
+  owner dashboard + Anthropic Admin/Usage-API reconciliation (both deferred);
+  remaining Meso backlog otherwise: billing annual prices (blocked on the owner's
+  annual numbers) + the group agent (LARGE owner-decision).


### PR DESCRIPTION
## What & why

Agent-usage tracking **Phase 3** — the early-warning push on top of Phase 2's
passive usage report. Billing launches at \$9.99/mo + \$1/active seat (D13); the AI
agent is the cost-bearing feature, so a power-user coach could quietly eat their
margin. Phase 2 computes per-coach cost vs revenue and a binary \`flagged\` (cost
already past revenue), but you have to *run a report* to see it. This phase makes
it **proactive**: the app emails the owner when a **paying** coach's estimated
monthly agent cost crosses a configurable fraction (default **50%**) of their
plan revenue — catching the tail risk before the month closes.

No Stripe. Migration `0026` is schedule-only (no schema change).

## Changes

- **`agent_usage_report`** — `CoachUsage.cost_to_revenue_ratio` (None at \$0
  revenue) + `at_risk(threshold)` (paying coach, `cost > threshold × revenue`,
  strict — it generalizes `flagged`, the `threshold == 1` case); module
  `margin_alerts(report, threshold)` (at-risk coaches, worst ratio first);
  `previous_month_bounds()` for the closed-month cron window.
- **`notifications.send_margin_alert_email`** → `settings.ADMINS` (owner-facing,
  from the `SERVER_EMAIL` robot); sent only when there are alerts and an admin
  address. New `margin_alert` subject/`.md`/`.html` templates.
- **`meso_agent_margin_alert`** command — `--month` / `--last-month` /
  `--threshold` / `--dry-run`; best-effort send (a mail failure is logged, never
  fails the sweep).
- **`MESO_MARGIN_ALERT_THRESHOLD`** setting (0.5) + `.env.example`; a blank value
  falls back to the default, and non-finite/non-positive thresholds are rejected.
- **`tasks.agent_margin_alert`** wraps the command with `--last-month`; migration
  `0026` registers a **monthly** `django_q.Schedule` (the first non-daily Meso
  sweep), **anchored to the 1st of next month** so it doesn't fire mid-deploy or
  lag a month behind the deploy day.

Free/trial coaches never alert (\$0 revenue is CAC by design — same rule as
`flagged`).

## Tests

Red→green: `test_agent_margin_alert.py` (ratio/at-risk/`margin_alerts` pure
logic, the previous-month window, the owner email, the command across
windows/thresholds/dry-run/blank-default/non-finite validation) +
`test_scheduler.py` (monthly registration, month-boundary anchoring, the task
wrapper over the previous month). Full meso + notifications suite green (1238);
ruff + DjHTML + `makemigrations --check` clean.

## Review

**Codex review loop: CLEAN after 3 fix iterations** — blank-threshold default
(P2), non-finite threshold rejection (P3), monthly-schedule anchoring (P2).

Docs synced in-PR (`agent-usage-plan.md` Phase 3 + `decisions.md`).

https://claude.ai/code/session_019A9KdsVs33wipsGjSaFWXV