### PR TITLE
docs(meso): plans for demo video, public sandbox, nav rename

### DIFF
--- a/docs/meso/demo-walkthrough-video-plan.md
+++ b/docs/meso/demo-walkthrough-video-plan.md
@@ -1,0 +1,94 @@
+# Meso — Level-1 walkthrough demo video (automated, re-recordable)
+
+Status: **PLANNED** — not started. Tracking issue: _(add issue link when filed)_.
+
+## Why
+
+A new, non-subscriber visitor currently cannot see Meso in action without
+creating an account: the public pages (`/meso/`, `/meso/coach/`) are text-only —
+0 screenshots, 0 video (verified live). The cheapest "level 1" demo is a short
+screen recording of the real product being used, which is far easier to consume
+than signing up.
+
+The catch: **the UI is still changing.** A hand-recorded video goes stale the
+moment a button moves, and nobody re-records by hand. So the deliverable is not
+a video — it's a **tool that regenerates the video on demand** from a scripted
+browser session, runnable with one command.
+
+This is the sibling of the [public sandbox demo](./public-sandbox-demo-plan.md)
+("level 2"). Both share the **pre-baked agent** mechanism (V4 below).
+
+## Definition of done
+
+- `just record-demo` (new recipe) seeds deterministic demo data, drives a
+  scripted flow through the Meso coach workspace in a real browser, and writes a
+  video file — with **zero manual steps**.
+- Re-running after a UI change produces an equivalent video by editing a
+  readable, labelled storyboard — not by re-shooting.
+- **No** real Anthropic, Stripe, email, or push calls happen during recording.
+  The agent step shows a fixed, curated proposal.
+
+## Decisions (recommended; proceed unless overridden)
+
+| # | Decision | Choice |
+|---|----------|--------|
+| V1 | **Tooling** | **Playwright (Python).** Native video recording (`record_video_dir`), headless-capable, auto-waiting selectors, and it matches the uv/pytest stack. Nothing browser-automation-related exists in the repo today (checked `pyproject.toml`), so add Playwright as a **dev** dependency. |
+| V2 | **Demo data** | Reuse `store_project.meso.demo.load_demo()` — it's idempotent (`@transaction.atomic`, upsert-by-natural-key) and built from fixed constants (`ATHLETES`, `SAMPLE_PLAN`, `GROUP` in `management/commands/seed_meso_demo.py`), so records are reproducible. |
+| V3 | **Auth for the browser** | Add a management command (e.g. `seed_demo_recording`) that creates a known coach `User` (email/password from env), `CoachProfile`, and calls `load_demo()`. The Playwright script logs in through the real allauth form **before** recording starts (login happens off-camera). Alternative: mint a session cookie server-side and inject it. |
+| V4 | **Agent step** | **Pre-baked proposal.** A demo/recording mode (`MESO_AGENT_FAKE=1` setting, or a "demo mode" flag) short-circuits `agent_propose()` / `_reserve_plan_draft()` to return a fixed curated `ProposalBatch`/`ChangeSet` with **no** Anthropic call. Deterministic, free, and reused by the sandbox plan. |
+| V5 | **Output** | MP4 (Playwright native), written to a **git-ignored** artifact dir (`docs/demo/out/` or `build/`), optional GIF via `ffmpeg`. **Do not commit the binary** — commit the tool and regenerate. Host the produced video wherever it's shown. |
+
+## Storyboard (the scripted flow)
+
+Each step: navigate → wait on a stable selector → brief legibility pause →
+(optional) caption overlay.
+
+1. Land on `/meso/` roster — 5 seeded athletes + a group already visible.
+2. Open an athlete (Maya Okonkwo) → her delivered program + logged session.
+3. Open the **designer** → a periodized week (loads / %1RM).
+4. Trigger the **AI agent** → the pre-baked proposal appears ("the agent proposes").
+5. **Approve** the proposal → it applies ("the coach approves").
+6. **Deliver** a week to the athlete/group → confirmation (send is stubbed).
+7. _(Optional)_ Switch to the athlete phone view `/meso/me/` and log a set.
+
+## Making it re-recordable (the core requirement)
+
+- **Stable selectors.** Drive the script off `data-testid` / ARIA-role
+  selectors, never pixel coordinates or brittle CSS. This means adding a small,
+  enumerated set of `data-testid` attributes to the elements the script touches
+  (minor template edits) so restyles don't break the run.
+- **Auto-waiting, not sleeps.** Wait on selectors/network-idle so perf changes
+  don't desync the recording.
+- **Deterministic data + agent** (V2, V4).
+- **One command.** `just record-demo` = seed → run → output.
+- **Readable storyboard.** The script encodes the 7 steps as labelled blocks so
+  updating a step after a UI change is a one-line edit.
+
+## Phases
+
+1. **Plumbing** — add Playwright dev dep + `playwright install chromium` note;
+   `just record-demo`; `seed_demo_recording` command; the `MESO_AGENT_FAKE`
+   short-circuit in the agent path (V4).
+2. **The script** — `scripts/record_demo.py` implementing the storyboard,
+   writing MP4 to the artifact dir.
+3. **Polish** — captions/cursor/zoom, GIF export, a short `docs/demo/README.md`.
+
+## Key files & pointers
+
+- `justfile` — recipe pattern is `uv run python app/manage.py <cmd>`; dev server
+  on `:8034`; `just services` brings up DB `:5434` / Redis `:6334`.
+- `app/store_project/meso/demo.py` — `load_demo()` / `clear_demo()` (reuse for seed).
+- `app/store_project/meso/management/commands/seed_meso_demo.py` — fixed
+  `ATHLETES` / `SAMPLE_PLAN` / `GROUP` constants.
+- `app/store_project/meso/views.py:2332` `agent_propose()` and `:622`
+  `_reserve_plan_draft()` — the pre-baked short-circuit point.
+- New: `scripts/record_demo.py` (scripts dir currently holds only `backup.sh`),
+  a `record-demo` just recipe, `seed_demo_recording` mgmt command.
+
+## Risks / open questions
+
+- **Binary storage.** Don't commit the MP4 (repo bloat) — commit the tool,
+  gitignore the output, host the video where it's used. Confirm the host.
+- **Playwright browser install** in CI/dev — document `playwright install chromium`.
+- **`data-testid` churn** — keep the added attributes minimal and named for the
+  storyboard steps.

--- a/docs/meso/demo-walkthrough-video-plan.md
+++ b/docs/meso/demo-walkthrough-video-plan.md
@@ -1,6 +1,6 @@
 # Meso — Level-1 walkthrough demo video (automated, re-recordable)
 
-Status: **PLANNED** — not started. Tracking issue: _(add issue link when filed)_.
+Status: **PLANNED** — not started. Tracking issue: [#388](https://github.com/lancegoyke/fitness-store/issues/388).
 
 ## Why
 

--- a/docs/meso/nav-rename-coaching-to-meso-plan.md
+++ b/docs/meso/nav-rename-coaching-to-meso-plan.md
@@ -1,6 +1,6 @@
 # Meso — rename top-nav "Coaching" → "Meso"
 
-Status: **PLANNED** — not started. Tracking issue: _(add issue link when filed)_.
+Status: **PLANNED** — not started. Tracking issue: [#390](https://github.com/lancegoyke/fitness-store/issues/390).
 
 ## Why
 

--- a/docs/meso/nav-rename-coaching-to-meso-plan.md
+++ b/docs/meso/nav-rename-coaching-to-meso-plan.md
@@ -1,0 +1,49 @@
+# Meso — rename top-nav "Coaching" → "Meso"
+
+Status: **PLANNED** — not started. Tracking issue: _(add issue link when filed)_.
+
+## Why
+
+The only path from the site to the Meso app is a top-nav link labelled
+**"Coaching"**. On a personal trainer's site that reads as "hire a coach," not
+"open our app," so first-time visitors don't discover Meso. Relabel the visible
+text to **"Meso"**. The URL/route is unchanged.
+
+## Scope (small, surgical)
+
+- **Change the anchor text** in `app/store_project/templates/_nav.html:15` from
+  `Coaching` to `Meso`. The link stays `{% url 'meso:roster' %}` (`/meso/`) and
+  keeps its `active` highlight on the `meso` namespace.
+- **Update the two tests** that assert the literal nav string:
+  - `app/store_project/pages/tests/test_design_system_pr3.py:137–138` and `:160`
+  - `app/store_project/meso/tests/test_design_reconnect.py:96–99`
+  (Docstring/comment mentions of "Coaching" in those test files can be tidied too.)
+
+## Explicitly out of scope / leave alone
+
+- **No mobile-nav duplicate.** `_nav.html` uses one `.nav-links` container
+  toggled via a CSS checkbox — there is a single link to change.
+- **`templates/meso/landing.html:23`** — "Coaching, periodized" is marketing
+  copy (eyebrow), **not** a nav label. Leave it.
+- The footer has no "Coaching" reference.
+- The URL/route name (`meso:roster`) does **not** change.
+
+## Note for reviewer — duplicate "Meso" wordmark?
+
+The Meso workspace sub-header already renders a **"Meso"** wordmark
+(`templates/meso/_meso_base.html:35–38`), but that sub-header appears **only on
+Meso pages**. Renaming the top-nav link to "Meso" therefore creates no
+duplication off-Meso; on Meso pages the active top-nav "Meso" alongside the
+workspace wordmark is consistent, not confusing.
+
+## Acceptance criteria
+
+- The top nav shows **"Meso"** linking to `/meso/`, active-highlighted on the
+  `meso` namespace.
+- Both updated tests pass; `just test` green.
+- No other visible "Coaching" **nav** labels remain (marketing copy untouched).
+
+## Risk
+
+Trivial. The only trap is the two **exact-HTML** test assertions — update them in
+the same change or the suite breaks.

--- a/docs/meso/public-sandbox-demo-plan.md
+++ b/docs/meso/public-sandbox-demo-plan.md
@@ -1,0 +1,124 @@
+# Meso — public, no-signup interactive sandbox (Level-2 demo)
+
+Status: **PLANNED** — not started. Tracking issue: _(add issue link when filed)_.
+
+## Why
+
+The public Meso pages funnel every CTA to signup; there is no way to *try* the
+product first. The owner's call: a **no-signup, fully interactive, ephemeral
+sandbox** — a visitor lands in a populated coach workspace and can actually use
+it. The **one** capability held back is the AI agent, which is gated behind
+creating a real account. That gate does double duty: it keeps **all** agent
+usage attributable/metered to a real account, and it is the natural conversion
+moment.
+
+Sibling of the [walkthrough video](./demo-walkthrough-video-plan.md) ("level 1").
+
+## Decisions (locked with owner)
+
+| # | Decision | Choice |
+|---|----------|--------|
+| S1 | **Model** | **Ephemeral per-visitor sandbox.** On entry, mint a throwaway coach `User` + `CoachProfile`, seed it via `load_demo()`, and **log the visitor in** as that account. No signup to enter. |
+| S2 | **Interactivity** | **Fully interactive except the agent.** Build/edit programs, log sessions, explore roster/groups/designer — all real writes, scoped to the throwaway coach. |
+| S3 | **Agent gate** | Running the AI agent **requires creating a real account.** In the sandbox, "Draft with AI" / agent actions route to signup ("Create an account to run the agent"). The sandbox **never** calls Anthropic — so agent usage is always tied to a tracked account. |
+| S4 | **Side effects** | Email + web-push to athletes are **suppressed** for sandbox coaches; Stripe checkout/portal/trial are **hidden/blocked** (there is no real user to bill). Inviting/requesting a real email address is disabled in the sandbox. |
+| S5 | **Expiry** | Sandbox accounts + data **auto-expire** after a TTL (recommend 24–48h) via a **django-q2** scheduled cleanup, mirroring the invite-expiry schedule. |
+| S6 | **Carry-over** | **Deferred.** Phase 1: creating an account from the sandbox starts a **fresh** real workspace (sandbox work is not migrated). Migrating the in-progress program into the new account is a documented Phase 3 stretch. |
+| S7 | **Isolation** | Each visitor is a distinct throwaway `User`; existing coach-scoping (`Plan.for_coach`, `editable_by`, etc.) isolates data by user for free. Sandbox users carry a marker so guards + cleanup can find them. |
+
+## Why "ephemeral, logged-in throwaway coach" is the right shape
+
+The seam research found ~20 login-gated views plus `request.user` scoping and
+CSRF on every form. A **read-only anon** approach would need a custom auth layer
+to special-case all of them. The ephemeral approach sidesteps that entirely:
+because the visitor is *genuinely logged in* as the throwaway coach, every
+existing `login_required` view, CSRF token, and scoping query **just works**. We
+only add (a) sandbox creation/entry, (b) a handful of guards on the
+side-effectful actions, and (c) expiry cleanup.
+
+## How it works
+
+**Entry — `GET /meso/demo/` (public):**
+- If the session already has a live sandbox, resume it.
+- Else create one: `User` (email `{uuid}@sandbox.invalid`, unusable/random
+  password), `CoachProfile`, **sandbox marker**, `load_demo(user)`,
+  `login(request, user)`, and record `expires_at` (session + a `SandboxSession`
+  row). Then redirect to `/meso/` — which now renders the full workspace.
+
+**Guards — a single `is_sandbox(user)` helper short-circuits:**
+- **Agent** — `agent_propose()` (`views.py:2332`) and the `draft=1` path in
+  `plan_create()` → `_reserve_plan_draft()` (`views.py:622`): return the **signup
+  gate** instead of dispatching. (No Anthropic call — satisfies S3.)
+- **Email/push** — `coach_invite()`, `coach_invite_resend()`,
+  `athlete_request_coach()`, and `_notify_athlete_delivered()`
+  (`views.py:1518/1580/1447/2264`, push at `:2279`): no-op for sandbox; and
+  disable inviting arbitrary real emails in the sandbox UI.
+- **Stripe** — `billing_subscribe()`, `billing_portal()`, `billing_start_trial()`
+  (`views.py:2578/2619/2640`): hidden/blocked in sandbox.
+
+**Expiry — django-q2 scheduled task:**
+- A `SandboxSession` (or a `is_sandbox` marker + `created`) with `expires_at`; a
+  scheduled job deletes expired sandbox users (cascade removes their data; or
+  call `clear_demo()` then delete the user). Register via a data migration
+  mirroring `meso/migrations/0018_register_invite_schedules.py`. See
+  [`scheduling-plan.md`](./scheduling-plan.md).
+
+## Landmines → mitigations (from seam research)
+
+| Landmine | Mitigation |
+|---|---|
+| ~20 `login_required` views + `request.user` scoping | Visitor is really logged in as the throwaway coach → no special-casing. |
+| CSRF on every POST form | Real session → tokens issued normally. |
+| Agent API cost | Never called in sandbox (S3). |
+| Email/push leakage | Demo athletes already opt out + `.demo.invalid`; block real-email invites/requests for sandbox coaches. |
+| Stripe | Hide/disable billing surfaces for sandbox. |
+| Bot abuse / DB growth | Rate-limit sandbox creation (per IP/session), short TTL, cap concurrent sandboxes, unusable password, no possible outbound email. |
+| Marking sandbox users | Add a small **`SandboxSession`** model (OneToOne user, `created`, `expires_at`, source ip) rather than overloading `is_demo` (which is relationship/group-scoped, not user-scoped). |
+
+## Phases
+
+1. **Spine** — `SandboxSession` model + marker; `/meso/demo/` create+seed+login;
+   `is_sandbox()` guards on agent/billing/invites/email; UI: agent buttons →
+   signup gate, hide billing, a persistent "You're in a live demo — create an
+   account to run the agent / keep your work" banner; `expires_at`.
+2. **Cleanup + hardening** — django-q2 expiry task (mirror `0018_register_
+   invite_schedules`), rate-limit creation, concurrent-sandbox cap.
+3. **Carry-over (deferred, S6)** — migrate the visitor's sandbox work into a
+   newly created real account at signup.
+
+## Surfacing
+
+- A public **"Try the demo — no signup"** button on `templates/meso/landing.html`
+  and `templates/meso/become_coach.html` (both already public), linking to
+  `/meso/demo/`.
+- Homepage surfacing is **deferred** per owner.
+
+## Key files & pointers
+
+- Routes/views: `app/store_project/meso/urls.py`, `app/store_project/meso/views.py`
+  (`RosterView:259` splits anon→landing; agent `:2332`; email `:1518/1580/1447/2264`;
+  Stripe `:2578/2619/2640`; `demo_load:703`).
+- Demo data: `app/store_project/meso/demo.py` (`load_demo`/`clear_demo`, `.demo.invalid`).
+- Models: `app/store_project/meso/models.py` (`CoachProfile:46` has `created`;
+  `CoachAthlete.is_demo:239`, `MesoGroup.is_demo:1782`; scoping `Plan.for_coach`/
+  `editable_by` `:993–1040`).
+- Scheduling precedent: `meso/migrations/0018_register_invite_schedules.py`,
+  `agent/jobs.py` (`async_task` from `django_q.tasks`).
+
+## Acceptance criteria
+
+- A logged-out visitor hits `/meso/demo/` and lands in a populated, interactive
+  coach workspace with **no login**.
+- They can create/edit a program and log a session; changes persist for the
+  session's lifetime.
+- Any agent/AI action shows a **signup gate** and **never** calls Anthropic.
+- No email, push, or Stripe side effects occur for sandbox coaches.
+- Two concurrent visitors get **isolated** workspaces.
+- Sandbox data **auto-expires** and is cleaned up on schedule.
+
+## Risks / open
+
+- Carry-over deferred (S6) — decide before Phase 3.
+- Abuse/DB growth — TTL + rate limit + cap are the controls.
+- "Real writes by an anonymous visitor" — the hard invariant is that a sandbox
+  coach can **never** send email or be billed; guard at the view layer, not just the UI.

--- a/docs/meso/public-sandbox-demo-plan.md
+++ b/docs/meso/public-sandbox-demo-plan.md
@@ -1,6 +1,6 @@
 # Meso — public, no-signup interactive sandbox (Level-2 demo)
 
-Status: **PLANNED** — not started. Tracking issue: _(add issue link when filed)_.
+Status: **PLANNED** — not started. Tracking issue: [#389](https://github.com/lancegoyke/fitness-store/issues/389).
 
 ## Why
 


### PR DESCRIPTION
Adds three **PLANNED** specs under `docs/meso/`, born from a first-time-user
usability review (a new non-subscriber can't currently see Meso in action or
reach a demo without signing up). Each is scoped to be worked as its own issue
in a separate session.

- **`demo-walkthrough-video-plan.md`** — a *tool* that regenerates a Meso
  walkthrough video on demand (Playwright, deterministic seed, pre-baked agent),
  so the "level 1" demo stays fresh as the UI changes.
- **`public-sandbox-demo-plan.md`** — a no-signup, ephemeral, fully interactive
  sandbox ("level 2"). Everything is real and editable **except** the AI agent,
  which is gated behind creating a real account (keeps agent usage tracked +
  doubles as the conversion hook).
- **`nav-rename-coaching-to-meso-plan.md`** — relabel the top-nav "Coaching"
  link to "Meso" so first-timers discover the app.

Docs-only (no code); implementation is tracked by the linked issues.


---
Tracked by: #388 (video) · #389 (sandbox) · #390 (nav rename)
