### PR TITLE
fix(meso): stop showing contraindications on the athlete roster

### DIFF
--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -102,7 +102,8 @@ def roster_athlete(
         "initials": initials(name),
         "tone": "neutral",
         "meta": " · ".join(meta_parts) or "No training history on file",
-        "flags": [c.label for c in _active_contraindications(user)],
+        # Contraindications are intentionally absent here (issue #382): they belong
+        # on the athlete profile, not as badges cluttering the scannable roster row.
         # Adherence to the latest delivered week; ``None`` hides the meter.
         "compliance": compliance,
         "status": "suspended" if suspended else "",

--- a/app/store_project/meso/tests/test_adherence.py
+++ b/app/store_project/meso/tests/test_adherence.py
@@ -23,6 +23,7 @@ from store_project.meso import adherence
 from store_project.meso import presenters
 from store_project.meso.factories import CoachAthleteFactory
 from store_project.meso.factories import CoachProfileFactory
+from store_project.meso.factories import ContraindicationFactory
 from store_project.meso.factories import MesocycleFactory
 from store_project.meso.factories import PlanFactory
 from store_project.meso.factories import SessionFactory
@@ -262,6 +263,16 @@ class TestRosterPresenters:
         user = UserFactory()
         row = presenters.roster_athlete(user)
         assert row["compliance"] is None
+
+    def test_roster_athlete_omits_contraindications(self):
+        # Issue #382: contraindications belong on the athlete profile, not the
+        # scannable roster row — the presenter must not carry them as flags.
+        user = UserFactory()
+        ContraindicationFactory(
+            athlete=user, text="Cervical spine — avoid overhead pressing"
+        )
+        row = presenters.roster_athlete(user)
+        assert "flags" not in row
 
     def test_roster_activity_shape(self):
         rel = CoachAthleteFactory()

--- a/app/store_project/meso/tests/test_views.py
+++ b/app/store_project/meso/tests/test_views.py
@@ -33,6 +33,20 @@ class TestRosterScoping:
         assert "Devon Reyes" not in body  # pending, not on roster
         assert "Priya Nair" not in body  # another coach's athlete
 
+    def test_roster_hides_contraindications(self, client):
+        # Issue #382: the roster is a scannable index of athletes; a client's
+        # contraindications live on their profile, not as badges on the row.
+        coach = UserFactory()
+        athlete = UserFactory(name="Maya Okonkwo")
+        CoachAthleteFactory(coach=coach, athlete=athlete)
+        ContraindicationFactory(
+            athlete=athlete, text="Cervical spine — avoid overhead pressing"
+        )
+        client.force_login(coach)
+        body = client.get(reverse("meso:roster")).content.decode()
+        assert "Maya Okonkwo" in body  # athlete still listed
+        assert "Cervical spine" not in body  # contraindication not shown here
+
     def test_anonymous_sees_landing_not_login(self, client):
         # First-time-UX Phase 3: ``/meso/`` no longer bounces an anonymous
         # visitor to login — it renders the public landing (front door).

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -295,7 +295,6 @@ class RosterView(TemplateView):
             CoachAthlete.objects.for_coach(self.request.user)
             .active()
             .select_related("athlete", "athlete__athlete_profile")
-            .prefetch_related("athlete__contraindications")
             .order_by("athlete__name", "athlete__email")
         )
         # The downgrade soft-suspends every active link beyond the oldest free cap

--- a/app/store_project/templates/meso/roster.html
+++ b/app/store_project/templates/meso/roster.html
@@ -80,9 +80,6 @@
               {% if a.is_demo %}
                 <span class="meso-badge meso-badge--muted"><i></i>Demo</span>
               {% endif %}
-              {% for f in a.flags %}
-                <span class="meso-badge meso-badge--warn"><i></i>{{ f }}</span>
-              {% endfor %}
               {% if a.compliance is not None %}
                 <div style="width:108px;display:flex;align-items:center;gap:8px;">
                   <div class="meso-meter"><span style="width:{{ a.compliance }}%;"></span></div>


### PR DESCRIPTION
Fixes #382

## Summary
Contraindications are useful athlete detail, but on the coach's **main roster** they clutter a screen meant to be scanned at a glance. This drops the per-row contraindication warning badges from the roster. The information is unchanged on the **athlete profile page**, which is the right place for it.

## Changes
- `presenters.py` — remove the `flags` key (built from active contraindications) from `roster_athlete`.
- `roster.html` — remove the `{% for f in a.flags %}` warning-badge loop from the roster row.
- `views.py` — drop the now-unused `athlete__contraindications` prefetch from the roster query (one fewer query).

The group-detail page's cross-group contraindication flags and the athlete profile's contraindications list are untouched — this is scoped to the individual roster only.

## Testing
- New `test_roster_hides_contraindications` (view): a coach's roster no longer renders an athlete's contraindication label.
- New `test_roster_athlete_omits_contraindications` (presenter): `roster_athlete` no longer carries a `flags` key.
- Existing `test_profile_renders_real_athlete` still passes — the profile keeps showing contraindications.
- Full meso suite green (1386 passed); ruff clean; `/codex-review-loop` returned CLEAN on the first pass.

https://claude.ai/code/session_01JX2o56d7pu41ZAJgMA3TR2