### PR TITLE
docs(meso): record group agent Phase 1 (shared-program editing, #350)

### DIFF
--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -1091,3 +1091,29 @@ _(Append dated entries here as decisions land.)_
   (deferred — needs an Admin API key + live org access). Remaining Meso backlog
   otherwise unchanged: billing annual prices (blocked on the owner's annual
   numbers) + the group agent (LARGE owner-decision).
+- 2026-06-30 — **Group agent Phase 1 built: the AI agent edits the shared program**
+  (PR #350, no migration). The proposal agent rejected a group plan with a `400`
+  (its grounding dereferenced a single `plan.athlete`); now it grounds on the
+  **group** and edits the group's **shared program** behind the same
+  propose → review → apply gate. `service.build_context` branches on `plan.is_group`
+  (a `_group_context`: members + each one's contraindications + the **folded** set
+  across all active members; no single-athlete `recent_logs`); `validation.forbidden_terms`
+  folds the contraindication backstop across **every active member** (a swap/add
+  unsafe for any one member is rejected — the shared row trains everyone);
+  `agent.apply` is **unchanged** (it already writes onto the shared
+  `ExercisePrescription`, so every member inherits). `agent_propose` drops the
+  `400` and tags a group run `trigger=group` (usage ledger → group, athlete null);
+  the review/status/apply endpoints widen `for_coach`→`editable_by` to cover group
+  batches (identical set for individual plans — no regression); `presenters.review_changes`
+  names the group; a group batch's post-apply link routes to the **designer** (no
+  individual deliver screen — group delivery is deliver-to-all). The client adds
+  group framing in the *user* turn (cached system prompt unchanged); the designer
+  shows the agent composer in Group mode (the stale "later phase" placeholder is
+  gone). **Decision:** shared-template editing is the first slice — it reuses the
+  entire pipeline (validation/apply/review/usage) and is consistent with the group
+  designer; **per-athlete auto-adjust generation (Phase 2)** — the agent emits
+  per-member `PrescriptionOverride`s — is the deferred follow-up. Red→green
+  (`test_group_agent.py`), Codex CLEAN iter 1, deploy success, prod-verified.
+  **Remaining Meso backlog:** billing annual prices (BLOCKED on owner numbers +
+  Stripe annual Prices); Anthropic Admin/Usage-API reconciliation (deferred, needs
+  Admin key); group agent Phase 2 (per-athlete auto-adjusts).

--- a/docs/meso/groups-plan.md
+++ b/docs/meso/groups-plan.md
@@ -349,3 +349,36 @@ agent, and athlete slices.
   only with a shared program + members.
 - Seed (`test_seed_demo.py`): the demo group's members get a materialized delivered plan, not
   duplicated on reseed.
+
+## Phase 5 — the group agent (the AI agent edits the shared program)
+
+Shipped 2026-06-30 (PR #350, no migration). The "What a group plan can't do yet"
+note above is now **superseded for the agent**: `agent_propose` no longer `400`s a
+group plan. The AI proposal agent edits the group's **shared program** behind the
+same propose → review → apply gate every individual run uses. **Per-athlete
+auto-adjust generation by the agent stays a later phase** — this is shared-template
+editing (the simplest correct first slice; the conservative folded backstop keeps
+it safe), consistent with how the group designer already works ("edit the shared
+program directly").
+
+- **Grounding (`agent.service.build_context`).** A group plan grounds on the
+  *group* (a new `_group_context`): name/focus, each active member + their active
+  contraindications, and the **folded** set across all active members. No
+  single-athlete `recent_logs`.
+- **Safety (`agent.validation.forbidden_terms`).** The contraindication backstop
+  folds across **every active member** — a swap/add unsafe for *any one* member is
+  rejected (the shared row trains everyone).
+- **Apply (`agent.apply`) is unchanged** — it writes onto the shared
+  `ExercisePrescription`, so every member inherits the edit.
+- **Scoping.** The review/status/apply endpoints widened from `for_coach`
+  (individual-only) to `editable_by`, so a coach reaches their group batches
+  (identical set for individual plans — no regression). A group run is tagged
+  `trigger=group` (usage ledger → attributed to the group, athlete null).
+- **Post-apply routing.** A group batch routes back to the **designer** (a group
+  has no individual deliver screen; delivery is deliver-to-all).
+- **Designer UI.** The agent composer / coachmark / review-gate note now render in
+  Group mode; the "group agent arrives in the next phase" placeholder is gone.
+
+Tests: `test_group_agent.py`. **Deferred:** group agent **Phase 2** = per-athlete
+auto-adjusts (the agent generates per-member `PrescriptionOverride`s instead of
+editing the shared row).


### PR DESCRIPTION
Docs-only follow-up to #350 (group agent Phase 1). Keeps the canonical Meso docs
honest so the backlog no longer describes the group agent as a "later phase":

- `docs/meso/groups-plan.md` — new **"Phase 5 — the group agent"** section
  (supersedes the Phase-2a "what a group plan can't do yet" note for the agent).
- `docs/meso/decisions.md` — dated entry recording the shared-template-editing
  design call and the deferred Phase 2 (per-athlete auto-adjusts).

No code change.

https://claude.ai/code/session_019A9KdsVs33wipsGjSaFWXV