### PR TITLE
Design system phase 2 PR C — reconcile phase-1 plan with #358 (docs-only)

### DIFF
--- a/docs/design-system-phase-2-plan.md
+++ b/docs/design-system-phase-2-plan.md
@@ -1,8 +1,11 @@
 # Design system — phase 2 plan (typography + remaining chrome)
 
-Status: **Scoped, not started** · Drafted 2026-06-30 · Follow-on to the
-**COMPLETE** `docs/design-system-unification-plan.md` (phase 1: PRs 1–3 + the
-nav-refresh #358).
+Status: **COMPLETE — PRs A, B & C all shipped** · Drafted & finished 2026-06-30 ·
+Follow-on to the **COMPLETE** `docs/design-system-unification-plan.md` (phase 1:
+PRs 1–3 + the nav-refresh #358). PR A = body typography (#363); PR B = footer
+chrome (#366); PR C = phase-1 doc reconcile (this change). Decisions taken:
+**Option A (system-ui)** for the body typeface, **Meso left on Hanken Grotesk**,
+footer **token refresh + nav gutter alignment**.
 
 ## Why a phase 2
 
@@ -28,7 +31,7 @@ Finish the "reads as one modern site" job: one typeface system across the whole
 site (main + Meso) and consistent top/bottom chrome, without adding build tooling
 (stay on Path B — static CSS + WhiteNoise).
 
-## PR A — Body typography unification (the big one)
+## PR A — Body typography unification (the big one) ✅ shipped (#363)
 
 ### Current state
 - Typography is centralized in **one rule**: `base.css`
@@ -85,7 +88,7 @@ Revisit B/C only if a branded display face is wanted later.
   mobile. Confirm no broken wrapping / overflow.
 - Codex review loop; ship through the human merge/deploy gate (mastering.fitness).
 
-## PR B — Footer chrome refresh (small)
+## PR B — Footer chrome refresh (small) ✅ shipped (#366)
 
 ### Current state
 `templates/_footer.html` = `.footer` (dark bar) with `.footer a` links;
@@ -109,7 +112,7 @@ Render `_footer.html` test + browser check on any page footer (incl. Meso, which
 also shows the footer via the main bases? — confirm: Meso shell does **not**
 include `_footer.html`; the main bases do). TDD + codex + gate as usual.
 
-## PR C — Reconcile the phase-1 plan doc (housekeeping, docs-only)
+## PR C — Reconcile the phase-1 plan doc (housekeeping, docs-only) ✅ shipped
 
 `docs/design-system-unification-plan.md` still describes PR 3 as the Meso-only
 `meso/_meso_sitenav.html` partial styled by `.meso-sitenav`. #358 **removed** that
@@ -143,8 +146,11 @@ pipeline and warrants its own plan. Not part of phase 2.
 - Ship through the human merge/deploy gate; merge to `main` auto-deploys via
   GH Actions (Django CI → Deploy) to mastering.fitness.
 
-## Open decisions to confirm at kickoff
-- **Body typeface: A (system-ui, recommended) / B (Inter webfont) / C (Hanken
-  site-wide)?**
-- Leave Meso on Hanken Grotesk (recommended) or unify it with the main body font?
-- Footer: token refresh only, or also align padding/rhythm with the nav?
+## Decisions taken at kickoff (resolved)
+- **Body typeface: A — `system-ui`** (the nav's stack), reused via a `--font`
+  token. Shipped in PR A (#363).
+- **Meso stays on Hanken Grotesk** (app sub-brand) — its shell doesn't load
+  base.css, so PR A left it untouched.
+- **Footer: token refresh *and* nav-gutter alignment** — moved onto
+  `--nav-bg` / `--nav-fg` and picked up the nav's `clamp(16px, 4vw, 40px)`
+  inline padding so top and bottom chrome pair. Shipped in PR B (#366).

--- a/docs/design-system-unification-plan.md
+++ b/docs/design-system-unification-plan.md
@@ -6,6 +6,14 @@ Status: **COMPLETE — PRs 1, 2 & 3 all implemented** · Started & finished
 reconnection (#354, built before PR 2 landed — it depends only on the PR 1 token
 foundation, not on PR 2). The whole site now runs on the one token-driven look.
 
+> **Update (2026-06-30, #358):** PR 3 first shipped a *Meso-only* nav partial;
+> the **#358 nav-refresh follow-up superseded it** with one shared nav
+> (`static/css/nav.css` + `_nav.html`) reused across the whole site *and* the
+> Meso shell. The PR 3 section below is reconciled to describe what's on `main`.
+> Later polish (body typography, footer chrome) continued in the separate
+> **`docs/design-system-phase-2-plan.md`** — phase 2: PR A (#363), PR B (#366),
+> and this doc-reconcile as PR C.
+
 ## Goal
 
 Make Mastering Fitness visually consistent by collapsing the competing styling
@@ -113,31 +121,46 @@ button-link underline fix. The original task list:
 - Store, home, account/auth, product/book pages — template-level cleanups beyond
   what the global re-skin already gave.
 
-### PR 3 — Meso reconnection ✅ implemented
-Done on branch `design-system-pr3-meso-reconnect`. Validated by
-`docs/spikes/basecoat/meso.html`.
+### PR 3 — Meso reconnection ✅ implemented (nav superseded by #358)
 
-- **Shared site nav** — a new `meso/_meso_sitenav.html` partial (the same
-  top-level links as `templates/_nav.html`: brand → home; About / Store /
-  Challenges / **Coaching** [active] / Contact; auth on the right) rides at the
-  top of the Meso shell via a `{% block site_nav %}` in `_meso_base.html`,
-  styled in `meso.css` (`.meso-sitenav`, a black bar matching the main-site
-  nav) since the shell loads only `meso.css`. The Meso workspace sub-header
-  (`.meso-topnav`) is kept below it.
-- **Athlete PWA keeps its installed-app feel** — the phone-first surfaces
-  (`athlete_home`, `athlete_session`, `offline`, `invite_claim`) override
-  `{% block site_nav %}` empty, so the marketing nav never clutters the
-  installed training app. The coach-facing `results` page (breadcrumb back to
-  the roster) keeps the nav.
-- **Accent points at the shared token** — `meso.css`'s `--accent` (and the
-  `--soft` / `--soft-line` / `--accent-deep` family) move from the Meso-only
-  `oklch(0.56 0.14 258)` to the site's steel-blue `#31759d` (mirroring base.css
-  `--accent` / `--accent-soft` / `--accent-line` / `--accent-deep`). The
-  standalone designer's inline token block is repointed to match, and the PWA
-  chrome (manifest `theme_color` + `_pwa_head.html` `theme-color`) moves to
-  `#31759d`. `PWA_CACHE_VERSION` bumped `v2 → v3` (the precached `meso.css`
-  changed).
-- Red→green tests in `meso/tests/test_design_reconnect.py`.
+First shipped on `design-system-pr3-meso-reconnect` (**#354**) as a **Meso-only**
+`meso/_meso_sitenav.html` partial styled by `.meso-sitenav` in `meso.css` — a
+black bar that *duplicated* the main-site nav (and had no mobile menu). The
+**#358 nav-refresh follow-up superseded that approach**: instead of a second nav
+just for Meso, it refactored the one real site nav and reused it everywhere.
+Validated by `docs/spikes/basecoat/meso.html`.
+
+**What's on `main` now (#358, `7156c10`):**
+
+- **One shared nav stylesheet** — a new `static/css/nav.css` (`.nav` / `.brand` /
+  `.link`), loaded by the main-site bases (`_base` / `_base_wide` / `_base_full`
+  / `home`) **and** by `_meso_base` via
+  `{% block site_nav %}{% include "_nav.html" %}{% endblock %}`, so the same bar
+  renders across the whole site and the Meso shell. `_nav.html` was rebuilt on
+  these classes off the old Every-Layout `class="box invert navbar"` markup
+  (whose dead rules were stripped from base.css). The `_meso_sitenav.html`
+  partial and its
+  `.meso-sitenav` CSS were **removed**.
+- **CSS-only mobile burger** — a visually-hidden, keyboard-focusable checkbox
+  toggles `:checked ~ .nav-links`; no JavaScript. Active section via
+  `request.resolver_match`.
+- **Identical in both shells** — `.nav` pins `font-family: system-ui` +
+  `line-height: 1.2` (and re-asserts `inherit` on `.nav *`), because base.css's
+  universal `* { font-family; line-height }` reaches the main site but not the
+  Meso shell; without pinning, the same bar rendered at different heights.
+- **Athlete PWA still opts out** — the phone-first surfaces (`athlete_home`,
+  `athlete_session`, `offline`, `invite_claim`) override `{% block site_nav %}`
+  empty, so the installed training app stays uncluttered. Coach-facing pages keep
+  the nav.
+- Tests: `pages/tests/test_design_system_pr3.py` (#358), plus the #354
+  `meso/tests/test_design_reconnect.py` reconciled (its marker `meso-sitenav` →
+  `<header class="nav">`).
+
+**Still from #354, unchanged by #358 — Meso's tokens point at the shared
+palette:** `meso.css`'s `--accent` (and the `--soft` / `--soft-line` /
+`--accent-deep` family) moved off the Meso-only `oklch(0.56 0.14 258)` to the
+site's steel-blue **`#31759d`** (mirroring base.css), and the PWA chrome
+(manifest `theme_color` + `_pwa_head.html` `theme-color`) moved to `#31759d`.
 
 The original task list for reference:
 


### PR DESCRIPTION
## What

Final phase-2 task (`docs/design-system-phase-2-plan.md`), **docs-only**. The
phase-1 plan (`docs/design-system-unification-plan.md`) still described PR 3 as
the Meso-only `_meso_sitenav.html` partial styled by `.meso-sitenav` — but
**#358** removed that in favour of one shared nav (`static/css/nav.css` +
`_nav.html`) reused across the whole site *and* the Meso shell via
`{% block site_nav %}`. This reconciles the doc with what's actually on `main`.

## Changes

- **`design-system-unification-plan.md`**
  - Status-header note that #358 superseded PR 3's Meso-only nav, with a pointer to the phase-2 plan.
  - Rewrote the **PR 3 section** to describe the shipped state: shared `nav.css`, `_nav.html` reused via `{% block site_nav %}` in all five bases, CSS-only mobile burger, `request.resolver_match` active section, the `system-ui`/`line-height` pin (base.css's universal reset doesn't reach the Meso shell), athlete-PWA opt-out, and the current test files. Kept the still-accurate #354 accent-token repoint to `#31759d`.
- **`design-system-phase-2-plan.md`**
  - Marked the doc **COMPLETE**; tagged PR A (#363) / PR B (#366) / PR C as shipped.
  - Converted "Open decisions to confirm at kickoff" → **"Decisions taken"** (system-ui body font; Meso stays on Hanken Grotesk; footer token-refresh + nav-gutter alignment).

## Verification

Every claim checked against the working tree before writing:
- `_meso_sitenav.html` **gone**; `.meso-sitenav` selector **gone** (only a retirement comment remains in `meso.css`).
- `static/css/nav.css` **exists**; loaded by `_base` / `_base_wide` / `_base_full` / `home` / `_meso_base`.
- `_meso_base.html` uses `{% block site_nav %}{% include "_nav.html" %}{% endblock %}`; the four athlete/PWA templates override it empty.
- Both `meso/tests/test_design_reconnect.py` (#354) and `pages/tests/test_design_system_pr3.py` (#358) exist; `meso.css` `--accent: #31759d`.
- Codex review loop: **CLEAN**.

Docs-only → `django.yml` `paths-ignore: docs/**` means no CI run and **no deploy** (expected). This closes out phase 2.

https://claude.ai/code/session_01XDG4X7h3sH7eNnimH9amEg