### PR TITLE
Meso — coach roster adherence (compliance meter + recent-activity feed)

### DIFF
--- a/app/store_project/meso/adherence.py
+++ b/app/store_project/meso/adherence.py
@@ -9,6 +9,8 @@ athlete slice, so the data is finally there to measure.
 Nothing here mutates state; it's a pure read layer the presenter formats.
 """
 
+from django.db.models import F
+
 from .models import CoachAthlete
 from .models import Plan
 from .models import SessionLog
@@ -89,9 +91,12 @@ def recent_logs(coach, *, limit=8):
     one." Spans individual and group-delivered sessions alike, since both root at
     the athlete's relationship with the coach. Ordered by when the log was
     written (``created_at``), so re-saving an old workout surfaces as fresh
-    activity and the order never depends on the nullable workout ``date``.
-    ``select_related`` the athlete + session so the presenter formats each event
-    without a per-row query.
+    activity and the order never depends on the nullable workout ``date``. The
+    log's ``athlete`` is tied to the plan's own athlete: the write path always
+    enforces this, but the model carries no DB constraint, so a stray mismatched
+    row (admin / import) must not surface an unrelated name + a profile link the
+    coach can't open. ``select_related`` the athlete + session so the presenter
+    formats each event without a per-row query.
     """
     return list(
         SessionLog.objects.filter(
@@ -100,6 +105,7 @@ def recent_logs(coach, *, limit=8):
             session__week__mesocycle__plan__relationship__status=(
                 CoachAthlete.Status.ACTIVE
             ),
+            athlete=F("session__week__mesocycle__plan__relationship__athlete"),
         )
         .exclude(session__week__mesocycle__plan__status=Plan.Status.ARCHIVED)
         .select_related("athlete", "session")

--- a/app/store_project/meso/adherence.py
+++ b/app/store_project/meso/adherence.py
@@ -1,0 +1,100 @@
+"""Coach-facing adherence — how much of the delivered work an athlete logged.
+
+Read-only aggregation over delivered weeks and the athletes' own *done*
+``SessionLog`` rows. It lights up the roster's long-standing ``compliance`` meter
+and ``activity`` feed placeholders (``presenters`` flagged both as "Phase 2/3
+concepts" awaiting logged data) — delivery + logging have existed since the
+athlete slice, so the data is finally there to measure.
+
+Nothing here mutates state; it's a pure read layer the presenter formats.
+"""
+
+from .models import CoachAthlete
+from .models import SessionLog
+from .models import Week
+
+
+def link_latest_delivered_week(link):
+    """The most recently delivered week across *all* of this link's plans.
+
+    Spans both the coach's individual plan and any group-delivery snapshot
+    (``source_group`` set) rooted at this relationship — both are work this coach
+    delivered to the athlete, so adherence should reflect whichever week was
+    delivered most recently. Returns ``None`` when the coach hasn't delivered
+    anything to this athlete yet.
+    """
+    return (
+        Week.objects.filter(
+            mesocycle__plan__relationship=link,
+            delivered_at__isnull=False,
+        )
+        .select_related("mesocycle")
+        .order_by("-delivered_at")
+        .first()
+    )
+
+
+def _done_session_count(session_ids, athlete):
+    """How many of ``session_ids`` the athlete has a *done* log for (one query)."""
+    return (
+        SessionLog.objects.filter(
+            session_id__in=session_ids,
+            athlete=athlete,
+            status=SessionLog.Status.DONE,
+        )
+        .values("session_id")
+        .distinct()
+        .count()
+    )
+
+
+def link_compliance(link):
+    """Percent (0–100) of the latest delivered week's sessions the athlete logged.
+
+    Measured against the most recently delivered week
+    (``link_latest_delivered_week``): the fraction of its sessions the athlete
+    has marked *done*, rounded to a whole percent. Returns ``None`` — so the
+    roster honestly hides the meter rather than showing a misleading ``0%`` —
+    when there's nothing to measure: no plan, no delivered week, or a delivered
+    week with no sessions. ``0`` (the coach delivered, the athlete hasn't logged
+    yet) is a real, distinct signal and is *not* collapsed to ``None``.
+
+    One ``link_latest_delivered_week`` query plus two small aggregates; bounded
+    and proportionate to the handful of athletes a roster renders.
+    """
+    if link is None:
+        return None
+    week = link_latest_delivered_week(link)
+    if week is None:
+        return None
+    session_ids = list(week.sessions.values_list("pk", flat=True))
+    if not session_ids:
+        return None
+    done = _done_session_count(session_ids, link.athlete)
+    return round(done / len(session_ids) * 100)
+
+
+def recent_logs(coach, *, limit=8):
+    """The coach's athletes' most recently completed sessions (newest first).
+
+    Scoped to the coach's *active* links (an ended relationship's history drops
+    off the feed, matching the roster's athlete list) and to *done* logs only —
+    the feed answers "who finished a session," not "who opened one." Spans
+    individual and group-delivered sessions alike, since both root at the
+    athlete's relationship with the coach. Ordered by when the log was written
+    (``created_at``), so re-saving an old workout surfaces as fresh activity and
+    the order never depends on the nullable workout ``date``. ``select_related``
+    the athlete + session so the presenter formats each event without a per-row
+    query.
+    """
+    return list(
+        SessionLog.objects.filter(
+            status=SessionLog.Status.DONE,
+            session__week__mesocycle__plan__relationship__coach=coach,
+            session__week__mesocycle__plan__relationship__status=(
+                CoachAthlete.Status.ACTIVE
+            ),
+        )
+        .select_related("athlete", "session")
+        .order_by("-created_at")[:limit]
+    )

--- a/app/store_project/meso/adherence.py
+++ b/app/store_project/meso/adherence.py
@@ -10,6 +10,7 @@ Nothing here mutates state; it's a pure read layer the presenter formats.
 """
 
 from .models import CoachAthlete
+from .models import Plan
 from .models import SessionLog
 from .models import Week
 
@@ -20,14 +21,18 @@ def link_latest_delivered_week(link):
     Spans both the coach's individual plan and any group-delivery snapshot
     (``source_group`` set) rooted at this relationship — both are work this coach
     delivered to the athlete, so adherence should reflect whichever week was
-    delivered most recently. Returns ``None`` when the coach hasn't delivered
-    anything to this athlete yet.
+    delivered most recently. **Archived** plans are excluded (matching
+    ``working_plan`` / ``athlete_home``): removing an athlete from a group
+    archives their materialized snapshot while the link stays active, and the
+    athlete can no longer see or log it, so it must not drive the meter. Returns
+    ``None`` when the coach hasn't delivered anything live to this athlete yet.
     """
     return (
         Week.objects.filter(
             mesocycle__plan__relationship=link,
             delivered_at__isnull=False,
         )
+        .exclude(mesocycle__plan__status=Plan.Status.ARCHIVED)
         .select_related("mesocycle")
         .order_by("-delivered_at")
         .first()
@@ -78,14 +83,15 @@ def recent_logs(coach, *, limit=8):
     """The coach's athletes' most recently completed sessions (newest first).
 
     Scoped to the coach's *active* links (an ended relationship's history drops
-    off the feed, matching the roster's athlete list) and to *done* logs only —
-    the feed answers "who finished a session," not "who opened one." Spans
-    individual and group-delivered sessions alike, since both root at the
-    athlete's relationship with the coach. Ordered by when the log was written
-    (``created_at``), so re-saving an old workout surfaces as fresh activity and
-    the order never depends on the nullable workout ``date``. ``select_related``
-    the athlete + session so the presenter formats each event without a per-row
-    query.
+    off the feed, matching the roster's athlete list), to non-**archived** plans
+    (a removed group member's archived snapshot must not resurface), and to
+    *done* logs only — the feed answers "who finished a session," not "who opened
+    one." Spans individual and group-delivered sessions alike, since both root at
+    the athlete's relationship with the coach. Ordered by when the log was
+    written (``created_at``), so re-saving an old workout surfaces as fresh
+    activity and the order never depends on the nullable workout ``date``.
+    ``select_related`` the athlete + session so the presenter formats each event
+    without a per-row query.
     """
     return list(
         SessionLog.objects.filter(
@@ -95,6 +101,7 @@ def recent_logs(coach, *, limit=8):
                 CoachAthlete.Status.ACTIVE
             ),
         )
+        .exclude(session__week__mesocycle__plan__status=Plan.Status.ARCHIVED)
         .select_related("athlete", "session")
         .order_by("-created_at")[:limit]
     )

--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -3,9 +3,10 @@
 The roster/profile templates were built against a fixtures module (since
 retired). Phase 1 feeds them real, scoped data for everything that exists yet —
 the athlete, their training history, and their (global) contraindications.
-Program/compliance/activity fields are Phase 2/3 concepts; we pass honest
-neutral values (``compliance=None``, ``status=""``, ``has_program=False``) so
-the layout holds without inventing numbers.
+Roster **compliance** (the per-athlete adherence meter) and **activity** (the
+recent-completed-sessions feed) are now wired off real logged data via
+``adherence``; the profile's ``compliance`` and ``has_program`` stay neutral
+until those surfaces grow their own slices.
 """
 
 import math
@@ -13,7 +14,9 @@ from collections import defaultdict
 
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.timesince import timesince
 
+from . import adherence
 from .billing import access as billing_access
 from .billing import agent_usage_report
 from .models import CoachAthlete
@@ -72,7 +75,9 @@ def _active_contraindications(user):
     return [c for c in user.contraindications.all() if c.active]
 
 
-def roster_athlete(user, *, suspended=False, demo=False, has_working_plan=False):
+def roster_athlete(
+    user, *, suspended=False, demo=False, has_working_plan=False, compliance=None
+):
     """A row in the coach's roster list.
 
     ``suspended`` marks an athlete whose link a downgrade froze (S6 Phase 5): the
@@ -82,6 +87,9 @@ def roster_athlete(user, *, suspended=False, demo=False, has_working_plan=False)
     one-click-demo athlete (first-time-UX Phase 2) so the row is clearly labeled.
     ``has_working_plan`` lets the roster hide the "Draft with AI" CTA for an
     athlete who already has a program (drafting only runs for a fresh plan).
+    ``compliance`` is the athlete's adherence to their latest delivered week
+    (``adherence.link_compliance``) — ``None`` when there's nothing delivered to
+    measure, so the meter stays hidden rather than reading a misleading ``0%``.
     """
     name = user.display_name()
     meta_parts = [p for p in [_training_label(user)] if p]
@@ -92,8 +100,8 @@ def roster_athlete(user, *, suspended=False, demo=False, has_working_plan=False)
         "tone": "neutral",
         "meta": " · ".join(meta_parts) or "No training history on file",
         "flags": [c.label for c in _active_contraindications(user)],
-        # Phase 2 (program/agent) and Phase 3 (logs) — hidden until they exist.
-        "compliance": None,
+        # Adherence to the latest delivered week; ``None`` hides the meter.
+        "compliance": compliance,
         "status": "suspended" if suspended else "",
         "status_label": "Suspended" if suspended else "",
         "is_demo": demo,
@@ -149,6 +157,46 @@ def roster_group(group):
         "meta": meta,
         "status_label": group.get_status_display(),
     }
+
+
+def _relative_when(dt):
+    """A compact "N ago" label for the activity feed (coarsest unit only).
+
+    ``humanize`` isn't installed, so this trims ``timesince`` to its leading
+    unit — "2 days, 3 hours" → "2 days ago" — and collapses a just-now log
+    ("0 minutes") to a friendly "just now".
+    """
+    coarse = timesince(dt).split(",")[0].strip()
+    if not coarse or coarse.startswith("0"):
+        return "just now"
+    return f"{coarse} ago"
+
+
+def roster_activity(coach, *, limit=8):
+    """The coach's recent-activity feed — athletes' latest completed sessions.
+
+    Lights up the roster's long-dead ``activity`` placeholder: each event names
+    the athlete, the session they logged, and how long ago. Scoped to the coach's
+    active links and *done* logs by ``adherence.recent_logs``.
+    """
+    events = []
+    for log in adherence.recent_logs(coach, limit=limit):
+        name = log.athlete.display_name()
+        session_label = log.session.name or f"Day {log.session.day_number}"
+        events.append(
+            {
+                "athlete": {
+                    "id": log.athlete.pk,
+                    "name": name,
+                    "initials": initials(name),
+                    "tone": "neutral",
+                },
+                "kind": "log",
+                "text": f"logged {session_label}",
+                "when": _relative_when(log.created_at),
+            }
+        )
+    return events
 
 
 def pending_invite(invite):

--- a/app/store_project/meso/tests/test_adherence.py
+++ b/app/store_project/meso/tests/test_adherence.py
@@ -1,0 +1,272 @@
+"""Coach-facing adherence — the roster ``compliance`` meter + ``activity`` feed.
+
+These pin the read-side aggregation that finally fills the roster's two
+long-standing placeholders (``presenters`` carried ``compliance=None`` and the
+view set ``activity=[]`` as "Phase 2/3 concepts awaiting logged data"):
+
+- ``adherence.link_compliance`` — what fraction of the latest *delivered* week's
+  sessions the athlete has marked *done*;
+- ``adherence.recent_logs`` / ``presenters.roster_activity`` — the coach's
+  athletes' most recent completed sessions, scoped to active links.
+
+The contract mirrors the athlete surface: delivery is the gate, ``done`` is the
+signal, and an athlete only ever counts their own logs.
+"""
+
+from datetime import timedelta
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+
+from store_project.meso import adherence
+from store_project.meso import presenters
+from store_project.meso.factories import CoachAthleteFactory
+from store_project.meso.factories import CoachProfileFactory
+from store_project.meso.factories import MesocycleFactory
+from store_project.meso.factories import PlanFactory
+from store_project.meso.factories import SessionFactory
+from store_project.meso.factories import SessionLogFactory
+from store_project.meso.factories import WeekFactory
+from store_project.meso.models import CoachAthlete
+from store_project.meso.models import SessionLog
+from store_project.users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def delivered_week(rel, *, sessions=3, done=0, delivered_at=None, index=1):
+    """A delivered week under ``rel`` with ``sessions`` days, ``done`` of them logged.
+
+    Returns the ``Week``. The first ``done`` sessions get a *done* ``SessionLog``
+    for the relationship's athlete; the rest are left un-logged.
+    """
+    meso = MesocycleFactory(plan=PlanFactory(relationship=rel), order=index)
+    week = WeekFactory(
+        mesocycle=meso,
+        index=index,
+        delivered_at=delivered_at or timezone.now(),
+    )
+    for n in range(sessions):
+        session = SessionFactory(week=week, day_number=n + 1, name=f"Day {n + 1}")
+        if n < done:
+            SessionLogFactory(
+                session=session,
+                athlete=rel.athlete,
+                status=SessionLog.Status.DONE,
+            )
+    return week
+
+
+# -- link_compliance -------------------------------------------------------
+
+
+class TestLinkCompliance:
+    def test_none_without_a_plan(self):
+        rel = CoachAthleteFactory()
+        assert adherence.link_compliance(rel) is None
+
+    def test_none_when_nothing_delivered(self):
+        rel = CoachAthleteFactory()
+        meso = MesocycleFactory(plan=PlanFactory(relationship=rel))
+        WeekFactory(mesocycle=meso, delivered_at=None)  # built, never delivered
+        assert adherence.link_compliance(rel) is None
+
+    def test_none_for_a_delivered_week_with_no_sessions(self):
+        rel = CoachAthleteFactory()
+        meso = MesocycleFactory(plan=PlanFactory(relationship=rel))
+        WeekFactory(mesocycle=meso, delivered_at=timezone.now())
+        assert adherence.link_compliance(rel) is None
+
+    def test_none_link_is_none(self):
+        assert adherence.link_compliance(None) is None
+
+    def test_zero_when_delivered_but_unlogged(self):
+        rel = CoachAthleteFactory()
+        delivered_week(rel, sessions=3, done=0)
+        # A real, distinct signal — the coach delivered, the athlete hasn't logged.
+        assert adherence.link_compliance(rel) == 0
+
+    def test_full_when_all_done(self):
+        rel = CoachAthleteFactory()
+        delivered_week(rel, sessions=4, done=4)
+        assert adherence.link_compliance(rel) == 100
+
+    def test_rounds_partial(self):
+        rel = CoachAthleteFactory()
+        delivered_week(rel, sessions=3, done=2)  # 66.6… → 67
+        assert adherence.link_compliance(rel) == 67
+
+    def test_only_counts_the_latest_delivered_week(self):
+        rel = CoachAthleteFactory()
+        now = timezone.now()
+        # An older, fully-logged week must not inflate the newest week's number.
+        delivered_week(
+            rel, sessions=2, done=2, delivered_at=now - timedelta(days=7), index=1
+        )
+        delivered_week(rel, sessions=2, done=0, delivered_at=now, index=2)
+        assert adherence.link_compliance(rel) == 0
+
+    def test_ignores_pending_logs(self):
+        rel = CoachAthleteFactory()
+        week = delivered_week(rel, sessions=2, done=1)
+        # A *pending* log on the second session must not count as done.
+        other = week.sessions.order_by("day_number").last()
+        SessionLogFactory(
+            session=other, athlete=rel.athlete, status=SessionLog.Status.PENDING
+        )
+        assert adherence.link_compliance(rel) == 50
+
+    def test_ignores_another_athletes_logs(self):
+        rel = CoachAthleteFactory()
+        week = delivered_week(rel, sessions=2, done=0)
+        stranger = UserFactory()
+        for session in week.sessions.all():
+            SessionLogFactory(
+                session=session, athlete=stranger, status=SessionLog.Status.DONE
+            )
+        # The stranger's done logs are not this athlete's adherence.
+        assert adherence.link_compliance(rel) == 0
+
+    def test_duplicate_done_logs_count_the_session_once(self):
+        rel = CoachAthleteFactory()
+        week = delivered_week(rel, sessions=2, done=0)
+        session = week.sessions.order_by("day_number").first()
+        # Two done logs for the *same* session (the model allows dated history)
+        # must count that session once, never push compliance past 100.
+        SessionLogFactory(
+            session=session, athlete=rel.athlete, status=SessionLog.Status.DONE
+        )
+        SessionLogFactory(
+            session=session, athlete=rel.athlete, status=SessionLog.Status.DONE
+        )
+        assert adherence.link_compliance(rel) == 50
+
+
+# -- recent_logs -----------------------------------------------------------
+
+
+class TestRecentLogs:
+    def test_only_done_logs(self):
+        rel = CoachAthleteFactory()
+        week = delivered_week(rel, sessions=2, done=1)
+        # The second session has only a pending log.
+        pending_session = week.sessions.order_by("day_number").last()
+        SessionLogFactory(
+            session=pending_session,
+            athlete=rel.athlete,
+            status=SessionLog.Status.PENDING,
+        )
+        logs = adherence.recent_logs(rel.coach)
+        assert len(logs) == 1
+        assert all(log.status == SessionLog.Status.DONE for log in logs)
+
+    def test_scoped_to_this_coach(self):
+        mine = CoachAthleteFactory()
+        delivered_week(mine, sessions=1, done=1)
+        other = CoachAthleteFactory()
+        delivered_week(other, sessions=1, done=1)
+        logs = adherence.recent_logs(mine.coach)
+        assert len(logs) == 1
+        assert logs[0].athlete_id == mine.athlete_id
+
+    def test_excludes_ended_relationships(self):
+        coach = UserFactory()
+        ended = CoachAthleteFactory(coach=coach, status=CoachAthlete.Status.ENDED)
+        delivered_week(ended, sessions=1, done=1)
+        assert adherence.recent_logs(coach) == []
+
+    def test_newest_first_and_limited(self):
+        rel = CoachAthleteFactory()
+        # 10 done sessions in one delivered week → 10 done logs, created in order.
+        delivered_week(rel, sessions=10, done=10)
+        logs = adherence.recent_logs(rel.coach, limit=3)
+        assert len(logs) == 3
+        created = [log.created_at for log in logs]
+        assert created == sorted(created, reverse=True)
+
+    def test_spans_multiple_athletes(self):
+        coach = UserFactory()
+        a = CoachAthleteFactory(coach=coach)
+        b = CoachAthleteFactory(coach=coach)
+        delivered_week(a, sessions=1, done=1)
+        delivered_week(b, sessions=1, done=1)
+        logs = adherence.recent_logs(coach)
+        assert {log.athlete_id for log in logs} == {a.athlete_id, b.athlete_id}
+
+
+# -- presenters ------------------------------------------------------------
+
+
+class TestRosterPresenters:
+    def test_roster_athlete_threads_compliance(self):
+        user = UserFactory()
+        row = presenters.roster_athlete(user, compliance=42)
+        assert row["compliance"] == 42
+
+    def test_roster_athlete_compliance_defaults_none(self):
+        user = UserFactory()
+        row = presenters.roster_athlete(user)
+        assert row["compliance"] is None
+
+    def test_roster_activity_shape(self):
+        rel = CoachAthleteFactory()
+        rel.athlete.name = "Maya Okonkwo"
+        rel.athlete.save(update_fields=["name"])
+        week = delivered_week(rel, sessions=1, done=0)
+        session = week.sessions.first()
+        session.name = "Lower"
+        session.save(update_fields=["name"])
+        SessionLogFactory(
+            session=session, athlete=rel.athlete, status=SessionLog.Status.DONE
+        )
+        events = presenters.roster_activity(rel.coach)
+        assert len(events) == 1
+        ev = events[0]
+        assert ev["athlete"]["name"] == "Maya Okonkwo"
+        assert ev["athlete"]["initials"] == "MO"
+        assert ev["athlete"]["id"] == rel.athlete.pk
+        assert "Lower" in ev["text"]
+        assert ev["when"]  # a non-empty relative-time label
+
+    def test_roster_activity_falls_back_to_day_label(self):
+        rel = CoachAthleteFactory()
+        week = delivered_week(rel, sessions=1, done=0)
+        session = week.sessions.first()
+        session.name = ""  # a blank session name
+        session.save(update_fields=["name"])
+        SessionLogFactory(
+            session=session, athlete=rel.athlete, status=SessionLog.Status.DONE
+        )
+        events = presenters.roster_activity(rel.coach)
+        assert events[0]["text"]  # never blank, even without a session name
+
+
+# -- RosterView integration ------------------------------------------------
+
+
+class TestRosterViewAdherence:
+    def test_compliance_meter_and_activity_render(self, client):
+        coach = UserFactory()
+        CoachProfileFactory(user=coach)
+        rel = CoachAthleteFactory(coach=coach)
+        rel.athlete.name = "Maya Okonkwo"
+        rel.athlete.save(update_fields=["name"])
+        week = delivered_week(rel, sessions=2, done=1)
+        session = week.sessions.order_by("day_number").first()
+        session.name = "Lower"
+        session.save(update_fields=["name"])
+        # Re-log so the activity text picks up the renamed session.
+        SessionLog.objects.filter(session=session, athlete=rel.athlete).delete()
+        SessionLogFactory(
+            session=session, athlete=rel.athlete, status=SessionLog.Status.DONE
+        )
+
+        client.force_login(coach)
+        resp = client.get(reverse("meso:roster"))
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        # Compliance meter for the one delivered+half-logged week.
+        assert "50%" in body
+        # Recent-activity feed names the athlete + the session they logged.
+        assert "Lower" in body

--- a/app/store_project/meso/tests/test_adherence.py
+++ b/app/store_project/meso/tests/test_adherence.py
@@ -226,6 +226,19 @@ class TestRecentLogs:
         # "recent activity."
         assert adherence.recent_logs(rel.coach) == []
 
+    def test_excludes_logs_by_a_non_linked_athlete(self):
+        rel = CoachAthleteFactory()
+        week = delivered_week(rel, sessions=1, done=0)
+        session = week.sessions.first()
+        stranger = UserFactory()
+        # A done log on the coach's session but by someone other than the plan's
+        # athlete (the model permits it; the write path never does) must not leak
+        # into the feed — it would show an unrelated name + an unreachable link.
+        SessionLogFactory(
+            session=session, athlete=stranger, status=SessionLog.Status.DONE
+        )
+        assert adherence.recent_logs(rel.coach) == []
+
     def test_spans_multiple_athletes(self):
         coach = UserFactory()
         a = CoachAthleteFactory(coach=coach)

--- a/app/store_project/meso/tests/test_adherence.py
+++ b/app/store_project/meso/tests/test_adherence.py
@@ -29,19 +29,27 @@ from store_project.meso.factories import SessionFactory
 from store_project.meso.factories import SessionLogFactory
 from store_project.meso.factories import WeekFactory
 from store_project.meso.models import CoachAthlete
+from store_project.meso.models import Plan
 from store_project.meso.models import SessionLog
 from store_project.users.factories import UserFactory
 
 pytestmark = pytest.mark.django_db
 
 
-def delivered_week(rel, *, sessions=3, done=0, delivered_at=None, index=1):
+def delivered_week(
+    rel, *, sessions=3, done=0, delivered_at=None, index=1, archived=False
+):
     """A delivered week under ``rel`` with ``sessions`` days, ``done`` of them logged.
 
     Returns the ``Week``. The first ``done`` sessions get a *done* ``SessionLog``
-    for the relationship's athlete; the rest are left un-logged.
+    for the relationship's athlete; the rest are left un-logged. ``archived``
+    parks the plan in the ARCHIVED state (e.g. a removed group member's
+    materialized snapshot).
     """
-    meso = MesocycleFactory(plan=PlanFactory(relationship=rel), order=index)
+    plan_status = Plan.Status.ARCHIVED if archived else Plan.Status.DRAFT
+    meso = MesocycleFactory(
+        plan=PlanFactory(relationship=rel, status=plan_status), order=index
+    )
     week = WeekFactory(
         mesocycle=meso,
         index=index,
@@ -128,6 +136,32 @@ class TestLinkCompliance:
         # The stranger's done logs are not this athlete's adherence.
         assert adherence.link_compliance(rel) == 0
 
+    def test_ignores_archived_plans(self):
+        rel = CoachAthleteFactory()
+        # The only delivered week lives on an archived plan (e.g. a removed
+        # group member's snapshot) — the athlete can't see/log it, so it must
+        # not drive the meter.
+        delivered_week(rel, sessions=2, done=2, archived=True)
+        assert adherence.link_compliance(rel) is None
+
+    def test_prefers_active_plan_over_newer_archived(self):
+        rel = CoachAthleteFactory()
+        now = timezone.now()
+        # A live (older) delivered plan plus a newer *archived* one: the meter
+        # measures the live program, not the hidden archived snapshot.
+        delivered_week(
+            rel, sessions=2, done=1, delivered_at=now - timedelta(days=2), index=1
+        )
+        delivered_week(
+            rel,
+            sessions=2,
+            done=2,
+            delivered_at=now,
+            index=2,
+            archived=True,
+        )
+        assert adherence.link_compliance(rel) == 50
+
     def test_duplicate_done_logs_count_the_session_once(self):
         rel = CoachAthleteFactory()
         week = delivered_week(rel, sessions=2, done=0)
@@ -184,6 +218,13 @@ class TestRecentLogs:
         assert len(logs) == 3
         created = [log.created_at for log in logs]
         assert created == sorted(created, reverse=True)
+
+    def test_excludes_archived_plans(self):
+        rel = CoachAthleteFactory()
+        delivered_week(rel, sessions=1, done=1, archived=True)
+        # A removed group member's archived snapshot must not resurface as
+        # "recent activity."
+        assert adherence.recent_logs(rel.coach) == []
 
     def test_spans_multiple_athletes(self):
         coach = UserFactory()

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -38,6 +38,7 @@ from store_project.notifications.emails import send_coach_invite_email
 from store_project.notifications.emails import send_coach_request_email
 from store_project.notifications.emails import send_week_delivered_email
 
+from . import adherence as meso_adherence
 from . import demo as meso_demo
 from . import one_rm as meso_one_rm
 from . import presenters
@@ -319,6 +320,9 @@ class RosterView(TemplateView):
                 suspended=link.pk in suspended,
                 demo=link.is_demo,
                 has_working_plan=link.pk in have_plan,
+                # Adherence to the athlete's latest delivered week (read-side
+                # aggregation over their done logs); ``None`` hides the meter.
+                compliance=meso_adherence.link_compliance(link),
             )
             for link in links
         ]
@@ -330,8 +334,7 @@ class RosterView(TemplateView):
         ctx["active"] = "roster"
         ctx["athletes"] = athletes
         # Groups (S1 Phase 1) read real rows; the shared program + per-athlete
-        # auto-adjusts land in groups Phase 2/3. Activity (Phase 3) needs logged
-        # sessions; needs-review (Phase 2) needs agent state. Empty until then.
+        # auto-adjusts land in groups Phase 2/3.
         ctx["groups"] = [presenters.roster_group(g) for g in groups]
         # Outstanding email invites the coach has sent — pending *or* expired (N4);
         # an expired one still shows so the coach can Resend it (Phase 3).
@@ -354,7 +357,9 @@ class RosterView(TemplateView):
         # Billing/paywall state (S6 Phase 3): tier, seat usage, and the upgrade
         # CTAs (start trial / subscribe / manage billing).
         ctx["billing"] = presenters.billing_state(self.request.user)
-        ctx["activity"] = []
+        # Recent-activity feed: the coach's athletes' latest completed sessions.
+        ctx["activity"] = presenters.roster_activity(self.request.user)
+        # Needs-review (agent batch state) is a separate slice — still neutral.
         ctx["needs_review"] = 0
         # First-run UX (Phase 2): a fresh coach with nothing yet gets an
         # onboarding card that teaches the model and offers the one-click demo;

--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -1176,3 +1176,41 @@ _(Append dated entries here as decisions land.)_
   prod-verified (`/meso/billing/` 302→login for anon, the route is live). **Remaining
   Meso backlog unchanged:** billing annual prices (BLOCKED on owner numbers + Stripe
   annual Prices); Anthropic Admin/Usage-API reconciliation (deferred, needs Admin key).
+- 2026-06-30 — **Coach roster adherence built: the compliance meter + activity
+  feed go live** (no migration). The roster carried two dead placeholders since
+  Phase 1 — `presenters.roster_athlete` returned `compliance=None` and `RosterView`
+  set `activity=[]`, both flagged in-code as "Phase 2/3 concepts awaiting logged
+  data." Delivery + logging have existed since the athlete slice, so the data was
+  finally there; this wires it. The roster **UI already existed** (the `meso-meter`
+  bar + the "Recent activity" card), so the slice is **backend-only**. New
+  `meso/adherence.py` (pure read-side aggregation): `link_compliance(link)` = the %
+  of the **latest delivered week's** sessions the athlete marked *done*
+  (`link_latest_delivered_week` spans the individual plan **and** any group-delivery
+  snapshot rooted at the link — adherence to whatever was delivered most recently);
+  `recent_logs(coach)` = the coach's active-link athletes' most recently completed
+  sessions. **Decisions:** `None` (no delivered week) hides the meter while `0` (the
+  coach delivered, the athlete hasn't logged) is a real, distinct signal that's
+  kept; ordering is by `created_at` (when logged) — *not* the nullable workout
+  `date`, whose NULL sort order differs SQLite↔Postgres. `presenters.roster_activity`
+  shapes the feed (athlete + session + a compact "N ago" off `timesince`, since
+  `humanize` isn't installed). **Profile page left untouched** — its compliance meter
+  is bundled behind `has_program` with still-unfilled `block`/`week`/`macrocycle`
+  placeholders, so lighting it up is a separate, larger slice. The seeded demo
+  already delivers + logs Maya's week, so the one-click demo showcases the meter for
+  free. Red→green (`test_adherence.py`, +25): compliance math/scoping (latest-week-
+  only, own-done-only, dedup, **archived-plan exclusion**), `recent_logs` scoping/
+  ordering (active links, **non-archived plans**, **athlete tied to the plan's own
+  athlete**), presenter shaping, the RosterView render. 1353 meso pytest green, ruff
+  + DjHTML + `makemigrations --check` clean. **Codex review loop CLEAN after 2 fix
+  iters** — both real: (1 = P2) the queries didn't exclude **archived** plans, so a
+  removed group member's archived snapshot (link stays active) could drive the meter/
+  feed for a program the athlete can't see → excluded, matching `working_plan`/
+  `athlete_home`; (2 = P2) `recent_logs` didn't tie `SessionLog.athlete` to the
+  plan's relationship athlete (the write path always does, but the model has no DB
+  constraint), so a stray mismatched row could leak an unrelated name + an unreachable
+  profile link → added an `F()` predicate. **Remaining Meso backlog unchanged:**
+  billing annual prices (BLOCKED on owner numbers + Stripe annual Prices); Anthropic
+  Admin/Usage-API reconciliation (deferred, needs Admin key). **Deferred follow-up:**
+  lighting up the athlete-profile program block (compliance + current block +
+  macrocycle) as its own slice; per-athlete `delivered`/`needs_review`/`drafting`
+  status badges (need agent/delivery state).


### PR DESCRIPTION
## What

Lights up the coach roster's two long-standing dead placeholders with real logged data:

- **Compliance meter** — per athlete, the % of their **latest delivered week's** sessions they've marked *done*.
- **Recent activity feed** — the coach's athletes' most recently completed sessions.

`presenters.roster_athlete` carried `compliance=None` and `RosterView` set `activity=[]` since Phase 1, both flagged in-code as *"Phase 2/3 concepts awaiting logged data."* Delivery + logging have existed since the athlete slice, so the data is finally there. The roster **UI already existed** (the `meso-meter` bar + the "Recent activity" card) — this is **backend-only, no migration**.

## How

New `meso/adherence.py` (pure read-side aggregation):
- `link_compliance(link)` — % of the latest delivered week's sessions done. `link_latest_delivered_week` spans the individual plan **and** any group-delivery snapshot rooted at the link (adherence to whatever was delivered most recently).
- `recent_logs(coach)` — the coach's active-link athletes' most recent completed sessions.

`presenters.roster_activity` shapes the feed (athlete + session + a compact "N ago"); `RosterView` wires both.

### Decisions
- `None` (nothing delivered) hides the meter; `0` (delivered, not yet logged) is a **real, distinct signal** and is kept.
- Activity ordered by `created_at` (when logged), **not** the nullable workout `date` (whose NULL sort order differs SQLite↔Postgres).
- **Profile page left untouched** — its compliance meter is bundled behind `has_program` with still-unfilled `block`/`week`/`macrocycle` placeholders, so lighting it up is a separate, larger slice.

## Tests

`test_adherence.py` (+25): compliance math/scoping (latest-week-only, own-done-only, dedup, **archived-plan exclusion**), `recent_logs` scoping/ordering (active links, **non-archived plans**, **athlete tied to the plan's own athlete**), presenter shaping, RosterView render. 1353 meso pytest green; ruff + DjHTML + `makemigrations --check` clean.

## Review

**Codex review loop CLEAN after 2 fix iters** — both real correctness/safety gaps:
1. (P2) Queries didn't exclude **archived** plans → a removed group member's archived snapshot (link stays active) could drive the meter/feed for a program the athlete can't see. Excluded, matching `working_plan`/`athlete_home`.
2. (P2) `recent_logs` didn't tie `SessionLog.athlete` to the plan's relationship athlete (write path always does, but no DB constraint) → a stray mismatched row could leak an unrelated name + an unreachable profile link. Added an `F()` predicate.

https://claude.ai/code/session_019A9KdsVs33wipsGjSaFWXV