### PR TITLE
feat(nav): rename top-nav "Coaching" → "Meso"

### DIFF
--- a/app/store_project/meso/tests/test_design_reconnect.py
+++ b/app/store_project/meso/tests/test_design_reconnect.py
@@ -8,7 +8,7 @@ rest of Mastering Fitness, and ``meso.css`` used its own purple-blue accent
 This phase reconnects Meso:
 
 - the **shared site nav** rides at the top of every coach-facing Meso shell page
-  (brand → home; About / Store / Challenges / Coaching / Contact; auth on the
+  (brand → home; About / Store / Challenges / Meso / Contact; auth on the
   right), so Meso reads as part of the same site, with the Meso workspace
   sub-header (``.meso-topnav``) kept below it;
 - the phone-first **athlete PWA** surfaces (home, session logger, offline,
@@ -89,13 +89,11 @@ class TestSharedSiteNav:
         assert reverse("challenges:challenge_filtered_list") in body
         assert reverse("pages:contact") in body
 
-    def test_coaching_link_is_marked_active(self, client):
+    def test_meso_link_is_marked_active(self, client):
         client.force_login(make_coach())
         body = client.get(reverse("meso:roster")).content.decode()
-        # Coaching is the current site section — the shared nav marks it active.
-        expected = '<a class="link active" href="%s">Coaching</a>' % reverse(
-            "meso:roster"
-        )
+        # Meso is the current site section — the shared nav marks it active.
+        expected = '<a class="link active" href="%s">Meso</a>' % reverse("meso:roster")
         assert expected in body
 
     def test_authenticated_coach_sees_account_and_logout(self, client):

--- a/app/store_project/meso/tests/test_landing.py
+++ b/app/store_project/meso/tests/test_landing.py
@@ -8,7 +8,7 @@ of Meso met a bare login wall, and Meso was linked from nowhere on the main site
 This phase splits ``/meso/`` on auth — an anonymous visitor sees a real landing
 page (what Meso is + two honest entry actions: log in as an athlete, or become a
 coach), while an authenticated visitor keeps the post-#311 role routing (coach →
-roster, anyone else → their training home). A single discreet "Coaching" link in
+roster, anyone else → their training home). A single discreet "Meso" link in
 the main-site nav makes Meso discoverable at all. See
 ``docs/archive/meso/first-time-ux-plan.md`` (Phase 3).
 

--- a/app/store_project/pages/tests/test_design_system_pr3.py
+++ b/app/store_project/pages/tests/test_design_system_pr3.py
@@ -134,7 +134,7 @@ class SharedNavMarkupTests(TestCase):
 
     def test_nav_keeps_every_site_section(self):
         html = _render_nav(AnonymousUser())
-        for label in ("About", "Store", "Challenges", "Coaching", "Contact"):
+        for label in ("About", "Store", "Challenges", "Meso", "Contact"):
             self.assertIn(f">{label}</a>", html)
 
     def test_nav_shows_auth_links_when_anonymous(self):
@@ -154,10 +154,10 @@ class SharedNavMarkupTests(TestCase):
         html = _render_nav(AnonymousUser(), match_url=url)
         self.assertIn(f'<a class="link active" href="{url}">Challenges</a>', html)
 
-    def test_coaching_section_highlights_inside_meso(self):
+    def test_meso_section_highlights_inside_meso(self):
         url = reverse("meso:roster")
         html = _render_nav(AnonymousUser(), match_url=url)
-        self.assertIn(f'<a class="link active" href="{url}">Coaching</a>', html)
+        self.assertIn(f'<a class="link active" href="{url}">Meso</a>', html)
 
     def test_about_section_highlights_on_about_page(self):
         url = reverse("pages:single", args=["about"])

--- a/app/store_project/templates/_nav.html
+++ b/app/store_project/templates/_nav.html
@@ -12,7 +12,7 @@
         <a class="link{% if rm.url_name == 'single' and rm.kwargs.slug == 'about' %} active{% endif %}" href="{% url 'pages:single' 'about' %}">About</a>
         <a class="link{% if rm.namespace == 'products' %} active{% endif %}" href="{% url 'products:store' %}">Store</a>
         <a class="link{% if rm.namespace == 'challenges' %} active{% endif %}" href="{% url 'challenges:challenge_filtered_list' %}">Challenges</a>
-        <a class="link{% if rm.namespace == 'meso' %} active{% endif %}" href="{% url 'meso:roster' %}">Coaching</a>
+        <a class="link{% if rm.namespace == 'meso' %} active{% endif %}" href="{% url 'meso:roster' %}">Meso</a>
         <a class="link{% if rm.url_name == 'contact' %} active{% endif %}" href="{% url 'pages:contact' %}">Contact</a>
       </nav>
       <span class="spacer"></span>


### PR DESCRIPTION
Fixes #390

## Summary
The only path from the site to the Meso app was a top-nav link labelled **"Coaching"**, which reads as "hire a coach," not "open our app" — so first-time visitors didn't discover Meso. This relabels the visible anchor text to **"Meso"**. The URL/route (`meso:roster` → `/meso/`) and the `active` highlight on the `meso` namespace are unchanged.

Plan: [`docs/meso/nav-rename-coaching-to-meso-plan.md`](https://github.com/lancegoyke/fitness-store/blob/main/docs/meso/nav-rename-coaching-to-meso-plan.md)

## Changes
- `app/store_project/templates/_nav.html` — anchor text `Coaching` → `Meso` (route + active highlight untouched).
- `pages/tests/test_design_system_pr3.py` — updated the two exact-HTML nav assertions + renamed `test_coaching_section_highlights_inside_meso` → `test_meso_section_highlights_inside_meso`.
- `meso/tests/test_design_reconnect.py` — updated the active-link assertion + renamed test + tidied the docstring.
- `meso/tests/test_landing.py` — tidied the docstring mention.

## Out of scope (left alone)
- `templates/meso/landing.html` "Coaching, periodized" — marketing eyebrow copy, not a nav label.
- Route name `meso:roster` — unchanged.

## Testing
`uv run pytest` on the three affected test files — **43 passed**. Pre-commit (ruff/DjHTML) green.