### PR TITLE
Meso agent usage Phase 4 — owner usage dashboard

### DIFF
--- a/app/store_project/meso/billing/agent_usage_report.py
+++ b/app/store_project/meso/billing/agent_usage_report.py
@@ -23,7 +23,9 @@ from dataclasses import dataclass
 from dataclasses import field
 from datetime import datetime
 from decimal import Decimal
+from decimal import InvalidOperation
 
+from django.conf import settings
 from django.db.models import Count
 from django.utils import timezone
 
@@ -38,6 +40,12 @@ BASE_PRICE_USD = Decimal("9.99")
 SEAT_PRICE_USD = Decimal("1.00")
 
 _ZERO = Decimal("0")
+
+# The margin-alert threshold the dashboard/sweep fall back to when neither a
+# per-run override nor ``MESO_MARGIN_ALERT_THRESHOLD`` supplies one — mirroring the
+# settings default (and the command's ``DEFAULT_THRESHOLD``). A paying coach whose
+# agent cost crosses this fraction of revenue is "at risk" (see ``margin_alerts``).
+DEFAULT_ALERT_THRESHOLD = Decimal("0.5")
 
 # Billing-tier buckets for the COGS-vs-CAC split (off each run's snapshot status).
 PAID = "paid"  # a real Stripe subscription — agent cost is COGS against revenue
@@ -75,6 +83,41 @@ def month_bounds(year, month):
         end_naive = datetime(year, month + 1, 1)
     tz = timezone.get_current_timezone()
     return timezone.make_aware(start_naive, tz), timezone.make_aware(end_naive, tz)
+
+
+def shift_month(year, month, step):
+    """``(year, month)`` shifted by ``step`` whole months (negative steps back).
+
+    Pure month arithmetic for the dashboard's prev/next navigation — rolls over a
+    year boundary in either direction (``shift_month(2026, 12, 1) == (2027, 1)``).
+    """
+    index = year * 12 + (month - 1) + step
+    return index // 12, index % 12 + 1
+
+
+def resolve_alert_threshold(raw=None):
+    """The margin-alert fraction from ``raw`` or the setting; never raises.
+
+    The dashboard variant of the command's ``_threshold`` validation: ``raw`` (or,
+    when ``None``, ``settings.MESO_MARGIN_ALERT_THRESHOLD``) is parsed to a positive,
+    finite ``Decimal``; anything blank/malformed/non-positive degrades to
+    :data:`DEFAULT_ALERT_THRESHOLD`. Unlike the command it returns the default
+    rather than erroring, so a misconfigured env value can never 500 the page.
+    """
+    if raw is None:
+        raw = getattr(settings, "MESO_MARGIN_ALERT_THRESHOLD", "")
+    raw = str(raw).strip()
+    if not raw:
+        return DEFAULT_ALERT_THRESHOLD
+    try:
+        value = Decimal(raw)
+    except InvalidOperation:
+        return DEFAULT_ALERT_THRESHOLD
+    # is_finite() first: it rejects Infinity/NaN and guards the comparison (a NaN
+    # comparison itself raises InvalidOperation).
+    if not value.is_finite() or value <= _ZERO:
+        return DEFAULT_ALERT_THRESHOLD
+    return value
 
 
 def current_month_bounds():
@@ -378,6 +421,18 @@ def _bucket(mapping, key):
         totals = Totals()
         mapping[key] = totals
     return totals
+
+
+def sorted_totals(mapping):
+    """A roll-up dict (``by_model``/``by_trigger``/``by_tier``) as cost-sorted pairs.
+
+    Returns ``(key, Totals)`` tuples ordered by estimated cost then run count,
+    descending — the heaviest bucket first — for the dashboard and the command's
+    roll-up tables to render without re-sorting.
+    """
+    return sorted(
+        mapping.items(), key=lambda kv: (kv[1].cost, kv[1].runs), reverse=True
+    )
 
 
 def margin_alerts(report, threshold):

--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -15,6 +15,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from .billing import access as billing_access
+from .billing import agent_usage_report
 from .models import CoachAthlete
 from .models import CoachInvite
 from .models import CoachSubscription
@@ -875,4 +876,40 @@ def athlete_log_payload(session_ctx):
             }
             for e in session_ctx["exercises"]
         ],
+    }
+
+
+def _pct_label(threshold):
+    """A fraction (``Decimal("0.5")``) as a whole-percent string (``"50"``).
+
+    ``normalize`` strips the trailing zeros a ``×100`` leaves; the ``:f`` format
+    keeps it out of scientific notation (``5E+1`` → ``"50"``).
+    """
+    return f"{(threshold * 100).normalize():f}"
+
+
+def usage_dashboard(report, *, threshold):
+    """Adapt a usage :class:`Report` into the owner dashboard's template context.
+
+    The owner-facing read surface (agent-usage Phase 4). Reuses the report's own
+    objects (``coaches``/``totals`` carry their cost/revenue/margin properties) and
+    adds: a ``YYYY-MM`` month label with prev/next links for navigation, the
+    margin-alert subset (paying coaches over ``threshold`` × revenue), and the
+    roll-ups pre-sorted by cost. ``threshold`` is the alert fraction (see
+    ``agent_usage_report.resolve_alert_threshold``).
+    """
+    year, month = report.start.year, report.start.month
+    prev_year, prev_month = agent_usage_report.shift_month(year, month, -1)
+    next_year, next_month = agent_usage_report.shift_month(year, month, 1)
+    return {
+        "report": report,
+        "month_label": report.start.strftime("%Y-%m"),
+        "prev_month": f"{prev_year:04d}-{prev_month:02d}",
+        "next_month": f"{next_year:04d}-{next_month:02d}",
+        "threshold": threshold,
+        "threshold_pct": _pct_label(threshold),
+        "alerts": agent_usage_report.margin_alerts(report, threshold),
+        "by_tier": agent_usage_report.sorted_totals(report.by_tier),
+        "by_model": agent_usage_report.sorted_totals(report.by_model),
+        "by_trigger": agent_usage_report.sorted_totals(report.by_trigger),
     }

--- a/app/store_project/meso/tests/test_agent_usage_dashboard.py
+++ b/app/store_project/meso/tests/test_agent_usage_dashboard.py
@@ -1,0 +1,229 @@
+"""The owner-facing agent-usage dashboard (agent-usage tracking v2, Phase 4).
+
+Phases 1–3 captured per-run usage/cost on ``AgentProposalBatch``, rolled it into a
+per-coach margin report (``build_report``), and pushed a monthly margin-alert email.
+This is the **owner-facing read surface**: a staff-gated web view of that same
+report — totals, the margin-alert subset, roll-ups by tier/model/trigger, and the
+per-coach cost-vs-revenue-margin table with a per-client breakdown — with month
+navigation. It reuses ``build_report`` + ``margin_alerts`` wholesale; this slice is
+the pure month helpers, the presenter, the view's staff gate, and the template.
+See ``docs/meso/agent-usage-plan.md``.
+"""
+
+from datetime import timedelta
+from decimal import Decimal
+
+import pytest
+from django.test import override_settings
+from django.urls import reverse
+from django.utils import timezone
+
+from store_project.meso.billing import agent_usage_report as report_mod
+from store_project.meso.factories import AgentProposalBatchFactory
+from store_project.meso.factories import CoachSubscriptionFactory
+from store_project.meso.factories import GroupPlanFactory
+from store_project.meso.factories import PlanFactory
+from store_project.meso.models import AgentProposalBatch
+from store_project.meso.models import CoachSubscription
+from store_project.users.factories import SuperAdminFactory
+from store_project.users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+URL = reverse("meso:usage_dashboard")
+
+
+def _at(when, **kw):
+    """Build a batch then stamp its auto-add ``created_at`` to ``when``."""
+    batch = AgentProposalBatchFactory(**kw)
+    AgentProposalBatch.objects.filter(pk=batch.pk).update(created_at=when)
+    batch.refresh_from_db()
+    return batch
+
+
+def _paid_run(start, *, cost="6.00", label_coach=None):
+    """An active paid coach with one in-window run costing ``cost``.
+
+    Revenue is base $9.99 + one seat = $10.99, so a $6.00 run trips the default
+    50% threshold (ratio ~0.55) — *at risk* but not yet ``flagged``.
+    """
+    sub = CoachSubscriptionFactory(status=CoachSubscription.Status.ACTIVE)
+    coach = sub.coach
+    if label_coach:
+        coach.name = label_coach
+        coach.save(update_fields=["name"])
+    plan = PlanFactory(relationship__coach=coach)
+    _at(
+        start + timedelta(days=1),
+        plan=plan,
+        coach=coach,
+        billing_status=CoachSubscription.Status.ACTIVE,
+        estimated_cost_usd=Decimal(cost),
+        input_tokens=1000,
+        output_tokens=500,
+    )
+    return coach
+
+
+# --- pure month helpers ---------------------------------------------------
+
+
+class TestShiftMonth:
+    def test_steps_forward_within_year(self):
+        assert report_mod.shift_month(2026, 6, 1) == (2026, 7)
+
+    def test_steps_backward_within_year(self):
+        assert report_mod.shift_month(2026, 6, -1) == (2026, 5)
+
+    def test_rolls_over_december_forward(self):
+        assert report_mod.shift_month(2026, 12, 1) == (2027, 1)
+
+    def test_rolls_under_january_backward(self):
+        assert report_mod.shift_month(2026, 1, -1) == (2025, 12)
+
+
+class TestResolveAlertThreshold:
+    @override_settings(MESO_MARGIN_ALERT_THRESHOLD="0.5")
+    def test_reads_the_setting_by_default(self):
+        assert report_mod.resolve_alert_threshold() == Decimal("0.5")
+
+    @override_settings(MESO_MARGIN_ALERT_THRESHOLD="0.75")
+    def test_honours_a_custom_setting(self):
+        assert report_mod.resolve_alert_threshold() == Decimal("0.75")
+
+    @override_settings(MESO_MARGIN_ALERT_THRESHOLD="")
+    def test_blank_setting_falls_back_to_default(self):
+        assert (
+            report_mod.resolve_alert_threshold() == report_mod.DEFAULT_ALERT_THRESHOLD
+        )
+
+    @pytest.mark.parametrize("bad", ["abc", "-1", "0", "NaN", "Infinity"])
+    def test_invalid_never_raises_returns_default(self, bad):
+        # The dashboard must render even with a misconfigured env value, so a bad
+        # threshold degrades to the default rather than 500ing the page.
+        assert (
+            report_mod.resolve_alert_threshold(bad)
+            == report_mod.DEFAULT_ALERT_THRESHOLD
+        )
+
+    def test_explicit_value_wins_over_the_setting(self):
+        assert report_mod.resolve_alert_threshold("0.9") == Decimal("0.9")
+
+
+class TestSortedTotals:
+    def test_orders_by_cost_descending(self):
+        cheap = report_mod.Totals()
+        cheap.add(AgentProposalBatchFactory.build(estimated_cost_usd=Decimal("1")))
+        dear = report_mod.Totals()
+        dear.add(AgentProposalBatchFactory.build(estimated_cost_usd=Decimal("9")))
+        ordered = report_mod.sorted_totals({"cheap": cheap, "dear": dear})
+        assert [key for key, _ in ordered] == ["dear", "cheap"]
+
+
+# --- presenter ------------------------------------------------------------
+
+
+class TestPresenter:
+    def test_navigation_and_rollups(self):
+        from store_project.meso import presenters
+
+        start, end = report_mod.month_bounds(2026, 6)
+        _paid_run(start)
+        report = report_mod.build_report(start=start, end=end)
+        ctx = presenters.usage_dashboard(report, threshold=Decimal("0.5"))
+        assert ctx["month_label"] == "2026-06"
+        assert ctx["prev_month"] == "2026-05"
+        assert ctx["next_month"] == "2026-07"
+        assert ctx["threshold_pct"] == "50"
+        # The at-risk paid coach surfaces in the alert subset.
+        assert len(ctx["alerts"]) == 1
+        # Roll-ups are (key, Totals) lists, not the raw dicts.
+        assert isinstance(ctx["by_tier"], list)
+        assert ctx["report"] is report
+
+
+# --- the view: staff gating -----------------------------------------------
+
+
+class TestStaffGate:
+    def test_anonymous_is_redirected_to_login(self, client):
+        resp = client.get(URL)
+        assert resp.status_code == 302
+        assert "/accounts/login/" in resp["Location"]
+
+    def test_authenticated_non_staff_is_forbidden(self, client):
+        client.force_login(UserFactory())
+        resp = client.get(URL)
+        assert resp.status_code == 403
+
+    def test_staff_gets_the_dashboard(self, client):
+        client.force_login(SuperAdminFactory())
+        resp = client.get(URL)
+        assert resp.status_code == 200
+        assert resp.templates[0].name == "meso/usage_dashboard.html"
+
+
+# --- the view: rendering --------------------------------------------------
+
+
+class TestRendering:
+    def test_renders_a_coachs_cost_and_label(self, client):
+        start, _ = report_mod.current_month_bounds()
+        _paid_run(start, cost="0.5000", label_coach="Dana Rivers")
+        client.force_login(SuperAdminFactory())
+        body = client.get(URL).content.decode()
+        assert "Dana Rivers" in body
+        assert "$0.50" in body
+
+    def test_empty_month_renders_a_friendly_note(self, client):
+        client.force_login(SuperAdminFactory())
+        body = client.get(URL).content.decode()
+        assert "No agent runs" in body
+
+    def test_a_specific_month_is_honoured(self, client):
+        # A run in May, none in June: ?month=2026-05 must show it, June must not.
+        may_start, _ = report_mod.month_bounds(2026, 5)
+        _paid_run(may_start, label_coach="May Coach")
+        client.force_login(SuperAdminFactory())
+        may = client.get(URL, {"month": "2026-05"}).content.decode()
+        june = client.get(URL, {"month": "2026-06"}).content.decode()
+        assert "May Coach" in may
+        assert "May Coach" not in june
+
+    def test_invalid_month_falls_back_to_current_with_a_message(self, client):
+        client.force_login(SuperAdminFactory())
+        resp = client.get(URL, {"month": "not-a-month"})
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        # Falls back to the current month (its label) and warns about the input.
+        now = timezone.localtime(timezone.now())
+        assert now.strftime("%Y-%m") in body
+
+    def test_margin_alert_is_surfaced(self, client):
+        start, _ = report_mod.current_month_bounds()
+        _paid_run(start, cost="6.00", label_coach="Tail Risk")
+        client.force_login(SuperAdminFactory())
+        body = client.get(URL).content.decode()
+        assert "Tail Risk" in body
+        # The alert region names the margin-alert framing.
+        assert "alert" in body.lower()
+
+    def test_month_nav_links_present(self, client):
+        client.force_login(SuperAdminFactory())
+        body = client.get(URL, {"month": "2026-06"}).content.decode()
+        assert "month=2026-05" in body
+        assert "month=2026-07" in body
+
+    def test_group_run_attributes_to_the_group(self, client):
+        start, end = report_mod.current_month_bounds()
+        group_plan = GroupPlanFactory()
+        _at(
+            start + timedelta(days=1),
+            plan=group_plan,
+            coach=group_plan.group.coach,
+            estimated_cost_usd=Decimal("0.10"),
+        )
+        client.force_login(SuperAdminFactory())
+        body = client.get(URL).content.decode()
+        assert f"Group: {group_plan.group.name}" in body

--- a/app/store_project/meso/urls.py
+++ b/app/store_project/meso/urls.py
@@ -12,11 +12,15 @@ from .views import MesoDesignerView
 from .views import OfflineView
 from .views import ResultsView
 from .views import RosterView
+from .views import UsageDashboardView
 
 app_name = "meso"
 urlpatterns = [
     path("", RosterView.as_view(), name="roster"),
     path("designer/", MesoDesignerView.as_view(), name="designer"),
+    # Owner-facing agent usage + margin dashboard (agent-usage Phase 4) —
+    # staff-gated, all-coach; the web read-out of meso_agent_usage_report.
+    path("usage/", UsageDashboardView.as_view(), name="usage_dashboard"),
     path("designer/<int:plan_id>/", MesoDesignerView.as_view(), name="designer_plan"),
     path("review/", ChangeReviewView.as_view(), name="review"),
     path(

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -11,6 +11,8 @@ from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.auth.mixins import UserPassesTestMixin
+from django.core.exceptions import PermissionDenied
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from django.db import transaction
@@ -45,6 +47,7 @@ from .agent import client as agent_client
 from .agent import jobs as agent_jobs
 from .agent import service as agent_service
 from .billing import access as billing_access
+from .billing import agent_usage_report as usage_report
 from .billing import seats as billing_seats
 from .billing import stripe_gateway as billing_gateway
 from .billing import webhooks as billing_webhooks
@@ -415,6 +418,60 @@ class GroupDetailView(LoginRequiredMixin, TemplateView):
         ctx["active"] = "roster"
         ctx["group"] = presenters.group_detail(group)
         return ctx
+
+
+class UsageDashboardView(UserPassesTestMixin, TemplateView):
+    """Owner-facing agent usage + margin dashboard (agent-usage Phase 4).
+
+    A **staff-gated**, all-coach view of the per-month usage report that Phases 1–3
+    capture, aggregate (``build_report``), and alert on (``margin_alerts``) — the
+    web read-out the ``meso_agent_usage_report`` command renders as text. Not
+    coach-scoped: it's the operator's cost/margin view across the whole tenant.
+
+    Gate: an anonymous visitor bounces to login (``UserPassesTestMixin`` default);
+    an authenticated non-staff user gets a flat 403 (``handle_no_permission``), so
+    a logged-in coach can't probe org-wide spend.
+    """
+
+    template_name = "meso/usage_dashboard.html"
+
+    def test_func(self):
+        return self.request.user.is_staff
+
+    def handle_no_permission(self):
+        # Authenticated-but-unauthorized → 403 (not a pointless login bounce);
+        # anonymous → the mixin's login redirect.
+        if self.request.user.is_authenticated:
+            raise PermissionDenied
+        return super().handle_no_permission()
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        start, end = self._window()
+        report = usage_report.build_report(start=start, end=end)
+        threshold = usage_report.resolve_alert_threshold()
+        ctx["active"] = "usage"
+        ctx.update(presenters.usage_dashboard(report, threshold=threshold))
+        return ctx
+
+    def _window(self):
+        """The report window from ``?month=YYYY-MM``; current month on bad input.
+
+        A hand-edited or malformed ``month`` degrades to the current month with a
+        flashed warning rather than erroring, so the page always renders.
+        """
+        raw = self.request.GET.get("month")
+        if raw:
+            try:
+                year, month = usage_report.parse_month(raw)
+            except ValueError:
+                messages.error(
+                    self.request,
+                    f"Ignoring invalid month {raw!r}; showing the current month.",
+                )
+            else:
+                return usage_report.month_bounds(year, month)
+        return usage_report.current_month_bounds()
 
 
 def _coach_active_athletes(coach, athlete_ids):

--- a/app/store_project/templates/meso/_meso_base.html
+++ b/app/store_project/templates/meso/_meso_base.html
@@ -32,6 +32,9 @@
           {% block navlinks %}
             <a class="meso-navlink {% if active == 'roster' %}is-active{% endif %}" href="{% url 'meso:roster' %}">Roster</a>
             <a class="meso-navlink {% if active == 'designer' %}is-active{% endif %}" href="{% url 'meso:designer' %}">Designer</a>
+            {% if request.user.is_staff %}
+              <a class="meso-navlink {% if active == 'usage' %}is-active{% endif %}" href="{% url 'meso:usage_dashboard' %}">Usage</a>
+            {% endif %}
           {% endblock %}
         </div>
         <div class="meso-spacer"></div>

--- a/app/store_project/templates/meso/_usage_rollup.html
+++ b/app/store_project/templates/meso/_usage_rollup.html
@@ -1,0 +1,19 @@
+{% comment %}
+  One roll-up card for the usage dashboard: a title and cost-sorted (key, Totals)
+  rows. ``rows`` is a list of (key, Totals) tuples from
+  ``agent_usage_report.sorted_totals``.
+{% endcomment %}
+<div class="meso-card meso-card--pad">
+  <p class="meso-eyebrow">{{ title }}</p>
+  {% for key, totals in rows %}
+    <div style="display:flex;align-items:baseline;gap:8px;padding:4px 0;">
+      <span style="min-width:0;color:var(--ink);">{{ key }}</span>
+      <div class="meso-spacer"></div>
+      <span class="meso-row-meta">
+        {{ totals.runs }} run{{ totals.runs|pluralize }} · ${{ totals.cost|floatformat:4 }}{% if totals.unknown_cost_runs %} · {{ totals.unknown_cost_runs }} unpriced{% endif %}
+      </span>
+    </div>
+  {% empty %}
+    <p class="meso-sub" style="margin:6px 0 0;">No runs.</p>
+  {% endfor %}
+</div>

--- a/app/store_project/templates/meso/usage_dashboard.html
+++ b/app/store_project/templates/meso/usage_dashboard.html
@@ -1,0 +1,126 @@
+{% extends "meso/_meso_base.html" %}
+
+{% block title %}Agent usage · Meso{% endblock %}
+
+{% block content %}
+  <div class="meso-page">
+    <div class="meso-crumbs">
+      <a href="{% url 'meso:roster' %}">Roster</a> <span>/</span> <span>Agent usage</span>
+    </div>
+
+    <div class="meso-pagehead">
+      <div>
+        <p class="meso-eyebrow">Owner · agent usage &amp; margin</p>
+        <h1 class="meso-h1">{{ month_label }}</h1>
+        <p class="meso-sub">
+          Estimated cost is internal; the Anthropic invoice is authoritative.
+        </p>
+      </div>
+      <div style="display:flex;align-items:center;gap:8px;">
+        <a class="meso-btn meso-btn--ghost" href="?month={{ prev_month }}">‹ {{ prev_month }}</a>
+        <a class="meso-btn meso-btn--ghost" href="{% url 'meso:usage_dashboard' %}">This month</a>
+        <a class="meso-btn meso-btn--ghost" href="?month={{ next_month }}">{{ next_month }} ›</a>
+      </div>
+    </div>
+
+    {% with t=report.totals %}
+      <div class="meso-card meso-card--pad" style="margin-bottom:14px;">
+        <p class="meso-eyebrow">Totals</p>
+        <p class="meso-sub" style="margin:6px 0 0;font-size:15px;color:var(--ink);">
+          {{ t.runs }} run{{ t.runs|pluralize }}
+          · {{ t.total_tokens }} tokens
+          · est. <b>${{ t.cost|floatformat:4 }}</b>
+          {% if t.unknown_cost_runs %}
+            · <span style="color:var(--warn);">{{ t.unknown_cost_runs }} unpriced</span>
+          {% endif %}
+        </p>
+        {% if report.eval_runs_excluded %}
+          <p class="meso-muted" style="margin:6px 0 0;font-size:12px;">
+            {{ report.eval_runs_excluded }} eval run{{ report.eval_runs_excluded|pluralize }} excluded.
+          </p>
+        {% endif %}
+      </div>
+    {% endwith %}
+
+    {% if alerts %}
+      <div class="meso-card meso-card--pad" style="margin-bottom:14px;border-left:3px solid var(--warn);">
+        <p class="meso-eyebrow" style="color:var(--warn);">
+          Margin alerts — paying coaches over {{ threshold_pct }}% of revenue
+        </p>
+        {% for coach in alerts %}
+          <div style="display:flex;align-items:baseline;gap:10px;padding:6px 0;border-bottom:1px solid var(--line-2);">
+            <b style="min-width:0;">{{ coach.label }}</b>
+            <span class="meso-row-meta">
+              cost ${{ coach.totals.cost|floatformat:4 }}
+              of ${{ coach.revenue|floatformat:2 }} revenue
+              · {% widthratio coach.cost_to_revenue_ratio 1 100 %}%
+            </span>
+          </div>
+        {% endfor %}
+      </div>
+    {% endif %}
+
+    <div class="meso-grid meso-grid--profile">
+      <!-- left rail: roll-ups -->
+      <div style="display:flex;flex-direction:column;gap:14px;">
+        {% include "meso/_usage_rollup.html" with title="By billing tier" rows=by_tier %}
+        {% include "meso/_usage_rollup.html" with title="By model" rows=by_model %}
+        {% include "meso/_usage_rollup.html" with title="By trigger" rows=by_trigger %}
+      </div>
+
+      <!-- main: per coach, highest cost first -->
+      <div style="display:flex;flex-direction:column;gap:14px;">
+        <div class="meso-card">
+          <div style="display:flex;align-items:center;gap:10px;padding:13px 16px;border-bottom:1px solid var(--line-2);">
+            <p class="meso-eyebrow" style="margin:0;">Per coach (highest cost first)</p>
+          </div>
+          {% for coach in report.coaches %}
+            <div style="padding:13px 16px;border-bottom:1px solid var(--line-2);">
+              <div style="display:flex;align-items:center;gap:10px;">
+                <div style="min-width:0;">
+                  <div class="meso-row-name">
+                    {{ coach.label }}
+                    {% if coach.flagged %}<span class="meso-badge meso-badge--warn"><i></i>over revenue</span>{% endif %}
+                  </div>
+                  <div class="meso-row-meta">
+                    {{ coach.billing_status }} · {{ coach.billable_seats }} seat{{ coach.billable_seats|pluralize }}
+                  </div>
+                </div>
+                <div class="meso-spacer"></div>
+                <span class="meso-row-meta" style="text-align:right;">
+                  {{ coach.totals.runs }} run{{ coach.totals.runs|pluralize }}
+                  · {{ coach.totals.total_tokens }} tok
+                </span>
+              </div>
+              <div style="display:flex;flex-wrap:wrap;gap:6px 16px;margin-top:6px;">
+                <span class="meso-row-meta">cost <b style="color:var(--ink);">${{ coach.totals.cost|floatformat:4 }}</b></span>
+                <span class="meso-row-meta">revenue ${{ coach.revenue|floatformat:2 }}</span>
+                <span class="meso-row-meta">
+                  margin
+                  <b style="color:{% if coach.margin < 0 %}var(--warn){% else %}var(--ok){% endif %};">${{ coach.margin|floatformat:2 }}</b>
+                </span>
+                {% if coach.totals.unknown_cost_runs %}
+                  <span class="meso-row-meta" style="color:var(--warn);">{{ coach.totals.unknown_cost_runs }} unpriced</span>
+                {% endif %}
+              </div>
+              {% if coach.clients %}
+                <div style="margin-top:8px;padding-left:10px;border-left:2px solid var(--line-2);display:flex;flex-direction:column;gap:3px;">
+                  {% for client in coach.clients %}
+                    <div class="meso-row-meta">
+                      {% if client.is_group %}<span class="meso-badge meso-badge--muted"><i></i>group</span> {% endif %}
+                      {{ client.label }}: {{ client.totals.runs }} run{{ client.totals.runs|pluralize }}, ${{ client.totals.cost|floatformat:4 }}
+                    </div>
+                  {% endfor %}
+                </div>
+              {% endif %}
+            </div>
+          {% empty %}
+            <div class="meso-row" style="color:var(--dim);padding:16px;">
+              No agent runs in this month.
+            </div>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/docs/meso/agent-usage-plan.md
+++ b/docs/meso/agent-usage-plan.md
@@ -1,6 +1,6 @@
 # Meso — agent usage & cost tracking
 
-**Status:** 🟢 Phase 1 (capture) shipped · 🟢 Phase 2 (report) shipped · 🟢 Phase 3 (margin alert) shipped · started 2026-06-30
+**Status:** 🟢 Phase 1 (capture) shipped · 🟢 Phase 2 (report) shipped · 🟢 Phase 3 (margin alert) shipped · 🟢 Phase 4 (owner dashboard) shipped · started 2026-06-30
 **Context:** Billing launches at **$9.99/mo base + $1/mo per active seat** (D13 in
 [`billing-plan.md`](./billing-plan.md)). The **AI agent is the cost-bearing
 feature** — every proposal run is a Claude API call. To confirm the $1/seat
@@ -177,8 +177,27 @@ def estimate_cost(model, usage) -> Decimal:
    previous-month window, the owner email, the command across windows/thresholds/
    dry-run/validation) + `test_scheduler.py` (the monthly registration + the task
    wrapper over the previous month).
-4. *(Deferred)* an owner **dashboard**; a reconciliation job against the Anthropic
-   Admin/Usage API (sanity-check our estimate vs the invoice).
+4. **Owner dashboard — ✅ DONE (no migration).** The web read-out of the Phase-2
+   report. `UsageDashboardView` (`/meso/usage/`, **staff-gated** via
+   `UserPassesTestMixin` on `is_staff` — anon bounces to login, an authenticated
+   non-staff coach gets a flat 403, so a coach can't probe org-wide spend) renders
+   `build_report` for a `?month=YYYY-MM` window (a malformed month degrades to the
+   current month with a flashed warning — never 500s). `presenters.usage_dashboard`
+   adapts the `Report` into the template context (a `YYYY-MM` label + prev/next
+   month nav, the threshold %, the `margin_alerts` subset, the roll-ups pre-sorted
+   by cost). New pure, tested helpers on `agent_usage_report`: `shift_month` (the
+   prev/next arithmetic), `resolve_alert_threshold` (a never-raising
+   settings/override resolver, `DEFAULT_ALERT_THRESHOLD` 0.5 — the dashboard must
+   render even with a misconfigured env value), and `sorted_totals` (cost-sorted
+   roll-up pairs). `usage_dashboard.html` + `_usage_rollup.html` render the totals,
+   the margin-alert banner, the by-tier/model/trigger roll-ups, and the per-coach
+   cost-vs-revenue-margin rows with a per-client breakdown; an `is_staff`-gated
+   "Usage" nav link in `_meso_base.html`. Tests: `test_agent_usage_dashboard.py`
+   (pure helpers, the presenter, the staff gate, month windowing/invalid-month
+   fallback, margin-alert surfacing, group attribution).
+5. *(Deferred)* a reconciliation job against the Anthropic Admin/Usage API
+   (sanity-check our estimate vs the invoice) — needs an Admin API key + live org
+   access, so it can't ship autonomously.
 
 This should land **before or with billing go-live** so the very first paid month
 produces real margin data — but it's independent of the Stripe wiring, so it can

--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -1063,3 +1063,31 @@ _(Append dated entries here as decisions land.)_
   owner dashboard + Anthropic Admin/Usage-API reconciliation (both deferred);
   remaining Meso backlog otherwise: billing annual prices (blocked on the owner's
   annual numbers) + the group agent (LARGE owner-decision).
+- 2026-06-30 — **Agent usage tracking Phase 4 (owner dashboard) built** (no
+  migration). The web read-out of the data Phases 1–3 capture/aggregate/alert on,
+  closing the deferred dashboard item. `UsageDashboardView` (`/meso/usage/`) is a
+  **staff-gated**, all-coach view of `build_report` for a `?month=YYYY-MM` window:
+  `UserPassesTestMixin` on `is_staff` bounces an anonymous visitor to login and
+  gives an authenticated non-staff coach a flat **403** (`handle_no_permission`),
+  so a coach can't probe org-wide spend; a malformed `month` degrades to the
+  current month with a flashed warning rather than 500ing. `presenters.usage_dashboard`
+  adapts the `Report` into the template context (a `YYYY-MM` label + prev/next
+  month nav, the threshold %, the `margin_alerts` subset, the roll-ups pre-sorted
+  by cost). Three new **pure, tested** helpers on `agent_usage_report`:
+  `shift_month` (prev/next month arithmetic, year-boundary safe), `resolve_alert_threshold`
+  (a **never-raising** settings/override resolver, `DEFAULT_ALERT_THRESHOLD` 0.5 —
+  the dashboard must render even with a misconfigured `MESO_MARGIN_ALERT_THRESHOLD`,
+  so unlike the command's `_threshold` it returns the default rather than erroring),
+  and `sorted_totals` (cost-sorted roll-up pairs). `usage_dashboard.html` +
+  `_usage_rollup.html` render the totals, a margin-alert banner, the by-tier/model/
+  trigger roll-ups, and the per-coach cost-vs-revenue-margin rows with a per-client
+  breakdown; an `is_staff`-gated **"Usage"** nav link in `_meso_base.html` (the
+  first owner-only meso surface). **No model change, no migration.** Red→green:
+  **+25 pytest** (`test_agent_usage_dashboard.py` — pure helpers, presenter, the
+  staff gate, month windowing / invalid-month fallback, margin-alert surfacing,
+  group attribution); 1263 meso pytest green, ruff + DjHTML + `makemigrations
+  --check` clean. **Codex review loop CLEAN on iteration 1.** **Remaining
+  agent-usage backlog:** only the Anthropic Admin/Usage-API reconciliation
+  (deferred — needs an Admin API key + live org access). Remaining Meso backlog
+  otherwise unchanged: billing annual prices (blocked on the owner's annual
+  numbers) + the group agent (LARGE owner-decision).


### PR DESCRIPTION
## What

The web read-out of the agent usage + margin data that Phases 1–3 capture
(`AgentProposalBatch` usage columns), aggregate (`build_report`), and alert on
(`margin_alerts`). Until now that data was only reachable via the
`meso_agent_usage_report` management command and the raw admin columns — this
surfaces it as a browsable **owner page at `/meso/usage/`** with month navigation.

## How

- **`UsageDashboardView`** (`UserPassesTestMixin` on `is_staff`) — the first
  owner-only meso surface. Anonymous → login redirect; an authenticated non-staff
  coach → flat **403** (`handle_no_permission`), so a coach can't probe org-wide
  spend; staff → the dashboard. `?month=YYYY-MM` windows the report; a malformed
  month degrades to the current month with a flashed warning (never 500s).
- **`agent_usage_report`** gains three pure, tested helpers: `shift_month`
  (prev/next nav, year-boundary safe), `resolve_alert_threshold` (a never-raising
  settings/override resolver, `DEFAULT_ALERT_THRESHOLD` 0.5 — the page must render
  even with a misconfigured env value), and `sorted_totals` (cost-sorted roll-up
  pairs).
- **`presenters.usage_dashboard`** adapts the `Report` into the template context
  (month label + prev/next, threshold %, `margin_alerts` subset, sorted roll-ups).
- **`usage_dashboard.html` + `_usage_rollup.html`**: totals, a margin-alert
  banner, roll-ups by tier/model/trigger, and per-coach cost-vs-revenue-margin
  rows with a per-client breakdown. `is_staff`-gated **"Usage"** nav link.

## Tests / checks

- **+25 pytest** (`test_agent_usage_dashboard.py`): pure helpers, the presenter,
  the staff gate (anon/non-staff/staff), month windowing + invalid-month
  fallback, margin-alert surfacing, group attribution.
- 1263 meso pytest green; ruff + DjHTML + `makemigrations --check` clean.
- **No model change, no migration.**
- Codex review loop: **CLEAN on iteration 1**.

Docs synced (`agent-usage-plan.md` Phase 4 + `decisions.md` log entry). Remaining
agent-usage backlog: only the deferred Anthropic Admin/Usage-API reconciliation.

https://claude.ai/code/session_019A9KdsVs33wipsGjSaFWXV