### PR TITLE
Meso — relationship-history view (past athletes + re-invite)

### DIFF
--- a/app/store_project/meso/management/commands/seed_meso_demo.py
+++ b/app/store_project/meso/management/commands/seed_meso_demo.py
@@ -354,6 +354,11 @@ PENDING_INVITE_EMAIL = "prospect@example.com"
 PENDING_REQUEST_EMAIL = "hopeful@example.com"
 PENDING_REQUEST_NAME = "Hopeful Newcomer"
 
+# A former athlete (an ENDED link) so the relationship-history surface ("Past
+# athletes", re-invitable) is visible on a fresh DB.
+PAST_ATHLETE_EMAIL = "alum@example.com"
+PAST_ATHLETE_NAME = "Jordan Alumni"
+
 
 def _months_before(today, months):
     """The date ``months`` whole months before ``today`` (day clamped to ≤28)."""
@@ -401,13 +406,14 @@ class Command(BaseCommand):
         self._ensure_group(coach)
         self._ensure_pending_invite(coach)
         self._ensure_pending_request(coach)
+        self._ensure_past_athlete(coach, today)
 
         self.stdout.write(
             self.style.SUCCESS(
                 f"✓ Meso demo seeded for {coach.email}: "
                 f"{len(ATHLETES)} athletes, 1 group (+ shared program), "
                 "1 sample plan, 1 logged session, 1 pending invite, "
-                "1 pending request."
+                "1 pending request, 1 past athlete."
             )
         )
 
@@ -422,6 +428,8 @@ class Command(BaseCommand):
         ).delete()
         # Drop the requester (their pending request link cascades with the user).
         User.objects.filter(email=PENDING_REQUEST_EMAIL).delete()
+        # Drop the former athlete (their ended link cascades with the user).
+        User.objects.filter(email=PAST_ATHLETE_EMAIL).delete()
         emails = [spec["email"] for spec in ATHLETES]
         deleted, _ = User.objects.filter(email__in=emails).delete()
         self.stdout.write(
@@ -521,6 +529,36 @@ class Command(BaseCommand):
                 "invited_by": CoachAthlete.InvitedBy.ATHLETE,
                 "responded_at": None,
                 "ended_at": None,
+            },
+        )
+
+    def _ensure_past_athlete(self, coach, today):
+        """A former athlete on an ENDED link so the history surface shows.
+
+        The relationship-history page ("Past athletes") lists ended/declined
+        links — a coach used to train this person, then the relationship ended.
+        ``update_or_create`` keeps a reseed idempotent and repairs the row back to
+        ``ended`` if a prior run (or a manual reopen) left it elsewhere.
+        """
+        alum, created = User.objects.get_or_create(
+            email=PAST_ATHLETE_EMAIL,
+            defaults={
+                "username": PAST_ATHLETE_EMAIL,
+                "name": PAST_ATHLETE_NAME,
+                "birthday": _years_before(today, 31),
+            },
+        )
+        if created:
+            alum.set_unusable_password()
+            alum.save(update_fields=["password"])
+        CoachAthlete.objects.update_or_create(
+            coach=coach,
+            athlete=alum,
+            defaults={
+                "status": CoachAthlete.Status.ENDED,
+                "invited_by": CoachAthlete.InvitedBy.COACH,
+                "responded_at": None,
+                "ended_at": timezone.now(),
             },
         )
 

--- a/app/store_project/meso/models.py
+++ b/app/store_project/meso/models.py
@@ -171,6 +171,15 @@ class CoachAthleteQuerySet(models.QuerySet):
     def pending(self):
         return self.filter(status__in=CoachAthlete.PENDING_STATUSES)
 
+    def closed(self):
+        """Terminal-state links — declined or ended (the relationship history).
+
+        These vanish from the active roster (only ``active()`` is shown), but the
+        row + its ``ended_at``/``responded_at`` timestamp + the archived plans all
+        persist, so a coach can review past athletes and re-invite them.
+        """
+        return self.filter(status__in=CoachAthlete.CLOSED_STATUSES)
+
     def for_coach(self, user):
         """Links where ``user`` is the coach (i.e. the coach's athletes)."""
         return self.filter(coach=user)
@@ -346,6 +355,24 @@ class CoachAthlete(models.Model):
     @property
     def is_pending(self):
         return self.status in self.PENDING_STATUSES
+
+    @property
+    def is_closed(self):
+        """Terminal state — declined or ended (a row the history surface shows)."""
+        return self.status in self.CLOSED_STATUSES
+
+    @property
+    def closed_at(self):
+        """When the link entered its terminal state, or ``None`` while open.
+
+        An ended link carries ``ended_at``; a declined one carries ``responded_at``
+        (``decline`` stamps it). Used to order and label the relationship history.
+        """
+        if self.status == self.Status.ENDED:
+            return self.ended_at
+        if self.status == self.Status.DECLINED:
+            return self.responded_at
+        return None
 
     def recipient(self):
         """The party whose acceptance the link is waiting on (None if not pending)."""

--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -410,11 +410,14 @@ def relationship_history(coach):
             row["when"] = link.closed_at or link.created_at
             past.append(row)
         else:
-            row["when"] = link.created_at
-            reconnecting.append(row)
+            # A re-invite reopens the row in place, so no field records *when* the
+            # re-invite was sent (``created_at`` is the original link date). The
+            # reconnecting surface shows state ("awaiting reply"), not a date, and
+            # orders by ``created_at`` only for a stable, deterministic sequence.
+            reconnecting.append((link.created_at, row))
     past.sort(key=lambda r: r["when"], reverse=True)
-    reconnecting.sort(key=lambda r: r["when"], reverse=True)
-    return {"past": past, "reconnecting": reconnecting}
+    reconnecting.sort(key=lambda pair: pair[0], reverse=True)
+    return {"past": past, "reconnecting": [row for _, row in reconnecting]}
 
 
 def agent_allowance(coach):

--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -363,6 +363,60 @@ def pending_request(link):
     }
 
 
+#: Human labels for the relationship-history surface, keyed by terminal/pending
+#: status. ``PENDING_COACH_INVITE`` here is a *re-invite* awaiting the athlete.
+_HISTORY_STATUS_LABELS = {
+    CoachAthlete.Status.ENDED: "Ended",
+    CoachAthlete.Status.DECLINED: "Declined",
+    CoachAthlete.Status.PENDING_COACH_INVITE: "Awaiting response",
+}
+
+
+def relationship_history(coach):
+    """The coach's relationship history: past athletes + pending re-invites.
+
+    A coach (or athlete) who ends a relationship — or declines an invite/request —
+    drops the ``CoachAthlete`` row to a terminal status, so it leaves the active
+    roster though the row + its archived plans persist. This surfaces those rows
+    in one query (mirroring ``athlete_pending``'s split):
+
+    - ``past`` — ended/declined links, newest-closed first, each re-invitable;
+    - ``reconnecting`` — re-invites awaiting the athlete's response (a coach-side
+      ``pending_coach_invite``, which the athlete sees on their training home and
+      which is surfaced nowhere else).
+
+    Demo relationships are excluded — history is about real past clients.
+    """
+    links = (
+        CoachAthlete.objects.for_coach(coach)
+        .exclude(is_demo=True)
+        .filter(status__in=list(_HISTORY_STATUS_LABELS))
+        .select_related("athlete")
+    )
+    past, reconnecting = [], []
+    for link in links:
+        name = link.athlete.display_name()
+        row = {
+            "id": link.athlete_id,
+            "name": name,
+            "initials": initials(name),
+            "token": link.token,
+            "status": link.status,
+            "status_label": _HISTORY_STATUS_LABELS[link.status],
+        }
+        if link.is_closed:
+            # ``closed_at`` is set for any link closed through the state machine;
+            # fall back to ``created_at`` for a hand-written/legacy row.
+            row["when"] = link.closed_at or link.created_at
+            past.append(row)
+        else:
+            row["when"] = link.created_at
+            reconnecting.append(row)
+    past.sort(key=lambda r: r["when"], reverse=True)
+    reconnecting.sort(key=lambda r: r["when"], reverse=True)
+    return {"past": past, "reconnecting": reconnecting}
+
+
 def agent_allowance(coach):
     """The free-tier AI-agent meter for the designer + roster card (S6 Phase 5).
 

--- a/app/store_project/meso/tests/test_relationship_history.py
+++ b/app/store_project/meso/tests/test_relationship_history.py
@@ -1,0 +1,360 @@
+"""Roster relationship-history view + re-invite (the "past athletes" surface).
+
+When a coach (or athlete) ends a relationship, or a pending invite/request is
+declined, the ``CoachAthlete`` row drops to a terminal status and vanishes from
+the active roster — yet the row, the ``ended_at`` timestamp, and the (now
+archived) plans all persist. This slice surfaces that history so a coach can see
+who they used to train and **re-invite** them, reopening the existing link to a
+fresh ``pending_coach_invite`` the athlete discovers on their training home.
+
+Covers:
+
+- ``CoachAthleteQuerySet.closed()`` (ended + declined; excludes active/pending);
+- the ``CoachAthlete.is_closed`` / ``closed_at`` helpers;
+- ``presenters.relationship_history`` (past + reconnecting split, coach scoping,
+  demo exclusion, newest-first ordering, status labels);
+- ``RelationshipHistoryView`` (login + coach-only gate, scoping, render);
+- ``relationship_reinvite`` (reopen → ``pending_coach_invite``, closed-only
+  no-op, coach-scoped 404, the seat gate, the athlete discovers it on home).
+"""
+
+import datetime
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+
+from store_project.meso import presenters
+from store_project.meso.factories import CoachAthleteFactory
+from store_project.meso.factories import CoachProfileFactory
+from store_project.meso.models import CoachAthlete
+from store_project.users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def make_coach(email="coach@example.com", name="Coach Carter"):
+    """A User who *is* a coach — a ``CoachProfile`` is the surface's gate."""
+    coach = UserFactory(email=email, name=name)
+    CoachProfileFactory(user=coach)
+    return coach
+
+
+def ended_link(coach, *, name="Past Athlete", ended_at=None):
+    athlete = UserFactory(name=name)
+    return CoachAthleteFactory(
+        coach=coach,
+        athlete=athlete,
+        status=CoachAthlete.Status.ENDED,
+        ended_at=ended_at or timezone.now(),
+    )
+
+
+# -- queryset / model ------------------------------------------------------
+
+
+class TestClosedQuerySet:
+    def test_closed_returns_ended_and_declined_only(self):
+        coach = UserFactory()
+        active = CoachAthleteFactory(coach=coach, status=CoachAthlete.Status.ACTIVE)
+        pending = CoachAthleteFactory(
+            coach=coach, status=CoachAthlete.Status.PENDING_COACH_INVITE
+        )
+        declined = CoachAthleteFactory(coach=coach, status=CoachAthlete.Status.DECLINED)
+        ended = CoachAthleteFactory(coach=coach, status=CoachAthlete.Status.ENDED)
+
+        closed = set(CoachAthlete.objects.for_coach(coach).closed())
+
+        assert closed == {declined, ended}
+        assert active not in closed
+        assert pending not in closed
+
+    def test_is_closed_property(self):
+        ended = CoachAthleteFactory.build(status=CoachAthlete.Status.ENDED)
+        declined = CoachAthleteFactory.build(status=CoachAthlete.Status.DECLINED)
+        active = CoachAthleteFactory.build(status=CoachAthlete.Status.ACTIVE)
+        pending = CoachAthleteFactory.build(
+            status=CoachAthlete.Status.PENDING_COACH_INVITE
+        )
+
+        assert ended.is_closed
+        assert declined.is_closed
+        assert not active.is_closed
+        assert not pending.is_closed
+
+    def test_closed_at_is_ended_at_for_an_ended_link(self):
+        link = CoachAthleteFactory(status=CoachAthlete.Status.ACTIVE)
+        link.end()
+
+        assert link.ended_at is not None
+        assert link.closed_at == link.ended_at
+
+    def test_closed_at_is_responded_at_for_a_declined_link(self):
+        link = CoachAthleteFactory(status=CoachAthlete.Status.PENDING_ATHLETE_REQUEST)
+        link.decline()
+
+        assert link.responded_at is not None
+        assert link.closed_at == link.responded_at
+
+    def test_closed_at_is_none_for_an_open_link(self):
+        active = CoachAthleteFactory.build(status=CoachAthlete.Status.ACTIVE)
+        pending = CoachAthleteFactory.build(
+            status=CoachAthlete.Status.PENDING_COACH_INVITE
+        )
+
+        assert active.closed_at is None
+        assert pending.closed_at is None
+
+
+# -- presenter -------------------------------------------------------------
+
+
+class TestRelationshipHistoryPresenter:
+    def test_splits_past_and_reconnecting(self):
+        coach = make_coach()
+        ended = ended_link(coach, name="Gone Gardner")
+        declined = CoachAthleteFactory(
+            coach=coach,
+            athlete=UserFactory(name="Nope Nelson"),
+            status=CoachAthlete.Status.DECLINED,
+        )
+        reinvited = CoachAthleteFactory(
+            coach=coach,
+            athlete=UserFactory(name="Back Baker"),
+            status=CoachAthlete.Status.PENDING_COACH_INVITE,
+        )
+        # An active link never appears in history.
+        CoachAthleteFactory(
+            coach=coach,
+            athlete=UserFactory(name="Active Avery"),
+            status=CoachAthlete.Status.ACTIVE,
+        )
+
+        history = presenters.relationship_history(coach)
+
+        past_ids = {row["id"] for row in history["past"]}
+        reconnecting_ids = {row["id"] for row in history["reconnecting"]}
+        assert past_ids == {ended.athlete_id, declined.athlete_id}
+        assert reconnecting_ids == {reinvited.athlete_id}
+
+    def test_scoped_to_the_coach(self):
+        coach = make_coach()
+        other = make_coach(email="other@example.com", name="Other One")
+        ours = ended_link(coach, name="Ours")
+        ended_link(other, name="Theirs")
+
+        history = presenters.relationship_history(coach)
+
+        names = {row["name"] for row in history["past"]}
+        assert names == {ours.athlete.name}
+
+    def test_excludes_demo_relationships(self):
+        coach = make_coach()
+        CoachAthleteFactory(
+            coach=coach,
+            athlete=UserFactory(name="Demo Dana"),
+            status=CoachAthlete.Status.ENDED,
+            ended_at=timezone.now(),
+            is_demo=True,
+        )
+        kept = ended_link(coach, name="Real Riley")
+
+        history = presenters.relationship_history(coach)
+
+        assert {row["id"] for row in history["past"]} == {kept.athlete_id}
+
+    def test_past_ordered_newest_first(self):
+        coach = make_coach()
+        older = ended_link(
+            coach,
+            name="Older",
+            ended_at=timezone.now() - datetime.timedelta(days=30),
+        )
+        newer = ended_link(
+            coach,
+            name="Newer",
+            ended_at=timezone.now() - datetime.timedelta(days=1),
+        )
+
+        history = presenters.relationship_history(coach)
+
+        assert [row["id"] for row in history["past"]] == [
+            newer.athlete_id,
+            older.athlete_id,
+        ]
+
+    def test_status_labels(self):
+        coach = make_coach()
+        ended_link(coach, name="Ended Ed")
+        CoachAthleteFactory(
+            coach=coach,
+            athlete=UserFactory(name="Declined Dee"),
+            status=CoachAthlete.Status.DECLINED,
+        )
+        CoachAthleteFactory(
+            coach=coach,
+            athlete=UserFactory(name="Awaiting Amy"),
+            status=CoachAthlete.Status.PENDING_COACH_INVITE,
+        )
+
+        history = presenters.relationship_history(coach)
+
+        labels = {row["name"]: row["status_label"] for row in history["past"]}
+        assert labels["Ended Ed"] == "Ended"
+        assert labels["Declined Dee"] == "Declined"
+        reconnecting = history["reconnecting"][0]
+        assert reconnecting["status_label"] == "Awaiting response"
+        # A re-invite is addressable for cancellation via its token.
+        assert reconnecting["token"]
+
+
+# -- history view ----------------------------------------------------------
+
+
+class TestRelationshipHistoryView:
+    def test_requires_login(self, client):
+        resp = client.get(reverse("meso:relationship_history"))
+        assert resp.status_code == 302
+        assert "/accounts/login" in resp["Location"]
+
+    def test_non_coach_redirected_to_training_home(self, client):
+        athlete = UserFactory()  # no CoachProfile, no coach-side link
+        client.force_login(athlete)
+
+        resp = client.get(reverse("meso:relationship_history"))
+
+        assert resp.status_code == 302
+        assert resp["Location"] == reverse("meso:athlete_home")
+
+    def test_coach_sees_their_past_athletes(self, client):
+        coach = make_coach()
+        link = ended_link(coach, name="Former Fiona")
+        client.force_login(coach)
+
+        resp = client.get(reverse("meso:relationship_history"))
+
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert "Former Fiona" in body
+        # A re-invite form addresses the link by token.
+        assert (
+            reverse("meso:relationship_reinvite", kwargs={"token": link.token}) in body
+        )
+
+    def test_does_not_leak_another_coachs_history(self, client):
+        coach = make_coach()
+        other = make_coach(email="other@example.com", name="Other Coach")
+        ended_link(other, name="Secret Sam")
+        client.force_login(coach)
+
+        resp = client.get(reverse("meso:relationship_history"))
+
+        assert "Secret Sam" not in resp.content.decode()
+
+    def test_roster_links_to_history(self, client):
+        coach = make_coach()
+        CoachAthleteFactory(coach=coach, status=CoachAthlete.Status.ACTIVE)
+        client.force_login(coach)
+
+        resp = client.get(reverse("meso:roster"))
+
+        assert reverse("meso:relationship_history") in resp.content.decode()
+
+
+# -- re-invite -------------------------------------------------------------
+
+
+class TestReinvite:
+    def test_reopens_a_closed_link_to_pending_coach_invite(self, client):
+        coach = make_coach()
+        link = ended_link(coach, name="Comeback Kid")
+        old_token = link.token
+        client.force_login(coach)
+
+        resp = client.post(
+            reverse("meso:relationship_reinvite", kwargs={"token": link.token})
+        )
+
+        assert resp.status_code == 302
+        link.refresh_from_db()
+        assert link.status == CoachAthlete.Status.PENDING_COACH_INVITE
+        assert link.invited_by == CoachAthlete.InvitedBy.COACH
+        assert link.ended_at is None
+        # Reopening rotates the token (the old history link dies).
+        assert link.token != old_token
+
+    def test_reinvited_athlete_sees_the_invite_on_their_home(self, client):
+        coach = make_coach(name="Coach Quinn")
+        link = ended_link(coach, name="Returning Rae")
+        athlete = link.athlete
+        client.force_login(coach)
+
+        client.post(reverse("meso:relationship_reinvite", kwargs={"token": link.token}))
+
+        pending = presenters.athlete_pending(athlete)
+        coaches = {row["coach"] for row in pending["invites"]}
+        assert "Coach Quinn" in coaches
+
+    def test_requires_post(self, client):
+        coach = make_coach()
+        link = ended_link(coach)
+        client.force_login(coach)
+
+        resp = client.get(
+            reverse("meso:relationship_reinvite", kwargs={"token": link.token})
+        )
+
+        assert resp.status_code == 405
+
+    def test_coach_scoped_foreign_token_is_404(self, client):
+        coach = make_coach()
+        other = make_coach(email="other@example.com")
+        link = ended_link(other, name="Not Yours")
+        client.force_login(coach)
+
+        resp = client.post(
+            reverse("meso:relationship_reinvite", kwargs={"token": link.token})
+        )
+
+        assert resp.status_code == 404
+        link.refresh_from_db()
+        assert link.status == CoachAthlete.Status.ENDED
+
+    def test_noop_on_an_active_link(self, client):
+        coach = make_coach()
+        link = CoachAthleteFactory(
+            coach=coach,
+            athlete=UserFactory(name="Still Here"),
+            status=CoachAthlete.Status.ACTIVE,
+        )
+        client.force_login(coach)
+
+        resp = client.post(
+            reverse("meso:relationship_reinvite", kwargs={"token": link.token})
+        )
+
+        assert resp.status_code == 302
+        link.refresh_from_db()
+        assert link.status == CoachAthlete.Status.ACTIVE
+
+    def test_seat_gate_blocks_a_free_coach_at_the_cap(self, client):
+        # Free tier: FREE_SEAT_LIMIT == 1 active billable seat. One active
+        # athlete already fills it, so re-activating a former athlete is gated.
+        coach = make_coach()
+        CoachAthleteFactory(
+            coach=coach,
+            athlete=UserFactory(name="Seat Taker"),
+            status=CoachAthlete.Status.ACTIVE,
+        )
+        link = ended_link(coach, name="Wants Back")
+        client.force_login(coach)
+
+        resp = client.post(
+            reverse("meso:relationship_reinvite", kwargs={"token": link.token}),
+            follow=True,
+        )
+
+        link.refresh_from_db()
+        assert link.status == CoachAthlete.Status.ENDED  # not reopened
+        messages = [m.message for m in resp.context["messages"]]
+        assert any("free athlete limit" in m for m in messages)

--- a/app/store_project/meso/tests/test_seed_demo.py
+++ b/app/store_project/meso/tests/test_seed_demo.py
@@ -123,6 +123,29 @@ class TestSeedCreatesDemo:
         seed(delete=True)
         assert not User.objects.filter(email="hopeful@example.com").exists()
 
+    def test_creates_a_past_athlete(self):
+        # The relationship-history surface ("Past athletes"): a former athlete on
+        # an ENDED link, so the surface is populated on a fresh DB.
+        seed()
+        coach = User.objects.get(email=COACH_EMAIL)
+        past = CoachAthlete.objects.for_coach(coach).closed()
+        assert past.count() == 1
+        link = past.get()
+        assert link.status == CoachAthlete.Status.ENDED
+        assert link.athlete.email == "alum@example.com"
+        assert link.ended_at is not None
+
+    def test_reseed_does_not_duplicate_past_athlete(self):
+        seed()
+        seed()
+        coach = User.objects.get(email=COACH_EMAIL)
+        assert CoachAthlete.objects.for_coach(coach).closed().count() == 1
+
+    def test_delete_removes_past_athlete(self):
+        seed()
+        seed(delete=True)
+        assert not User.objects.filter(email="alum@example.com").exists()
+
     def test_creates_one_sample_plan(self):
         seed()
         coach = User.objects.get(email=COACH_EMAIL)
@@ -342,9 +365,10 @@ class TestIdempotent:
         seed()
         coach = User.objects.get(email=COACH_EMAIL)
         assert User.objects.filter(email__in=ATHLETE_EMAILS).count() == 5
-        # 5 active athletes + 1 pending athlete→coach request (N4 Phase 2).
+        # 5 active athletes + 1 pending athlete→coach request (N4 Phase 2) + 1
+        # ended past athlete (the relationship-history surface).
         assert CoachAthlete.objects.for_coach(coach).active().count() == 5
-        assert CoachAthlete.objects.for_coach(coach).count() == 6
+        assert CoachAthlete.objects.for_coach(coach).count() == 7
         assert Plan.objects.for_coach(coach).count() == 1
         # Children are not re-created on a second run (the individual sample plan;
         # ``for_coach`` excludes the group-delivery snapshots seeded in Phase 4).

--- a/app/store_project/meso/urls.py
+++ b/app/store_project/meso/urls.py
@@ -11,6 +11,7 @@ from .views import DeliverView
 from .views import GroupDetailView
 from .views import MesoDesignerView
 from .views import OfflineView
+from .views import RelationshipHistoryView
 from .views import ResultsView
 from .views import RosterView
 from .views import UsageDashboardView
@@ -18,6 +19,12 @@ from .views import UsageDashboardView
 app_name = "meso"
 urlpatterns = [
     path("", RosterView.as_view(), name="roster"),
+    # Past athletes — ended/declined relationships, with re-invite.
+    path(
+        "history/",
+        RelationshipHistoryView.as_view(),
+        name="relationship_history",
+    ),
     path("designer/", MesoDesignerView.as_view(), name="designer"),
     # Owner-facing agent usage + margin dashboard (agent-usage Phase 4) —
     # staff-gated, all-coach; the web read-out of meso_agent_usage_report.
@@ -108,6 +115,11 @@ urlpatterns = [
         "relationship/<uuid:token>/end/",
         views.relationship_end,
         name="relationship_end",
+    ),
+    path(
+        "relationship/<uuid:token>/reinvite/",
+        views.relationship_reinvite,
+        name="relationship_reinvite",
     ),
     # Athlete → coach requests (N4 Phase 2): the athlete asks, then may withdraw.
     path("request/", views.athlete_request_coach, name="athlete_request_coach"),

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -369,6 +369,34 @@ class RosterView(TemplateView):
         return ctx
 
 
+class RelationshipHistoryView(LoginRequiredMixin, TemplateView):
+    """Past athletes (``/meso/history/``) — the coach surface for closed links.
+
+    An ended or declined ``CoachAthlete`` vanishes from the active roster, but the
+    row + archived plans persist. This lists those past relationships so the coach
+    can see who they used to train and **re-invite** them (reopening the link to a
+    fresh ``pending_coach_invite`` the athlete sees on their training home), plus
+    any such re-invites still awaiting a response. A coach surface, so a non-coach
+    is routed to their training home (mirroring ``RosterView``).
+    """
+
+    template_name = "meso/relationship_history.html"
+
+    def get(self, request, *args, **kwargs):
+        if not _is_coach(request.user):
+            return redirect("meso:athlete_home")
+        return super().get(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        history = presenters.relationship_history(self.request.user)
+        ctx["active"] = "roster"
+        ctx["past"] = history["past"]
+        ctx["reconnecting"] = history["reconnecting"]
+        ctx["is_empty"] = not history["past"] and not history["reconnecting"]
+        return ctx
+
+
 class AthleteProfileView(LoginRequiredMixin, TemplateView):
     """Full athlete record — only viewable by a coach with an active link."""
 
@@ -1324,6 +1352,44 @@ def relationship_end(request, token):
     billing_seats.schedule_seat_sync(link.coach)
     messages.success(request, "Relationship ended.")
     return redirect("meso:roster")
+
+
+@login_required
+@require_POST
+def relationship_reinvite(request, token):
+    """Coach re-invites a former athlete from the relationship-history surface.
+
+    Reopens the existing closed (ended/declined) ``CoachAthlete`` link to a fresh
+    ``pending_coach_invite`` (``CoachAthlete.invite`` rotates the token + clears
+    the close timestamps), which the athlete — already a registered user — sees
+    on their training home and accepts/declines. Coach-scoped (a foreign token is
+    a 404). The seat gate (D4) applies: a free coach at the cap can't re-activate
+    a seat they aren't paying for until they upgrade — accepting would create a
+    billable seat. A non-closed link (already active/pending) is a friendly no-op.
+    Locks the row so a re-invite can't race a concurrent claim. The pending peer
+    link is then visible on this page's "Reconnecting" list (surfaced nowhere
+    else), so the coach can see where the re-invited athlete went.
+    """
+    with transaction.atomic():
+        link = get_object_or_404(
+            CoachAthlete.objects.select_for_update(),
+            token=token,
+            coach=request.user,
+        )
+        if not link.is_closed:
+            messages.info(request, "That relationship isn't closed.")
+            return redirect("meso:relationship_history")
+        # Seat gate (D4): accepting the re-invite would consume a billable seat.
+        if not billing_access.can_add_athlete(request.user):
+            messages.error(request, SEAT_LIMIT_MESSAGE)
+            return redirect("meso:relationship_history")
+        athlete = link.athlete
+        CoachAthlete.invite(coach=request.user, athlete=athlete)
+    messages.success(
+        request,
+        f"Re-invited {athlete.display_name()} — they'll see it on their training home.",
+    )
+    return redirect("meso:relationship_history")
 
 
 # -- athlete → coach requests (N4 Phase 2) ---------------------------------

--- a/app/store_project/templates/meso/relationship_history.html
+++ b/app/store_project/templates/meso/relationship_history.html
@@ -36,7 +36,7 @@
               <div class="meso-avatar">{{ r.initials }}</div>
               <div style="min-width:0;">
                 <div class="meso-row-name">{{ r.name }}</div>
-                <div class="meso-row-meta">Re-invited {{ r.when|date:"M j" }} · awaiting their reply</div>
+                <div class="meso-row-meta">Awaiting their reply</div>
               </div>
               <div class="meso-spacer"></div>
               <span class="meso-badge"><i></i>{{ r.status_label }}</span>

--- a/app/store_project/templates/meso/relationship_history.html
+++ b/app/store_project/templates/meso/relationship_history.html
@@ -1,0 +1,75 @@
+{% extends "meso/_meso_base.html" %}
+
+{% block title %}Past athletes · Meso{% endblock %}
+
+{% block content %}
+  <div class="meso-page">
+    <div class="meso-pagehead">
+      <div>
+        <p class="meso-eyebrow">Coach workspace</p>
+        <h1 class="meso-h1">Past athletes</h1>
+        <p class="meso-sub">Relationships you've ended or that were declined. Re-invite anyone to pick back up — their archived programs are kept.</p>
+      </div>
+      <div class="meso-spacer"></div>
+      <a class="meso-btn meso-btn--ghost" href="{% url 'meso:roster' %}">← Back to roster</a>
+    </div>
+
+    <div style="display:flex;flex-direction:column;gap:18px;max-width:640px;">
+
+      {% if is_empty %}
+        <div class="meso-card meso-card--pad">
+          <p class="meso-sub" style="margin:0;">No past relationships yet. When you or an athlete ends a relationship — or an invite is declined — it shows here so you can re-invite them later.</p>
+        </div>
+      {% endif %}
+
+      {% if reconnecting %}
+        <!-- Re-invites awaiting the athlete's response (a coach-side pending peer
+             link, surfaced nowhere else): so a just-re-invited athlete is visible. -->
+        <div class="meso-card">
+          <div style="display:flex;align-items:center;gap:10px;padding:13px 16px;border-bottom:1px solid var(--line-2);">
+            <p class="meso-eyebrow" style="margin:0;">Reconnecting</p>
+            <div class="meso-spacer"></div>
+            <span class="meso-row-meta">{{ reconnecting|length }} awaiting reply</span>
+          </div>
+          {% for r in reconnecting %}
+            <div class="meso-row" style="cursor:default;">
+              <div class="meso-avatar">{{ r.initials }}</div>
+              <div style="min-width:0;">
+                <div class="meso-row-name">{{ r.name }}</div>
+                <div class="meso-row-meta">Re-invited {{ r.when|date:"M j" }} · awaiting their reply</div>
+              </div>
+              <div class="meso-spacer"></div>
+              <span class="meso-badge"><i></i>{{ r.status_label }}</span>
+            </div>
+          {% endfor %}
+        </div>
+      {% endif %}
+
+      {% if past %}
+        <div class="meso-card">
+          <div style="display:flex;align-items:center;gap:10px;padding:13px 16px;border-bottom:1px solid var(--line-2);">
+            <p class="meso-eyebrow" style="margin:0;">Past relationships</p>
+            <div class="meso-spacer"></div>
+            <span class="meso-row-meta">{{ past|length }} athlete{{ past|length|pluralize }}</span>
+          </div>
+          {% for a in past %}
+            <div class="meso-row" style="cursor:default;">
+              <div class="meso-avatar" style="background:var(--rail);color:var(--dim);">{{ a.initials }}</div>
+              <div style="min-width:0;">
+                <div class="meso-row-name">{{ a.name }}</div>
+                <div class="meso-row-meta">{{ a.status_label }}{% if a.when %} {{ a.when|date:"M j, Y" }}{% endif %}</div>
+              </div>
+              <div class="meso-spacer"></div>
+              <span class="meso-badge meso-badge--muted"><i></i>{{ a.status_label }}</span>
+              <form method="post" action="{% url 'meso:relationship_reinvite' token=a.token %}" style="margin:0;">
+                {% csrf_token %}
+                <button type="submit" class="meso-btn meso-btn--ghost" style="padding:5px 10px;font-size:12px;">Re-invite</button>
+              </form>
+            </div>
+          {% endfor %}
+        </div>
+      {% endif %}
+
+    </div>
+  </div>
+{% endblock %}

--- a/app/store_project/templates/meso/roster.html
+++ b/app/store_project/templates/meso/roster.html
@@ -67,6 +67,7 @@
             <p class="meso-eyebrow" style="margin:0;">Individuals</p>
             <div class="meso-spacer"></div>
             <span class="meso-row-meta">{{ athletes|length }} athlete{{ athletes|length|pluralize }}</span>
+            <a href="{% url 'meso:relationship_history' %}" class="meso-row-meta" style="text-decoration:none;color:var(--accent-ink);white-space:nowrap;">· Past athletes →</a>
           </div>
           {% for a in athletes %}
             <a class="meso-row" href="{% url 'meso:athlete' a.id %}">


### PR DESCRIPTION
## What & why

Ended/declined `CoachAthlete` links currently **vanish** from the active roster — `RosterView` only queries `.active()` — even though the row, the `ended_at` timestamp, and the (now archived) plans all persist. A coach had no way to see who they used to train or re-engage them. This slice surfaces that history.

The other open autonomous slice (push re-deliver debounce) was already deemed low-value in the 2026-06-29 YAGNI review ("already mitigated by the push `tag` collapse"), so this is the genuine next slice.

## What's in it

- **Model:** `CoachAthleteQuerySet.closed()` (ended + declined) + `CoachAthlete.is_closed` / `closed_at` (ended_at for ended, responded_at for declined) helpers.
- **Presenter:** `relationship_history(coach)` — one-query split into `past` (ended/declined, newest-closed first, re-invitable) and `reconnecting` (coach-side `pending_coach_invite` re-invites awaiting the athlete — surfaced nowhere else). Demo links excluded.
- **Views:** `RelationshipHistoryView` (`/meso/history/`) — login-gated, coach-only (a non-coach is routed to their training home, mirroring `RosterView`). `relationship_reinvite` (POST) reopens a closed link to a fresh `pending_coach_invite` via `CoachAthlete.invite` (row-locked under explicit `transaction.atomic()`), **seat-gated** (D4), closed-only no-op, coach-scoped 404. The re-invited athlete — already a registered user — discovers the invite on their training home (the canonical peer-invite surface).
- **UI:** a discreet "Past athletes" link on the roster + `relationship_history.html`.
- **Seed:** a demo past (ended) athlete so the surface shows on a fresh DB.

## Notes

- **No migration** — a QuerySet method + two properties, no new fields.
- **+24 tests** (`test_relationship_history.py` + seed coverage). Full meso suite **1404 passing**, ruff + DjHTML + `makemigrations --check` clean.
- **Codex review loop: CLEAN after 1 fix iter** — the one P2 (a re-invite reopens the row in place, so `created_at` is the *original* date; the reconnecting surface now shows state, not a stale "Re-invited {date}").

https://claude.ai/code/session_019A9KdsVs33wipsGjSaFWXV