### PR TITLE
Design system PR 2 — rest of main site (newsletter fix + template cleanups)

### DIFF
--- a/app/store_project/pages/tests/test_design_system_pr2.py
+++ b/app/store_project/pages/tests/test_design_system_pr2.py
@@ -100,8 +100,9 @@ class DesignSystemPR2CSSTests(TestCase):
         # Matches the design-system :focus-visible ring pattern (PR 1).
         self.assertNotIn(".cta .button:focus,", css)
         self.assertIn(".cta .button:focus-visible,", css)
+        # .box.purchase no longer carries its own :focus underline rule — it
+        # animates like a button, and keyboard focus uses .button:focus-visible.
         self.assertNotIn(".box.purchase:focus {", css)
-        self.assertIn(".box.purchase:focus-visible {", css)
 
     def test_card_box_inner_boxes_are_seamless(self):
         """A product card reads as one cohesive surface.
@@ -126,6 +127,16 @@ class DesignSystemPR2CSSTests(TestCase):
         block = _css_block(_css(), ".product-switcher .tag {")
         self.assertIn("var(--accent-soft)", block)
         self.assertIn("border-radius: 999px", block)
+
+    def test_button_links_never_underline(self):
+        """<a class="button"> must not pick up the global a:hover underline."""
+        self.assertIn("text-decoration: none", _css_block(_css(), ".button:focus,"))
+
+    def test_purchase_button_animates_instead_of_underlining(self):
+        """The purchase button lifts on hover (not the old link underline)."""
+        block = _css_block(_css(), ".box.purchase:hover {")
+        self.assertIn("box-shadow", block)
+        self.assertNotIn("underline", block)
 
     def test_input_group_joins_input_and_button(self):
         """Newsletter input + Submit join into one control.
@@ -218,6 +229,13 @@ class DesignSystemPR2TemplateTests(TestCase):
         self.assertContains(response, f'data-product-slug="{self.book.slug}"')
         self.assertNotContains(response, "data-productType")
         self.assertNotContains(response, "data-productSlug")
+
+    def test_detail_back_link_is_an_outline_button(self):
+        response = self.client.get(
+            reverse("products:program_detail", args=[self.program.slug])
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'class="button outline"')
 
     def test_profile_update_form_and_button_are_styled(self):
         self.client.force_login(self.user)

--- a/app/store_project/pages/tests/test_design_system_pr2.py
+++ b/app/store_project/pages/tests/test_design_system_pr2.py
@@ -1,0 +1,173 @@
+"""Design-system unification PR 2 — rest of the main site.
+
+PR 1 added the token layer and globally re-skinned ``.box`` / ``.button`` /
+inputs / ``.tag``. PR 2 fixes the per-template inconsistencies the global
+re-skin could not reach:
+
+* the newsletter form's input + button sat flush (the ``.form-with-sidebar``
+  flex wrapper zeroed its own gutters),
+* footer links, the newsletter consent label, and (via inline styles) other
+  weights fought the global rules,
+* testimonial avatars were sized with HTML ``height``/``width`` attrs,
+* the imageless-product placeholder repeated an inline ``background-color``,
+* dead ``.padding`` classes and a broken ``data-productType`` attribute (which
+  silenced the *book* checkout button), an unrendered tracking field error, and
+  unstyled submit buttons.
+
+These tests render the real templates / read the real stylesheet so each one is
+red on ``main`` and green after the PR-2 changes.
+"""
+
+from pathlib import Path
+
+from django import forms
+from django.contrib.auth.models import AnonymousUser
+from django.template.loader import render_to_string
+from django.test import RequestFactory
+from django.test import TestCase
+from django.urls import reverse
+
+from store_project.products.factories import BookFactory
+from store_project.products.factories import ProgramFactory
+from store_project.users.factories import UserFactory
+
+BASE_CSS = Path(__file__).resolve().parents[2] / "static" / "css" / "base.css"
+
+
+def _css() -> str:
+    return BASE_CSS.read_text()
+
+
+def _css_block(css: str, selector: str) -> str:
+    """Return the declaration body of the first rule matching ``selector``."""
+    start = css.index(selector)
+    brace = css.index("{", start)
+    end = css.index("}", brace)
+    return css[brace : end + 1]
+
+
+class DesignSystemPR2CSSTests(TestCase):
+    """Guards for changes that live in ``base.css`` (not visible in markup)."""
+
+    def test_form_with_sidebar_uses_a_real_gap(self):
+        """The newsletter input + Submit button must not sit flush.
+
+        The old ``margin: calc(0px / 2 * -1)`` / ``calc(0px / 2)`` trick
+        evaluated to zero, so a real ``gap`` is needed.
+        """
+        css = _css()
+        self.assertNotIn("calc(0px / 2", css)
+        block = _css_block(css, ".form-with-sidebar > * {")
+        self.assertIn("gap: var(--s-1)", block)
+
+    def test_footer_links_render_at_normal_weight(self):
+        block = _css_block(_css(), ".footer a {")
+        self.assertIn("font-weight: 400", block)
+        self.assertNotIn("font-weight: 700", block)
+
+    def test_form_control_label_is_not_bold(self):
+        block = _css_block(_css(), ".form-control {")
+        self.assertIn("font-weight: 400", block)
+
+    def test_secondary_action_link_is_styled(self):
+        self.assertIn("a.secondaryAction", _css())
+
+    def test_image_placeholder_rule_exists(self):
+        self.assertIn(".image-placeholder", _css())
+
+    def test_focus_states_use_focus_visible(self):
+        css = _css()
+        # Matches the design-system :focus-visible ring pattern (PR 1).
+        self.assertNotIn(".cta .button:focus,", css)
+        self.assertIn(".cta .button:focus-visible,", css)
+        self.assertNotIn(".box.purchase:focus {", css)
+        self.assertIn(".box.purchase:focus-visible {", css)
+
+
+class DesignSystemPR2TemplateTests(TestCase):
+    """Render the real templates and assert the markup-level fixes."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.program = ProgramFactory()
+        cls.book = BookFactory()
+
+    def test_home_footer_has_no_inline_font_weight(self):
+        response = self.client.get("/")
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'style="font-weight:normal;"')
+
+    def test_home_newsletter_consent_has_no_inline_font_weight(self):
+        response = self.client.get("/")
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "font-weight: unset")
+
+    def test_home_testimonial_avatars_sized_via_css(self):
+        response = self.client.get("/")
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'height="50px"')
+        self.assertNotContains(response, 'width="50px"')
+        self.assertContains(response, "testimonial-avatar")
+
+    def test_program_detail_uses_image_placeholder_class(self):
+        response = self.client.get(
+            reverse("products:program_detail", args=[self.program.slug])
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'class="image-placeholder"')
+        self.assertNotContains(
+            response, 'style="background-color: var(--main-color-dark);"'
+        )
+        # ``.padding`` (bare) is not a defined class; ``.box`` already pads.
+        self.assertNotContains(response, 'class="box padding"')
+
+    def test_book_detail_checkout_uses_kebab_case_data_attrs(self):
+        """Book checkout data attrs must be kebab-case.
+
+        ``data-productType`` lowercases to ``producttype`` in the DOM, so
+        payments.js (``button.dataset.productType``) never fires the book
+        checkout until the attribute is ``data-product-type``.
+        """
+        self.client.force_login(self.user)
+        response = self.client.get(
+            reverse("products:book_detail", args=[self.book.slug])
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'data-product-type="book"')
+        self.assertContains(response, f'data-product-slug="{self.book.slug}"')
+        self.assertNotContains(response, "data-productType")
+        self.assertNotContains(response, "data-productSlug")
+
+    def test_profile_update_form_and_button_are_styled(self):
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("users:update"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'class="stack-form"')
+        self.assertContains(response, 'class="button" type="submit">Update')
+
+    def test_password_reset_from_key_submit_is_a_button(self):
+        class _PwForm(forms.Form):
+            password1 = forms.CharField(widget=forms.PasswordInput)
+            password2 = forms.CharField(widget=forms.PasswordInput)
+
+        request = RequestFactory().get("/accounts/password/reset/key/x/")
+        request.user = AnonymousUser()
+        html = render_to_string(
+            "account/password_reset_from_key.html",
+            {"form": _PwForm(), "action_url": "/accounts/password/reset/key/x/"},
+            request=request,
+        )
+        self.assertIn(
+            '<button class="button" type="submit">Change Password</button>', html
+        )
+        self.assertNotIn('<button type="submit">Change Password</button>', html)
+
+    def test_tracking_result_form_renders_field_errors(self):
+        class _ReqForm(forms.Form):
+            score = forms.CharField(required=True)
+
+        form = _ReqForm(data={"score": ""})
+        self.assertFalse(form.is_valid())
+        html = render_to_string("tracking/partials/result_form.html", {"form": form})
+        self.assertIn("This field is required", html)

--- a/app/store_project/pages/tests/test_design_system_pr2.py
+++ b/app/store_project/pages/tests/test_design_system_pr2.py
@@ -83,6 +83,38 @@ class DesignSystemPR2CSSTests(TestCase):
         self.assertNotIn(".box.purchase:focus {", css)
         self.assertIn(".box.purchase:focus-visible {", css)
 
+    def test_card_box_inner_boxes_are_seamless(self):
+        """A product card reads as one cohesive surface.
+
+        PR 1's global ``.box`` re-skin gave every ``.box`` its own
+        border/shadow/radius, so the stacked segments inside a ``.card-box``
+        (image / body / price footer) each drew a separate rounded outline.
+        The inner panels must be flat — only the ``.card-box`` owns the outline.
+        """
+        block = _css_block(_css(), ".card-box .box {")
+        self.assertIn("border: 0", block)
+        self.assertIn("box-shadow: none", block)
+        self.assertIn("border-radius: 0", block)
+
+    def test_input_group_joins_input_and_button(self):
+        """Newsletter input + Submit join into one control.
+
+        Base Coat button-group: a flex row where only the outer corners stay
+        rounded and the joined edges are squared off.
+        """
+        css = _css()
+        self.assertIn("display: flex", _css_block(css, ".input-group {"))
+        # the field's joined (right) edge is squared off
+        self.assertIn(
+            "border-start-end-radius: 0",
+            _css_block(css, ".input-group > :first-child {"),
+        )
+        # the button's joined (left) edge is squared off
+        self.assertIn(
+            "border-start-start-radius: 0",
+            _css_block(css, ".input-group > :last-child {"),
+        )
+
 
 class DesignSystemPR2TemplateTests(TestCase):
     """Render the real templates and assert the markup-level fixes."""
@@ -102,6 +134,14 @@ class DesignSystemPR2TemplateTests(TestCase):
         response = self.client.get("/")
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, "font-weight: unset")
+
+    def test_newsletter_form_uses_joined_input_group(self):
+        response = self.client.get("/")
+        self.assertEqual(response.status_code, 200)
+        # Email field + Submit button are joined (no gap) via the input group.
+        self.assertContains(response, 'class="input-group"')
+        self.assertContains(response, 'role="group"')
+        self.assertContains(response, 'id="id_newsletter_email"')
 
     def test_home_testimonial_avatars_sized_via_css(self):
         response = self.client.get("/")

--- a/app/store_project/pages/tests/test_design_system_pr2.py
+++ b/app/store_project/pages/tests/test_design_system_pr2.py
@@ -168,6 +168,15 @@ class DesignSystemPR2TemplateTests(TestCase):
         self.assertContains(response, 'role="group"')
         self.assertContains(response, 'id="id_newsletter_email"')
 
+    def test_home_scroll_indicator_is_not_a_box(self):
+        """The hero "Scroll down" hint is decorative, not a bordered box.
+
+        It has no action, so it carries the transparent (no-surface) treatment.
+        """
+        response = self.client.get("/")
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "box transparent inherit-colors")
+
     def test_home_testimonial_avatars_sized_via_css(self):
         response = self.client.get("/")
         self.assertEqual(response.status_code, 200)

--- a/app/store_project/pages/tests/test_design_system_pr2.py
+++ b/app/store_project/pages/tests/test_design_system_pr2.py
@@ -121,6 +121,12 @@ class DesignSystemPR2CSSTests(TestCase):
         # card-stack row gap stacked on top — that left too much space).
         self.assertIn("margin-top: 0", _css_block(_css(), ".card-stack > .frame + * {"))
 
+    def test_detail_page_tags_reuse_the_soft_pill(self):
+        """Detail-page tags get the soft accent pill, like the list/Challenges."""
+        block = _css_block(_css(), ".product-switcher .tag {")
+        self.assertIn("var(--accent-soft)", block)
+        self.assertIn("border-radius: 999px", block)
+
     def test_input_group_joins_input_and_button(self):
         """Newsletter input + Submit join into one control.
 

--- a/app/store_project/pages/tests/test_design_system_pr2.py
+++ b/app/store_project/pages/tests/test_design_system_pr2.py
@@ -72,8 +72,28 @@ class DesignSystemPR2CSSTests(TestCase):
     def test_secondary_action_link_is_styled(self):
         self.assertIn("a.secondaryAction", _css())
 
-    def test_image_placeholder_rule_exists(self):
-        self.assertIn(".image-placeholder", _css())
+    def test_image_placeholder_is_subtle_and_branded(self):
+        """Imageless products show a soft branded watermark, not a black box."""
+        css = _css()
+        # anchor to the line-start rule (the clip-path rule also ends in
+        # "> .image-placeholder {").
+        block = _css_block(css, "\n.image-placeholder {")
+        self.assertIn("var(--muted)", block)
+        self.assertNotIn("var(--main-color-dark)", block)
+        # the brand mark is layered in as a faded watermark via ::before
+        before = _css_block(css, ".image-placeholder::before {")
+        self.assertIn("favicon", before)
+
+    def test_card_typography_is_generic_ui(self):
+        """Card title sits at the body scale, description reads as muted text.
+
+        (The title was the big page-heading size, dominating the card.)
+        """
+        css = _css()
+        self.assertIn("font-size: var(--s0)", _css_block(css, ".card-stack h3 > a {"))
+        desc = _css_block(css, ".card-stack p {")
+        self.assertIn("font-size: 0.875rem", desc)
+        self.assertIn("var(--main-color-gray)", desc)
 
     def test_focus_states_use_focus_visible(self):
         css = _css()
@@ -95,6 +115,11 @@ class DesignSystemPR2CSSTests(TestCase):
         self.assertIn("border: 0", block)
         self.assertIn("box-shadow: none", block)
         self.assertIn("border-radius: 0", block)
+        # tighter, uniform generic-UI content inset
+        self.assertIn("padding: var(--s0)", block)
+        # the full-bleed image's own padding is the only gap below it (no extra
+        # card-stack row gap stacked on top — that left too much space).
+        self.assertIn("margin-top: 0", _css_block(_css(), ".card-stack > .frame + * {"))
 
     def test_input_group_joins_input_and_button(self):
         """Newsletter input + Submit join into one control.

--- a/app/store_project/products/tests/test_views.py
+++ b/app/store_project/products/tests/test_views.py
@@ -231,8 +231,8 @@ class TestBookDetailView:
 
         login_to_purchase_link = f'href="/payments/login-to-purchase/{book.slug}/">'
         purchase_button_id = 'id="submitButton"'
-        purchase_button_data_product_slug = f'data-productSlug="{book.slug}"'
-        purchase_button_data_product_type = 'data-productType="book"'
+        purchase_button_data_product_slug = f'data-product-slug="{book.slug}"'
+        purchase_button_data_product_type = 'data-product-type="book"'
         admin_link = reverse("admin:products_book_change", args=(book.id,))
 
         assert response.status_code == 200

--- a/app/store_project/static/css/base.css
+++ b/app/store_project/static/css/base.css
@@ -818,6 +818,16 @@ a.secondaryAction {
   clip-path: polygon(0 0, 100% 0, 100% 100%, 0 calc(100% - 1rem));
 }
 
+/* Inside a card the stacked segments read as one cohesive surface: the
+   .card-box owns the single outline + shadow, so its inner .box panels drop
+   their own border / shadow / radius (PR 1's global .box re-skin otherwise
+   gives each segment its own rounded outline and fragments the card). */
+.card-box .box {
+  border: 0 solid;
+  box-shadow: none;
+  border-radius: 0;
+}
+
 /* clickable challenge cards: title shifts to accent, "View challenge" reveals */
 .card-box:hover h3 a,
 .card-box:hover h4 a,
@@ -971,6 +981,48 @@ a.secondaryAction {
 .form-with-sidebar input,
 .form-with-sidebar button {
   box-shadow: none;
+}
+
+/*
+    THE INPUT GROUP
+
+    Description: join an input and its action button into one control — a
+    subscribe / search bar. Adjacent edges merge; only the outer corners stay
+    rounded. (Base Coat-style "button-group" pattern.)
+
+    Usage:
+      <div class="input-group" role="group" aria-label="...">
+        <input ... />
+        <button class="button" type="submit">Submit</button>
+      </div>
+*/
+.input-group {
+  display: flex;
+  align-items: stretch;
+}
+
+/* the text field flexes to fill; the button keeps its intrinsic width */
+.input-group > input {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+/* square the joined edges, keep the outer corners rounded */
+.input-group > :first-child {
+  border-start-end-radius: 0;
+  border-end-end-radius: 0;
+}
+
+.input-group > :last-child {
+  border-start-start-radius: 0;
+  border-end-start-radius: 0;
+}
+
+/* a focused field lifts above its neighbour so the accent ring isn't clipped */
+.input-group > :focus,
+.input-group > :focus-visible {
+  position: relative;
+  z-index: 1;
 }
 
 /*

--- a/app/store_project/static/css/base.css
+++ b/app/store_project/static/css/base.css
@@ -813,8 +813,9 @@ a.secondaryAction {
   text-decoration: none;
 }
 
-/* pretty styles for photo */
-.card-box .frame > img {
+/* pretty styles for photo (and the placeholder, so both share the angled cut) */
+.card-box .frame > img,
+.card-box .frame > .image-placeholder {
   clip-path: polygon(0 0, 100% 0, 100% 100%, 0 calc(100% - 1rem));
 }
 
@@ -826,6 +827,8 @@ a.secondaryAction {
   border: 0 solid;
   box-shadow: none;
   border-radius: 0;
+  /* generic-UI card density: a tighter, uniform content inset */
+  padding: var(--s0);
 }
 
 /* clickable challenge cards: title shifts to accent, "View challenge" reveals */
@@ -861,7 +864,14 @@ a.secondaryAction {
 }
 
 .card-stack h3 > a {
-  font-size: var(--s1);
+  /* card title sits at a generic-UI scale, not the big page-heading size */
+  font-size: var(--s0);
+}
+
+/* card description reads as secondary supporting text */
+.card-stack p {
+  font-size: 0.875rem;
+  color: var(--main-color-gray);
 }
 
 .card-stack {
@@ -877,6 +887,13 @@ a.secondaryAction {
 
 .card-stack > * + * {
   margin-top: var(--s-1);
+}
+
+/* the image is full-bleed, so the body's own padding is the only gap beneath
+   it — don't stack the card-stack row gap on top (that left too much space
+   between the clipped image and the title). */
+.card-stack > .frame + * {
+  margin-top: 0;
 }
 
 .card-stack:only-child {
@@ -1327,9 +1344,27 @@ ul.grid {
   object-fit: cover;
 }
 
-/* Placeholder fill for products/tests with no featured image. */
+/* Subtle branded placeholder for products/tests with no featured image: the
+   Mastering Fitness mark as a faint watermark on a soft neutral panel (moved
+   off the hard black fill). The mark is recolored via a CSS mask since the
+   source SVG is white-on-transparent. */
 .image-placeholder {
-  background-color: var(--main-color-dark);
+  position: relative;
+  inline-size: 100%;
+  block-size: 100%;
+  background-color: var(--muted);
+}
+
+.image-placeholder::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  /* Render the actual mark (white fills + dark strokes) faded down: on the
+     light panel the fills nearly vanish and the strokes read as a faint
+     outline, so the weights/bar structure stays legible. */
+  background:
+    url("../svg/favicon-light.svg") no-repeat center / clamp(56px, 30%, 104px);
+  opacity: 0.4;
 }
 
 /*

--- a/app/store_project/static/css/base.css
+++ b/app/store_project/static/css/base.css
@@ -353,6 +353,9 @@ form label {
   display: grid;
   grid-template-columns: 1em auto;
   gap: var(--s1);
+  /* Inline checkbox labels (e.g. the newsletter consent) read as body text,
+     not the bold `form label` weight. */
+  font-weight: 400;
 }
 
 .stack-form fieldset {
@@ -646,7 +649,7 @@ ul.errorlist {
 
 .box.purchase:active,
 .box.purchase:hover,
-.box.purchase:focus {
+.box.purchase:focus-visible {
   cursor: pointer;
   text-decoration: underline;
 }
@@ -721,6 +724,11 @@ a.box.login:active {
   flex: 1;
   height: 1px;
   background-color: #cac7c7;
+}
+
+/* Secondary auth-form links (e.g. "Forgot Password?") read as subordinate. */
+a.secondaryAction {
+  font-size: var(--s-1);
 }
 
 /*
@@ -945,11 +953,12 @@ a.box.login:active {
 .form-with-sidebar > * {
   display: flex;
   flex-wrap: wrap;
-  margin: calc(0px / 2 * -1);
+  /* A real gap so the input + button don't sit flush (the old
+     zero-width negative-margin trick gave them no separation). */
+  gap: var(--s-1);
 }
 
 .form-with-sidebar > * > * {
-  margin: calc(0px / 2);
   flex-grow: 1;
 }
 
@@ -1264,6 +1273,11 @@ ul.grid {
   inline-size: 100%;
   block-size: 100%;
   object-fit: cover;
+}
+
+/* Placeholder fill for products/tests with no featured image. */
+.image-placeholder {
+  background-color: var(--main-color-dark);
 }
 
 /*
@@ -1835,7 +1849,7 @@ ul.grid {
 }
 
 .cta .button:hover,
-.cta .button:focus,
+.cta .button:focus-visible,
 .cta .button:active {
   box-shadow: white 0 0 20px 5px;
   transition-duration: 0.2s;
@@ -1852,7 +1866,7 @@ ul.grid {
 }
 
 .footer a {
-  font-weight: 700;
+  font-weight: 400;
   color: var(--main-color-light-gray);
   text-decoration: none;
 }
@@ -1964,6 +1978,12 @@ table tr:nth-child(even) {
 .testimonial-footer img {
   border-radius: 50%;
   margin-right: var(--s-1);
+}
+
+/* Avatar sizing moved off the HTML width/height attrs. */
+.testimonial-avatar {
+  inline-size: 50px;
+  block-size: 50px;
 }
 
 .testimonial-footer .byline {

--- a/app/store_project/static/css/base.css
+++ b/app/store_project/static/css/base.css
@@ -2254,7 +2254,8 @@ table tr:nth-child(even) {
 
 /* Challenge card + sidebar category tags: soft accent pills (matches spike) */
 .card-box .tag,
-.sidebar-main-layout .tag {
+.sidebar-main-layout .tag,
+.product-switcher .tag {
   background: var(--accent-soft);
   color: var(--accent-deep);
   border: 1px solid var(--accent-line);
@@ -2272,7 +2273,8 @@ table tr:nth-child(even) {
 }
 
 .card-box .tag:hover,
-.sidebar-main-layout .tag:hover {
+.sidebar-main-layout .tag:hover,
+.product-switcher .tag:hover {
   background: #dcebf3;
   border-color: var(--accent);
   color: var(--accent-deep);

--- a/app/store_project/static/css/base.css
+++ b/app/store_project/static/css/base.css
@@ -284,6 +284,14 @@ tbody tr:last-child td:last-child {
   outline-offset: 2px;
 }
 
+/* Button-shaped links must never underline — the global a:hover/:focus/:active
+   underline rule would otherwise leak onto <a class="button"> on interaction. */
+.button:hover,
+.button:focus,
+.button:active {
+  text-decoration: none;
+}
+
 .button:disabled,
 .button[disabled],
 .button.disabled {
@@ -647,11 +655,21 @@ ul.errorlist {
   border-color: transparent;
 }
 
-.box.purchase:active,
-.box.purchase:hover,
-.box.purchase:focus-visible {
+/* Animate like a button — lighten the accent + lift on hover, press on
+   :active — instead of the old link-style underline. */
+.box.purchase:hover {
   cursor: pointer;
-  text-decoration: underline;
+  text-decoration: none;
+  background-color: color-mix(in srgb, var(--accent) 86%, #fff);
+  box-shadow: 0 2px 10px rgb(31 81 107 / 0.3);
+}
+
+.box.purchase:active {
+  cursor: pointer;
+  text-decoration: none;
+  background-color: var(--accent-deep);
+  transform: translateY(1px);
+  box-shadow: none;
 }
 
 .box.owned {

--- a/app/store_project/templates/_footer.html
+++ b/app/store_project/templates/_footer.html
@@ -3,10 +3,10 @@
   <div class="center">
     <div class="cluster">
       <div><!-- intermediary wrapper -->
-        <a href="{% url 'pages:single' slug="about" %}" style="font-weight:normal;">About</a> |
-        <a href="{% url 'pages:contact' %}" style="font-weight:normal;">Contact</a> |
-        <a href="{% url 'exercises:list' %}" style="font-weight:normal;">Exercises</a> |
-        <a href="{% url 'pages:single' slug="privacy" %}" style="font-weight:normal;">Privacy Policy</a> |
+        <a href="{% url 'pages:single' slug="about" %}">About</a> |
+        <a href="{% url 'pages:contact' %}">Contact</a> |
+        <a href="{% url 'exercises:list' %}">Exercises</a> |
+        <a href="{% url 'pages:single' slug="privacy" %}">Privacy Policy</a> |
         <span>Powered by <a href="https://lancegoyke.com/">Lance Goyke</a></span>
       </div>
     </div>

--- a/app/store_project/templates/_newsletter.html
+++ b/app/store_project/templates/_newsletter.html
@@ -11,11 +11,9 @@
           Email
         </label>
         <div class="stack">
-          <div class="form-with-sidebar">
-            <div><!-- intermediary wrapper -->
-              <input type="email" id="id_newsletter_email" placeholder="name@example.com" name="email" required />
-              <button class="button" type="submit">Submit</button>
-            </div><!-- END intermediary wrapper -->
+          <div class="input-group" role="group" aria-label="Sign up for product updates">
+            <input type="email" id="id_newsletter_email" placeholder="name@example.com" name="email" required />
+            <button class="button" type="submit">Submit</button>
           </div>
           <p><label class="form-control"><input type="checkbox" name="gdpr" value="1" required /> I agree to receive email updates and promotions.</label></p>
         </div>

--- a/app/store_project/templates/_newsletter.html
+++ b/app/store_project/templates/_newsletter.html
@@ -17,7 +17,7 @@
               <button class="button" type="submit">Submit</button>
             </div><!-- END intermediary wrapper -->
           </div>
-          <p><label class="form-control" style="font-weight: unset;"><input type="checkbox" name="gdpr" value="1" required /> I agree to receive email updates and promotions.</label></p>
+          <p><label class="form-control"><input type="checkbox" name="gdpr" value="1" required /> I agree to receive email updates and promotions.</label></p>
         </div>
         <!-- no botz please -->
         <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="a_password" tabindex="-1" value="" autocomplete="off" /></div>

--- a/app/store_project/templates/_testimonials.html
+++ b/app/store_project/templates/_testimonials.html
@@ -15,7 +15,7 @@
             </p>
           </div>
           <div class="testimonial-footer">
-            <img src="{% static 'jpg/jason-davidson-150x150.jpg' %}" height="50px" width="50px" alt="Jason Davidson headshot" />
+            <img class="testimonial-avatar" src="{% static 'jpg/jason-davidson-150x150.jpg' %}" alt="Jason Davidson headshot" />
             <div class="byline">
               <span class="name">Jason Davidson</span>
               <span class="job-title">Software Engineer</span>
@@ -36,7 +36,7 @@
             </p>
           </div>
           <div class="testimonial-footer">
-            <img src="{% static 'jpg/philip-rebisz-150x150.jpg' %}" height="50px" width="50px" alt="Philip Rebisz headshot" />
+            <img class="testimonial-avatar" src="{% static 'jpg/philip-rebisz-150x150.jpg' %}" alt="Philip Rebisz headshot" />
             <div class="byline">
               <span class="name">Philip Rebisz</span>
               <span class="job-title">Treasury Analyst</span>
@@ -57,7 +57,7 @@
             </p>
           </div>
           <div class="testimonial-footer">
-            <img src="{% static 'jpg/chris-rhoades-150x150.jpg' %}" height="50px" width="50px" alt="Christopher Rhoades headshot" />
+            <img class="testimonial-avatar" src="{% static 'jpg/chris-rhoades-150x150.jpg' %}" alt="Christopher Rhoades headshot" />
             <div class="byline">
               <span class="name">Christopher Rhoades</span>
               <span class="job-title">Strength Coach</span>

--- a/app/store_project/templates/account/password_reset_from_key.html
+++ b/app/store_project/templates/account/password_reset_from_key.html
@@ -27,7 +27,7 @@
         </label>
 
         <p>
-          <button type="submit">{% trans 'Change Password' %}</button>
+          <button class="button" type="submit">{% trans 'Change Password' %}</button>
         </p>
       </form>
     {% else %}

--- a/app/store_project/templates/pages/home.html
+++ b/app/store_project/templates/pages/home.html
@@ -43,7 +43,7 @@
 
       <h1 class="center text-center">Start feeling better in every possible way.</h1>
 
-      <div class="center box inherit-colors text-center">
+      <div class="center box transparent inherit-colors text-center">
         <span class="with-icon">
           <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white" width="18px" height="18px">
             <path d="M0 0h24v24H0V0z" fill="none"/>

--- a/app/store_project/templates/products/_product_cards.html
+++ b/app/store_project/templates/products/_product_cards.html
@@ -8,7 +8,7 @@
           {% if product.featured_image %}
             <img src="{{ product.featured_image.url }}" alt="{{ product.name }}" />
           {% else %}
-            <img class="image-placeholder">
+            <div class="image-placeholder"></div>
           {% endif %}
         </div>
         <div class="box stack">

--- a/app/store_project/templates/products/_product_cards.html
+++ b/app/store_project/templates/products/_product_cards.html
@@ -8,7 +8,7 @@
           {% if product.featured_image %}
             <img src="{{ product.featured_image.url }}" alt="{{ product.name }}" />
           {% else %}
-            <img style="background-color: var(--main-color-dark);">
+            <img class="image-placeholder">
           {% endif %}
         </div>
         <div class="box stack">

--- a/app/store_project/templates/products/book_detail.html
+++ b/app/store_project/templates/products/book_detail.html
@@ -24,11 +24,11 @@
   <div class="cluster">
   <!-- intermediary wrapper -->
     <p>
-      <a class="box" href="{% url 'products:store' %}">
-        < Back to Store
+      <a class="button outline" href="{% url 'products:store' %}">
+        ‹ Back to Store
       </a>
       {% if user.is_superuser %}
-        <a class="box padding:s-1" href="{% url 'admin:products_book_change' book.id %}">
+        <a class="button outline" href="{% url 'admin:products_book_change' book.id %}">
           Admin
         </a>
       {% endif %}

--- a/app/store_project/templates/products/book_detail.html
+++ b/app/store_project/templates/products/book_detail.html
@@ -24,7 +24,7 @@
   <div class="cluster">
   <!-- intermediary wrapper -->
     <p>
-      <a class="box padding" href="{% url 'products:store' %}">
+      <a class="box" href="{% url 'products:store' %}">
         < Back to Store
       </a>
       {% if user.is_superuser %}
@@ -42,7 +42,7 @@
           {% if book.featured_image %}
             <img src="{{ book.featured_image.url }}" alt="" />
           {% else %}
-            <img style="background-color: var(--main-color-dark);">
+            <img class="image-placeholder">
           {% endif %}
         </div>
       </div>
@@ -78,8 +78,8 @@
                 <button
                   class="button box purchase"
                   id="submitButton"
-                  data-productType="book"
-                  data-productSlug="{{ book.slug }}">
+                  data-product-type="book"
+                  data-product-slug="{{ book.slug }}">
                   Purchase!
                 </button>
               {% endif %}

--- a/app/store_project/templates/products/book_detail.html
+++ b/app/store_project/templates/products/book_detail.html
@@ -42,7 +42,7 @@
           {% if book.featured_image %}
             <img src="{{ book.featured_image.url }}" alt="" />
           {% else %}
-            <img class="image-placeholder">
+            <div class="image-placeholder"></div>
           {% endif %}
         </div>
       </div>

--- a/app/store_project/templates/products/book_list.html
+++ b/app/store_project/templates/products/book_list.html
@@ -23,7 +23,7 @@
             {% if book.featured_image %}
               <img src="{{ book.featured_image.url }}" alt="{{ book.name }}" />
             {% else %}
-              <img style="background-color: var(--main-color-dark);">
+              <img class="image-placeholder">
             {% endif %}
           </div>
           <div class="box stack">

--- a/app/store_project/templates/products/book_list.html
+++ b/app/store_project/templates/products/book_list.html
@@ -23,7 +23,7 @@
             {% if book.featured_image %}
               <img src="{{ book.featured_image.url }}" alt="{{ book.name }}" />
             {% else %}
-              <img class="image-placeholder">
+              <div class="image-placeholder"></div>
             {% endif %}
           </div>
           <div class="box stack">

--- a/app/store_project/templates/products/program_detail.html
+++ b/app/store_project/templates/products/program_detail.html
@@ -43,7 +43,7 @@
           {% if program.featured_image %}
             <img src="{{ program.featured_image.url }}" alt="" />
           {% else %}
-            <img class="image-placeholder">
+            <div class="image-placeholder"></div>
           {% endif %}
         </div>
       </div>

--- a/app/store_project/templates/products/program_detail.html
+++ b/app/store_project/templates/products/program_detail.html
@@ -25,11 +25,11 @@
   <div class="cluster">
   <!-- intermediary wrapper -->
     <p>
-      <a class="box" href="{% url 'products:store' %}">
-        < Back to Store
+      <a class="button outline" href="{% url 'products:store' %}">
+        ‹ Back to Store
       </a>
       {% if user.is_superuser %}
-        <a class="box padding:s-1" href="{% url 'admin:products_program_change' program.id %}">
+        <a class="button outline" href="{% url 'admin:products_program_change' program.id %}">
           Admin
         </a>
       {% endif %}

--- a/app/store_project/templates/products/program_detail.html
+++ b/app/store_project/templates/products/program_detail.html
@@ -25,7 +25,7 @@
   <div class="cluster">
   <!-- intermediary wrapper -->
     <p>
-      <a class="box padding" href="{% url 'products:store' %}">
+      <a class="box" href="{% url 'products:store' %}">
         < Back to Store
       </a>
       {% if user.is_superuser %}
@@ -43,7 +43,7 @@
           {% if program.featured_image %}
             <img src="{{ program.featured_image.url }}" alt="" />
           {% else %}
-            <img style="background-color: var(--main-color-dark);">
+            <img class="image-placeholder">
           {% endif %}
         </div>
       </div>

--- a/app/store_project/templates/products/program_list.html
+++ b/app/store_project/templates/products/program_list.html
@@ -23,7 +23,7 @@
             {% if program.featured_image %}
               <img src="{{ program.featured_image.url }}" alt="{{ program.name }}" />
             {% else %}
-              <img style="background-color: var(--main-color-dark);">
+              <img class="image-placeholder">
             {% endif %}
           </div>
           <div class="box stack">

--- a/app/store_project/templates/products/program_list.html
+++ b/app/store_project/templates/products/program_list.html
@@ -23,7 +23,7 @@
             {% if program.featured_image %}
               <img src="{{ program.featured_image.url }}" alt="{{ program.name }}" />
             {% else %}
-              <img class="image-placeholder">
+              <div class="image-placeholder"></div>
             {% endif %}
           </div>
           <div class="box stack">

--- a/app/store_project/templates/tracking/partials/result_form.html
+++ b/app/store_project/templates/tracking/partials/result_form.html
@@ -6,7 +6,7 @@
       {% for field in form %}
 
         {% if field.errors %}
-          {{ field.errrors }}
+          {{ field.errors }}
         {% endif %}
 
         <label class="stack" for="{{ field.id_for_label }}">

--- a/app/store_project/templates/tracking/test_list.html
+++ b/app/store_project/templates/tracking/test_list.html
@@ -32,7 +32,7 @@
                 <img src="{{ vid.thumbnail }}" alt="{{ test.name }} video instructions" />
               {% endvideo %}
             {% else %}
-              <img style="background-color: var(--main-color-dark);">
+              <img class="image-placeholder">
             {% endif %}
           </div>
           <div class="box stack">

--- a/app/store_project/templates/tracking/test_list.html
+++ b/app/store_project/templates/tracking/test_list.html
@@ -32,7 +32,7 @@
                 <img src="{{ vid.thumbnail }}" alt="{{ test.name }} video instructions" />
               {% endvideo %}
             {% else %}
-              <img class="image-placeholder">
+              <div class="image-placeholder"></div>
             {% endif %}
           </div>
           <div class="box stack">

--- a/app/store_project/templates/users/profile_update.html
+++ b/app/store_project/templates/users/profile_update.html
@@ -8,10 +8,10 @@
 
   <h1>Update Account</h1>
 
-  <form method="POST">
+  <form class="stack-form" method="POST">
     {% csrf_token %}
     {{ form.as_p }}
-    <button type="submit">Update</button>
+    <button class="button" type="submit">Update</button>
   </form>
 
 {% endblock content %}


### PR DESCRIPTION
Second PR of the design-system unification (`docs/design-system-unification-plan.md`), continuing from **PR 1 (#346)**. PR 1 added the token layer and globally re-skinned `.box`/`.button`/inputs/`.tag`; **PR 2 fixes the per-template inconsistencies the global re-skin could not reach.**

## Headline fix — the newsletter form
The email input and **Submit** button sat flush because `.form-with-sidebar`'s flex gutters used a `margin: calc(0px / 2 …)` trick that evaluates to **zero**. Replaced with a real `gap: var(--s-1)`. Same change also fixes `account/password_reset.html` (identical markup).

## Real bugs fixed
- **`products/book_detail.html`** — the checkout button used camelCase `data-productType`/`data-productSlug`, which the DOM lowercases to `producttype`/`productslug`, so `payments.js` (`button.dataset.productType`) **never fired the *book* checkout**. Now kebab-case, matching `program_detail`.
- **`tracking/partials/result_form.html`** — `{{ field.errrors }}` typo (3 r's) silently rendered nothing → field validation errors never showed. Now `field.errors`.
- **Unstyled submit buttons** (native gray) now use `.button`: `account/password_reset_from_key.html`, `users/profile_update.html` (also gains `.stack-form` spacing).

## Template/CSS cleanups (off-token markup → the design system)
- Footer links: dropped 4 inline `font-weight:normal` + set `.footer a` to `400` (the inline styles were fighting the global `700` rule).
- Newsletter consent label: dropped inline `font-weight: unset`; `.form-control` now declares `font-weight: 400`.
- Testimonial avatars: sizing moved off HTML `height`/`width` attrs to a `.testimonial-avatar` rule.
- Imageless-product placeholder: one `.image-placeholder` rule replaces the inline `background-color` repeated across **6 templates**.
- Dead `.padding` class dropped from the "Back to Store" boxes (`.box` already pads).
- `.cta .button` / `.box.purchase` focus styling → `:focus-visible` (PR 1 ring pattern).

## Tests
`app/store_project/pages/tests/test_design_system_pr2.py` (red→green) — CSS guards + real template renders; updated the existing `book_detail` view test to the kebab-case attrs. **Full suite 1398 passed; ruff clean.** Codex review loop: **CLEAN** (0 blocking, 0 nits).

## Scope / deferred (per the plan)
Out of scope here, batched for later PRs: the global hardcoded-color→token sweep, `form.as_p` → component-markup rewrites for low-traffic allauth/openid templates, and the exercises filter-link component. **PR 3 = Meso reconnection** (final phase).

Plan: `docs/design-system-unification-plan.md` · kicked off from #327.