### PR TITLE
Design system PR 3 — Meso reconnection (final phase)

### DIFF
--- a/app/store_project/meso/tests/test_design_reconnect.py
+++ b/app/store_project/meso/tests/test_design_reconnect.py
@@ -1,0 +1,160 @@
+"""Design-system unification — PR 3: Meso reconnection (final phase).
+
+PRs 1–2 unified the *main* site on one token-driven look. Meso still read as a
+separate website: its shell (``_meso_base.html``) carried no link back to the
+rest of Mastering Fitness, and ``meso.css`` used its own purple-blue accent
+(``oklch(0.56 0.14 258)``) instead of the site's steel-blue ``#31759d``.
+
+This phase reconnects Meso:
+
+- the **shared site nav** rides at the top of every coach-facing Meso shell page
+  (brand → home; About / Store / Challenges / Coaching / Contact; auth on the
+  right), so Meso reads as part of the same site, with the Meso workspace
+  sub-header (``.meso-topnav``) kept below it;
+- the phone-first **athlete PWA** surfaces (home, session logger, offline,
+  invite-claim) suppress that nav to keep their installed-app feel;
+- ``meso.css``, the standalone designer's inline tokens, and the PWA chrome
+  (manifest ``theme_color``) all point at the shared steel-blue accent.
+
+See ``docs/design-system-unification-plan.md`` (PR 3) and the validating spike
+``docs/spikes/basecoat/meso.html``.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from django.contrib.staticfiles import finders
+from django.urls import reverse
+
+from store_project.meso.factories import CoachAthleteFactory
+from store_project.meso.factories import ExercisePrescriptionFactory
+from store_project.meso.factories import MesocycleFactory
+from store_project.meso.factories import PlanFactory
+from store_project.meso.factories import SessionFactory
+from store_project.meso.factories import WeekFactory
+from store_project.meso.models import CoachAthlete
+from store_project.meso.models import CoachProfile
+from store_project.meso.models import Plan
+from store_project.users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+SHARED_ACCENT = "#31759d"  # the site's steel-blue (base.css --accent)
+OLD_ACCENT = "oklch(0.56 0.14 258)"  # the Meso-only accent being retired
+SITENAV_MARK = "meso-sitenav"  # class only the shared site nav carries
+
+
+def make_coach():
+    coach = UserFactory()
+    CoachProfile.objects.create(user=coach)
+    return coach
+
+
+def seed_plan(coach=None, athlete=None):
+    """A minimal owned, active plan with one current week → session → cell."""
+    rel = CoachAthleteFactory(
+        coach=coach or UserFactory(),
+        athlete=athlete or UserFactory(),
+        status=CoachAthlete.Status.ACTIVE,
+    )
+    plan = PlanFactory(
+        relationship=rel, title="Hypertrophy Block", status=Plan.Status.ACTIVE
+    )
+    meso = MesocycleFactory(plan=plan, name="Hypertrophy", order=0)
+    week = WeekFactory(mesocycle=meso, index=1, is_current=True)
+    session = SessionFactory(week=week, day_number=1, name="Lower")
+    ExercisePrescriptionFactory(
+        session=session, name="Box Squat", sets="4", reps="6", load="70", rpe="7"
+    )
+    return plan, session
+
+
+# ---------------------------------------------------------------------------
+# The shared site nav rides on the coach-facing Meso shell
+# ---------------------------------------------------------------------------
+
+
+class TestSharedSiteNav:
+    def test_roster_carries_shared_site_nav(self, client):
+        client.force_login(make_coach())
+        body = client.get(reverse("meso:roster")).content.decode()
+        assert SITENAV_MARK in body
+        # the same top-level links as the main-site nav (templates/_nav.html)
+        assert reverse("pages:home") in body
+        assert reverse("products:store") in body
+        assert reverse("challenges:challenge_filtered_list") in body
+        assert reverse("pages:contact") in body
+
+    def test_coaching_link_is_marked_active(self, client):
+        client.force_login(make_coach())
+        body = client.get(reverse("meso:roster")).content.decode()
+        # Coaching is the current site section.
+        assert "Coaching" in body
+        assert "is-active" in body
+
+    def test_authenticated_coach_sees_account_and_logout(self, client):
+        client.force_login(make_coach())
+        body = client.get(reverse("meso:roster")).content.decode()
+        assert reverse("account_logout") in body
+        assert reverse("users:profile") in body
+
+    def test_anonymous_landing_reconnects_to_the_site(self, client):
+        # The public front door also carries the shared nav (cold visitor → site),
+        # showing the logged-out auth actions.
+        body = client.get(reverse("meso:roster")).content.decode()
+        assert SITENAV_MARK in body
+        assert reverse("pages:home") in body
+        assert reverse("account_signup") in body
+
+    def test_shared_nav_does_not_leak_coach_only_surfaces(self, client):
+        # The site nav is the *site* nav, not the coach workspace nav — it must
+        # never advertise the Designer (kept in the .meso-topnav sub-header).
+        body = client.get(reverse("meso:roster")).content.decode()  # anon landing
+        # the site nav block itself carries no designer link
+        assert SITENAV_MARK in body
+        assert reverse("meso:designer") not in body
+
+
+# ---------------------------------------------------------------------------
+# The phone-first athlete PWA keeps its installed-app feel (no site nav)
+# ---------------------------------------------------------------------------
+
+
+class TestAthletePwaSuppressesSiteNav:
+    def test_athlete_home_has_no_site_nav(self, client):
+        plan, _ = seed_plan()
+        client.force_login(plan.relationship.athlete)
+        body = client.get(reverse("meso:athlete_home")).content.decode()
+        assert SITENAV_MARK not in body
+
+    def test_offline_page_has_no_site_nav(self, client):
+        body = client.get(reverse("meso:offline")).content.decode()
+        assert SITENAV_MARK not in body
+
+
+# ---------------------------------------------------------------------------
+# Every Meso accent surface points at the shared steel-blue
+# ---------------------------------------------------------------------------
+
+
+class TestSharedAccent:
+    def test_meso_css_uses_the_shared_accent(self):
+        path = finders.find("css/meso.css")
+        assert path, "meso.css must be resolvable as a static file"
+        css = Path(path).read_text()
+        assert SHARED_ACCENT in css
+        assert OLD_ACCENT not in css
+
+    def test_designer_inline_tokens_use_the_shared_accent(self, client):
+        # The standalone designer carries its own inline token block.
+        plan, _ = seed_plan()
+        client.force_login(plan.relationship.coach)
+        url = reverse("meso:designer_plan", kwargs={"plan_id": plan.pk})
+        body = client.get(url).content.decode()
+        assert SHARED_ACCENT in body
+        assert OLD_ACCENT not in body
+
+    def test_pwa_theme_color_matches_the_shared_accent(self, client):
+        data = json.loads(client.get(reverse("meso:manifest")).content)
+        assert data["theme_color"] == SHARED_ACCENT

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -1041,7 +1041,7 @@ def _clean_logged_sets(raw_sets, session):
 # The worker is rendered from a template that resolves the *hashed* asset URLs via
 # ``{% static %}`` at render time, so its precache list stays valid every deploy.
 
-PWA_THEME_COLOR = "#3c73c5"  # meso accent (oklch(0.56 0.14 258))
+PWA_THEME_COLOR = "#31759d"  # shared site accent (base.css --accent, steel-blue)
 PWA_BACKGROUND_COLOR = "#f5f6f7"  # meso app background (--bg)
 
 
@@ -1091,7 +1091,8 @@ def manifest_webmanifest(request):
 # Bumped when the cached shell changes so the worker drops stale caches on
 # activate. Keep in sync with the cache name baked into the worker template.
 # v2: added meso_onboarding.js to the precached shell (first-time UX Phase 4).
-PWA_CACHE_VERSION = "meso-pwa-v2"
+# v3: re-skinned meso.css to the shared steel-blue accent (design-system PR 3).
+PWA_CACHE_VERSION = "meso-pwa-v3"
 
 
 @require_GET

--- a/app/store_project/static/css/meso.css
+++ b/app/store_project/static/css/meso.css
@@ -33,11 +33,15 @@ body.meso {
   --line-2: #f1f3f5;
   --radius: 8px;
   --pad: 14px;
-  --accent: oklch(0.56 0.14 258);
+  /* Accent points at the shared site token (base.css --accent, steel-blue) so
+     Meso reads as part of Mastering Fitness — design-system unification PR 3.
+     The soft/line/deep values mirror the site's hand-picked --accent-soft /
+     --accent-line / --accent-deep rather than a color-mix, to match exactly. */
+  --accent: #31759d;
   --accent-ink: #ffffff;
-  --soft: color-mix(in srgb, var(--accent) 9%, #fff);
-  --soft-line: color-mix(in srgb, var(--accent) 26%, #fff);
-  --accent-deep: color-mix(in srgb, var(--accent) 82%, #1a1a1a);
+  --soft: #eaf2f7;
+  --soft-line: #bcd6e4;
+  --accent-deep: #1f516b;
   --warn: #b4541f;
   --warn-soft: #fbefe8;
   --ok: #2f8f56;
@@ -274,6 +278,55 @@ body.meso {
 }
 .meso-spacer {
   flex: 1;
+}
+
+/* --- shared site nav (design-system unification PR 3) ---
+   Reconnects the Meso workspace to the rest of Mastering Fitness: the same
+   top-level navigation as templates/_nav.html, styled here because the Meso
+   shell loads only meso.css. It rides above the Meso workspace sub-header
+   (.meso-topnav), and matches the main-site nav's black bar / light links. */
+.meso-sitenav {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px 26px;
+  padding: 13px clamp(16px, 4vw, 40px);
+  background: #0a0a0a;
+  color: #ededed;
+}
+.meso-sitenav-brand {
+  font-weight: 700;
+  font-size: 17px;
+  letter-spacing: -0.01em;
+  color: #ededed;
+  text-decoration: none;
+}
+.meso-sitenav-links {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px 20px;
+}
+.meso-sitenav-links a {
+  color: #ededed;
+  opacity: 0.82;
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 500;
+}
+.meso-sitenav-links a:hover,
+.meso-sitenav-links a:focus-visible {
+  opacity: 1;
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+.meso-sitenav-links a.is-active {
+  opacity: 1;
+  text-decoration: underline;
+  text-underline-offset: 5px;
+}
+.meso-sitenav-spacer {
+  margin-left: auto;
 }
 
 /* --- page scaffold --- */

--- a/app/store_project/templates/meso/_meso_base.html
+++ b/app/store_project/templates/meso/_meso_base.html
@@ -22,6 +22,12 @@
     {% block head_extra %}{% endblock %}
   </head>
   <body class="meso">
+    {% comment %}
+      The shared site nav reconnects Meso to the rest of Mastering Fitness
+      (design-system unification PR 3). Rendered by default; the phone-first
+      athlete PWA pages override this block to keep their installed-app feel.
+    {% endcomment %}
+    {% block site_nav %}{% include "meso/_meso_sitenav.html" %}{% endblock %}
     <div class="meso-app">
       <nav class="meso-topnav">
         <a class="meso-brand" href="{% url 'meso:roster' %}">

--- a/app/store_project/templates/meso/_meso_sitenav.html
+++ b/app/store_project/templates/meso/_meso_sitenav.html
@@ -1,0 +1,30 @@
+{% comment %}
+Design-system unification PR 3 — the shared site nav, reconnecting the Meso
+workspace to the rest of Mastering Fitness.
+
+Mirrors the main-site nav (templates/_nav.html: same links, same auth split) but
+is styled by meso.css, because the Meso shell loads only meso.css (not base.css).
+Rendered by default from _meso_base.html's {% block site_nav %}; the phone-first
+athlete PWA pages override that block to keep their installed-app feel. "Coaching"
+is the active section on every Meso page.
+{% endcomment %}
+<header class="meso-sitenav">
+  <a class="meso-sitenav-brand" href="{% url 'pages:home' %}">Mastering Fitness</a>
+  <nav class="meso-sitenav-links">
+    <a href="{% url 'pages:single' 'about' %}">About</a>
+    <a href="{% url 'products:store' %}">Store</a>
+    <a href="{% url 'challenges:challenge_filtered_list' %}">Challenges</a>
+    <a class="is-active" href="{% url 'meso:roster' %}">Coaching</a>
+    <a href="{% url 'pages:contact' %}">Contact</a>
+  </nav>
+  <span class="meso-sitenav-spacer"></span>
+  <nav class="meso-sitenav-links">
+    {% if user.is_authenticated %}
+      <a href="{% url 'users:profile' %}">Account</a>
+      <a href="{% url 'account_logout' %}">Logout</a>
+    {% else %}
+      <a href="{% url 'account_login' %}">Login</a>
+      <a href="{% url 'account_signup' %}">Signup</a>
+    {% endif %}
+  </nav>
+</header>

--- a/app/store_project/templates/meso/_pwa_head.html
+++ b/app/store_project/templates/meso/_pwa_head.html
@@ -7,7 +7,7 @@ theme/apple meta, the service-worker registration, and the push config the
 `meso_push.js` subscribe flow reads.
 {% endcomment %}
 <link rel="manifest" href="{% url 'meso:manifest' %}" />
-<meta name="theme-color" content="#3c73c5" />
+<meta name="theme-color" content="#31759d" />
 <meta name="mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-status-bar-style" content="default" />

--- a/app/store_project/templates/meso/athlete_home.html
+++ b/app/store_project/templates/meso/athlete_home.html
@@ -4,6 +4,9 @@
 
 {% block pwa %}{% include "meso/_pwa_head.html" %}{% endblock %}
 
+{# Phone-first PWA surface — no marketing site nav (keep the installed-app feel). #}
+{% block site_nav %}{% endblock %}
+
 {% block navlinks %}
   <a class="meso-navlink {% if active == 'training' %}is-active{% endif %}" href="{% url 'meso:athlete_home' %}">Training</a>
 {% endblock %}

--- a/app/store_project/templates/meso/athlete_session.html
+++ b/app/store_project/templates/meso/athlete_session.html
@@ -5,6 +5,9 @@
 
 {% block pwa %}{% include "meso/_pwa_head.html" %}{% endblock %}
 
+{# Phone-first PWA surface — no marketing site nav (keep the installed-app feel). #}
+{% block site_nav %}{% endblock %}
+
 {% block head_extra %}
   <script defer src="{% static 'js/meso_athlete.js' %}"></script>
   <script defer src="{% static 'js/alpine.min.js' %}"></script>

--- a/app/store_project/templates/meso/designer.html
+++ b/app/store_project/templates/meso/designer.html
@@ -28,7 +28,7 @@
       class="meso meso-root"
       x-data="meso()"
       x-ref="root"
-      style="--bg:#f5f6f7;--surface:#ffffff;--rail:#fbfbfc;--ink:#16181c;--dim:#71777e;--line:#e7e9ec;--line-2:#f1f3f5;--radius:8px;--pad:14px;--accent:oklch(0.56 0.14 258);--accent-ink:#ffffff;--soft:color-mix(in srgb,var(--accent) 9%,#fff);--soft-line:color-mix(in srgb,var(--accent) 26%,#fff);--accent-deep:color-mix(in srgb,var(--accent) 82%,#1a1a1a);--warn:#b4541f;--warn-soft:#fbefe8;--ok:#2f8f56;display:flex;flex-direction:column;height:100vh;min-width:1240px;overflow:hidden;background:var(--bg);color:var(--ink);font-family:'Hanken Grotesk',system-ui,-apple-system,sans-serif;font-size:14px;line-height:1.45;-webkit-font-smoothing:antialiased;"
+      style="--bg:#f5f6f7;--surface:#ffffff;--rail:#fbfbfc;--ink:#16181c;--dim:#71777e;--line:#e7e9ec;--line-2:#f1f3f5;--radius:8px;--pad:14px;--accent:#31759d;--accent-ink:#ffffff;--soft:#eaf2f7;--soft-line:#bcd6e4;--accent-deep:#1f516b;--warn:#b4541f;--warn-soft:#fbefe8;--ok:#2f8f56;display:flex;flex-direction:column;height:100vh;min-width:1240px;overflow:hidden;background:var(--bg);color:var(--ink);font-family:'Hanken Grotesk',system-ui,-apple-system,sans-serif;font-size:14px;line-height:1.45;-webkit-font-smoothing:antialiased;"
     >
       <!-- Delivered toast -->
       <template x-if="delivered">

--- a/app/store_project/templates/meso/invite_claim.html
+++ b/app/store_project/templates/meso/invite_claim.html
@@ -10,6 +10,8 @@
 {% block head_top %}<meta name="referrer" content="no-referrer" />{% endblock %}
 
 {# A brand-new athlete may have no coach/athlete role yet — strip the coach nav. #}
+{# Focused single-action onboarding screen — no marketing site nav either. #}
+{% block site_nav %}{% endblock %}
 {% block navlinks %}{% endblock %}
 {% block topnav_actions %}{% endblock %}
 {% block topnav_avatar %}{% endblock %}

--- a/app/store_project/templates/meso/offline.html
+++ b/app/store_project/templates/meso/offline.html
@@ -9,6 +9,9 @@ page exists (athlete slice Phase 4b — S7). Deliberately login-free so it rende
 for an anonymous fetch rather than a useless cached login redirect.
 {% endcomment %}
 
+{# Phone-first PWA offline fallback — no marketing site nav. #}
+{% block site_nav %}{% endblock %}
+
 {% block navlinks %}
   <a class="meso-navlink" href="{% url 'meso:athlete_home' %}">Training</a>
 {% endblock %}

--- a/docs/design-system-unification-plan.md
+++ b/docs/design-system-unification-plan.md
@@ -1,7 +1,9 @@
 # Design-system unification — plan
 
-Status: **PR 1 implemented** (Foundation + 3 pain points) · Started 2026-06-30 ·
-Kicked off from issue #327. PRs 2–3 still to come.
+Status: **PR 1 + PR 3 implemented** · Started 2026-06-30 · Kicked off from issue
+#327. PR 1 = Foundation + 3 pain points. PR 3 = Meso reconnection (built next,
+out of sequence — it depends only on the PR 1 token foundation, not on PR 2).
+**PR 2 (rest of main site) still to come.**
 
 ## Goal
 
@@ -104,7 +106,34 @@ removed from `INSTALLED_APPS` / settings / deps. Red→green tests in
 - Store, home, account/auth, product/book pages — template-level cleanups beyond
   what the global re-skin already gave.
 
-### PR 3 — Meso reconnection (final phase)
+### PR 3 — Meso reconnection ✅ implemented
+Done on branch `design-system-pr3-meso-reconnect`. Validated by
+`docs/spikes/basecoat/meso.html`.
+
+- **Shared site nav** — a new `meso/_meso_sitenav.html` partial (the same
+  top-level links as `templates/_nav.html`: brand → home; About / Store /
+  Challenges / **Coaching** [active] / Contact; auth on the right) rides at the
+  top of the Meso shell via a `{% block site_nav %}` in `_meso_base.html`,
+  styled in `meso.css` (`.meso-sitenav`, a black bar matching the main-site
+  nav) since the shell loads only `meso.css`. The Meso workspace sub-header
+  (`.meso-topnav`) is kept below it.
+- **Athlete PWA keeps its installed-app feel** — the phone-first surfaces
+  (`athlete_home`, `athlete_session`, `offline`, `invite_claim`) override
+  `{% block site_nav %}` empty, so the marketing nav never clutters the
+  installed training app. The coach-facing `results` page (breadcrumb back to
+  the roster) keeps the nav.
+- **Accent points at the shared token** — `meso.css`'s `--accent` (and the
+  `--soft` / `--soft-line` / `--accent-deep` family) move from the Meso-only
+  `oklch(0.56 0.14 258)` to the site's steel-blue `#31759d` (mirroring base.css
+  `--accent` / `--accent-soft` / `--accent-line` / `--accent-deep`). The
+  standalone designer's inline token block is repointed to match, and the PWA
+  chrome (manifest `theme_color` + `_pwa_head.html` `theme-color`) moves to
+  `#31759d`. `PWA_CACHE_VERSION` bumped `v2 → v3` (the precached `meso.css`
+  changed).
+- Red→green tests in `meso/tests/test_design_reconnect.py`.
+
+The original task list for reference:
+
 - Add the shared site nav to `_meso_base.html`.
 - Point `meso.css` tokens at the shared core tokens (keep Meso's component
   density / workspace chrome). Validated by `docs/spikes/basecoat/meso.html`.


### PR DESCRIPTION
Reconnects the Meso app to the rest of Mastering Fitness — the final phase of the
design-system unification (`docs/design-system-unification-plan.md`). Built next
(out of sequence) because it depends only on **PR 1's** token foundation, not on
PR 2; **PR 2 (rest of main site) is still to come.** Validated by the spike at
`docs/spikes/basecoat/meso.html`.

## What changed

**Shared site nav**
- New `meso/_meso_sitenav.html` partial — the same top-level links as
  `templates/_nav.html` (brand → home; About / Store / Challenges / **Coaching**
  [active] / Contact; auth split on the right). It rides at the top of the Meso
  shell via a `{% block site_nav %}` in `_meso_base.html`, styled in `meso.css`
  (`.meso-sitenav`, a black bar matching the main-site nav) because the Meso
  shell loads only `meso.css`. The Meso workspace sub-header (`.meso-topnav`)
  stays below it.

**Athlete PWA keeps its installed-app feel**
- The phone-first surfaces (`athlete_home`, `athlete_session`, `offline`,
  `invite_claim`) override the `site_nav` block empty, so the marketing nav never
  clutters the installed training app. The coach-facing `results` page (it
  breadcrumbs back to the roster) keeps the nav.

**Accent points at the shared token**
- `meso.css`'s `--accent` (and the `--soft` / `--soft-line` / `--accent-deep`
  family) move from the Meso-only `oklch(0.56 0.14 258)` to the site's steel-blue
  `#31759d` (mirroring base.css `--accent` / `--accent-soft` / `--accent-line` /
  `--accent-deep`). The standalone designer's inline token block is repointed to
  match, and the PWA chrome (manifest `theme_color` + `_pwa_head.html`
  `theme-color`) moves to `#31759d`.
- `PWA_CACHE_VERSION` bumped `v2 → v3` (the precached `meso.css` changed, so the
  worker must drop the stale cache on activate).

## Tests
- Red→green `meso/tests/test_design_reconnect.py`: shared nav on coach surfaces
  (links + active Coaching + coach auth split), public-landing reconnection,
  athlete-PWA suppression, and the accent repoint across `meso.css`, the
  designer inline tokens, and the manifest `theme_color`.
- Full project suite green (1460 passed); `ruff` + DjHTML + biome +
  `makemigrations --check` clean.
- **Codex review loop: CLEAN on iteration 1.**

Refs #327.

https://claude.ai/code/session_019A9KdsVs33wipsGjSaFWXV