### PR TITLE
docs: archive 12 finished plans under docs/archive/

### DIFF
--- a/app/store_project/meso/agent/__init__.py
+++ b/app/store_project/meso/agent/__init__.py
@@ -1,7 +1,7 @@
 """The Meso agent: a Claude proposal engine behind the human review gate (B6).
 
 The agent writes ``ProposedChange`` rows grouped into an ``AgentProposalBatch``;
-the coach still approves. See ``docs/meso/agent-plan.md``.
+the coach still approves. See ``docs/archive/meso/agent-plan.md``.
 
 - ``client``     — wraps the anthropic SDK (the only network boundary).
 - ``validation`` — the deterministic server-side guardrail (contraindications

--- a/app/store_project/meso/agent/client.py
+++ b/app/store_project/meso/agent/client.py
@@ -14,7 +14,7 @@ extended/adaptive thinking, and this is a single constrained extraction. The
 stable system prompt is sent with ``cache_control`` (prompt caching); the
 volatile per-plan grounding + instruction go in the user turn. Revisit auto
 ``tool_choice`` + adaptive thinking when the agent becomes multi-turn — see
-``docs/meso/agent-plan.md``.
+``docs/archive/meso/agent-plan.md``.
 """
 
 import json

--- a/app/store_project/meso/management/commands/seed_meso_demo.py
+++ b/app/store_project/meso/management/commands/seed_meso_demo.py
@@ -1,6 +1,6 @@
 """Seed the Meso coach-side demo: a coach, athletes, relationships, a plan.
 
-Phase 5 of the persistence slice (``docs/meso/persistence-plan.md``) retires the
+Phase 5 of the persistence slice (``docs/archive/meso/persistence-plan.md``) retires the
 client-side mock for the coach-side screens. This command stands up the same
 demo the prototype showed — **now real, DB-backed rows** — so a fresh dev
 database renders the roster, athlete profile, and designer from actual data:

--- a/app/store_project/meso/models.py
+++ b/app/store_project/meso/models.py
@@ -2,7 +2,7 @@
 
 This is the first real (DB-backed) slice of the Meso program designer, which
 once ran entirely on a fixtures module (since retired now every screen is
-DB-backed). See ``docs/meso/persistence-plan.md`` (Phase 1) and
+DB-backed). See ``docs/archive/meso/persistence-plan.md`` (Phase 1) and
 ``docs/meso/decisions.md``.
 
 Multi-coach SaaS (B1): every coach is an account, athletes are Users who log in
@@ -499,7 +499,7 @@ class CoachInvite(models.Model):
     invited email (email-only login coexists with social providers, so a new
     athlete may sign up under a different address). The coach sees who accepted on
     the roster and can ``end`` the link if it's wrong. See
-    ``docs/meso/invites-plan.md``.
+    ``docs/archive/meso/invites-plan.md``.
     """
 
     #: How long a fresh claim link stays valid before it must be resent (N4 P3).
@@ -1028,7 +1028,7 @@ class PlanQuerySet(models.QuerySet):
         individual-only deliver/results/review flows) — this is the wider gate for
         the one screen that handles both. A materialized group-delivery plan
         (``source_group`` set) is excluded: the coach edits the *shared* program,
-        never a member's derived snapshot. See ``docs/meso/groups-plan.md``.
+        never a member's derived snapshot. See ``docs/archive/meso/groups-plan.md``.
         """
         return self.filter(
             models.Q(
@@ -1507,7 +1507,7 @@ class WeekDelivery(models.Model):
 # The agent is a *proposal engine behind the existing review gate*: it writes
 # ``ProposedChange`` rows grouped into an ``AgentProposalBatch``; the coach still
 # approves (apply lands in Phase 2). Proposals are inert until then, so writing
-# them is safe. See ``docs/meso/agent-plan.md``.
+# them is safe. See ``docs/archive/meso/agent-plan.md``.
 # ---------------------------------------------------------------------------
 
 
@@ -1744,7 +1744,7 @@ class LoggedSet(models.Model):
 # ``GroupMembership`` linking it to an **active** ``CoachAthlete`` relationship,
 # so membership structurally implies an active coaching link and per-athlete
 # overrides/delivered plans (later) hang off the same relationship that owns
-# individual plans (D-a). See ``docs/meso/groups-plan.md``.
+# individual plans (D-a). See ``docs/archive/meso/groups-plan.md``.
 # ---------------------------------------------------------------------------
 
 
@@ -2196,7 +2196,7 @@ class PrescriptionOverride(models.Model):
     owns the member's individual plans — D-a), and targets a prescription in the
     membership's group's shared program (a same-group invariant enforced by
     ``GroupMembership.set_override`` and ``clean``). One override per
-    member+prescription. See ``docs/meso/groups-plan.md``.
+    member+prescription. See ``docs/archive/meso/groups-plan.md``.
     """
 
     # The widest sane load scaling — a 50% deload through a +100% bump. Outside
@@ -2338,7 +2338,7 @@ class PushSubscription(models.Model):
 # athlete's logged history** (the best Epley estimate per lift), so it survives a
 # device change, powers the logger's suggested load on any device, and is visible
 # to the coach in the designer when they prescribe a %1RM. See
-# ``one_rm.py`` (derive/refresh/read) and ``docs/meso/one-rm-plan.md``.
+# ``one_rm.py`` (derive/refresh/read) and ``docs/archive/meso/one-rm-plan.md``.
 # ---------------------------------------------------------------------------
 
 
@@ -2359,7 +2359,7 @@ class AthleteOneRm(models.Model):
     it (logs only ever raised the derived estimate), and it survives a device
     change and is visible to the coach — the gap the per-device localStorage
     override left open. Clearing a manual value reverts the lift to its
-    log-derived estimate. See ``one_rm.py`` and ``docs/meso/one-rm-plan.md``.
+    log-derived estimate. See ``one_rm.py`` and ``docs/archive/meso/one-rm-plan.md``.
     """
 
     class Source(models.TextChoices):

--- a/app/store_project/meso/one_rm.py
+++ b/app/store_project/meso/one_rm.py
@@ -15,7 +15,7 @@ promoted out of per-device localStorage (Phase 2b) into ``AthleteOneRm`` rows:
 
 Identity follows the hybrid B4 rule (``serializers._exercise_key``): a
 catalog-linked lift by FK, a free-text lift by normalized name. See
-``docs/meso/one-rm-plan.md``.
+``docs/archive/meso/one-rm-plan.md``.
 """
 
 import math

--- a/app/store_project/meso/serializers.py
+++ b/app/store_project/meso/serializers.py
@@ -546,7 +546,7 @@ def latest_delivered_week(plan):
     is reflected, by design; the frozen ``WeekDelivery`` snapshot is the
     historical record for the (deferred) "changes since last delivery" diff, not
     a separate athlete-facing view. Newest delivery wins so the athlete lands on
-    the week their coach just sent. See ``docs/meso/athlete-plan.md``.
+    the week their coach just sent. See ``docs/archive/meso/athlete-plan.md``.
     """
     return (
         models.Week.objects.filter(mesocycle__plan=plan, delivered_at__isnull=False)

--- a/app/store_project/meso/tests/test_agent_models.py
+++ b/app/store_project/meso/tests/test_agent_models.py
@@ -3,7 +3,7 @@
 ``AgentProposalBatch`` is one agent run behind the review gate; ``ProposedChange``
 is a single proposed edit it wrote (swap / progress / volume / deload), targeting
 a real session/prescription within the plan. Both start ``pending`` — the coach
-still approves (apply lands in Phase 2). See ``docs/meso/agent-plan.md``.
+still approves (apply lands in Phase 2). See ``docs/archive/meso/agent-plan.md``.
 """
 
 import pytest

--- a/app/store_project/meso/tests/test_athlete_logging.py
+++ b/app/store_project/meso/tests/test_athlete_logging.py
@@ -8,7 +8,7 @@ stamps the date. These are the first *real* logged rows — the ones
 fabricated in tests).
 
 The tests pin the same discipline as the read surface (see
-``docs/meso/athlete-plan.md``): the endpoint is athlete-scoped (only the
+``docs/archive/meso/athlete-plan.md``): the endpoint is athlete-scoped (only the
 logged-in athlete, only a **delivered** session they own), every out-of-scope
 target is a flat 404, bad input is a 400 that writes nothing, and the write is
 idempotent (re-logging updates the same ``SessionLog`` rather than piling up

--- a/app/store_project/meso/tests/test_athlete_surface.py
+++ b/app/store_project/meso/tests/test_athlete_surface.py
@@ -9,7 +9,7 @@ an athlete at ``/meso/athlete/<uuid>/``):
 - ``/meso/me/session/<id>/`` shows one delivered session's prescribed exercises,
   read-only.
 
-These tests pin the **scoping contract** (see ``docs/meso/athlete-plan.md``):
+These tests pin the **scoping contract** (see ``docs/archive/meso/athlete-plan.md``):
 an athlete sees only plans across their *active* coaches, only **delivered**
 weeks, and never another athlete's data. Delivery — not plan status — is the
 publish gate; an undelivered week is invisible even to its own athlete.

--- a/app/store_project/meso/tests/test_demo.py
+++ b/app/store_project/meso/tests/test_demo.py
@@ -5,7 +5,7 @@ Phase 1 made individual plan creation real; this phase lets a brand-new coach
 ``meso/demo.py`` wraps the seed's building blocks into ``load_demo`` /
 ``clear_demo`` / ``has_demo``, scoped to the requesting coach.
 
-The guardrails these tests pin (``docs/meso/first-time-ux-plan.md``, Q3):
+The guardrails these tests pin (``docs/archive/meso/first-time-ux-plan.md``, Q3):
 
 - **coach-scoped + collision-free** — each coach's demo athletes are namespaced,
   so two coaches can both load the demo and neither sees the other's data;

--- a/app/store_project/meso/tests/test_design_reconnect.py
+++ b/app/store_project/meso/tests/test_design_reconnect.py
@@ -16,7 +16,7 @@ This phase reconnects Meso:
 - ``meso.css``, the standalone designer's inline tokens, and the PWA chrome
   (manifest ``theme_color``) all point at the shared steel-blue accent.
 
-See ``docs/design-system-unification-plan.md`` (PR 3) and the validating spike
+See ``docs/archive/design-system-unification-plan.md`` (PR 3) and the validating spike
 ``docs/spikes/basecoat/meso.html``.
 """
 

--- a/app/store_project/meso/tests/test_group_create.py
+++ b/app/store_project/meso/tests/test_group_create.py
@@ -5,7 +5,7 @@ but a group could still only be born from the seed/admin. Phase 2b is the
 create-group entry point: a coach names a group, gives it a focus, and picks
 members from their roster.
 
-These tests pin the contract (see ``docs/meso/groups-plan.md``): ``name`` is
+These tests pin the contract (see ``docs/archive/meso/groups-plan.md``): ``name`` is
 required, members are scoped to the coach's *active* links (a foreign/stale pick
 is silently ignored, never a leak or a 500), and a successful create lands on
 the new group's detail page. The model helper (``create_for_coach``) carries the

--- a/app/store_project/meso/tests/test_group_overrides.py
+++ b/app/store_project/meso/tests/test_group_overrides.py
@@ -12,7 +12,7 @@ These tests pin: the model shape (unique per member+prescription, the
 same-group tenancy guard), the ``set_override`` / ``clear_override`` helpers,
 the effective-program resolution + the ``adj`` label, the serialized ``adj``
 overlay the designer renders, and the override API endpoint. See
-``docs/meso/groups-plan.md``.
+``docs/archive/meso/groups-plan.md``.
 """
 
 import pytest

--- a/app/store_project/meso/tests/test_group_program.py
+++ b/app/store_project/meso/tests/test_group_program.py
@@ -14,7 +14,7 @@ the editable-by scoping (the designer + autosave surface accepts a group plan
 the coach owns; ``for_coach`` stays individual-only so the individual-only
 deliver/results/review flows never see a group plan), the shared-plan helpers,
 the serialized group payload the designer hydrates Group mode from, and the
-group-design entry point. See ``docs/meso/groups-plan.md``.
+group-design entry point. See ``docs/archive/meso/groups-plan.md``.
 """
 
 import pytest

--- a/app/store_project/meso/tests/test_groups.py
+++ b/app/store_project/meso/tests/test_groups.py
@@ -6,7 +6,7 @@ tenancy-correct foundation: ``MesoGroup`` (coach-owned) + ``GroupMembership``
 (group ↔ an *active* ``CoachAthlete`` link), scoped reads, and the roster
 *Groups* card + a coach-scoped group detail page.
 
-These tests pin the scoping contract (see ``docs/meso/groups-plan.md``): a coach
+These tests pin the scoping contract (see ``docs/archive/meso/groups-plan.md``): a coach
 sees only their own groups; a group's *displayed* members are scoped to active
 links, so ending a relationship hides the member without deleting the membership
 row (reopening the link restores them).

--- a/app/store_project/meso/tests/test_invite_lifecycle.py
+++ b/app/store_project/meso/tests/test_invite_lifecycle.py
@@ -16,7 +16,7 @@ adds a time-to-live and an explicit *resend*:
 - the ``meso_expire_invites`` management command sweeps overdue pending invites;
 - the coach roster surfaces expired invites with a Resend action.
 
-See ``docs/meso/invites-plan.md``. Mail is best-effort on
+See ``docs/archive/meso/invites-plan.md``. Mail is best-effort on
 ``transaction.on_commit``, so send-asserting view tests wrap the request in
 ``django_capture_on_commit_callbacks`` (same idiom as ``test_invites``).
 """

--- a/app/store_project/meso/tests/test_invite_reminders.py
+++ b/app/store_project/meso/tests/test_invite_reminders.py
@@ -17,7 +17,7 @@ reminder before the link lapses:
   emails each best-effort, and stamps them — the reminder peer of
   ``meso_expire_invites``.
 
-See ``docs/meso/invites-plan.md``. Mail is best-effort; the command sends
+See ``docs/archive/meso/invites-plan.md``. Mail is best-effort; the command sends
 synchronously (no request, no ``on_commit``), so send-asserting tests read
 ``mail.outbox`` directly.
 """

--- a/app/store_project/meso/tests/test_invites.py
+++ b/app/store_project/meso/tests/test_invites.py
@@ -4,7 +4,7 @@ A coach invites a real person *by email* (who may not have an account yet), we
 send a tokened claim link, and whoever follows it while authenticated
 materializes — and immediately activates — a ``CoachAthlete`` link. This is the
 ``CoachInvite`` artifact that sits in front of the Phase-1 peer-invite state
-machine; see ``docs/meso/invites-plan.md``.
+machine; see ``docs/archive/meso/invites-plan.md``.
 
 These tests cover:
 

--- a/app/store_project/meso/tests/test_landing.py
+++ b/app/store_project/meso/tests/test_landing.py
@@ -10,7 +10,7 @@ page (what Meso is + two honest entry actions: log in as an athlete, or become a
 coach), while an authenticated visitor keeps the post-#311 role routing (coach →
 roster, anyone else → their training home). A single discreet "Coaching" link in
 the main-site nav makes Meso discoverable at all. See
-``docs/meso/first-time-ux-plan.md`` (Phase 3).
+``docs/archive/meso/first-time-ux-plan.md`` (Phase 3).
 
 These tests cover:
 

--- a/app/store_project/meso/tests/test_load_type.py
+++ b/app/store_project/meso/tests/test_load_type.py
@@ -10,7 +10,7 @@ per-athlete override resolver, and the group deliver fan-out, and rendered as a
 
 RPE is unchanged and orthogonal (its own column, coexists with either type).
 A ``LoggedSet`` has no ``load_type`` — an athlete always logs the actual weight
-lifted (absolute). See ``docs/meso/units-rpe-plan.md``.
+lifted (absolute). See ``docs/archive/meso/units-rpe-plan.md``.
 """
 
 import json

--- a/app/store_project/meso/tests/test_one_rm.py
+++ b/app/store_project/meso/tests/test_one_rm.py
@@ -10,7 +10,7 @@ the designer when prescribing a %1RM.
 These tests pin: the lift-identity key + uniqueness, the Epley derivation
 (matching ``meso_athlete.js`` exactly), the refresh-on-log write path, the read
 helper, the log-endpoint integration, the presenter/serializer threading, and
-the backfill of existing history. See ``docs/meso/one-rm-plan.md``.
+the backfill of existing history. See ``docs/archive/meso/one-rm-plan.md``.
 """
 
 import datetime

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -1479,7 +1479,7 @@ def request_withdraw(request, token):
 # by email (who may not have an account yet), we send a tokened claim link, and
 # whoever follows it while authenticated materializes — and immediately activates
 # — a CoachAthlete link. Distinct from the peer-invite token views above, which
-# act on an existing CoachAthlete between two Users. See docs/meso/invites-plan.md.
+# act on an existing CoachAthlete between two Users. See docs/archive/meso/invites-plan.md.
 
 
 @login_required

--- a/docs/archive/design-system-phase-2-plan.md
+++ b/docs/archive/design-system-phase-2-plan.md
@@ -1,7 +1,7 @@
 # Design system — phase 2 plan (typography + remaining chrome)
 
 Status: **COMPLETE — PRs A, B & C all shipped** · Drafted & finished 2026-06-30 ·
-Follow-on to the **COMPLETE** `docs/design-system-unification-plan.md` (phase 1:
+Follow-on to the **COMPLETE** `docs/archive/design-system-unification-plan.md` (phase 1:
 PRs 1–3 + the nav-refresh #358). PR A = body typography (#363); PR B = footer
 chrome (#366); PR C = phase-1 doc reconcile (this change). Decisions taken:
 **Option A (system-ui)** for the body typeface, **Meso left on Hanken Grotesk**,
@@ -114,7 +114,7 @@ include `_footer.html`; the main bases do). TDD + codex + gate as usual.
 
 ## PR C — Reconcile the phase-1 plan doc (housekeeping, docs-only) ✅ shipped
 
-`docs/design-system-unification-plan.md` still describes PR 3 as the Meso-only
+`docs/archive/design-system-unification-plan.md` still describes PR 3 as the Meso-only
 `meso/_meso_sitenav.html` partial styled by `.meso-sitenav`. #358 **removed** that
 in favor of the shared `nav.css` + `_nav.html` reused in `_meso_base` via
 `{% block site_nav %}`. Update the PR 3 section (and the status header) to record

--- a/docs/archive/design-system-phase-3-plan.md
+++ b/docs/archive/design-system-phase-3-plan.md
@@ -2,8 +2,8 @@
 
 Status: **✅ COMPLETE — all three PRs shipped & deployed.** Drafted 2026-06-30 ·
 Implements issue **#352 "[UI] Redesign auth pages"** · Follow-on to the
-**COMPLETE** `docs/design-system-unification-plan.md` (phase 1: PRs 1–3 +
-nav-refresh #358) and **COMPLETE** `docs/design-system-phase-2-plan.md` (PR A
+**COMPLETE** `docs/archive/design-system-unification-plan.md` (phase 1: PRs 1–3 +
+nav-refresh #358) and **COMPLETE** `docs/archive/design-system-phase-2-plan.md` (PR A
 body typography #363, PR B footer #366, PR C docs #367).
 
 **Shipped:**

--- a/docs/archive/design-system-unification-plan.md
+++ b/docs/archive/design-system-unification-plan.md
@@ -11,7 +11,7 @@ foundation, not on PR 2). The whole site now runs on the one token-driven look.
 > (`static/css/nav.css` + `_nav.html`) reused across the whole site *and* the
 > Meso shell. The PR 3 section below is reconciled to describe what's on `main`.
 > Later polish (body typography, footer chrome) continued in the separate
-> **`docs/design-system-phase-2-plan.md`** — phase 2: PR A (#363), PR B (#366),
+> **`docs/archive/design-system-phase-2-plan.md`** — phase 2: PR A (#363), PR B (#366),
 > and this doc-reconcile as PR C.
 
 ## Goal

--- a/docs/archive/meso/agent-plan.md
+++ b/docs/archive/meso/agent-plan.md
@@ -4,7 +4,7 @@
 (PR #282, squash `ee7d456`; deployed) · Phase 3 done & merged (PR #284, squash `5bfe754`; deployed) ·
 Phase 4 done & merged (PR #286, squash `82fd360`; Django CI green, deployed to Hetzner —
 migration `meso.0005` applied) · created 2026-06-27 · **agent slice complete**
-**Companion to:** [`decisions.md`](./decisions.md) (B6) · [`persistence-plan.md`](./persistence-plan.md)
+**Companion to:** [`decisions.md`](../../meso/decisions.md) (B6) · [`persistence-plan.md`](./persistence-plan.md)
 **Goal of this slice:** replace the designer's canned agent-chat engine
 (`detectIntent`/`applyIntent` in `meso.js`) and the review screen
 (`mockdata.PROPOSED_CHANGES`) with a **real Claude proposal engine behind the

--- a/docs/archive/meso/athlete-plan.md
+++ b/docs/archive/meso/athlete-plan.md
@@ -11,12 +11,12 @@ notifications — done & merged, PR #293, squash `dfbebee`; deployed to Hetzner;
 +9 tests, no migration) + 4b (PWA + web push — **built**, see Phase 4b below;
 +43 tests, 354 meso / 494 project-wide; ruff clean; **one migration**
 `0006_pushsubscription`; new dep `pywebpush`).**
-**Companion to:** [`decisions.md`](./decisions.md) (B2, S3, S7, N1/D-a/D-b) ·
+**Companion to:** [`decisions.md`](../../meso/decisions.md) (B2, S3, S7, N1/D-a/D-b) ·
 [`persistence-plan.md`](./persistence-plan.md) · [`agent-plan.md`](./agent-plan.md)
 **Goal of this slice:** give the **athlete** a real, logged-in surface — see the
 plan their coach delivered, log the sessions they train — and feed those logs
 back into the coach's results screen and the agent's grounding. This is item 3
-in the [decisions.md suggested sequence](./decisions.md#suggested-sequence):
+in the [decisions.md suggested sequence](../../meso/decisions.md#suggested-sequence):
 *"Athlete delivery + logging — the athlete PWA surface, notifications, then
 results feeding back to the agent."*
 

--- a/docs/archive/meso/chat-thread-plan.md
+++ b/docs/archive/meso/chat-thread-plan.md
@@ -10,7 +10,7 @@ resumes polling (carries `pollUrl`, `meso.js` `resumeDrafting`) instead of going
 stale; and a long restored thread scrolls to its latest turn on load. · created
 2026-06-28
 **Companion to:** [`agent-plan.md`](./agent-plan.md) (the chat went live in agent
-Phase 3, but the thread was never persisted) · [`decisions.md`](./decisions.md) (B6)
+Phase 3, but the thread was never persisted) · [`decisions.md`](../../meso/decisions.md) (B6)
 **Goal of this slice:** the designer's agent-chat conversation **survives a page
 reload**. Today the chat is ephemeral — `meso.js` re-seeds `messages` to a single
 orienting greeting on every load, so a coach who proposes changes, navigates away,

--- a/docs/archive/meso/first-time-ux-plan.md
+++ b/docs/archive/meso/first-time-ux-plan.md
@@ -6,7 +6,7 @@ plan creation) + Phase 2 (coach first-run: one-click demo + empty-state teaching
 first-run: install prompt + first-log coachmark) + Phase 5 (designer & agent
 self-explanation: dismissible coachmarks + review-gate note + real left-rail
 chrome) all done**
-**Companion to:** [`decisions.md`](./decisions.md) (B1 multi-coach, B2 athlete
+**Companion to:** [`decisions.md`](../../meso/decisions.md) (B1 multi-coach, B2 athlete
 login, N3 roles, N4 invites) · [`invites-plan.md`](./invites-plan.md) ·
 [`athlete-plan.md`](./athlete-plan.md) · [`groups-plan.md`](./groups-plan.md)
 **Goal of this slice:** make Meso **obvious to use for a first-time visitor**
@@ -107,7 +107,7 @@ all.** "Obvious to use" presupposes "usable," so this is Phase 1.
 
 ## Decisions this slice rests on
 
-From [`decisions.md`](./decisions.md): **B1** (multi-coach SaaS), **B2** (athletes
+From [`decisions.md`](../../meso/decisions.md): **B1** (multi-coach SaaS), **B2** (athletes
 are `User`s who log in; coach edits their plan), **N3** (roles: a user is a coach
 via a `CoachProfile` *or* a coach-side link *or* a sent invite — post-#311
 `RosterView` routes on exactly this, so the role is **load-bearing now, not

--- a/docs/archive/meso/groups-plan.md
+++ b/docs/archive/meso/groups-plan.md
@@ -1,7 +1,7 @@
 # Meso — groups slice (S1) plan
 
 **Status:** living document · started 2026-06-28
-**Decision context:** [`decisions.md`](./decisions.md) S1 — *Groups: "shared program +
+**Decision context:** [`decisions.md`](../../meso/decisions.md) S1 — *Groups: "shared program +
 per-athlete auto-adjust" modeling (template + override diffs)*. Deferred until individuals
 worked; the individual coach + athlete + agent slices are now complete, so groups is the
 main remaining Meso feature area.

--- a/docs/archive/meso/invites-plan.md
+++ b/docs/archive/meso/invites-plan.md
@@ -1,6 +1,6 @@
 # Meso — N4 athlete onboarding / invites
 
-The still-open foundation decision (N4 in [`decisions.md`](./decisions.md)): how an
+The still-open foundation decision (N4 in [`decisions.md`](../../meso/decisions.md)): how an
 athlete *joins* a coach. Phase 1 of persistence shipped a peer-invite **state
 machine + tokened URLs** on `CoachAthlete` (`invite`/`request`/`accept`/`decline`/
 `end`) and the `invite_accept`/`invite_decline` token views — but those require the
@@ -214,7 +214,7 @@ the notifications function).
 The `meso_expire_invites` + `meso_remind_expiring_invites` sweeps are no longer
 hand-run: they're registered as daily `django_q.Schedule` rows (migration
 `meso/0018`) and executed by an app-managed **django-q2** `qcluster` worker
-(ORM broker). Design + rationale in [`scheduling-plan.md`](./scheduling-plan.md).
+(ORM broker). Design + rationale in [`scheduling-plan.md`](../../meso/scheduling-plan.md).
 
 ## Deferred (Phase 5+)
 

--- a/docs/archive/meso/one-rm-plan.md
+++ b/docs/archive/meso/one-rm-plan.md
@@ -9,7 +9,7 @@ device change, and invisible to the coach.** This slice promotes it to a real,
 **auto-derived** row.
 
 See [`units-rpe-plan.md`](./units-rpe-plan.md) for the slice it completes and
-[`decisions.md`](./decisions.md) for the standing decisions.
+[`decisions.md`](../../meso/decisions.md) for the standing decisions.
 
 ---
 

--- a/docs/archive/meso/persistence-plan.md
+++ b/docs/archive/meso/persistence-plan.md
@@ -4,7 +4,7 @@
 merged 2026-06-27 (PR #271); Phase 3 merged 2026-06-27 (PR #274); Phase 4 merged 2026-06-27
 (PR #276); Phase 5 merged & deployed 2026-06-27 (PR #278, `seed_meso_demo` + coach-side mock
 retired) · created 2026-06-26 · **next = the agent slice (B6)**
-**Companion to:** [`decisions.md`](./decisions.md)
+**Companion to:** [`decisions.md`](../../meso/decisions.md)
 **Goal of this slice:** turn the **coach-side** screens (designer, roster, athlete profile)
 from client-side mocks into real, DB-backed, **tenant-scoped** data. No agent, no athlete app
 yet — the review and results screens keep running on seeded data until their own slices.

--- a/docs/archive/meso/units-rpe-plan.md
+++ b/docs/archive/meso/units-rpe-plan.md
@@ -1,7 +1,7 @@
 # Meso — units & RPE/%1RM slice (S2) plan
 
 **Status:** living document · started 2026-06-28
-**Decision context:** [`decisions.md`](./decisions.md) S2 — *Units & RPE vs %1RM —
+**Decision context:** [`decisions.md`](../../meso/decisions.md) S2 — *Units & RPE vs %1RM —
 per-athlete/coach setting; needs a home.* The major Meso slices (individual coach +
 agent + athlete PWA + groups) are all built and deployed (`mockdata.py` is gone), so
 S2 is the next deferred secondary decision picked up.

--- a/docs/meso/agent-account-and-cost-controls.md
+++ b/docs/meso/agent-account-and-cost-controls.md
@@ -55,7 +55,7 @@ graceful-degradation layer.
   the bare apex, so it's unaffected by apex email-DNS changes.)
 - **Prod key:** `ANTHROPIC_API_KEY` in the Hetzner box `.env` (and the local `.env`)
   — read by both `web` and the `qcluster` worker (a separate process rebuilds its
-  own Claude client, see [`agent-plan.md`](./agent-plan.md)).
+  own Claude client, see [`agent-plan.md`](../archive/meso/agent-plan.md)).
 
 ## Step 1 — Dedicated business email (`@mastering.fitness`)
 

--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -97,7 +97,7 @@ Provider is **Claude** (project standing guidance). Real decisions:
   omitted (incompatible with a forced `tool_choice`). Contraindications enforced deterministically in
   `meso/agent/validation.py` (not just the prompt); the coach still approves. Execution is sync for
   now (background job + streamed status deferred); eval golden cases deferred. Full phasing in
-  [`agent-plan.md`](./agent-plan.md).
+  [`agent-plan.md`](../archive/meso/agent-plan.md).
 
 ---
 
@@ -148,7 +148,7 @@ request form lives). **Phase 3 built** — invite *lifecycle*: a 14-day TTL (`ex
 new `EXPIRED` status, lazy + swept expiry (the claim path refuses a stale token;
 `meso_expire_invites` bulk-sweeps overdue invites), and an explicit **resend** (rotates the
 token + resets the clock, re-arms an expired invite) surfaced on the roster. Plan + deferred
-items in [`invites-plan.md`](./invites-plan.md).
+items in [`invites-plan.md`](../archive/meso/invites-plan.md).
 
 ---
 
@@ -156,8 +156,8 @@ items in [`invites-plan.md`](./invites-plan.md).
 
 | # | Decision | Note |
 |---|----------|------|
-| S1 | **Groups** — "shared program + per-athlete auto-adjust" modeling (template + override diffs) | 🟡 In progress — Phase 1 (group + membership spine + read surface) + Phase 2a (shared group program + Group-mode designer) + Phase 3 (per-athlete overrides — the `adj` overlay) built; plan in [`groups-plan.md`](./groups-plan.md) |
-| S2 | **Units & RPE vs %1RM** | ✅ Complete — units (kg/lb) shipped with earlier slices; Phase 1 (first-class `load_type` `abs`/`pct`) + Phase 2a (agent %1RM-awareness — prompt + a deterministic %1RM progression bound) + Phase 2b (athlete %1RM logging ergonomics — the estimated-1RM helper) all built & deployed. **Follow-up: persisted, coach-visible 1RM** (Phase 1 — `AthleteOneRm`, auto-derived from logged history) built. Plans in [`units-rpe-plan.md`](./units-rpe-plan.md) / [`one-rm-plan.md`](./one-rm-plan.md) |
+| S1 | **Groups** — "shared program + per-athlete auto-adjust" modeling (template + override diffs) | 🟡 In progress — Phase 1 (group + membership spine + read surface) + Phase 2a (shared group program + Group-mode designer) + Phase 3 (per-athlete overrides — the `adj` overlay) built; plan in [`groups-plan.md`](../archive/meso/groups-plan.md) |
+| S2 | **Units & RPE vs %1RM** | ✅ Complete — units (kg/lb) shipped with earlier slices; Phase 1 (first-class `load_type` `abs`/`pct`) + Phase 2a (agent %1RM-awareness — prompt + a deterministic %1RM progression bound) + Phase 2b (athlete %1RM logging ergonomics — the estimated-1RM helper) all built & deployed. **Follow-up: persisted, coach-visible 1RM** (Phase 1 — `AthleteOneRm`, auto-derived from logged history) built. Plans in [`units-rpe-plan.md`](../archive/meso/units-rpe-plan.md) / [`one-rm-plan.md`](../archive/meso/one-rm-plan.md) |
 | S3 | **Delivery & notifications** | ✅ Built — push (PWA, Phase 4b) + email (`django-ses` + `notifications`). **Email opt-out shipped** (2026-06-29): the delivery email now carries a working one-click `List-Unsubscribe` (RFC 8058) honored by a per-athlete flag — see decision log. |
 | S4 | **Results ↔ `challenges`/records** | ✅ Resolved (2026-06-29, YAGNI review): **keep separate, build nothing now.** The "results screen shows a PR" premise was mock-only (the real results screen never showed a PR), and `challenges.Record` is time-based (wrong domain for a strength PR). Meso already owns best-lift data via `AthleteOneRm`. A motivational PR badge stays deferred until there's a concrete need. |
 | S5 | **Real-time transport** | ❌ Deferred (YAGNI, 2026-06-29): the agent result is atomic behind a human review gate and the stack is WSGI — SSE/websockets buy ~1.5s over a cheap bounded poll for disproportionate ASGI/channels/Redis-channel-layer infra. Revisit only if the agent itself becomes genuinely streaming. |
@@ -244,7 +244,7 @@ _(Append dated entries here as decisions land.)_
   it. **Contraindications enforced in a deterministic validation layer** (current-week scoping,
   target consistency, swap-only contraindication backstop, plural-folded), not just the prompt;
   human approval gate unchanged. 47 new tests (146 meso / 286 project-wide); local Codex review clean
-  (8 rounds). Build plan + phasing in [`agent-plan.md`](./agent-plan.md). Resume point → agent Phase 2
+  (8 rounds). Build plan + phasing in [`agent-plan.md`](../archive/meso/agent-plan.md). Resume point → agent Phase 2
   (per-change approve/reject + **apply** back into the program).
 - 2026-06-27 — **Agent Phase 2 built & merged** (PR #282, squash `ee7d456`; Django CI green, deployed
   to Hetzner — **no migration**, `status`/`payload` already existed): the review gate now **writes
@@ -289,7 +289,7 @@ _(Append dated entries here as decisions land.)_
   → either a **persisted chat thread** (saving the designer conversation, deferred since Phase 3) or the
   **athlete-facing slice** (delivery + logging PWA, then results feeding back to the agent — decisions S3/S7).
 - 2026-06-27 — **Athlete-facing slice started** (decision: build item 3 of the suggested sequence — the
-  athlete surface — over the persisted chat thread). Plan + phasing in [`athlete-plan.md`](./athlete-plan.md)
+  athlete surface — over the persisted chat thread). Plan + phasing in [`athlete-plan.md`](../archive/meso/athlete-plan.md)
   (Phase 1 read surface · Phase 2 logging · Phase 3 results-feedback · Phase 4 PWA + notifications, S3/S7).
   **Phase 1 built** (branch `meso-athlete-phase1`): the athlete's own read surface — `AthleteHomeView`
   (`/meso/me/`) lists their active-coach, non-archived plans with each plan's latest **delivered** week +
@@ -363,7 +363,7 @@ _(Append dated entries here as decisions land.)_
   doesn't go stale. **No model, no migration** — same "reuse what exists, defer new tables" taste as the
   athlete slice. Built red→green: **+16 tests** (`test_chat_thread.py`; 379 meso / 519 project-wide), ruff
   clean. **Local Codex review: 0 blocking across 3 rounds → CLEAN** (two nits fixed: the drafting resume-poll
-  and the scroll-to-latest). Plan in [`chat-thread-plan.md`](./chat-thread-plan.md). **Deferred:** a dedicated
+  and the scroll-to-latest). Plan in [`chat-thread-plan.md`](../archive/meso/chat-thread-plan.md). **Deferred:** a dedicated
   `ChatMessage` model (only if the agent ever sends text not tied to a batch) · editing past turns ·
   pagination of a very long thread. Resume point → next-slice options: **groups (S1)** is the main remaining
   Meso feature area.
@@ -384,7 +384,7 @@ _(Append dated entries here as decisions land.)_
   relationship + an inactive link **on creation only** (so a since-ended row stays re-savable). Built red→green:
   **+28 tests** (`test_groups.py` + seed coverage; 407 meso / 545 project-wide), ruff clean, `makemigrations
   --check` clean. **Local Codex review: 0 blocking → CLEAN** (3 rounds; two P2 membership-tenancy nits fixed).
-  Plan + phasing in [`groups-plan.md`](./groups-plan.md). Resume point → **groups Phase 2** (the shared group
+  Plan + phasing in [`groups-plan.md`](../archive/meso/groups-plan.md). Resume point → **groups Phase 2** (the shared group
   program: `Plan.group` FK + nullable `relationship`, the designer's Group mode, create-group UI).
 - 2026-06-28 — **Groups slice (S1) Phase 2a built** (branch `meso-groups-phase2a`). The **shared group
   program**: a `Plan` rooted at a `MesoGroup` instead of a `CoachAthlete` relationship. Phase 2 is split (like
@@ -405,7 +405,7 @@ _(Append dated entries here as decisions land.)_
   shared program" card; the seeded demo group gets a shared program. `initials` moved to `serializers` (avoids a
   presenters import cycle). Built red→green: **+29 tests** (`test_group_program.py` + seed coverage; 583
   project-wide), ruff clean, `makemigrations --check` clean. Plan + build notes in
-  [`groups-plan.md`](./groups-plan.md). Resume point → **groups Phase 3** (per-athlete overrides: the `adj`
+  [`groups-plan.md`](../archive/meso/groups-plan.md). Resume point → **groups Phase 3** (per-athlete overrides: the `adj`
   overlay — `PrescriptionOverride`, effective-program resolution, the designer's per-row `adj` badge), then
   **Phase 2b** (create-group UI) and **Phase 4** (deliver-to-all).
 - 2026-06-28 — **Groups slice (S1) Phase 3 built** (branch `meso-groups-phase3`). **Per-athlete overrides —
@@ -428,7 +428,7 @@ _(Append dated entries here as decisions land.)_
   override *editor* yet** — the badge renders off seed/admin/API-created diffs; the click-to-adjust UI is the
   immediate follow-up. Built red→green: **+41 tests** (`test_group_overrides.py` + seed coverage; 625
   project-wide), full suite + 30 JS tests green, ruff + format clean, `makemigrations --check` clean. Plan +
-  build notes in [`groups-plan.md`](./groups-plan.md). Resume point → the **override editor UI** (click a row
+  build notes in [`groups-plan.md`](../archive/meso/groups-plan.md). Resume point → the **override editor UI** (click a row
   to set a member's adjust), then **Phase 2b** (create-group UI) and **Phase 4** (deliver-to-all — fan a
   per-athlete *resolved* snapshot out to each member, reusing `resolve_prescription`).
 - 2026-06-28 — **Groups slice (S1) COMPLETE** (Phases 2b + 3-editor + 4 all built, merged & deployed — PRs
@@ -443,7 +443,7 @@ _(Append dated entries here as decisions land.)_
   toggles `%` ⇄ the unit and autosaves the type; the athlete sees a `%` target and the coach results screen
   labels a %1RM target with `%`. Migration `meso.0011`. Agent %1RM-awareness deferred to Phase 2 (the agent
   is type-agnostic — a %1RM number progresses as a number). Plan + phasing in
-  [`units-rpe-plan.md`](./units-rpe-plan.md).
+  [`units-rpe-plan.md`](../archive/meso/units-rpe-plan.md).
 - 2026-06-28 — **S2 Phase 2a — agent %1RM-awareness** (branch `meso-units-rpe-phase2a-agent`, **no
   migration**). Phase 2 split 2a/2b (groups-slice cadence). The agent grounding already carried each row's
   `load_type` (Phase 1 wired `serialize_prescription`), so the two real gaps were the **prompt** (never
@@ -452,7 +452,7 @@ _(Append dated entries here as decisions land.)_
   `progress` on a `PERCENT`-typed target to `0 < pct ≤ 120` (rejects an absolute-looking "180" or a
   non-numeric value, normalizes `'82.5 %'` → `'82.5'`), leaving the absolute path unbounded. The agent still
   does **not** change a row's type. Athlete %1RM logging ergonomics remain → **Phase 2b**. Plan in
-  [`units-rpe-plan.md`](./units-rpe-plan.md).
+  [`units-rpe-plan.md`](../archive/meso/units-rpe-plan.md).
 - 2026-06-28 — **S2 Phase 2b — athlete %1RM logging ergonomics → S2 COMPLETE** (branch
   `meso-units-rpe-phase2b`, **no migration**). A %1RM target is an *intensity, not a weight*: Phase 1 let
   the athlete *see* the `%`, but converting "75%" to a bar load was still manual. Phase 2b adds an
@@ -469,7 +469,7 @@ _(Append dated entries here as decisions land.)_
   frontend), ruff + prettier clean, `makemigrations --check` clean. **Local Codex review: CLEAN on
   iteration 1.** **Deferred:** a persisted/coach-visible estimated 1RM (model + migration) and
   auto-deriving it from logged history. **The whole Meso feature area is now real & deployed; S2 is
-  complete — no obvious next big slice, ask the user.** Plan in [`units-rpe-plan.md`](./units-rpe-plan.md)
+  complete — no obvious next big slice, ask the user.** Plan in [`units-rpe-plan.md`](../archive/meso/units-rpe-plan.md)
 - 2026-06-28 — **S2 follow-up: persisted, auto-derived, coach-visible 1RM — Phase 1 built** (branch
   `meso-one-rm-phase1`). The deferred Phase-2b follow-up: the athlete's estimated 1RM lived only in
   per-device `localStorage`. Phase 1 promotes it to a real **`AthleteOneRm`** row (one per
@@ -484,7 +484,7 @@ _(Append dated entries here as decisions land.)_
   no single athlete, so none). The seed derives Maya's Box Squat 1RM (84) so the demo shows it. Built
   red→green: **+33 pytest** (`test_one_rm.py`; 600 meso / 740 project-wide) + **+5 Vitest** (65 frontend)
   + a seed assertion, ruff + format clean, `makemigrations --check` clean. Plan in
-  [`one-rm-plan.md`](./one-rm-plan.md). **Deferred:** manual entry persisted server-side (a `source` field
+  [`one-rm-plan.md`](../archive/meso/one-rm-plan.md). **Deferred:** manual entry persisted server-side (a `source` field
   + endpoint — today logs only *raise* the estimate), coach-editable 1RM, smarter derivation / unit
   conversion..
 - 2026-06-28 — **S2 follow-up — Phase 2: manual, server-persisted 1RM built** (branch
@@ -505,7 +505,7 @@ _(Append dated entries here as decisions land.)_
   is now a **debounced best-effort server POST** (`saveOneRm`/`_postOneRm`) — the `meso-e1rm` localStorage
   store is **retired**. Admin surfaces `source` (`list_display` + `list_filter`). Built red→green: **+28
   pytest** (`test_one_rm.py`; 664 meso / 776 project-wide) + **+8 Vitest** (70 frontend, net), ruff +
-  prettier + `makemigrations --check` clean. Plan in [`one-rm-plan.md`](./one-rm-plan.md). **Deferred
+  prettier + `makemigrations --check` clean. Plan in [`one-rm-plan.md`](../archive/meso/one-rm-plan.md). **Deferred
   (Phase 3+):** coach-editable 1RM (the `source` field already supports it), offline persistence of a
   manual edit, smarter derivation / cross-unit conversion.
 - 2026-06-29 — **N4 — athlete onboarding / email invites — Phase 1 built** (branch
@@ -533,7 +533,7 @@ _(Append dated entries here as decisions land.)_
   `no-referrer` meta into a new `_meso_base` `head_top` block that precedes the font `<link>`s; a
   P2 claim race — `select_for_update` on the invite row in the claim/revoke views). Plan +
   deferred (athlete→coach request UI, resend/expiry, stub-athlete) in
-  [`invites-plan.md`](./invites-plan.md).
+  [`invites-plan.md`](../archive/meso/invites-plan.md).
 - 2026-06-29 — **N4 — athlete onboarding / invites — Phase 2 built** (branch
   `meso-invites-phase2`, **no migration**). Closes the bidirectional half the relationship spine
   always supported in the model (`CoachAthlete.request` → `pending_athlete_request`) but never in
@@ -556,7 +556,7 @@ _(Append dated entries here as decisions land.)_
   (`hopeful@example.com`) so the surface shows on a fresh DB (idempotent + torn down). Built
   red→green: **+34 pytest** (`test_requests.py`) + 3 seed assertions; full suite green (867).
   **Codex review loop CLEAN on iteration 1.** Plan + deferred (resend/expiry, stub-athlete,
-  attribution) in [`invites-plan.md`](./invites-plan.md).
+  attribution) in [`invites-plan.md`](../archive/meso/invites-plan.md).
 - 2026-06-29 — **N4 — invites — Phase 3 built** (branch `meso-invites-phase3`). Invite
   *lifecycle*: a TTL + an explicit resend, closing the top deferred item. **One migration**
   (`0016_coachinvite_expiry`): `CoachInvite.expires_at` + a new `Status.EXPIRED`. A fresh invite
@@ -576,7 +576,7 @@ _(Append dated entries here as decisions land.)_
   "expired" state; admin lists `expires_at`; the demo invite seeds via `open_for` (real TTL).
   Built red→green: **+38 pytest** (`test_invite_lifecycle.py`); full project suite 904 + 83 Vitest
   green. Plan + deferred (configurable TTL, expiry reminder, cron scheduling, stub-athlete) in
-  [`invites-plan.md`](./invites-plan.md).
+  [`invites-plan.md`](../archive/meso/invites-plan.md).
 - 2026-06-29 — **Agent job → django-q `async_task` built** (branch `meso-agent-django-q`,
   **no migration**). Closes the top deferred item of the scheduling plan: `meso/agent/jobs.py` ran
   the proposal job on a bare daemon thread because there was no queue; now that django-q2 + the
@@ -634,7 +634,7 @@ _(Append dated entries here as decisions land.)_
   needed an off switch. Admin surfaces + filters the flag. Built red→green: **+16 pytest**
   (`test_unsubscribe.py`); ruff + format + `makemigrations --check` clean.
 - 2026-06-29 — **First-time UX / onboarding slice planned** (not built; plan in
-  [`first-time-ux-plan.md`](./first-time-ux-plan.md)). The feature area is broad
+  [`first-time-ux-plan.md`](../archive/meso/first-time-ux-plan.md)). The feature area is broad
   and deployed but has never had an onboarding pass. The plan covers all three
   first-timers (cold visitor · new coach · new athlete) and surfaces the
   **headline blocker**: a coach **cannot create an individual program in the UI** —
@@ -684,7 +684,7 @@ _(Append dated entries here as decisions land.)_
   plan creation, the headline structural fix (`Plan.scaffold` + `CoachAthlete.create_plan` /
   `working_plan` + `plan_create` / `session_add` endpoints + wired CTAs). A real coach can now
   build an individual program in the UI with no seed. Plan in
-  [`first-time-ux-plan.md`](./first-time-ux-plan.md).
+  [`first-time-ux-plan.md`](../archive/meso/first-time-ux-plan.md).
 - 2026-06-29 — **First-time UX — Phase 2 built** (branch `meso-first-time-ux-phase2`): **coach
   first-run — one-click demo + empty-state teaching** (Q3). `meso/demo.py`
   (`load_demo` / `clear_demo` / `has_demo`) is a coach-scoped, idempotent wrapper over the
@@ -727,7 +727,7 @@ _(Append dated entries here as decisions land.)_
   `makemigrations --check` clean. **Codex review loop CLEAN on iteration 1.** Resume
   point → first-time-UX **Phase 4** (athlete install/first-log polish) **or Phase 5**
   (designer/agent self-explanation). Plan in
-  [`first-time-ux-plan.md`](./first-time-ux-plan.md).
+  [`first-time-ux-plan.md`](../archive/meso/first-time-ux-plan.md).
 - 2026-06-30 — **First-time UX — Phase 4 built & merged** (branch
   `meso-first-time-ux-phase4`, PR #330, **no migration**): **athlete first-run
   polish** — a PWA **install prompt** + a one-time **first-log coachmark**. The
@@ -752,7 +752,7 @@ _(Append dated entries here as decisions land.)_
   **Prod-verified:** `/meso/sw.js` now serves `CACHE = "meso-pwa-v2"` + the hashed
   `meso_onboarding.*.js` (HTTP 200). Resume point → first-time-UX **Phase 5**
   (designer/agent self-explanation) **or** the add-week/week-switcher deferral. Plan in
-  [`first-time-ux-plan.md`](./first-time-ux-plan.md).
+  [`first-time-ux-plan.md`](../archive/meso/first-time-ux-plan.md).
 - 2026-06-30 — **First-time UX — Phase 5 built** (branch `meso-first-time-ux-phase5`,
   **no migration**): **designer & agent self-explanation** — the **last first-time-UX
   phase**. The designer is a self-contained Alpine page that shipped a pile of
@@ -789,7 +789,7 @@ _(Append dated entries here as decisions land.)_
   **completes the first-time-UX slice** (Phases 1–5). Remaining Meso backlog: the
   **add-week / week-switcher** deferral (designer is single-current-week) and **S6
   billing Phase 5 annual prices** (blocked on the owner's per-seat number + a Stripe
-  annual Price). Plan in [`first-time-ux-plan.md`](./first-time-ux-plan.md).
+  annual Price). Plan in [`first-time-ux-plan.md`](../archive/meso/first-time-ux-plan.md).
 - 2026-06-29 — **Multi-week designer built** (branch `meso-multi-week-designer`,
   **no migration**): closes the long-standing **add-week / week-switcher** deferral.
   A plan was effectively **single-week** — `Plan.scaffold` materialized one `Week`


### PR DESCRIPTION
## What & why

Reviewed every doc in `docs/` for completion and moved the **finished plans** into a new `docs/archive/` folder, keeping the live tree focused on active/reference docs. Each archived plan was verified as fully shipped against **git history + surviving code artifacts** (not just its self-declared "COMPLETE" banner), via a classify → skeptic-audit review pass.

Layout mirrors the live tree one level down: top-level plans → `docs/archive/`, meso plans → `docs/archive/meso/`.

## Archived (12)

- `docs/archive/` — `design-system-unification-plan`, `design-system-phase-2-plan`, `design-system-phase-3-plan`
- `docs/archive/meso/` — `agent-plan`, `athlete-plan`, `chat-thread-plan`, `first-time-ux-plan`, `groups-plan`, `invites-plan`, `one-rm-plan`, `persistence-plan`, `units-rpe-plan`

## Kept live (not archived) — and why

| Doc | Reason |
|---|---|
| `deploy-hetzner.md` | Runbook (day-2 ops / rollback) |
| `meso/decisions.md` | Living decision-log, still appended |
| `meso/scheduling-plan.md` | ADR/reference for a live subsystem, linked from `CLAUDE.md` |
| `meso/agent-account-and-cost-controls.md` | Drafted, **not yet executed** (open checkboxes) |
| `meso/agent-usage-plan.md` | Phase 6 unshipped + canonical ref for the live margin-alert schedule |
| `meso/billing-plan.md` | All phases shipped but feature ships **dormant** (Stripe env unset in prod); sole activation runbook |

## Reference integrity

All inbound references repointed so nothing dangles:
- Doc-to-doc markdown links (incl. the `decisions.md` index) — fixed with correct relative depths.
- ~30 source-file docstring/comment breadcrumbs (`models.py`, `views.py`, `agent/`, tests, …) → now point at `docs/archive/…`.

Verified: **0 stale old-path refs**, **all 62 intra-doc markdown links resolve**, all changed Python files compile. Source edits are **comment-only — no functional change**.

## Notes

- Touches `app/` (comment-only), so this does **not** hit the docs-only `paths-ignore` CI skip — Django CI runs.
- Left a pre-existing stale step in `meso/billing-plan.md` (says migration 0021 registers the reconcile-seats schedule, but 0028 dropped it) untouched — happy to fix separately.

https://claude.ai/code/session_01XDG4X7h3sH7eNnimH9amEg