### PR TITLE
Meso — group agent (Phase 1): the AI agent edits a group's shared program

### DIFF
--- a/app/store_project/meso/agent/client.py
+++ b/app/store_project/meso/agent/client.py
@@ -218,8 +218,20 @@ SYSTEM_PROMPT = (
 )
 
 
+_GROUP_FRAMING = (
+    "This is a GROUP's SHARED program — every listed member trains off it, so "
+    "your edits apply to ALL of them. Ground on the group context: honor EVERY "
+    "member's contraindications (the group.contraindications list folds them "
+    "together). Do not personalize per athlete here; edit the one shared week.\n\n"
+)
+
+
 def _user_prompt(context, instruction):
+    # Group framing lives in the volatile user turn (not the cached system prompt)
+    # so individual runs keep their stable, cache-friendly prompt unchanged.
+    framing = _GROUP_FRAMING if "group" in context else ""
     return (
+        f"{framing}"
         "Plan context (JSON):\n"
         f"{json.dumps(context, ensure_ascii=False, sort_keys=True)}\n\n"
         f"Coach instruction:\n{instruction}"

--- a/app/store_project/meso/agent/service.py
+++ b/app/store_project/meso/agent/service.py
@@ -63,20 +63,60 @@ def _coach_style(coach):
     return {"tags": profile.programming_style or [], "avoid": profile.avoid_rules}
 
 
-def build_context(plan):
-    """Everything the model is grounded on, as a JSON-serializable dict."""
+def _group_context(group):
+    """Group grounding (groups Phase 1 — the group agent edits the shared program).
+
+    A group plan has no single athlete, so the agent grounds on the *group*: its
+    name/focus, each active member with their own active contraindications, and —
+    most importantly for safety — the **folded** set of every member's
+    contraindications. The shared row trains everyone, so the agent must honor the
+    union; the deterministic backstop (``validation.forbidden_terms``) folds the
+    same way, regardless of what the model returns.
+    """
+    members = group.active_member_users()
+    member_data = []
+    folded = set()
+    for user in members:
+        texts = [c.text for c in user.contraindications.all() if c.active]
+        folded.update(texts)
+        member_data.append({"name": user.display_name(), "contraindications": texts})
     return {
-        "plan": serializers.serialize_plan(plan),
-        "athlete": {
-            "name": plan.athlete.display_name(),
-            "contraindications": [
-                c.text for c in plan.athlete.contraindications.filter(active=True)
-            ],
-        },
-        "coach_style": _coach_style(plan.coach),
-        # What the athlete actually logged recently (Phase 4 grounding).
-        "recent_logs": serializers.serialize_recent_logs(plan, limit=RECENT_LOG_LIMIT),
+        "name": group.name,
+        "focus": group.focus or "",
+        "member_count": len(member_data),
+        "members": member_data,
+        # The union the shared program must honor — every member's constraints.
+        "contraindications": sorted(folded),
     }
+
+
+def build_context(plan):
+    """Everything the model is grounded on, as a JSON-serializable dict.
+
+    An **individual** plan grounds on its one athlete (profile, contraindications,
+    recent logs). A **group** plan grounds on the group instead (members + the
+    contraindications folded across them); there is no single athlete log stream,
+    so ``recent_logs`` is empty for a group.
+    """
+    context = {
+        "plan": serializers.serialize_plan(plan),
+        "coach_style": _coach_style(plan.coach),
+    }
+    if plan.is_group:
+        context["group"] = _group_context(plan.group)
+        context["recent_logs"] = []
+        return context
+    context["athlete"] = {
+        "name": plan.athlete.display_name(),
+        "contraindications": [
+            c.text for c in plan.athlete.contraindications.filter(active=True)
+        ],
+    }
+    # What the athlete actually logged recently (Phase 4 grounding).
+    context["recent_logs"] = serializers.serialize_recent_logs(
+        plan, limit=RECENT_LOG_LIMIT
+    )
+    return context
 
 
 def create_drafting_batch(
@@ -202,7 +242,7 @@ def run_proposal_job(batch_id, *, client=None):
     ``(batch, rejected)``.
     """
     batch = models.AgentProposalBatch.objects.select_related(
-        "plan", "plan__relationship", "plan__relationship__athlete"
+        "plan", "plan__relationship", "plan__relationship__athlete", "plan__group"
     ).get(pk=batch_id)
     try:
         client = client or client_module.get_default_client()

--- a/app/store_project/meso/agent/validation.py
+++ b/app/store_project/meso/agent/validation.py
@@ -116,11 +116,30 @@ def _avoid_clause(text):
     return text
 
 
+def _active_contraindication_texts(plan):
+    """Active contraindication texts the plan must honor.
+
+    An **individual** plan honors its one athlete's; a **group** plan honors the
+    union across *every active member* — the shared row trains all of them, so a
+    movement unsafe for any one member is forbidden for the whole group.
+    """
+    if plan.is_group:
+        texts = []
+        for user in plan.group.active_member_users():
+            texts.extend(c.text for c in user.contraindications.all() if c.active)
+        return texts
+    return [c.text for c in plan.athlete.contraindications.filter(active=True)]
+
+
 def forbidden_terms(plan):
-    """Movement terms a swap must not re-introduce, from active contraindications."""
+    """Movement terms a swap must not re-introduce, from active contraindications.
+
+    Folds across a group's active members for a group plan (the conservative
+    backstop — see ``_active_contraindication_texts``).
+    """
     terms = set()
-    for c in plan.athlete.contraindications.filter(active=True):
-        terms |= _significant_words(_avoid_clause(c.text))
+    for text in _active_contraindication_texts(plan):
+        terms |= _significant_words(_avoid_clause(text))
     return terms
 
 

--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -398,10 +398,14 @@ def review_changes(batch):
     """Context for the review screen from a real ``AgentProposalBatch`` (B6).
 
     Feeds the same template the prototype fixtures did, so a real batch renders
-    unchanged; per-change approve/reject persistence + apply land in Phase 2.
+    unchanged; per-change approve/reject persistence + apply land in Phase 2. A
+    **group** batch (the group agent edits the shared program) has no single
+    athlete, so the review heading names the *group* instead.
     """
+    plan = batch.plan
+    subject = plan.group.name if plan.is_group else plan.athlete.display_name()
     return {
-        "athlete": {"name": batch.plan.athlete.display_name()},
+        "athlete": {"name": subject},
         "changes": [serialize_proposed_change(c) for c in batch.changes.all()],
     }
 

--- a/app/store_project/meso/tests/test_group_agent.py
+++ b/app/store_project/meso/tests/test_group_agent.py
@@ -1,0 +1,395 @@
+"""Group agent — Phase 1: the AI agent edits a group's SHARED program.
+
+The agent used to reject a group plan with a 400 — its grounding dereferenced a
+single ``plan.athlete``. This slice grounds it on the *group* instead (the active
+members and their contraindications **folded across all of them**) and lets it
+propose edits to the shared program behind the same propose → review → apply gate
+every individual run uses. Two properties matter:
+
+- **Safety is conservative.** The contraindication backstop folds *every* active
+  member's active contraindications, so a swap/add unsafe for **any one** member
+  is rejected — the shared row trains everyone.
+- **The edit lands on the shared template.** ``agent.apply`` writes onto the
+  shared ``ExercisePrescription``, so every member inherits it (per-member
+  auto-adjust generation stays a later phase).
+
+The review/status/apply endpoints are scoped to a plan the coach may *edit*
+(``editable_by``), which now includes their group plans — a foreign coach still
+404s. A group run is tagged ``trigger=group`` for the usage ledger (attributed to
+the group, athlete null).
+"""
+
+import pytest
+from django.urls import reverse
+
+from store_project.meso import presenters
+from store_project.meso.agent import apply as agent_apply
+from store_project.meso.agent import service
+from store_project.meso.agent import validation
+from store_project.meso.factories import ContraindicationFactory
+from store_project.meso.factories import GroupMembershipFactory
+from store_project.meso.factories import MesoGroupFactory
+from store_project.meso.factories import ProposedChangeFactory
+from store_project.meso.models import AgentProposalBatch
+from store_project.meso.models import CoachAthlete
+from store_project.meso.models import CoachSubscription
+from store_project.meso.models import ProposedChange
+from store_project.meso.serializers import current_week
+from store_project.meso.tests.test_agent_endpoint import install_fake
+from store_project.meso.tests.test_agent_endpoint import propose
+from store_project.meso.tests.test_agent_endpoint import status_url
+from store_project.users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def make_group_plan(*, coach=None, members=2):
+    """A comped coach's group with ``members`` active athletes + a shared plan.
+
+    Comped so the paid-only agent gate (S6) stays open. Returns
+    ``(coach, group, plan, athletes)`` where ``plan`` is the group's scaffolded
+    shared program (a current week with two starter days).
+    """
+    coach = coach or UserFactory()
+    CoachSubscription.comp(coach)
+    group = MesoGroupFactory(coach=coach)
+    athletes = [
+        GroupMembershipFactory(group=group).relationship.athlete for _ in range(members)
+    ]
+    plan = group.create_shared_plan()
+    return coach, group, plan, athletes
+
+
+def first_presc(plan):
+    """A shared prescription in the group plan's current week."""
+    week = current_week(plan)
+    return week.sessions.first().prescriptions.first()
+
+
+def swap_result(presc, *, introduces, title="New exercise → swap"):
+    return {
+        "summary": "Swapped a shared lift.",
+        "changes": [
+            {
+                "kind": "swap",
+                "prescription_id": presc.pk,
+                "day_label": "Day 1",
+                "title": title,
+                "before": "New exercise",
+                "after": introduces,
+                "rationale": "Fits the group's focus.",
+                "honors": "",
+                "introduces_exercise": introduces,
+            }
+        ],
+    }
+
+
+class TestGroupContext:
+    def test_group_plan_grounds_on_the_group_not_an_athlete(self):
+        coach, group, plan, athletes = make_group_plan()
+        ctx = service.build_context(plan)
+        # A group has no single athlete to ground on.
+        assert "athlete" not in ctx
+        assert ctx["recent_logs"] == []
+        g = ctx["group"]
+        assert g["name"] == group.name
+        assert g["member_count"] == 2
+
+    def test_group_context_folds_member_contraindications(self):
+        coach, group, plan, athletes = make_group_plan()
+        ContraindicationFactory(
+            athlete=athletes[0], text="L knee — avoid deep knee flexion under load"
+        )
+        ContraindicationFactory(athlete=athletes[1], text="No overhead pressing")
+
+        g = service.build_context(plan)["group"]
+
+        folded = " ".join(g["contraindications"]).lower()
+        assert "knee flexion" in folded
+        assert "overhead pressing" in folded
+        # Each member also carries their own, so the agent knows whose is whose.
+        per_member = {len(m["contraindications"]) for m in g["members"]}
+        assert per_member == {1}
+
+    def test_individual_plan_context_is_unchanged(self):
+        # The individual path keeps its athlete block + recent_logs contract.
+        from store_project.meso.tests.test_agent_validation import make_plan
+
+        plan, _, _ = make_plan()
+        ctx = service.build_context(plan)
+        assert "group" not in ctx
+        assert "name" in ctx["athlete"]
+        assert ctx["recent_logs"] == []
+
+
+class TestGroupForbiddenTerms:
+    def test_folds_across_active_members(self):
+        coach, group, plan, athletes = make_group_plan()
+        ContraindicationFactory(
+            athlete=athletes[0], text="L knee — avoid deep knee flexion under load"
+        )
+        ContraindicationFactory(
+            athlete=athletes[1], text="No overhead pressing movements"
+        )
+
+        terms = validation.forbidden_terms(plan)
+
+        assert "flexion" in terms  # member 0
+        assert "overhead" in terms  # member 1
+        assert "pressing" in terms
+
+    def test_excludes_an_ended_members_contraindication(self):
+        coach, group, plan, athletes = make_group_plan(members=1)
+        gone = GroupMembershipFactory(group=group)
+        ContraindicationFactory(
+            athlete=gone.relationship.athlete, text="No deadlifting"
+        )
+        gone.relationship.status = CoachAthlete.Status.ENDED
+        gone.relationship.save(update_fields=["status"])
+
+        assert "deadlifting" not in validation.forbidden_terms(plan)
+
+
+class TestGroupAgentEndpoint:
+    def test_accepts_a_group_plan_and_tags_the_run(self, client, monkeypatch):
+        coach, group, plan, athletes = make_group_plan()
+        presc = first_presc(plan)
+        install_fake(monkeypatch, swap_result(presc, introduces="Front Squat"))
+        client.force_login(coach)
+
+        resp = propose(client, plan, "progress the group")
+
+        assert resp.status_code == 202
+        batch = AgentProposalBatch.objects.get(pk=resp.json()["batch_id"])
+        assert batch.plan_id == plan.pk
+        assert batch.coach == coach
+        # A group run attributes to the group (athlete null) and is tagged group.
+        assert batch.trigger == AgentProposalBatch.Trigger.GROUP
+        assert batch.status == AgentProposalBatch.Status.PENDING
+        assert batch.changes.count() == 1
+
+    def test_status_poll_returns_the_group_batch(self, client, monkeypatch):
+        coach, group, plan, athletes = make_group_plan()
+        presc = first_presc(plan)
+        install_fake(monkeypatch, swap_result(presc, introduces="Front Squat"))
+        client.force_login(coach)
+
+        batch_id = propose(client, plan).json()["batch_id"]
+        data = client.get(status_url(batch_id)).json()
+
+        assert data["status"] == AgentProposalBatch.Status.PENDING
+        assert len(data["changes"]) == 1
+        assert f"/meso/review/{batch_id}/" in data["review_url"]
+
+    def test_folded_backstop_drops_a_swap_unsafe_for_any_member(
+        self, client, monkeypatch
+    ):
+        coach, group, plan, athletes = make_group_plan()
+        # Only the SECOND member flags knee flexion; the shared row trains both,
+        # so the swap must still be rejected.
+        ContraindicationFactory(
+            athlete=athletes[1], text="L knee — avoid deep knee flexion under load"
+        )
+        presc = first_presc(plan)
+        install_fake(
+            monkeypatch,
+            swap_result(presc, introduces="Deep Knee Flexion Drill"),
+        )
+        client.force_login(coach)
+
+        batch_id = propose(client, plan).json()["batch_id"]
+        data = client.get(status_url(batch_id)).json()
+
+        assert data["status"] == AgentProposalBatch.Status.PENDING
+        assert data["changes"] == []  # dropped by the folded backstop
+        assert "review_url" not in data
+
+    def test_foreign_coach_cannot_propose_on_a_group(self, client, monkeypatch):
+        coach, group, plan, athletes = make_group_plan()
+        install_fake(monkeypatch, {"summary": "", "changes": []})
+        other = UserFactory()
+        CoachSubscription.comp(other)
+        client.force_login(other)
+
+        resp = propose(client, plan, "go")
+
+        # The plan exists but the foreigner can't edit it → 403 (mirrors the
+        # individual ``test_non_owner_forbidden``), and nothing is persisted.
+        assert resp.status_code == 403
+        assert not AgentProposalBatch.objects.exists()
+
+
+class TestGroupReviewApply:
+    def make_group_batch(self, *, status=AgentProposalBatch.Status.PENDING):
+        coach, group, plan, athletes = make_group_plan()
+        presc = first_presc(plan)
+        batch = AgentProposalBatch.objects.create(
+            plan=plan,
+            coach=coach,
+            instruction="swap it",
+            status=status,
+            trigger=AgentProposalBatch.Trigger.GROUP,
+        )
+        change = ProposedChangeFactory(
+            batch=batch,
+            kind=ProposedChange.Kind.SWAP,
+            prescription=presc,
+            payload={"name": "Front Squat"},
+        )
+        return coach, plan, presc, batch, change
+
+    def test_status_endpoint_serves_a_group_batch(self, client):
+        coach, plan, presc, batch, change = self.make_group_batch()
+        client.force_login(coach)
+        resp = client.get(status_url(batch.pk))
+        assert resp.status_code == 200
+        assert resp.json()["status"] == AgentProposalBatch.Status.PENDING
+
+    def test_review_screen_renders_a_group_batch(self, client):
+        coach, plan, presc, batch, change = self.make_group_batch()
+        client.force_login(coach)
+        resp = client.get(reverse("meso:review_batch", kwargs={"batch_id": batch.pk}))
+        assert resp.status_code == 200
+        # The review heading names the group, not a (None) athlete.
+        assert plan.group.name in resp.content.decode()
+
+    def test_apply_writes_onto_the_shared_prescription(self, client):
+        coach, plan, presc, batch, change = self.make_group_batch()
+        client.force_login(coach)
+        resp = client.post(
+            reverse("meso:api_batch_apply", kwargs={"batch_id": batch.pk})
+        )
+        assert resp.status_code == 200
+        presc.refresh_from_db()
+        # Every member trains off this shared row, so the swap reaches all of them.
+        assert presc.name == "Front Squat"
+        batch.refresh_from_db()
+        assert batch.status == AgentProposalBatch.Status.APPLIED
+
+    def test_foreign_coach_cannot_review_a_group_batch(self, client):
+        coach, plan, presc, batch, change = self.make_group_batch()
+        client.force_login(UserFactory())
+        resp = client.get(reverse("meso:review_batch", kwargs={"batch_id": batch.pk}))
+        assert resp.status_code == 404
+
+    def test_apply_sends_a_group_batch_back_to_the_designer(self, client):
+        # A group plan has no individual deliver screen (delivery is to-all), so the
+        # post-apply redirect must land on the designer, not a 404ing deliver page.
+        coach, plan, presc, batch, change = self.make_group_batch()
+        client.force_login(coach)
+        resp = client.post(
+            reverse("meso:api_batch_apply", kwargs={"batch_id": batch.pk})
+        )
+        assert resp.status_code == 200
+        assert resp.json()["deliver_url"] == reverse(
+            "meso:designer_plan", kwargs={"plan_id": plan.pk}
+        )
+        # And that deliver screen really would 404 for a group plan (why we reroute).
+        assert (
+            client.get(
+                reverse("meso:deliver_plan", kwargs={"plan_id": plan.pk})
+            ).status_code
+            == 404
+        )
+
+
+class TestReviewPresenter:
+    def test_group_batch_subject_is_the_group_name(self):
+        coach, group, plan, athletes = make_group_plan()
+        batch = AgentProposalBatch.objects.create(
+            plan=plan, coach=coach, instruction="x"
+        )
+        ctx = presenters.review_changes(batch)
+        assert ctx["athlete"]["name"] == group.name
+
+
+class TestClientFraming:
+    def test_group_context_adds_shared_program_framing(self):
+        from store_project.meso.agent import client as agent_client
+
+        context = {"group": {"name": "Squad", "members": []}}
+        prompt = agent_client._user_prompt(context, "progress everyone")
+        assert "SHARED program" in prompt
+        assert "every member" in prompt.lower()
+
+    def test_individual_context_keeps_the_plain_prompt(self):
+        from store_project.meso.agent import client as agent_client
+
+        context = {"athlete": {"name": "Maya"}}
+        prompt = agent_client._user_prompt(context, "progress the squat")
+        assert "SHARED program" not in prompt
+
+
+class TestGroupDesignerUI:
+    def _designer_template(self):
+        from pathlib import Path
+
+        path = (
+            Path(__file__).resolve().parents[2] / "templates" / "meso" / "designer.html"
+        )
+        return path.read_text()
+
+    def _meso_js(self):
+        from pathlib import Path
+
+        from django.contrib.staticfiles import finders
+
+        return Path(finders.find("js/meso.js")).read_text()
+
+    def test_stale_next_phase_placeholder_is_gone(self):
+        # The "group agent arrives in the next phase" copy contradicts this slice.
+        html = self._designer_template()
+        js = self._meso_js()
+        assert "arrives in the next phase" not in html
+        assert "arrives in the next phase" not in js
+
+    def test_meso_js_group_greeting_invites_the_agent(self):
+        js = self._meso_js()
+        # The group greeting now invites the coach to use the agent on the shared
+        # program rather than telling them it's unavailable.
+        assert "Ask me to adjust it" in js
+
+    def test_group_designer_renders_the_agent_composer(self, client):
+        coach, group, plan, athletes = make_group_plan()
+        client.force_login(coach)
+        resp = client.get(reverse("meso:designer_plan", kwargs={"plan_id": plan.pk}))
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert "Ask the agent to adjust the program" in body
+
+    def test_group_designer_hydrates_a_persisted_group_thread(self, client):
+        # Group plans can now have agent batches; the persisted-thread hydration
+        # must not dereference a (None) athlete.
+        coach, group, plan, athletes = make_group_plan()
+        AgentProposalBatch.objects.create(
+            plan=plan,
+            coach=coach,
+            instruction="lighten the squats",
+            summary="Done.",
+            status=AgentProposalBatch.Status.PENDING,
+            trigger=AgentProposalBatch.Trigger.GROUP,
+        )
+        client.force_login(coach)
+        resp = client.get(reverse("meso:designer_plan", kwargs={"plan_id": plan.pk}))
+        assert resp.status_code == 200
+        assert "lighten the squats" in resp.content.decode()
+
+
+class TestGroupApplyUnit:
+    def test_apply_batch_edits_the_shared_row(self):
+        coach, group, plan, athletes = make_group_plan()
+        presc = first_presc(plan)
+        batch = AgentProposalBatch.objects.create(
+            plan=plan, coach=coach, instruction="x"
+        )
+        ProposedChangeFactory(
+            batch=batch,
+            kind=ProposedChange.Kind.SWAP,
+            prescription=presc,
+            payload={"name": "Romanian Deadlift"},
+        )
+        result = agent_apply.apply_batch(batch)
+        assert result["applied"] == 1
+        presc.refresh_from_db()
+        assert presc.name == "Romanian Deadlift"

--- a/app/store_project/meso/tests/test_group_program.py
+++ b/app/store_project/meso/tests/test_group_program.py
@@ -344,21 +344,31 @@ class TestGroupPlanEndpoints:
         )
         assert resp.status_code == 400
 
-    def test_agent_rejects_group_plan(self, client):
-        # The group agent is a later phase; grounding assumes an athlete.
+    def test_agent_accepts_group_plan(self, client, monkeypatch):
+        # The group agent (Phase 1) edits the SHARED program: a group plan is no
+        # longer a 400 — it grounds on the group and runs behind the review gate.
+        # Full coverage lives in ``test_group_agent.py``.
+        from store_project.meso.agent import client as agent_client_module
+        from store_project.meso.tests.test_agent_service import FakeClient
+
         coach = UserFactory()
         # The AI agent is paid-only (S6 Phase 3, D4), so a coach iterating a plan
         # with the agent in these tests has full access — comp keeps the gate open.
         CoachSubscription.comp(coach)
         group = MesoGroupFactory(coach=coach)
         plan = group.create_shared_plan()
+        monkeypatch.setattr(
+            agent_client_module,
+            "get_default_client",
+            lambda: FakeClient({"summary": "", "changes": []}),
+        )
         client.force_login(coach)
         resp = client.post(
             reverse("meso:api_plan_agent", kwargs={"plan_id": plan.pk}),
             data={"instruction": "progress loads"},
             content_type="application/json",
         )
-        assert resp.status_code == 400
+        assert resp.status_code == 202
 
 
 # -- view: group detail surfaces the shared-program entry point --------------

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -2269,11 +2269,6 @@ def agent_propose(request, plan_id):
                 },
                 status=402,
             )
-        if plan.is_group:
-            # The agent grounds on a single athlete's profile + logs; a group agent
-            # (per-athlete auto-adjusts) is groups Phase 3. Reject before any work
-            # so it never dereferences ``plan.athlete``.
-            return HttpResponseBadRequest("The agent isn't available for groups yet.")
         try:
             payload = json.loads(request.body or "{}")
         except json.JSONDecodeError:
@@ -2297,8 +2292,16 @@ def agent_propose(request, plan_id):
                 status=503,
             )
 
+        # A group run grounds on the group (members + folded contraindications)
+        # and edits the shared program (groups Phase 1); tag it ``group`` for the
+        # usage ledger (attributed to the group, athlete null).
+        trigger = (
+            AgentProposalBatch.Trigger.GROUP
+            if plan.is_group
+            else AgentProposalBatch.Trigger.MANUAL
+        )
         batch = agent_service.create_drafting_batch(
-            plan, instruction, coach=request.user
+            plan, instruction, coach=request.user, trigger=trigger
         )
     # The batch is committed; enqueue the worker run and bump the plan outside the
     # lock so neither holds the coach row.
@@ -2351,12 +2354,18 @@ def batch_status(request, batch_id):
 
 
 def _coach_batch_or_404(request, batch_id):
-    """The batch the requester coaches, or raise ``Http404``."""
+    """The batch the requester coaches, or raise ``Http404``.
+
+    Scoped to a plan the coach may *edit* (``editable_by``), so it covers an
+    individual plan over an active relationship **and** a group plan the coach owns
+    (the group agent runs behind this same review gate) — a foreign/unknown batch
+    is a 404.
+    """
     batch = (
         AgentProposalBatch.objects.filter(
-            pk=batch_id, plan__in=Plan.objects.for_coach(request.user)
+            pk=batch_id, plan__in=Plan.objects.editable_by(request.user)
         )
-        .select_related("plan", "plan__relationship")
+        .select_related("plan", "plan__relationship", "plan__group")
         .first()
     )
     if batch is None:
@@ -2370,7 +2379,7 @@ def change_set_status(request, pk):
     """Persist a coach's approve/reject decision on one proposed change."""
     change = (
         ProposedChange.objects.filter(
-            pk=pk, batch__plan__in=Plan.objects.for_coach(request.user)
+            pk=pk, batch__plan__in=Plan.objects.editable_by(request.user)
         )
         .select_related("batch")
         .first()
@@ -2412,14 +2421,21 @@ def batch_apply(request, batch_id):
             {"ok": False, "error": "This batch has already been resolved."}, status=409
         )
     result = agent_apply.apply_batch(batch)
+    # Where the review screen sends the coach next. An individual plan has a
+    # deliver screen; a group plan's delivery is deliver-to-all (no individual
+    # deliver screen — ``DeliverView`` is ``for_coach`` individual-only and would
+    # 404 a group plan), so a group batch lands back in the designer where the
+    # shared program + its group delivery live.
+    if batch.plan.is_group:
+        next_url = reverse("meso:designer_plan", kwargs={"plan_id": batch.plan_id})
+    else:
+        next_url = reverse("meso:deliver_plan", kwargs={"plan_id": batch.plan_id})
     return JsonResponse(
         {
             "ok": True,
             "applied": result["applied"],
             "skipped": result["skipped"],
-            "deliver_url": reverse(
-                "meso:deliver_plan", kwargs={"plan_id": batch.plan_id}
-            ),
+            "deliver_url": next_url,
         }
     )
 
@@ -2658,7 +2674,7 @@ class ChangeReviewView(LoginRequiredMixin, TemplateView):
             # working plan.
             batch = (
                 AgentProposalBatch.objects.filter(
-                    plan__in=Plan.objects.for_coach(request.user),
+                    plan__in=Plan.objects.editable_by(request.user),
                     status=AgentProposalBatch.Status.PENDING,
                 )
                 .order_by("-created_at")
@@ -2676,9 +2692,9 @@ class ChangeReviewView(LoginRequiredMixin, TemplateView):
         batch = (
             AgentProposalBatch.objects.filter(
                 pk=kwargs["batch_id"],
-                plan__in=Plan.objects.for_coach(self.request.user),
+                plan__in=Plan.objects.editable_by(self.request.user),
             )
-            .select_related("plan", "plan__relationship__athlete")
+            .select_related("plan", "plan__relationship__athlete", "plan__group")
             .first()
         )
         if batch is None:

--- a/app/store_project/static/js/meso.js
+++ b/app/store_project/static/js/meso.js
@@ -197,10 +197,11 @@ function createMeso() {
       // The real athlete identity for the individual left rail (null for groups).
       this.athlete = data.athlete || null;
       // A group shared program opens in Group mode and renders its real identity
-      // (members / flags); an individual plan stays in Individual mode. The group
-      // agent (per-athlete auto-adjusts) is a later phase, so swap the agent
-      // greeting for a group-appropriate one (the live composer is hidden in the
-      // template — hydrateThread keeps this when the plan has no batches).
+      // (members / flags); an individual plan stays in Individual mode. The agent
+      // edits the shared program for a group (groups Phase 1) — it grounds on the
+      // members + their folded contraindications — so swap the greeting for a
+      // group-appropriate one (hydrateThread keeps this when the plan has no
+      // batches). Per-athlete auto-adjusts are still a later phase.
       this.group = data.group || null;
       if (this.group) {
         this.mode = "group";
@@ -208,7 +209,7 @@ function createMeso() {
           {
             id: 1,
             role: "agent",
-            text: "This is the group's shared program — every member trains off it. Edit it directly here; a group agent that auto-adjusts each athlete arrives in the next phase.",
+            text: "This is the group's shared program — every member trains off it. Ask me to adjust it and I'll propose changes for you to review; I honor every member's contraindications. (Per-athlete auto-adjusts come in a later phase.)",
           },
         ];
       }

--- a/app/store_project/templates/meso/designer.html
+++ b/app/store_project/templates/meso/designer.html
@@ -207,21 +207,22 @@
             <div x-show="agentTyping" class="meso-flex" style="align-items:center;gap:5px;font-size:11px;color:var(--dim);"><div style="width:6px;height:6px;border-radius:50%;background:var(--accent);"></div>drafting&#8230;</div>
             <div x-show="!agentTyping" class="meso-flex" style="align-items:center;gap:5px;font-size:11px;color:var(--dim);"><div style="width:6px;height:6px;border-radius:50%;background:var(--ok);"></div>ready</div>
             <div style="flex:1;"></div>
-            <div style="font-size:11px;color:var(--dim);">grounded on profile + logs</div>
+            <div style="font-size:11px;color:var(--dim);" x-text="isGroup ? 'grounded on the group' : 'grounded on profile + logs'"></div>
           </div>
 
           <!-- How the agent works (Phase 5): a persistent note making the review
                gate explicit — a first-timer won't expect the agent to only
-               *propose*. Always shown for an individual plan (the group agent is
-               a later phase, so its composer is hidden). -->
-          <div x-show="isIndividual" style="flex:0 0 auto;display:flex;align-items:flex-start;gap:7px;padding:8px 16px;border-bottom:1px solid var(--line-2);background:var(--rail);font-size:11px;line-height:1.4;color:var(--dim);">
+               *propose*. Shown in both modes: the group agent (groups Phase 1)
+               edits the shared program behind the same review gate. -->
+          <div style="flex:0 0 auto;display:flex;align-items:flex-start;gap:7px;padding:8px 16px;border-bottom:1px solid var(--line-2);background:var(--rail);font-size:11px;line-height:1.4;color:var(--dim);">
             <span style="font-weight:700;color:var(--accent-deep);white-space:nowrap;">Propose &#8594; review &#8594; apply</span>
             <span>The agent proposes; you review every change before it touches the program — nothing applies until you approve.</span>
           </div>
 
           <!-- Agent coachmark (Phase 5): dismissible first-run orientation for the
-               agent column. Individual-only (no live composer in group mode). -->
-          <div x-show="isIndividual && coachmarkVisible('agent')" style="flex:0 0 auto;display:flex;align-items:flex-start;gap:9px;margin:12px 14px 0;padding:11px 12px;background:var(--soft);border:1px solid var(--soft-line);border-left:3px solid var(--accent);border-radius:9px;">
+               agent column. Shown in both modes — the agent is live for groups
+               too (groups Phase 1, the shared program). -->
+          <div x-show="coachmarkVisible('agent')" style="flex:0 0 auto;display:flex;align-items:flex-start;gap:9px;margin:12px 14px 0;padding:11px 12px;background:var(--soft);border:1px solid var(--soft-line);border-left:3px solid var(--accent);border-radius:9px;">
             <div style="flex:1;min-width:0;line-height:1.4;">
               <div style="font-size:12.5px;font-weight:700;color:var(--accent-deep);">Talk to the agent</div>
               <div style="font-size:11.5px;color:var(--accent-deep);opacity:0.85;">Ask in plain words &#8212; &#8220;lighten Friday,&#8221; &#8220;add a deload week.&#8221; It drafts changes you can review.</div>
@@ -272,16 +273,8 @@
             </template>
           </div>
 
-          <!-- The agent grounds on one athlete's profile + logs; a group agent
-               (per-athlete auto-adjusts) is groups Phase 3, so group mode shows a
-               note instead of the live composer. -->
-          <template x-if="isGroup">
-            <div style="flex:0 0 auto;border-top:1px solid var(--line-2);padding:13px 14px 15px;font-size:12px;color:var(--dim);line-height:1.4;">
-              The agent works per athlete &#8212; a group agent that auto-adjusts each member arrives in the next phase. Edit the shared program directly for now.
-            </div>
-          </template>
           {% if can_use_agent %}
-            <div x-show="isIndividual" style="flex:0 0 auto;border-top:1px solid var(--line-2);padding:11px 14px 13px;">
+            <div style="flex:0 0 auto;border-top:1px solid var(--line-2);padding:11px 14px 13px;">
               <div style="display:flex;gap:6px;overflow-x:auto;padding-bottom:9px;">
                 <template x-for="c in chips" :key="c.label">
                   <button data-hover="chip" @click="onChip(c.label)" :disabled="agentTyping" x-text="c.label" style="appearance:none;cursor:pointer;font:inherit;white-space:nowrap;font-size:11.5px;font-weight:550;color:var(--ink);background:var(--surface);border:1px solid var(--line);border-radius:999px;padding:6px 11px;flex:0 0 auto;"></button>
@@ -302,8 +295,9 @@
           <!-- Agent gate (S6 Phase 3 / Phase 5): a free coach who has spent their
                monthly agent allowance sees an upgrade CTA where the composer would
                be. Billing actions live on the roster (the endpoint also 402s, so
-               this isn't the only guard). -->
-            <div x-show="isIndividual" style="flex:0 0 auto;border-top:1px solid var(--line-2);padding:13px 14px 15px;">
+               this isn't the only guard). Shown in both modes (the group agent is
+               metered the same way). -->
+            <div style="flex:0 0 auto;border-top:1px solid var(--line-2);padding:13px 14px 15px;">
               <p style="margin:0 0 9px;font-size:12px;color:var(--dim);line-height:1.4;">You've used all {{ agent_allowance.allowance }} free agent run{{ agent_allowance.allowance|pluralize }} this month. Start your free trial or subscribe ({{ price_summary }}) for unlimited agent runs.</p>
               <a href="{% url 'meso:roster' %}" data-hover="brighten" style="display:inline-block;text-decoration:none;font:inherit;font-size:12.5px;font-weight:650;color:var(--accent-ink);background:var(--accent);border-radius:8px;padding:8px 14px;">Upgrade to use the agent</a>
             </div>


### PR DESCRIPTION
## What

The AI proposal agent rejected a **group** plan with a `400` — its grounding
dereferenced a single `plan.athlete`. This slice grounds it on the **group**
instead and lets it edit the group's **shared program** behind the same
propose → review → apply gate every individual run uses. Per-athlete auto-adjust
generation by the agent stays a later phase. **No model change, no migration.**

## How

- **`service.build_context`** branches on `plan.is_group`: a group plan grounds on
  the group (name/focus, each active member + their contraindications, and the
  **folded** set across all members), with no single-athlete `recent_logs`.
- **`validation.forbidden_terms`** folds the contraindication backstop across
  **every active member** — a swap/add unsafe for *any one* member is rejected,
  since the shared row trains everyone (conservative by design).
- **`agent_propose`** drops the group `400` and tags a group run `trigger=group`
  for the usage ledger (attributed to the group, athlete null).
- The **review / status / apply** endpoints widen from `for_coach`
  (individual-only) to `editable_by` so they cover a coach's group batches —
  identical set for individual plans, so **no regression**; `presenters.review_changes`
  names the group when there is no single athlete.
- **`agent.apply` is unchanged** — it writes onto the shared `ExercisePrescription`
  so every member inherits the edit. After applying a group batch, the review
  screen routes back to the **designer** (a group has no individual deliver screen;
  delivery is deliver-to-all).
- **Client** adds group framing in the *user* turn — the cached system prompt is
  unchanged (individual runs keep their cache-friendly prompt).
- **Designer:** the agent composer / coachmark / review-gate note now render in
  Group mode; the stale "group agent arrives in the next phase" placeholder is gone.

## Tests

New `test_group_agent.py` (22 tests): context folding, the folded contraindication
backstop, the endpoint accept + `trigger=group`, group review/status/apply
scoping, post-apply routing to the designer, the presenter, and the designer
UI/thread hydration. Updated the group-program test that pinned the old `400`.

Full suite green (1284 meso pytest + 115 vitest), ruff + DjHTML + `makemigrations
--check` clean. **Codex review loop: CLEAN on iteration 1.**

https://claude.ai/code/session_019A9KdsVs33wipsGjSaFWXV