### PR TITLE
docs(meso): fix stale reconcile-seats deploy step in billing-plan

### DIFF
--- a/docs/meso/billing-plan.md
+++ b/docs/meso/billing-plan.md
@@ -221,8 +221,10 @@ deploy succeeds without them (like the VAPID push keys):
    `invoice.payment_failed`. Set `MESO_STRIPE_WEBHOOK_SECRET` to that endpoint's
    signing secret (a *separate* secret from the products webhook's
    `STRIPE_ENDPOINT_SECRET`).
-3. The `qcluster` already runs the daily sweeps; the `meso-reconcile-seats`
-   schedule registers itself via migration `0021`.
+3. No billing sweep is needed. The flat plan has no per-seat quantity to
+   reconcile, so the old daily `meso-reconcile-seats` schedule (registered by
+   `0021`) was retired by migration `0028`. Billing state is kept current by the
+   Stripe webhook (step 2) alone.
 
 1. **Phase 1 — the spine (DONE).** `CoachSubscription` model + migration;
    constants (`FREE_SEAT_LIMIT`, `TRIAL_DAYS`, price-id setting); the


### PR DESCRIPTION
## What

Deploy step 3 in `docs/meso/billing-plan.md` said the `meso-reconcile-seats` daily schedule "registers itself via migration `0021`." That's stale: Phase 7's flat-plan pivot (D14) removed per-seat billing, and migration `0028_drop_reconcile_seats_schedule` deleted that schedule.

Corrected step 3: the flat plan needs **no billing sweep** — subscription state is kept current by the Stripe webhook (step 2) alone.

## Why

`billing-plan.md` was intentionally kept live (not archived in #379) because it's the sole **activation runbook** for the dormant billing feature — so its deploy steps need to be accurate.

Docs-only change (one file), so it hits the `paths-ignore` CI/deploy skip.

https://claude.ai/code/session_01XDG4X7h3sH7eNnimH9amEg