### PR TITLE
Design system phase 3 PR C — second-tier auth pages onto the auth card

### DIFF
--- a/app/store_project/pages/tests/test_design_system_phase3.py
+++ b/app/store_project/pages/tests/test_design_system_phase3.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 from allauth.account.forms import default_token_generator
 from allauth.account.utils import user_pk_to_url_str
+from django.template.loader import render_to_string
 from django.test import SimpleTestCase
 from django.test import TestCase
 from django.urls import reverse
@@ -29,6 +30,7 @@ from store_project.users.factories import UserFactory
 APP_ROOT = Path(__file__).resolve().parents[2]
 CSS_DIR = APP_ROOT / "static" / "css"
 BASE_CSS = CSS_DIR / "base.css"
+TEMPLATE_DIR = APP_ROOT / "templates"
 
 
 def _css_block(css: str, selector: str) -> str:
@@ -124,18 +126,19 @@ class Phase3LoginTemplateTests(TestCase):
 
 
 class Phase3NoticePageRegressionTests(TestCase):
-    """Notice pages that still extend ``account/base.html`` are unharmed.
+    """The inactive notice keeps its copy + nav across the card repoint.
 
-    PR A introduces the card via a *dedicated* ``account/base_auth_card.html``
-    that only the login page extends — precisely so the notice pages, which
-    still extend ``account/base.html`` and override its ``content`` block, keep
-    rendering their own content instead of an empty card.
+    PR A introduced the card via a *dedicated* ``account/base_auth_card.html`` so
+    the notice pages — which then still extended ``account/base.html`` — were left
+    untouched. PR C brings those notice pages onto the card explicitly (inheritance
+    alone could not carry it — see ``Phase3SecondTierAuthPageTests``); this guards
+    that the migration preserves the notice's own copy and the shared nav.
     """
 
     def test_inactive_page_still_renders_its_content(self):
         resp = self.client.get(reverse("account_inactive"))
         self.assertEqual(resp.status_code, 200)
-        # The notice's own content block still renders (not blanked by the shell).
+        # The notice's own copy still renders (not blanked by the card shell).
         self.assertContains(resp, "This account is inactive.")
         # ...and the shared nav still frames it.
         self.assertContains(resp, 'class="nav"')
@@ -288,3 +291,141 @@ class Phase3PasswordResetFromKeyTemplateTests(TestCase):
         self.assertContains(resp, 'name="password2"')
         self.assertContains(resp, 'class="button block"', count=1)
         self.assertContains(resp, "csrfmiddlewaretoken")
+
+
+# ---------------------------------------------------------------------------
+# PR C — second-tier auth pages onto the same card
+#
+# PR C brings the remaining allauth auth pages — password change/set, the email-
+# address manager, the confirmation + notice pages, and the socialaccount confirm/
+# connections pages — onto ``account/base_auth_card.html``. Template guards only
+# (the card CSS all shipped in PR A): each renders the real page (or, for the pages
+# the happy-path flow can't cleanly reach, the real template) and asserts the card
+# wrapper plus any surviving form wiring / notice copy.
+#
+# NB the notice pages formerly extended ``account/base.html`` and defined their own
+# ``{% block content %}``, so inheritance alone could NOT have carried the card to
+# them — each was repointed onto the card's ``auth_*`` blocks explicitly.
+# ``render_to_string`` guards the pages the happy path can't reach (set-password
+# needs an unusable-password user; signup-closed / verified-email-required / the
+# socialaccount confirm live behind flow state), matching the plan's "guard that
+# each notice page actually renders the card wrapper, since inheritance won't."
+# ---------------------------------------------------------------------------
+
+CARD_PANEL = 'class="box stack auth-card__panel"'
+
+
+class Phase3SecondTierAuthPageTests(TestCase):
+    """The second-tier auth pages wear the shared card.
+
+    ``TestCase`` (DB access) — allauth touches the session/DB on these GETs.
+    """
+
+    def _login(self):
+        # force_login bypasses auth entirely — no password needed on the user.
+        user = UserFactory()
+        self.client.force_login(user)
+        return user
+
+    # --- reachable through the real view ---
+
+    def test_password_change_renders_the_card(self):
+        self._login()
+        resp = self.client.get(reverse("account_change_password"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, CARD_PANEL)
+        self.assertContains(resp, 'class="nav"')
+        # allauth's exact form wiring survives the migration.
+        self.assertContains(resp, "csrfmiddlewaretoken")
+        self.assertContains(resp, 'name="oldpassword"')
+        self.assertContains(resp, 'name="password1"')
+        self.assertContains(resp, 'name="password2"')
+        # The pre-unification layout is gone.
+        self.assertNotContains(resp, "stack-auth-form")
+
+    def test_email_manager_renders_the_card(self):
+        self._login()
+        resp = self.client.get(reverse("account_email"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, CARD_PANEL)
+        self.assertContains(resp, "csrfmiddlewaretoken")
+        # The add-email field survives.
+        self.assertContains(resp, 'name="email"')
+
+    def test_email_confirm_invalid_key_renders_the_card(self):
+        resp = self.client.get(
+            reverse("account_confirm_email", kwargs={"key": "bogus-key"})
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, CARD_PANEL)
+
+    def test_password_reset_done_renders_the_card(self):
+        resp = self.client.get(reverse("account_reset_password_done"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, CARD_PANEL)
+
+    def test_password_reset_from_key_done_renders_the_card(self):
+        resp = self.client.get(reverse("account_reset_password_from_key_done"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, CARD_PANEL)
+
+    def test_account_inactive_renders_the_card(self):
+        resp = self.client.get(reverse("account_inactive"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, CARD_PANEL)
+        # The notice copy survives the repoint onto the card.
+        self.assertContains(resp, "This account is inactive.")
+
+    def test_verification_sent_renders_the_card(self):
+        resp = self.client.get(reverse("account_email_verification_sent"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, CARD_PANEL)
+
+    def test_socialaccount_connections_renders_the_card(self):
+        self._login()
+        resp = self.client.get(reverse("socialaccount_connections"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, CARD_PANEL)
+        # A fresh user has no linked accounts (so no CSRF-bearing remove form);
+        # the always-present "add a provider" footer confirms the migration.
+        self.assertContains(resp, "Add a 3rd Party Account")
+
+    def test_socialaccount_login_cancelled_renders_the_card(self):
+        resp = self.client.get(reverse("socialaccount_login_cancelled"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, CARD_PANEL)
+
+    # --- rendered directly (the happy-path flow can't reach these cleanly) ---
+
+    def test_password_set_renders_the_card(self):
+        html = render_to_string("account/password_set.html")
+        self.assertIn(CARD_PANEL, html)
+
+    def test_signup_closed_renders_the_card(self):
+        html = render_to_string("account/signup_closed.html")
+        self.assertIn(CARD_PANEL, html)
+        # The notice copy survives.
+        self.assertIn("sign up is currently closed", html)
+
+    def test_verified_email_required_renders_the_card(self):
+        html = render_to_string("account/verified_email_required.html")
+        self.assertIn(CARD_PANEL, html)
+
+    def test_socialaccount_login_confirm_renders_the_card(self):
+        html = render_to_string("socialaccount/login.html")
+        self.assertIn(CARD_PANEL, html)
+
+    def test_socialaccount_authentication_error_renders_the_card(self):
+        html = render_to_string("socialaccount/authentication_error.html")
+        self.assertIn(CARD_PANEL, html)
+
+    def test_socialaccount_signup_extends_the_card(self):
+        """The social finish-signup form extends the card base.
+
+        It carries a bound ``sociallogin`` form the happy path can't fake here, so
+        guard the migration at the source rather than by rendering: it extends the
+        card base, not the old ``_base.html`` content shell.
+        """
+        source = (TEMPLATE_DIR / "socialaccount" / "signup.html").read_text()
+        self.assertIn('extends "account/base_auth_card.html"', source)
+        self.assertNotIn('extends "_base.html"', source)

--- a/app/store_project/templates/account/account_inactive.html
+++ b/app/store_project/templates/account/account_inactive.html
@@ -1,11 +1,11 @@
-{% extends "account/base.html" %}
+{% extends "account/base_auth_card.html" %}
 
 {% load i18n %}
 
-{% block head_title %}{% trans "Account Inactive" %}{% endblock %}
+{% block head_title %}{% trans "Account Inactive" %}{% endblock head_title %}
 
-{% block content %}
-  <h1>{% trans "Account Inactive" %}</h1>
+{% block auth_title %}{% trans "Account inactive" %}{% endblock auth_title %}
 
-  <p>{% trans "This account is inactive." %}</p>
-{% endblock %}
+{% block auth_body %}
+  <p class="auth-card__description text-center">{% trans "This account is inactive." %}</p>
+{% endblock auth_body %}

--- a/app/store_project/templates/account/email.html
+++ b/app/store_project/templates/account/email.html
@@ -1,22 +1,27 @@
-{% extends "_base.html" %}
+{% extends "account/base_auth_card.html" %}
 
 {% load i18n %}
 
-{% block head_title %}{% trans "E-mail Addresses" %}{% endblock %}
+{% block head_title %}{% trans "E-mail Addresses" %}{% endblock head_title %}
 
-{% block content %}
-  <h1>{% trans "E-mail Addresses" %}</h1>
+{% block auth_title %}{% trans "Email addresses" %}{% endblock auth_title %}
+
+{% block auth_description %}
+  <p class="auth-card__description text-center">
+    {% trans "Manage the email addresses linked to your account." %}
+  </p>
+{% endblock auth_description %}
+
+{% block auth_body %}
   {% if user.emailaddress_set.all %}
-    <p>{% trans 'The following e-mail addresses are associated with your account:' %}</p>
-
-    <form action="{% url 'account_email' %}" class="email_list" method="post">
+    <form action="{% url 'account_email' %}" class="stack email_list" method="post">
       {% csrf_token %}
-      <fieldset class="blockLabels">
+      <fieldset class="stack blockLabels">
 
         {% for emailaddress in user.emailaddress_set.all %}
           <div class="ctrlHolder">
-            <label for="email_radio_{{forloop.counter}}" class="{% if emailaddress.primary %}primary_email{%endif%}">
-              <input id="email_radio_{{forloop.counter}}" type="radio" name="email" {% if emailaddress.primary or user.emailaddress_set.count == 1 %}checked="checked"{%endif %} value="{{emailaddress.email}}"/>
+            <label for="email_radio_{{ forloop.counter }}" class="{% if emailaddress.primary %}primary_email{% endif %}">
+              <input id="email_radio_{{ forloop.counter }}" type="radio" name="email" {% if emailaddress.primary or user.emailaddress_set.count == 1 %}checked="checked"{% endif %} value="{{ emailaddress.email }}"/>
               {{ emailaddress.email }}
               {% if emailaddress.verified %}
                 <span class="verified">{% trans "Verified" %}</span>
@@ -29,40 +34,37 @@
         {% endfor %}
 
         <div class="cluster">
-          <div class="buttonHolder">
-            <button class="secondaryAction button" type="submit" name="action_primary" >{% trans 'Make Primary' %}</button>
-            <button class="secondaryAction button" type="submit" name="action_send" >{% trans 'Re-send Verification' %}</button>
-            <button class="primaryAction button" type="submit" name="action_remove" >{% trans 'Remove' %}</button>
-          </div>
+          <button class="secondaryAction button" type="submit" name="action_primary">{% trans 'Make Primary' %}</button>
+          <button class="secondaryAction button" type="submit" name="action_send">{% trans 'Re-send Verification' %}</button>
+          <button class="primaryAction button" type="submit" name="action_remove">{% trans 'Remove' %}</button>
         </div>
 
       </fieldset>
     </form>
-
   {% else %}
-    <p><strong>{% trans 'Warning:'%}</strong> {% trans "You currently do not have any e-mail address set up. You should really add an e-mail address so you can receive notifications, reset your password, etc." %}</p>
+    <p><strong>{% trans 'Warning:' %}</strong> {% trans "You currently do not have any e-mail address set up. You should really add an e-mail address so you can receive notifications, reset your password, etc." %}</p>
   {% endif %}
+{% endblock auth_body %}
 
-  <div class="stack-auth-form">
-    <h2 class="text-center font-size:smallish">{% trans "Add E-mail Address" %}</h2>
-
-    <form class="add_email" method="post" action="{% url 'account_email' %}">
-      {% csrf_token %}
-
-      <p>
-        <label class="stack" for="{{ form.email.id_for_label }}">
-          <span>Email</span>
-          {{ form.email }}
-          {{ form.email.errors }}
-        </label>
-      </p>
-
-      <button class="button" name="action_add" type="submit">{% trans "Add E-mail" %}</button>
-    </form>
+{% block auth_footer %}
+  <div class="or-separator">
+    <div></div>
+    <i>{% trans "or" %}</i>
+    <div></div>
   </div>
 
-{% endblock content %}
+  <form class="stack add_email" method="post" action="{% url 'account_email' %}">
+    {% csrf_token %}
 
+    <div class="stack">
+      <label for="{{ form.email.id_for_label }}">{% trans "Add email address" %}</label>
+      {{ form.email }}
+      {{ form.email.errors }}
+    </div>
+
+    <button class="button block" name="action_add" type="submit">{% trans "Add Email" %}</button>
+  </form>
+{% endblock auth_footer %}
 
 {% block javascript %}
   <script type="text/javascript">

--- a/app/store_project/templates/account/email_confirm.html
+++ b/app/store_project/templates/account/email_confirm.html
@@ -1,31 +1,29 @@
-{% extends "_base.html" %}
+{% extends "account/base_auth_card.html" %}
 
 {% load i18n %}
 {% load account %}
 
-{% block head_title %}{% trans "Confirm E-mail Address" %}{% endblock %}
+{% block head_title %}{% trans "Confirm E-mail Address" %}{% endblock head_title %}
 
+{% block auth_title %}{% trans "Confirm your email" %}{% endblock auth_title %}
 
-{% block content %}
-  <h1>{% trans "Confirm E-mail Address" %}</h1>
-
+{% block auth_body %}
   {% if confirmation %}
 
     {% user_display confirmation.email_address.user as user_display %}
 
-    <p>{% blocktrans with confirmation.email_address.email as email %}Please confirm that <a href="mailto:{{ email }}">{{ email }}</a> is an e-mail address for user {{ user_display }}.{% endblocktrans %}</p>
+    <p class="auth-card__description text-center">{% blocktrans with confirmation.email_address.email as email %}Please confirm that <a href="mailto:{{ email }}">{{ email }}</a> is an e-mail address for user {{ user_display }}.{% endblocktrans %}</p>
 
     <form method="post" action="{% url 'account_confirm_email' confirmation.key %}">
       {% csrf_token %}
-      <button class="button" type="submit">{% trans 'Confirm' %}</button>
+      <button class="button block" type="submit">{% trans 'Confirm' %}</button>
     </form>
 
   {% else %}
 
     {% url 'account_email' as email_url %}
 
-    <p>{% blocktrans %}This e-mail confirmation link expired or is invalid. Please <a href="{{ email_url }}">issue a new e-mail confirmation request</a>.{% endblocktrans %}</p>
+    <p class="auth-card__description text-center">{% blocktrans %}This e-mail confirmation link expired or is invalid. Please <a href="{{ email_url }}">issue a new e-mail confirmation request</a>.{% endblocktrans %}</p>
 
   {% endif %}
-
-{% endblock content %}
+{% endblock auth_body %}

--- a/app/store_project/templates/account/password_change.html
+++ b/app/store_project/templates/account/password_change.html
@@ -1,51 +1,50 @@
-{% extends "_base.html" %}
+{% extends "account/base_auth_card.html" %}
 
 {% load i18n %}
 
-{% block head_title %}{% trans "Change Password" %}{% endblock %}
+{% block head_title %}{% trans "Change Password" %}{% endblock head_title %}
 
-{% block content %}
-  <h1>{% trans "Change Password" %}</h1>
+{% block auth_title %}{% trans "Change your password" %}{% endblock auth_title %}
 
-  <div class="stack-auth-form">
-    <form class="login center" method="POST" action="{% url 'account_change_password' %}" class="password_change">
-      {% csrf_token %}
+{% block auth_description %}
+  <p class="auth-card__description text-center">
+    {% trans "Enter your current password, then choose a new one." %}
+  </p>
+{% endblock auth_description %}
+
+{% block auth_body %}
+  <form class="stack" method="POST" action="{% url 'account_change_password' %}">
+    {% csrf_token %}
+
+    {% if form.non_field_errors %}
       <div class="messages">
         {{ form.non_field_errors }}
       </div>
+    {% endif %}
 
-      <p>
-        <label class="stack" for="id_email">
-          <span>Email</span>
-          <input id="id_email" type="text" name="email" value="{{ request.user.email }}" disabled>
-        </label>
-      </p>
+    <div class="stack">
+      <label for="id_email">{% trans "Email" %}</label>
+      <input id="id_email" type="text" name="email" value="{{ request.user.email }}" disabled>
+    </div>
 
-      <p>
-        <label class="stack" for="{{ form.oldpassword.id_for_label }}">
-          <span>Current Password</span>
-          {{ form.oldpassword }}
-          {{ form.oldpassword.errors }}
-        </label>
-      </p>
+    <div class="stack">
+      <label for="{{ form.oldpassword.id_for_label }}">{% trans "Current Password" %}</label>
+      {{ form.oldpassword }}
+      {{ form.oldpassword.errors }}
+    </div>
 
-      <p>
-        <label class="stack" for="{{ form.password1.id_for_label }}">
-          <span>New Password</span>
-          {{ form.password1 }}
-          {{ form.password1.errors }}
-        </label>
-      </p>
+    <div class="stack">
+      <label for="{{ form.password1.id_for_label }}">{% trans "New Password" %}</label>
+      {{ form.password1 }}
+      {{ form.password1.errors }}
+    </div>
 
-      <p>
-        <label class="stack" for="{{ form.password2.id_for_label }}">
-          <span>New Password (again)</span>
-          {{ form.password2 }}
-          {{ form.password2.errors }}
-        </label>
-      </p>
+    <div class="stack">
+      <label for="{{ form.password2.id_for_label }}">{% trans "New Password (again)" %}</label>
+      {{ form.password2 }}
+      {{ form.password2.errors }}
+    </div>
 
-      <button class="button" type="submit" name="action">{% trans "Change Password" %}</button>
-    </form>
-  </div>
-{% endblock %}
+    <button class="button block" type="submit" name="action">{% trans "Change Password" %}</button>
+  </form>
+{% endblock auth_body %}

--- a/app/store_project/templates/account/password_reset_done.html
+++ b/app/store_project/templates/account/password_reset_done.html
@@ -1,16 +1,16 @@
-{% extends "_base.html" %}
+{% extends "account/base_auth_card.html" %}
 
 {% load i18n %}
 {% load account %}
 
-{% block head_title %}{% trans "Password Reset" %}{% endblock %}
+{% block head_title %}{% trans "Password Reset" %}{% endblock head_title %}
 
-{% block content %}
-  <h1>{% trans "Password Reset" %}</h1>
+{% block auth_title %}{% trans "Check your email" %}{% endblock auth_title %}
 
+{% block auth_body %}
   {% if user.is_authenticated %}
     {% include "account/snippets/already_logged_in.html" %}
   {% endif %}
 
-  <p>{% blocktrans %}We have sent you an e-mail. Please contact us if you do not receive it within a few minutes.{% endblocktrans %}</p>
-{% endblock %}
+  <p class="auth-card__description text-center">{% blocktrans %}We have sent you an e-mail. Please contact us if you do not receive it within a few minutes.{% endblocktrans %}</p>
+{% endblock auth_body %}

--- a/app/store_project/templates/account/password_reset_from_key_done.html
+++ b/app/store_project/templates/account/password_reset_from_key_done.html
@@ -1,9 +1,11 @@
-{% extends "_base.html" %}
+{% extends "account/base_auth_card.html" %}
 
 {% load i18n %}
-{% block head_title %}{% trans "Password Updated" %}{% endblock %}
 
-{% block content %}
-  <h1>{% trans "Password Updated" %}</h1>
-  <p>{% trans 'Your password is now changed.' %}</p>
-{% endblock %}
+{% block head_title %}{% trans "Password Updated" %}{% endblock head_title %}
+
+{% block auth_title %}{% trans "Password updated" %}{% endblock auth_title %}
+
+{% block auth_body %}
+  <p class="auth-card__description text-center">{% trans 'Your password is now changed.' %}</p>
+{% endblock auth_body %}

--- a/app/store_project/templates/account/password_set.html
+++ b/app/store_project/templates/account/password_set.html
@@ -1,15 +1,39 @@
-{% extends "_base.html" %}
+{% extends "account/base_auth_card.html" %}
 
 {% load i18n %}
 
-{% block head_title %}{% trans "Set Password" %}{% endblock %}
+{% block head_title %}{% trans "Set Password" %}{% endblock head_title %}
 
-{% block content %}
-  <h1>{% trans "Set Password" %}</h1>
+{% block auth_title %}{% trans "Set your password" %}{% endblock auth_title %}
 
-  <form method="POST" action="{% url 'account_set_password' %}" class="password_set">
+{% block auth_description %}
+  <p class="auth-card__description text-center">
+    {% trans "Choose a password for your account." %}
+  </p>
+{% endblock auth_description %}
+
+{% block auth_body %}
+  <form class="stack" method="POST" action="{% url 'account_set_password' %}">
     {% csrf_token %}
-    {{ form.as_p }}
-    <input class="button" type="submit" name="action" value="{% trans 'Set Password' %}"/>
+
+    {% if form.non_field_errors %}
+      <div class="messages">
+        {{ form.non_field_errors }}
+      </div>
+    {% endif %}
+
+    <div class="stack">
+      <label for="{{ form.password1.id_for_label }}">{% trans "Password" %}</label>
+      {{ form.password1 }}
+      {{ form.password1.errors }}
+    </div>
+
+    <div class="stack">
+      <label for="{{ form.password2.id_for_label }}">{% trans "Password (again)" %}</label>
+      {{ form.password2 }}
+      {{ form.password2.errors }}
+    </div>
+
+    <button class="button block" type="submit" name="action">{% trans "Set Password" %}</button>
   </form>
-{% endblock %}
+{% endblock auth_body %}

--- a/app/store_project/templates/account/signup_closed.html
+++ b/app/store_project/templates/account/signup_closed.html
@@ -1,11 +1,11 @@
-{% extends "account/base.html" %}
+{% extends "account/base_auth_card.html" %}
 
 {% load i18n %}
 
-{% block head_title %}{% trans "Sign Up Closed" %}{% endblock %}
+{% block head_title %}{% trans "Sign Up Closed" %}{% endblock head_title %}
 
-{% block content %}
-  <h1>{% trans "Sign Up Closed" %}</h1>
+{% block auth_title %}{% trans "Sign up closed" %}{% endblock auth_title %}
 
-  <p>{% trans "We are sorry, but the sign up is currently closed." %}</p>
-{% endblock %}
+{% block auth_body %}
+  <p class="auth-card__description text-center">{% trans "We are sorry, but the sign up is currently closed." %}</p>
+{% endblock auth_body %}

--- a/app/store_project/templates/account/verification_sent.html
+++ b/app/store_project/templates/account/verification_sent.html
@@ -1,12 +1,11 @@
-{% extends "account/base.html" %}
+{% extends "account/base_auth_card.html" %}
 
 {% load i18n %}
 
-{% block head_title %}{% trans "Verify Your E-mail Address" %}{% endblock %}
+{% block head_title %}{% trans "Verify Your E-mail Address" %}{% endblock head_title %}
 
-{% block content %}
-  <h1>{% trans "Verify Your E-mail Address" %}</h1>
+{% block auth_title %}{% trans "Verify your email" %}{% endblock auth_title %}
 
-  <p>{% blocktrans %}We have sent an e-mail to you for verification. Follow the link provided to finalize the signup process. Please contact us if you do not receive it within a few minutes.{% endblocktrans %}</p>
-
-{% endblock %}
+{% block auth_body %}
+  <p class="auth-card__description text-center">{% blocktrans %}We have sent an e-mail to you for verification. Follow the link provided to finalize the signup process. Please contact us if you do not receive it within a few minutes.{% endblocktrans %}</p>
+{% endblock auth_body %}

--- a/app/store_project/templates/account/verified_email_required.html
+++ b/app/store_project/templates/account/verified_email_required.html
@@ -1,23 +1,21 @@
-{% extends "account/base.html" %}
+{% extends "account/base_auth_card.html" %}
 
 {% load i18n %}
 
-{% block head_title %}{% trans "Verify Your E-mail Address" %}{% endblock %}
+{% block head_title %}{% trans "Verify Your E-mail Address" %}{% endblock head_title %}
 
-{% block content %}
-  <h1>{% trans "Verify Your E-mail Address" %}</h1>
+{% block auth_title %}{% trans "Verify your email" %}{% endblock auth_title %}
 
+{% block auth_body %}
   {% url 'account_email' as email_url %}
 
-  <p>{% blocktrans %}This part of the site requires us to verify that
+  <p class="auth-card__description">{% blocktrans %}This part of the site requires us to verify that
     you are who you claim to be. For this purpose, we require that you
     verify ownership of your e-mail address. {% endblocktrans %}</p>
 
-  <p>{% blocktrans %}We have sent an e-mail to you for
+  <p class="auth-card__description">{% blocktrans %}We have sent an e-mail to you for
     verification. Please click on the link inside this e-mail. Please
     contact us if you do not receive it within a few minutes.{% endblocktrans %}</p>
 
-  <p>{% blocktrans %}<strong>Note:</strong> you can still <a href="{{ email_url }}">change your e-mail address</a>.{% endblocktrans %}</p>
-
-
-{% endblock %}
+  <p class="auth-card__description">{% blocktrans %}<strong>Note:</strong> you can still <a href="{{ email_url }}">change your e-mail address</a>.{% endblocktrans %}</p>
+{% endblock auth_body %}

--- a/app/store_project/templates/socialaccount/authentication_error.html
+++ b/app/store_project/templates/socialaccount/authentication_error.html
@@ -1,14 +1,11 @@
-{% extends "_base.html" %}
+{% extends "account/base_auth_card.html" %}
+
 {% load i18n %}
-{% load allauth %}
-{% block head_title %}
-  {% trans "Third-Party Login Failure" %}
-{% endblock head_title %}
-{% block content %}
-  {% element h1 %}
-    {% trans "Third-Party Login Failure" %}
-  {% endelement %}
-  {% element p %}
-    {% trans "An error occurred while attempting to login via your third-party account." %}
-  {% endelement %}
-{% endblock content %}
+
+{% block head_title %}{% trans "Third-Party Login Failure" %}{% endblock head_title %}
+
+{% block auth_title %}{% trans "Third-party login failure" %}{% endblock auth_title %}
+
+{% block auth_body %}
+  <p class="auth-card__description text-center">{% trans "An error occurred while attempting to login via your third-party account." %}</p>
+{% endblock auth_body %}

--- a/app/store_project/templates/socialaccount/connections.html
+++ b/app/store_project/templates/socialaccount/connections.html
@@ -1,22 +1,22 @@
-{% extends "_base.html" %}
+{% extends "account/base_auth_card.html" %}
 
 {% load i18n %}
 
-{% block head_title %}{% trans "Account Connections" %}{% endblock %}
+{% block head_title %}{% trans "Account Connections" %}{% endblock head_title %}
 
-{% block content %}
-  <h1>{% trans "Account Connections" %}</h1>
+{% block auth_title %}{% trans "Account connections" %}{% endblock auth_title %}
 
+{% block auth_body %}
   {% if form.accounts %}
-    <p>{% blocktrans %}You can sign in to your account using any of the following third party accounts:{% endblocktrans %}</p>
+    <p class="auth-card__description text-center">{% blocktrans %}You can sign in to your account using any of the following third party accounts:{% endblocktrans %}</p>
 
-    <form class="stack-form" method="post" action="{% url 'socialaccount_connections' %}">
+    <form class="stack" method="post" action="{% url 'socialaccount_connections' %}">
       {% csrf_token %}
 
-      <fieldset>
-        <legend>Linked Social Accounts</legend>
+      <fieldset class="stack">
+        <legend>{% trans "Linked Social Accounts" %}</legend>
         {% if form.non_field_errors %}
-          <div id="errorMsg">{{ form.non_field_errors }}</div>
+          <div class="messages">{{ form.non_field_errors }}</div>
         {% endif %}
 
         {% for base_account in form.accounts %}
@@ -24,31 +24,33 @@
             <div>
               <label for="id_account_{{ base_account.id }}">
                 <input id="id_account_{{ base_account.id }}" type="radio" name="account" value="{{ base_account.id }}"/>
-                <span class="socialaccount_provider {{ base_account.provider }} {{ account.get_brand.id }}">{{account.get_brand.name}}</span>
+                <span class="socialaccount_provider {{ base_account.provider }} {{ account.get_brand.id }}">{{ account.get_brand.name }}</span>
                 as <em>{{ account }}</em>
               </label>
             </div>
           {% endwith %}
         {% endfor %}
 
-        <div>
-          <button class="button" type="submit">{% trans 'Remove' %}</button>
-        </div>
-
+        <button class="button block" type="submit">{% trans 'Remove' %}</button>
       </fieldset>
-
     </form>
-
   {% else %}
-    <p>{% trans 'You currently have no social network accounts connected to this account.' %}</p>
+    <p class="auth-card__description text-center">{% trans 'You currently have no social network accounts connected to this account.' %}</p>
   {% endif %}
+{% endblock auth_body %}
 
-  <h2>{% trans 'Add a 3rd Party Account' %}</h2>
+{% block auth_footer %}
+  <div class="or-separator">
+    <div></div>
+    <i>{% trans "or" %}</i>
+    <div></div>
+  </div>
+
+  <h2 class="text-center">{% trans 'Add a 3rd Party Account' %}</h2>
 
   <ul class="socialaccount_providers">
     {% include "socialaccount/snippets/provider_list.html" with process="connect" %}
   </ul>
 
   {% include "socialaccount/snippets/login_extra.html" %}
-
-{% endblock content %}
+{% endblock auth_footer %}

--- a/app/store_project/templates/socialaccount/login.html
+++ b/app/store_project/templates/socialaccount/login.html
@@ -1,29 +1,30 @@
-{% extends "_base.html" %}
+{% extends "account/base_auth_card.html" %}
+
 {% load i18n %}
-{% load allauth %}
-{% block head_title %}
-  {% trans "Sign In" %}
-{% endblock head_title %}
-{% block content %}
+
+{% block head_title %}{% trans "Sign In" %}{% endblock head_title %}
+
+{% block auth_title %}
   {% if process == "connect" %}
-    {% element h1 %}
-      {% blocktrans with provider.name as provider %}Connect {{ provider }}{% endblocktrans %}
-    {% endelement %}
-    {% element p %}
-      {% blocktrans with provider.name as provider %}You are about to connect a new third-party account from {{ provider }}.{% endblocktrans %}
-    {% endelement %}
+    {% blocktrans with provider.name as provider %}Connect {{ provider }}{% endblocktrans %}
   {% else %}
-    {% element h1 %}
-      {% blocktrans with provider.name as provider %}Sign In Via {{ provider }}{% endblocktrans %}
-    {% endelement %}
-    {% element p %}
-      {% blocktrans with provider.name as provider %}You are about to sign in using a third-party account from {{ provider }}.{% endblocktrans %}
-    {% endelement %}
+    {% blocktrans with provider.name as provider %}Sign In Via {{ provider }}{% endblocktrans %}
   {% endif %}
-  {% element form method="post" no_visible_fields=True %}
-    {% slot actions %}
-      {% csrf_token %}
-      <button class="primaryAction button" type="submit">{% trans "Continue" %}</button>
-    {% endslot %}
-  {% endelement %}
-{% endblock content %}
+{% endblock auth_title %}
+
+{% block auth_description %}
+  <p class="auth-card__description text-center">
+    {% if process == "connect" %}
+      {% blocktrans with provider.name as provider %}You are about to connect a new third-party account from {{ provider }}.{% endblocktrans %}
+    {% else %}
+      {% blocktrans with provider.name as provider %}You are about to sign in using a third-party account from {{ provider }}.{% endblocktrans %}
+    {% endif %}
+  </p>
+{% endblock auth_description %}
+
+{% block auth_body %}
+  <form method="post">
+    {% csrf_token %}
+    <button class="primaryAction button block" type="submit">{% trans "Continue" %}</button>
+  </form>
+{% endblock auth_body %}

--- a/app/store_project/templates/socialaccount/login_cancelled.html
+++ b/app/store_project/templates/socialaccount/login_cancelled.html
@@ -1,15 +1,13 @@
-{% extends "_base.html" %}
+{% extends "account/base_auth_card.html" %}
 
 {% load i18n %}
 
-{% block head_title %}{% trans "Login Cancelled" %}{% endblock %}
+{% block head_title %}{% trans "Login Cancelled" %}{% endblock head_title %}
 
-{% block content %}
+{% block auth_title %}{% trans "Login cancelled" %}{% endblock auth_title %}
 
-  <h1>{% trans "Login Cancelled" %}</h1>
-
+{% block auth_body %}
   {% url 'account_login' as login_url %}
 
-  <p>{% blocktrans %}Logging in to our site using one of your existing social accounts has been cancelled. If this was a mistake, please proceed to <a href="{{login_url}}">sign in</a>.{% endblocktrans %}</p>
-
-{% endblock %}
+  <p class="auth-card__description text-center">{% blocktrans %}Logging in to our site using one of your existing social accounts has been cancelled. If this was a mistake, please proceed to <a href="{{ login_url }}">sign in</a>.{% endblocktrans %}</p>
+{% endblock auth_body %}

--- a/app/store_project/templates/socialaccount/signup.html
+++ b/app/store_project/templates/socialaccount/signup.html
@@ -1,27 +1,25 @@
-{% extends "_base.html" %}
+{% extends "account/base_auth_card.html" %}
+
 {% load i18n %}
 {% load allauth %}
-{% block head_title %}
-  {% trans "Signup" %}
-{% endblock head_title %}
-{% block content %}
-  {% element h1 %}
-    {% trans "Sign Up" %}
-  {% endelement %}
-  {% element p %}
-    {% blocktrans with provider_name=account.get_provider.name site_name=site.name %}You are about to use your {{provider_name}} account to login to
-      {{site_name}}. As a final step, please complete the following form:{% endblocktrans %}
-  {% endelement %}
+
+{% block head_title %}{% trans "Signup" %}{% endblock head_title %}
+
+{% block auth_title %}{% trans "Sign Up" %}{% endblock auth_title %}
+
+{% block auth_description %}
+  <p class="auth-card__description text-center">
+    {% blocktrans with provider_name=account.get_provider.name site_name=site.name %}You are about to use your {{ provider_name }} account to login to {{ site_name }}. As a final step, please complete the following form:{% endblocktrans %}
+  </p>
+{% endblock auth_description %}
+
+{% block auth_body %}
   {% url 'socialaccount_signup' as action_url %}
-  {% element form form=form method="post" action=action_url %}
-    {% slot body %}
-      {% csrf_token %}
-      {% element fields form=form unlabeled=True %}
-      {% endelement %}
-      {{ redirect_field }}
-    {% endslot %}
-    {% slot actions %}
-      <button class="primaryAction button" type="submit" style="margin-top: var(--s0)">{% trans "Sign Up" %}</button>
-    {% endslot %}
-  {% endelement %}
-{% endblock content %}
+  <form class="stack" method="post" action="{{ action_url }}">
+    {% csrf_token %}
+    {% element fields form=form unlabeled=True %}
+    {% endelement %}
+    {{ redirect_field }}
+    <button class="primaryAction button block" type="submit">{% trans "Sign Up" %}</button>
+  </form>
+{% endblock auth_body %}


### PR DESCRIPTION
Repoints the **remaining django-allauth auth pages** onto the shared `account/base_auth_card.html` shell introduced in **PR A (#372)** and extended in **PR B (#374/#375)**, so the whole auth surface wears one basecoat login-card look instead of a grab-bag of pre-unification `.box.login` / `.stack-auth-form` treatments.

Implements issue #352 · `docs/design-system-phase-3-plan.md` **PR C** (the final phase-3 slice). **Template migration only — no new CSS** (the card gaps all shipped in PR A), **no model changes / no migration**.

## What changed (15 templates)
- **`account/`** — `password_change`, `password_set`, `email` (manage addresses), `email_confirm`, `password_reset_done`, `password_reset_from_key_done`, `account_inactive`, `signup_closed`, `verification_sent`, `verified_email_required`.
- **`socialaccount/`** — `login` (the connect / sign-in confirm), `connections`, `login_cancelled`, `authentication_error`, `signup`.

Each now extends the card base and fills its `auth_title` / `auth_description` / `auth_body` / `auth_footer` slots. Form wiring (CSRF, allauth field names, actions, the email-remove confirm JS, the provider list) is preserved; submit buttons move to the full-width `.button.block`.

## Notes on the two awkward corners
- **Notice pages** (`account_inactive`, `signup_closed`, `verification_sent`, `verified_email_required`) formerly extended `account/base.html` and defined their own `{% block content %}`, so inheritance alone could **not** carry the card to them — each is repointed onto the card's `auth_*` blocks **explicitly** (exactly the plan's caveat).
- **socialaccount confirm pages** drop allauth's `{% element %}`/`{% slot %}` DSL for the card's plain markup; the social **finish-signup** form keeps `{% element fields %}` because it needs a bound `sociallogin` form.

## Tests (red-green)
New guards in `test_design_system_phase3.py` (a `Phase3SecondTierAuthPageTests` class): each renders the real page — or, for pages the happy-path flow can't cleanly reach (set-password needs an unusable-password user; signup-closed / verified-email-required / the socialaccount confirm live behind flow state), the real template via `render_to_string` — and asserts the card wrapper plus surviving form wiring / notice copy. Red on `main`, green after the migration. The PR-A notice-page regression guard is updated to reflect that PR C now brings the inactive notice onto the card while its copy + nav survive.

- **1638 project pytest green**, ruff + DjHTML clean, no migrations.
- **Codex review loop: CLEAN, iteration 1** (no blocking, no nits).

https://claude.ai/code/session_019A9KdsVs33wipsGjSaFWXV