### PR TITLE
Design system phase 3 PR B follow-up — preserve signup ?next passthrough

### DIFF
--- a/app/store_project/pages/tests/test_design_system_phase3.py
+++ b/app/store_project/pages/tests/test_design_system_phase3.py
@@ -201,6 +201,16 @@ class Phase3SignupTemplateTests(TestCase):
     def test_signup_shared_nav_still_frames_the_card(self):
         self.assertContains(self.resp, 'class="nav"')
 
+    def test_signup_signin_link_preserves_next(self):
+        """The header "Sign in" link keeps allauth's ?next passthrough.
+
+        allauth exposes the redirect-preserving login URL as ``login_url``; a
+        hard-coded ``{% url 'account_login' %}`` would drop the ``next`` a user
+        carried in from a protected page.
+        """
+        resp = self.client.get(reverse("account_signup") + "?next=/dashboard/")
+        self.assertContains(resp, "/accounts/login/?next=")
+
     def test_signup_social_anchors_and_media_survive(self):
         """Both provider anchors + the providers media JS survive the migration."""
         self.assertContains(self.resp, 'id="google"')

--- a/app/store_project/templates/account/signup.html
+++ b/app/store_project/templates/account/signup.html
@@ -11,7 +11,7 @@
 {% block auth_description %}
   <p class="auth-card__description text-center">
     {% trans "Enter your email below to create your account." %}
-    <a href="{% url 'account_login' %}">{% trans "Sign in" %}</a>
+    <a href="{{ login_url }}">{% trans "Sign in" %}</a>
   </p>
 {% endblock auth_description %}
 


### PR DESCRIPTION
Small follow-up to **PR B (#374)**. The Codex review loop flagged (P2) that the auth-card migration hard-coded signup's header **"Sign in"** link to `{% url 'account_login' %}`, dropping the redirect django-allauth exposes as `login_url`. #374 was merged just before this fix landed (a review/merge race), so main currently ships the regression.

**Impact:** a user sent to signup from a protected page (`?next=…`) who clicks "Sign in" instead of signing up lands on the default redirect target rather than their original destination. (The hidden `next` input and the social buttons already preserve it; only this one link dropped it.)

**Fix:** restore `{{ login_url }}` — the pre-migration behavior.

**Red-green guard:** `test_signup_signin_link_preserves_next` renders signup with `?next=/dashboard/` and asserts the sign-in link carries `?next=` (red on the hard-coded URL, green with `login_url`).

Verified live on prod before this fix: `<a href="/accounts/login/">Sign in</a>` (drops `next`).

Note: `login.html` (shipped in PR A #372) has the symmetric hard-coded `account_signup` link — a candidate for a separate tidy-up, intentionally left out of this focused follow-up.

https://claude.ai/code/session_01XDG4X7h3sH7eNnimH9amEg