### PR TITLE
Meso — coach-facing billing & usage page

### DIFF
--- a/app/store_project/meso/billing/agent_usage_report.py
+++ b/app/store_project/meso/billing/agent_usage_report.py
@@ -242,6 +242,21 @@ class ClientUsage:
 
 
 @dataclass
+class ClientRun:
+    """A coach's *run count* against one client — the coach-facing breakdown row.
+
+    Deliberately carries **no cost**: the coach-facing billing page (the ``coach``
+    surface, not the owner dashboard) shows what they pay (revenue) and how much
+    they've used (run counts), never the internal per-run cost estimate. So this is
+    the run-count sibling of :class:`ClientUsage` (which carries the COGS ``Totals``).
+    """
+
+    label: str
+    is_group: bool
+    runs: int
+
+
+@dataclass
 class CoachUsage:
     """One coach's month: cost vs revenue, the margin, and a per-client breakdown."""
 
@@ -433,6 +448,37 @@ def sorted_totals(mapping):
     return sorted(
         mapping.items(), key=lambda kv: (kv[1].cost, kv[1].runs), reverse=True
     )
+
+
+def coach_run_breakdown(coach, *, start, end):
+    """One coach's agent runs in ``[start, end)`` grouped by client, heaviest first.
+
+    The coach-facing per-client breakdown ("Devon 3 · Priya 2 · the squad 1"). A
+    client is the athlete on an individual plan, or the group on a group plan
+    (``_attribution``). **Run counts only** — no cost (the coach never sees COGS).
+
+    Counts *every* batch the coach started in the window (eval runs included — a
+    real coach never has them, and counting all batches keeps this reconciled with
+    ``billing/access.agent_runs_this_month``, which the free-tier meter reads, so
+    the breakdown total always equals the headline "runs this month").
+    """
+    batches = AgentProposalBatch.objects.filter(
+        coach=coach, created_at__gte=start, created_at__lt=end
+    ).select_related(
+        "plan",
+        "plan__relationship__athlete",
+        "plan__group",
+    )
+    clients = {}  # key -> ClientRun
+    for batch in batches:
+        key, label, is_group = _attribution(batch.plan)
+        row = clients.get(key)
+        if row is None:
+            row = ClientRun(label=label, is_group=is_group, runs=0)
+            clients[key] = row
+        row.runs += 1
+    # Heaviest first; the label tiebreak keeps equal-count rows in a stable order.
+    return sorted(clients.values(), key=lambda r: (-r.runs, r.label))
 
 
 def margin_alerts(report, threshold):

--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -253,6 +253,45 @@ def billing_state(coach):
     }
 
 
+def coach_billing(coach):
+    """The coach-facing billing & usage page context (agent-usage — coach surface).
+
+    The complement to the staff-only owner dashboard (``usage_dashboard``): that
+    shows org-wide **cost** (COGS); this shows *one coach* their **bill** (revenue
+    they owe — base + per active seat) and **how much agent they've used** this
+    month, broken down per athlete/group. The hard line: a coach sees what they pay
+    and how much they've used, **never** the internal per-run cost estimate, so this
+    context carries run counts and revenue only — no ``cost``/``margin`` keys.
+
+    ``billed_seats`` floors the active-seat count at one to mirror Stripe billing
+    (``stripe_gateway`` rejects a seat quantity of 0), so a coach with no active
+    athletes still sees the one-seat minimum their subscription would charge. The
+    month window is the report's current calendar month, the same window the
+    free-tier agent meter counts against, so ``runs_this_month`` reconciles with the
+    allowance in ``state["agent"]``.
+    """
+    state = billing_state(coach)
+    seats = state["seat_count"]
+    billed_seats = max(seats, 1)
+    base = agent_usage_report.BASE_PRICE_USD
+    seat_unit = agent_usage_report.SEAT_PRICE_USD
+    seat_cost = seat_unit * billed_seats
+    start, end = agent_usage_report.current_month_bounds()
+    breakdown = agent_usage_report.coach_run_breakdown(coach, start=start, end=end)
+    return {
+        "state": state,
+        "base_price": base,
+        "seat_unit_price": seat_unit,
+        "seats": seats,
+        "billed_seats": billed_seats,
+        "seat_cost": seat_cost,
+        "projected_total": base + seat_cost,
+        "runs_this_month": sum(row.runs for row in breakdown),
+        "breakdown": breakdown,
+        "month_label": start.strftime("%B %Y"),
+    }
+
+
 def athlete_pending(user):
     """Pending coach links the athlete sees on their training home (N4 Phase 2).
 

--- a/app/store_project/meso/tests/test_coach_billing.py
+++ b/app/store_project/meso/tests/test_coach_billing.py
@@ -1,0 +1,225 @@
+"""The coach-facing billing & usage page (agent-usage tracking — coach surface).
+
+The owner dashboard (``UsageDashboardView``, Phase 4) is **staff-gated** and shows
+org-wide *cost* (COGS) so a coach can't probe what the agent costs the business.
+This is the complementary **coach-scoped** read: a coach sees *their* plan, the
+seats they pay for, their projected bill (the revenue they owe — base + per-seat),
+and how many AI-agent runs they've spent this month broken down by athlete/group.
+
+The hard line this slice draws: a coach sees **what they pay** (revenue) and
+**how much they've used** (run counts), never the internal per-run **cost**
+estimate (``estimated_cost_usd``) — that's owner-only. The tests below pin both
+the projected-bill math and that no internal cost figure leaks onto the page.
+See ``docs/meso/agent-usage-plan.md``.
+"""
+
+from datetime import timedelta
+from decimal import Decimal
+
+import pytest
+from django.urls import reverse
+
+from store_project.meso.billing import agent_usage_report as report_mod
+from store_project.meso.factories import AgentProposalBatchFactory
+from store_project.meso.factories import CoachAthleteFactory
+from store_project.meso.factories import CoachProfileFactory
+from store_project.meso.factories import CoachSubscriptionFactory
+from store_project.meso.factories import GroupPlanFactory
+from store_project.meso.factories import PlanFactory
+from store_project.meso.models import AgentProposalBatch
+from store_project.meso.models import CoachSubscription
+from store_project.meso.presenters import coach_billing
+from store_project.users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+URL = reverse("meso:billing")
+
+
+def _coach():
+    """A user who counts as a coach (``_is_coach`` true via a ``CoachProfile``)."""
+    return CoachProfileFactory().user
+
+
+def _run_for(coach, *, plan=None, when=None, **kw):
+    """One in-window agent run for ``coach`` (``created_at`` stamped to ``when``)."""
+    if plan is None:
+        plan = PlanFactory(relationship__coach=coach)
+    batch = AgentProposalBatchFactory(plan=plan, coach=coach, **kw)
+    if when is not None:
+        AgentProposalBatch.objects.filter(pk=batch.pk).update(created_at=when)
+        batch.refresh_from_db()
+    return batch
+
+
+# -- coach_run_breakdown (the per-client run-count helper) -----------------
+
+
+class TestCoachRunBreakdown:
+    def test_groups_a_coachs_runs_by_client_sorted_by_count(self):
+        coach = _coach()
+        heavy = PlanFactory(relationship__coach=coach)
+        light = PlanFactory(relationship__coach=coach)
+        for _ in range(3):
+            _run_for(coach, plan=heavy)
+        _run_for(coach, plan=light)
+
+        start, end = report_mod.current_month_bounds()
+        rows = report_mod.coach_run_breakdown(coach, start=start, end=end)
+
+        assert [r.runs for r in rows] == [3, 1]  # heaviest client first
+        labels = {r.label: r.runs for r in rows}
+        assert labels[heavy.relationship.athlete.display_name()] == 3
+        assert labels[light.relationship.athlete.display_name()] == 1
+
+    def test_attributes_a_group_plan_to_the_group(self):
+        coach = _coach()
+        group_plan = GroupPlanFactory(group__coach=coach, group__name="Squad A")
+        _run_for(coach, plan=group_plan, trigger=AgentProposalBatch.Trigger.GROUP)
+
+        start, end = report_mod.current_month_bounds()
+        (row,) = report_mod.coach_run_breakdown(coach, start=start, end=end)
+
+        assert row.is_group is True
+        assert row.label == "Group: Squad A"
+        assert row.runs == 1
+
+    def test_scopes_to_the_coach(self):
+        coach = _coach()
+        other = _coach()
+        _run_for(coach)
+        _run_for(other)
+
+        start, end = report_mod.current_month_bounds()
+        rows = report_mod.coach_run_breakdown(coach, start=start, end=end)
+
+        assert sum(r.runs for r in rows) == 1
+
+    def test_windows_to_the_month(self):
+        coach = _coach()
+        start, end = report_mod.current_month_bounds()
+        _run_for(coach, when=start + timedelta(days=1))  # in window
+        _run_for(coach, when=start - timedelta(days=1))  # previous month
+
+        rows = report_mod.coach_run_breakdown(coach, start=start, end=end)
+
+        assert sum(r.runs for r in rows) == 1
+
+
+# -- coach_billing (the presenter) -----------------------------------------
+
+
+class TestCoachBillingPresenter:
+    def test_projected_bill_is_base_plus_per_seat(self):
+        coach = _coach()
+        for _ in range(3):
+            CoachAthleteFactory(coach=coach)  # 3 billable seats
+
+        ctx = coach_billing(coach)
+
+        assert ctx["seats"] == 3
+        assert ctx["billed_seats"] == 3
+        assert ctx["base_price"] == Decimal("9.99")
+        assert ctx["seat_cost"] == Decimal("3.00")
+        assert ctx["projected_total"] == Decimal("12.99")
+
+    def test_projected_bill_floors_billed_seats_at_one(self):
+        # A coach with zero active athletes still pays for one seat (Stripe floors
+        # the seat quantity at 1), so the projection is base + one seat, not bare base.
+        coach = _coach()
+
+        ctx = coach_billing(coach)
+
+        assert ctx["seats"] == 0
+        assert ctx["billed_seats"] == 1
+        assert ctx["projected_total"] == Decimal("10.99")
+
+    def test_runs_this_month_matches_the_breakdown(self):
+        coach = _coach()
+        plan = PlanFactory(relationship__coach=coach)
+        for _ in range(4):
+            _run_for(coach, plan=plan)
+
+        ctx = coach_billing(coach)
+
+        assert ctx["runs_this_month"] == 4
+        assert sum(r.runs for r in ctx["breakdown"]) == 4
+
+    def test_carries_billing_state_and_agent_allowance(self):
+        coach = _coach()  # free, no subscription row
+
+        ctx = coach_billing(coach)
+
+        assert ctx["state"]["status"] == CoachSubscription.Status.FREE
+        # The free-tier agent meter rides along for the "N of M runs left" line.
+        assert (
+            ctx["state"]["agent"]["allowance"] == CoachSubscription.FREE_AGENT_ALLOWANCE
+        )
+
+    def test_does_not_leak_internal_cost(self):
+        coach = _coach()
+        _run_for(coach, estimated_cost_usd=Decimal("8.123456"))
+
+        ctx = coach_billing(coach)
+
+        # The coach surface is revenue + run counts only — no COGS estimate.
+        assert "cost" not in ctx
+        assert "margin" not in ctx
+        for row in ctx["breakdown"]:
+            assert not hasattr(row, "cost")
+            assert not hasattr(row, "estimated_cost_usd")
+
+
+# -- BillingView (the page + its gate) -------------------------------------
+
+
+class TestBillingView:
+    def test_anonymous_is_redirected_to_login(self, client):
+        resp = client.get(URL)
+        assert resp.status_code == 302
+        assert "/accounts/login/" in resp["Location"]
+
+    def test_non_coach_is_redirected_to_training_home(self, client):
+        client.force_login(UserFactory())  # a pure athlete — no coach signal
+        resp = client.get(URL)
+        assert resp.status_code == 302
+        assert resp["Location"] == reverse("meso:athlete_home")
+
+    def test_coach_sees_plan_bill_and_breakdown(self, client):
+        coach = _coach()
+        plan = PlanFactory(relationship__coach=coach)
+        athlete_name = plan.relationship.athlete.display_name()
+        _run_for(coach, plan=plan)
+
+        client.force_login(coach)
+        resp = client.get(URL)
+        body = resp.content.decode()
+
+        assert resp.status_code == 200
+        assert "10.99" in body  # base $9.99 + the one seat = projected bill
+        assert athlete_name in body  # the per-athlete run breakdown
+
+    def test_only_shows_the_coachs_own_runs(self, client):
+        coach = _coach()
+        other = _coach()
+        other_plan = PlanFactory(relationship__coach=other)
+        other_name = other_plan.relationship.athlete.display_name()
+        _run_for(other, plan=other_plan)
+
+        client.force_login(coach)
+        resp = client.get(URL)
+
+        assert other_name not in resp.content.decode()
+
+    def test_internal_cost_estimate_never_renders(self, client):
+        coach = CoachSubscriptionFactory(
+            status=CoachSubscription.Status.ACTIVE,
+            coach=_coach(),
+        ).coach
+        CoachAthleteFactory(coach=coach)
+        _run_for(coach, estimated_cost_usd=Decimal("8.123456"))
+
+        client.force_login(coach)
+        body = client.get(URL).content.decode()
+
+        assert "8.12" not in body  # the COGS estimate is owner-only

--- a/app/store_project/meso/urls.py
+++ b/app/store_project/meso/urls.py
@@ -6,6 +6,7 @@ from .views import AthleteProfileView
 from .views import AthleteSessionView
 from .views import BecomeCoachView
 from .views import ChangeReviewView
+from .views import CoachBillingView
 from .views import DeliverView
 from .views import GroupDetailView
 from .views import MesoDesignerView
@@ -197,8 +198,10 @@ urlpatterns = [
     # a landing page + the action that creates the CoachProfile.
     path("coach/", BecomeCoachView.as_view(), name="become_coach"),
     path("coach/start/", views.start_coaching, name="start_coaching"),
-    # Billing (S6): subscribe via Stripe Checkout, manage via the hosted Portal,
-    # and the clean subscription webhook (separate from the products webhook).
+    # Billing (S6): the coach-facing plan/usage page, then subscribe via Stripe
+    # Checkout, manage via the hosted Portal, and the clean subscription webhook
+    # (separate from the products webhook).
+    path("billing/", CoachBillingView.as_view(), name="billing"),
     path("billing/subscribe/", views.billing_subscribe, name="billing_subscribe"),
     path("billing/portal/", views.billing_portal, name="billing_portal"),
     # Start the no-card local trial (S6 Phase 3) — the free path to full access.

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -474,6 +474,34 @@ class UsageDashboardView(UserPassesTestMixin, TemplateView):
         return usage_report.current_month_bounds()
 
 
+class CoachBillingView(LoginRequiredMixin, TemplateView):
+    """Coach-facing billing & plan page (agent-usage — coach surface).
+
+    A coach's own plan/tier, the bill they owe (base + per active seat), the
+    upgrade CTAs, and their AI-agent runs this month broken down per athlete/group
+    — the coach-scoped complement to the staff-only owner usage dashboard (which
+    shows org-wide *cost*). A coach never sees the internal cost estimate here, only
+    what they pay and how much they've used (``presenters.coach_billing``).
+
+    Gate: anonymous → login (``LoginRequiredMixin``); a pure athlete (no coach
+    signal) is routed to their training home, mirroring the roster's role split, so
+    a non-coach never lands on an empty billing surface.
+    """
+
+    template_name = "meso/coach_billing.html"
+
+    def get(self, request, *args, **kwargs):
+        if not _is_coach(request.user):
+            return redirect("meso:athlete_home")
+        return super().get(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx["active"] = "billing"
+        ctx.update(presenters.coach_billing(self.request.user))
+        return ctx
+
+
 def _coach_active_athletes(coach, athlete_ids):
     """Resolve posted athlete ids to this coach's *active*-link athletes.
 

--- a/app/store_project/templates/meso/_meso_base.html
+++ b/app/store_project/templates/meso/_meso_base.html
@@ -38,6 +38,7 @@
           {% block navlinks %}
             <a class="meso-navlink {% if active == 'roster' %}is-active{% endif %}" href="{% url 'meso:roster' %}">Roster</a>
             <a class="meso-navlink {% if active == 'designer' %}is-active{% endif %}" href="{% url 'meso:designer' %}">Designer</a>
+            <a class="meso-navlink {% if active == 'billing' %}is-active{% endif %}" href="{% url 'meso:billing' %}">Billing</a>
             {% if request.user.is_staff %}
               <a class="meso-navlink {% if active == 'usage' %}is-active{% endif %}" href="{% url 'meso:usage_dashboard' %}">Usage</a>
             {% endif %}

--- a/app/store_project/templates/meso/coach_billing.html
+++ b/app/store_project/templates/meso/coach_billing.html
@@ -1,0 +1,117 @@
+{% extends "meso/_meso_base.html" %}
+
+{% block title %}Billing · Meso{% endblock %}
+
+{% block content %}
+  <div class="meso-page">
+    <div class="meso-crumbs">
+      <a href="{% url 'meso:roster' %}">Roster</a> <span>/</span> <span>Billing &amp; usage</span>
+    </div>
+
+    <div class="meso-pagehead">
+      <div>
+        <p class="meso-eyebrow">Your plan &amp; agent usage</p>
+        <h1 class="meso-h1">{{ state.status_label }}</h1>
+        <p class="meso-sub">{{ month_label }}</p>
+      </div>
+    </div>
+
+    <div class="meso-grid meso-grid--profile">
+      <!-- left: plan + bill -->
+      <div style="display:flex;flex-direction:column;gap:14px;">
+        <div class="meso-card meso-card--pad" style="display:flex;flex-direction:column;gap:11px;">
+          <div style="display:flex;align-items:center;gap:8px;">
+            <p class="meso-eyebrow" style="margin:0;">Plan</p>
+            <div class="meso-spacer"></div>
+            <span class="meso-badge {% if state.is_active %}meso-badge--ok{% else %}meso-badge--muted{% endif %}"><i></i>{{ state.status_label }}</span>
+          </div>
+
+          {% if state.over_limit %}
+            <p class="meso-sub" style="margin:0;color:var(--warn);">Over your plan limit &#8212; {{ state.seat_count }} of {{ state.seat_limit }} athlete{{ state.seat_limit|pluralize }}. Your longest-standing athletes stay editable; the other {{ state.suspended_count }} {{ state.suspended_count|pluralize:"is,are" }} suspended until you re-subscribe or end a relationship.</p>
+          {% elif state.on_trial %}
+            <p class="meso-sub" style="margin:0;">Free trial &#8212; ends {{ state.trial_end|date:"M j" }}. Subscribe to keep full access when it ends.</p>
+          {% elif state.is_active %}
+            <p class="meso-sub" style="margin:0;">{{ state.seat_count }} active athlete{{ state.seat_count|pluralize }} &#183; full access.</p>
+          {% else %}
+            <p class="meso-sub" style="margin:0;">Free plan &#8212; {{ state.seat_count }} of {{ state.seat_limit }} athlete{{ state.seat_limit|pluralize }}. Subscribe for unlimited athletes and agent runs.</p>
+          {% endif %}
+
+          <!-- The bill: base + per active seat (Stripe floors the seat line at 1). -->
+          <div style="border-top:1px solid var(--line-2);padding-top:11px;">
+            <p class="meso-eyebrow" style="margin:0 0 6px;">
+              {% if state.has_stripe_subscription %}Your monthly bill{% else %}If you subscribe{% endif %}
+            </p>
+            <div style="display:flex;flex-direction:column;gap:3px;">
+              <div class="meso-row-meta">Base <span style="float:right;color:var(--ink);">${{ base_price|floatformat:2 }}</span></div>
+              <div class="meso-row-meta">{{ billed_seats }} active seat{{ billed_seats|pluralize }} &#215; ${{ seat_unit_price|floatformat:2 }} <span style="float:right;color:var(--ink);">${{ seat_cost|floatformat:2 }}</span></div>
+              <div class="meso-row-name" style="border-top:1px solid var(--line-2);margin-top:5px;padding-top:6px;">Total <span style="float:right;">${{ projected_total|floatformat:2 }}/mo</span></div>
+            </div>
+            {% if not state.is_active %}
+              <p class="meso-muted" style="margin:8px 0 0;font-size:12px;">You aren't being charged on the free plan &#8212; this is what a subscription would cost at your current athlete count.</p>
+            {% endif %}
+          </div>
+
+          <div style="display:flex;gap:8px;flex-wrap:wrap;">
+            {% if state.can_start_trial %}
+              <form method="post" action="{% url 'meso:billing_start_trial' %}" style="margin:0;">
+                {% csrf_token %}
+                <button type="submit" class="meso-btn meso-btn--primary">Start free trial</button>
+              </form>
+            {% endif %}
+            {% if not state.is_active or state.on_trial or state.over_limit %}
+              <form method="post" action="{% url 'meso:billing_subscribe' %}" style="margin:0;">
+                {% csrf_token %}
+                <button type="submit" class="meso-btn {% if state.can_start_trial %}meso-btn--ghost{% else %}meso-btn--primary{% endif %}">Subscribe</button>
+              </form>
+            {% endif %}
+            {% if state.has_stripe_subscription %}
+              <form method="post" action="{% url 'meso:billing_portal' %}" style="margin:0;">
+                {% csrf_token %}
+                <button type="submit" class="meso-btn meso-btn--ghost">Manage billing</button>
+              </form>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+
+      <!-- right: agent usage this month -->
+      <div style="display:flex;flex-direction:column;gap:14px;">
+        <div class="meso-card">
+          <div style="display:flex;align-items:center;gap:10px;padding:13px 16px;border-bottom:1px solid var(--line-2);">
+            <p class="meso-eyebrow" style="margin:0;">AI agent this month</p>
+            <div class="meso-spacer"></div>
+            <span class="meso-row-meta" style="color:var(--ink);">{{ runs_this_month }} run{{ runs_this_month|pluralize }}</span>
+          </div>
+
+          {% if state.agent.metered %}
+            <div style="padding:11px 16px;border-bottom:1px solid var(--line-2);">
+              <p class="meso-sub" style="margin:0;">
+                Free allowance &#8212; {{ state.agent.remaining }} of {{ state.agent.allowance }} run{{ state.agent.allowance|pluralize }} left this month.
+                {% if not state.agent.can_use %}<span style="color:var(--warn);">You're out of free runs &#8212; subscribe for unlimited.</span>{% endif %}
+              </p>
+            </div>
+          {% else %}
+            <div style="padding:11px 16px;border-bottom:1px solid var(--line-2);">
+              <p class="meso-sub" style="margin:0;">Unlimited agent runs on your plan.</p>
+            </div>
+          {% endif %}
+
+          {% for row in breakdown %}
+            <div style="display:flex;align-items:center;gap:10px;padding:10px 16px;border-bottom:1px solid var(--line-2);">
+              <span class="meso-row-name" style="min-width:0;">
+                {% if row.is_group %}<span class="meso-badge meso-badge--muted"><i></i>group</span> {% endif %}{{ row.label }}
+              </span>
+              <div class="meso-spacer"></div>
+              <span class="meso-row-meta">{{ row.runs }} run{{ row.runs|pluralize }}</span>
+            </div>
+          {% empty %}
+            <div class="meso-row" style="color:var(--dim);padding:16px;">
+              No agent runs yet this month. Open a program in the
+              <a href="{% url 'meso:designer' %}" style="color:var(--accent-ink);">Designer</a> and ask the agent for help.
+            </div>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## What & why

The owner usage dashboard (`/meso/usage/`, agent-usage Phase 4) is **staff-gated** and shows org-wide **cost** (COGS) so a coach can't probe what the agent costs the business. This adds the coach-scoped complement: a coach can see, on their own page, **what they pay** and **how much they've used** — never the internal per-run cost estimate.

A new page at **`/meso/billing/`** shows:
- **Plan / tier** — free / trial / active / comped, with the same status copy and upgrade CTAs (start trial / subscribe / manage billing) the roster card already carries.
- **The bill** — base ($9.99) + per active seat ($1), with the seat line floored at 1 to mirror Stripe billing. Labelled "Your monthly bill" for a Stripe subscriber, "If you subscribe" otherwise (a soft upsell for free/trial coaches).
- **AI agent this month** — the run count, the free-tier allowance line ("N of M free runs left"), and a per-athlete/group breakdown of where the runs went.

## How

- `agent_usage_report.coach_run_breakdown(coach, *, start, end)` + a `ClientRun` row (**run counts only, no cost**). Reuses the existing `_attribution` so a group plan attributes to the group; counts *all* of the coach's in-window batches so the total reconciles with `billing/access.agent_runs_this_month` (the free-tier meter).
- `presenters.coach_billing` — composes `billing_state` + the projected bill + the breakdown. Carries revenue and run counts only, no `cost`/`margin` keys.
- `CoachBillingView` at `meso:billing` — `LoginRequiredMixin`; a non-coach (pure athlete) is routed to their training home, mirroring the roster's role split. Template `coach_billing.html`; a "Billing" nav link in `_meso_base.html` (renders only on coach surfaces — athlete pages override the `navlinks` block).

## Tests

Red→green: **+14 pytest** (`test_coach_billing.py`) covering the breakdown helper (grouping, group attribution, coach-scoping, month window), the presenter's bill math + the **no-COGS-leak** invariant, and the view's gate + scoping + that the internal cost estimate never renders.

**No model change, no migration.** Full meso suite 1328 passing, ruff + DjHTML + `makemigrations --check` clean. **Codex review loop: CLEAN on iteration 1.**

https://claude.ai/code/session_019A9KdsVs33wipsGjSaFWXV