### PR TITLE
fix(meso): keep x-show badges flexed so the program tag dot sits inline

### DIFF
--- a/app/store_project/static/css/meso.css
+++ b/app/store_project/static/css/meso.css
@@ -208,11 +208,16 @@ button.meso-card,
   box-shadow: 0 0 0 3px var(--soft);
 }
 
-/* Display helper for elements toggled by x-show. Alpine resets style.display to
-   "" when revealing, which would drop an inline `display:flex`; sourcing the
-   flex from a class makes that reset fall back to flex instead of block. */
+/* Display helpers for elements toggled by x-show. Alpine resets style.display
+   to "" when revealing, which would drop an inline `display` value; sourcing the
+   display from a class makes that reset fall back to the intended value instead
+   of the element default (block). */
 .meso .meso-flex {
   display: flex;
+}
+
+.meso .meso-inline-block {
+  display: inline-block;
 }
 
 /* Segmented controls (mode / view / period toggles). The prototype rendered an

--- a/app/store_project/templates/meso/deliver.html
+++ b/app/store_project/templates/meso/deliver.html
@@ -24,7 +24,7 @@
     </div>
 
     <!-- pre-deliver -->
-    <div x-show="!delivered" style="display:flex;flex-direction:column;gap:14px;">
+    <div x-show="!delivered" class="meso-flex" style="flex-direction:column;gap:14px;">
       <div class="meso-card meso-card--pad">
         <div style="display:flex;align-items:center;gap:13px;">
           <div class="meso-avatar meso-avatar--lg {% if athlete.tone == 'accent' %}meso-avatar--accent{% endif %}">{{ athlete.initials }}</div>

--- a/app/store_project/templates/meso/designer.html
+++ b/app/store_project/templates/meso/designer.html
@@ -244,7 +244,7 @@
                             <div style="width:17px;height:17px;border-radius:5px;background:var(--accent);display:flex;align-items:center;justify-content:center;color:var(--accent-ink);font-size:10px;flex:0 0 auto;margin-top:1px;">&#10003;</div>
                             <div style="line-height:1.3;min-width:0;">
                               <div style="font-size:12.5px;font-weight:700;color:var(--accent-deep);" x-text="ch.title"></div>
-                              <div x-show="ch.member" style="font-size:10.5px;font-weight:650;color:var(--accent-ink);background:var(--accent);border-radius:5px;padding:1px 6px;display:inline-block;margin:3px 0 1px;" x-text="ch.member"></div>
+                              <div x-show="ch.member" class="meso-inline-block" style="font-size:10.5px;font-weight:650;color:var(--accent-ink);background:var(--accent);border-radius:5px;padding:1px 6px;margin:3px 0 1px;" x-text="ch.member"></div>
                               <div style="font-size:11.5px;color:var(--accent-deep);opacity:0.8;">
                                 <span x-show="ch.before" style="text-decoration:line-through;" x-text="ch.before"></span>
                                 <span x-show="ch.before && ch.after"> &#8594; </span>

--- a/app/store_project/templates/meso/designer.html
+++ b/app/store_project/templates/meso/designer.html
@@ -84,7 +84,7 @@
 
         <div style="flex:1;"></div>
 
-        <div x-show="cycleLabel" style="display:flex;align-items:center;gap:6px;padding:5px 11px;border-radius:7px;background:var(--soft);border:1px solid var(--soft-line);font-size:11.5px;font-weight:600;color:var(--accent-deep);">
+        <div x-show="cycleLabel" class="meso-flex" style="align-items:center;gap:6px;padding:5px 11px;border-radius:7px;background:var(--soft);border:1px solid var(--soft-line);font-size:11.5px;font-weight:600;color:var(--accent-deep);">
           <div style="width:6px;height:6px;border-radius:50%;background:var(--accent);"></div>
           <span x-text="cycleLabel"></span>
         </div>
@@ -222,7 +222,7 @@
           <!-- Agent coachmark (Phase 5): dismissible first-run orientation for the
                agent column. Shown in both modes — the agent is live for groups
                too (groups Phase 1, the shared program). -->
-          <div x-show="coachmarkVisible('agent')" style="flex:0 0 auto;display:flex;align-items:flex-start;gap:9px;margin:12px 14px 0;padding:11px 12px;background:var(--soft);border:1px solid var(--soft-line);border-left:3px solid var(--accent);border-radius:9px;">
+          <div x-show="coachmarkVisible('agent')" class="meso-flex" style="flex:0 0 auto;align-items:flex-start;gap:9px;margin:12px 14px 0;padding:11px 12px;background:var(--soft);border:1px solid var(--soft-line);border-left:3px solid var(--accent);border-radius:9px;">
             <div style="flex:1;min-width:0;line-height:1.4;">
               <div style="font-size:12.5px;font-weight:700;color:var(--accent-deep);">Talk to the agent</div>
               <div style="font-size:11.5px;color:var(--accent-deep);opacity:0.85;">Ask in plain words &#8212; &#8220;lighten Friday,&#8221; &#8220;add a deload week.&#8221; It drafts changes you can review.</div>
@@ -342,7 +342,7 @@
               <!-- Week switcher (multi-week designer): view any week, append the
                    next one, or make the viewed week the live (deliver-target)
                    one. Hidden until a real plan is loaded. -->
-              <div x-show="live && weeks.length" style="display:flex;align-items:center;gap:7px;flex-wrap:wrap;margin-bottom:16px;">
+              <div x-show="live && weeks.length" class="meso-flex" style="align-items:center;gap:7px;flex-wrap:wrap;margin-bottom:16px;">
                 <template x-for="w in weeks" :key="w.id">
                   <button type="button" @click="switchWeek(w.id)" data-hover="rail" :title="w.current ? 'Live week — delivery sends this one' : ('View ' + w.label)" :style="`appearance:none;cursor:pointer;font:inherit;display:inline-flex;align-items:center;gap:5px;font-size:11.5px;font-weight:650;padding:6px 11px;border-radius:999px;border:1px solid ${weekIsViewed(w) ? 'var(--accent)' : 'var(--line)'};background:${weekIsViewed(w) ? 'var(--accent)' : 'var(--surface)'};color:${weekIsViewed(w) ? 'var(--accent-ink)' : 'var(--ink)'};`">
                     <span x-text="w.label"></span>
@@ -355,7 +355,7 @@
 
               <!-- Grid coachmark (Phase 5): dismissible first-run note for the
                    week grid. Shown in both modes (the grid edits the same way). -->
-              <div x-show="coachmarkVisible('grid')" style="display:flex;align-items:flex-start;gap:9px;margin-bottom:16px;padding:11px 13px;background:var(--soft);border:1px solid var(--soft-line);border-left:3px solid var(--accent);border-radius:9px;">
+              <div x-show="coachmarkVisible('grid')" class="meso-flex" style="align-items:flex-start;gap:9px;margin-bottom:16px;padding:11px 13px;background:var(--soft);border:1px solid var(--soft-line);border-left:3px solid var(--accent);border-radius:9px;">
                 <div style="flex:1;min-width:0;line-height:1.4;">
                   <div style="font-size:12.5px;font-weight:700;color:var(--accent-deep);">The week grid</div>
                   <div style="font-size:11.5px;color:var(--accent-deep);opacity:0.85;">Tap any cell &#8212; sets, reps, load, RPE, or notes &#8212; to edit it. Every change autosaves.</div>
@@ -510,7 +510,7 @@
               <!-- Phone-preview coachmark (Phase 5): dismissible first-run note
                    making clear this is the athlete's real phone view, and the
                    path to delivery. Full-width so it sits above the phone. -->
-              <div x-show="coachmarkVisible('phone')" style="flex:0 0 100%;display:flex;align-items:flex-start;gap:9px;max-width:760px;padding:11px 13px;background:var(--soft);border:1px solid var(--soft-line);border-left:3px solid var(--accent);border-radius:9px;">
+              <div x-show="coachmarkVisible('phone')" class="meso-flex" style="flex:0 0 100%;align-items:flex-start;gap:9px;max-width:760px;padding:11px 13px;background:var(--soft);border:1px solid var(--soft-line);border-left:3px solid var(--accent);border-radius:9px;">
                 <div style="flex:1;min-width:0;line-height:1.4;">
                   <div style="font-size:12.5px;font-weight:700;color:var(--accent-deep);">Preview as your athlete</div>
                   <div style="font-size:11.5px;color:var(--accent-deep);opacity:0.85;">This is exactly what your athlete sees on their phone. Preview it, then Deliver to send the week.</div>


### PR DESCRIPTION
Fixes #384

## Summary

The Meso designer's program tag rendered its blue status dot **above** the
"Hypertrophy · Wk 2 / 4" text instead of inline with it.

**Root cause.** Alpine's `x-show` clears the inline `display` property when it
reveals an element (`x-show` show-path runs `el.style.removeProperty("display")`
— verified in the vendored `alpine.min.js` 3.11.1). Any `x-show` element that
sourced its `display` from its *inline* style therefore reverts to the element
default `display:block` when shown, so its children stack vertically. For the
program tag that dropped the 6px dot onto its own line above the label.

This is a known gotcha in this codebase — `meso.css` already ships a `.meso-flex`
helper with a comment documenting exactly this, and several rows (e.g. the
autosaved indicator) already use it. The affected rows just forgot to.

**Fix.** Source `display` from a class (which survives Alpine's inline-`display`
reset) instead of inline styles, keeping the other inline props as-is. Adds a
`.meso-inline-block` sibling to `.meso-flex` for the one pill that needs
`inline-block`, and generalizes the helper comment to cover any display value.

## Changes

`app/store_project/templates/meso/designer.html` — six `x-show` rows moved off
inline `display`:

- **Program tag** (`Hypertrophy · Wk N / M`) → `.meso-flex` — the reported bug
- Agent, grid, and phone **coachmarks** → `.meso-flex` (icon was stacking above text)
- **Multi-week switcher** → `.meso-flex` (week pills were stacking vertically)
- Change-attribution **member pill** → `.meso-inline-block` (was stretching full-width)

`app/store_project/templates/meso/deliver.html`

- Pre-deliver card stack → `.meso-flex` (restores the 14px `gap` block layout dropped)

`app/store_project/static/css/meso.css`

- Adds `.meso-inline-block` next to `.meso-flex`; generalizes the doc comment

After this, no `x-show` element in the Meso templates sources `display` from an
inline style — the whole class of bug is swept.

## Testing

- Standalone repros using the actual vendored `alpine.min.js` for all three
  shapes (flex row, flex column, inline-block): each buggy variant reproduces
  the stack/stretch/gap-loss, each fixed variant renders correctly, and a
  no-`x-show` control renders fine — isolating the cause to the `x-show` reset.
- `uv run pytest app/store_project/meso` → **1384 passed** (template/CSS-only change).
- Pre-commit (DjHTML + Biome) passed.

https://claude.ai/code/session_01JX2o56d7pu41ZAJgMA3TR2