### PR TITLE
feat(meso): 'just record-demo' — automated, re-recordable walkthrough video (#388)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,6 +98,14 @@ SENTRY_DSN=
 ANTHROPIC_API_KEY=
 MESO_AGENT_MODEL=claude-opus-4-8
 MESO_AGENT_RUN_SYNC=false
+# Demo/sandbox mode: pre-baked agent proposals, no Anthropic call and no API key
+# needed (a recorded walkthrough video / public sandbox). Off by default.
+MESO_AGENT_FAKE=false
+# Known credentials `manage.py seed_demo_recording` gives the demo-video coach
+# (and Maya, the demo athlete). Dev-only defaults — the command refuses to run
+# with DEBUG=False unless --force.
+MESO_DEMO_COACH_EMAIL=demo-coach@demo.invalid
+MESO_DEMO_COACH_PASSWORD=meso-demo-recording
 #
 # Web push (PWA). Generate a VAPID keypair (`vapid --gen`, or py_vapid): PUBLIC is
 # the base64url uncompressed point, PRIVATE the base64url raw key. Blank => push is

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ repomix-output.*
 # Front-end test suite (vitest)
 node_modules/
 coverage/
+
+# Meso demo-video recorder output (issue #388) — commit the tool
+# (scripts/record_demo.py), never the generated binary; `just record-demo`
+# regenerates it on demand. See docs/demo/README.md.
+docs/demo/out/

--- a/app/config/settings/base.py
+++ b/app/config/settings/base.py
@@ -290,6 +290,16 @@ MESO_AGENT_RUN_SYNC = os.environ.get("MESO_AGENT_RUN_SYNC", "false").lower() in 
     "true",
     "yes",
 )
+# Demo/sandbox mode (issues #388/#389): swap the Claude client for a curated,
+# deterministic one (``agent.fake.FakeDemoClient``) with no Anthropic call and no
+# network — for a re-recordable walkthrough video or a public sandbox that must
+# not require (or spend) a real API key. Checked before the API-key gate in
+# ``get_default_client``, so it works even when ``ANTHROPIC_API_KEY`` is unset.
+MESO_AGENT_FAKE = os.environ.get("MESO_AGENT_FAKE", "false").lower() in (
+    "1",
+    "true",
+    "yes",
+)
 
 # Meso web push (athlete PWA — decision S3/S7). Optional: with no keys configured,
 # push is a silent no-op (subscriptions are still stored, but nothing is sent) so

--- a/app/store_project/meso/agent/client.py
+++ b/app/store_project/meso/agent/client.py
@@ -342,7 +342,17 @@ class MesoAgentClient:
 
 
 def get_default_client():
-    """The configured client, or ``None`` when no API key is set."""
+    """The configured client, or ``None`` when no API key is set.
+
+    Checked before the API-key gate: demo/sandbox mode (``MESO_AGENT_FAKE``,
+    #388/#389) swaps in a curated, no-network ``FakeDemoClient`` so a recorded
+    walkthrough or a public sandbox needs no real key at all — and never spends
+    one, even if ``ANTHROPIC_API_KEY`` happens to be configured.
+    """
+    if getattr(settings, "MESO_AGENT_FAKE", False):
+        from .fake import FakeDemoClient
+
+        return FakeDemoClient()
     api_key = getattr(settings, "ANTHROPIC_API_KEY", "")
     if not api_key:
         return None

--- a/app/store_project/meso/agent/fake.py
+++ b/app/store_project/meso/agent/fake.py
@@ -16,6 +16,7 @@ camera. No randomness, no network, no ``anthropic`` import.
 import re
 
 from ..models import LoadType
+from .validation import _singular
 
 # Candidate swap targets, roughly ordered by how often they're a safe alternative
 # to a common lower-body/posterior-chain lift. Picked by elimination against the
@@ -53,7 +54,11 @@ def _contraindication_words(context):
     words = set()
     for text in texts:
         cleaned = re.sub(r"[^a-z\s]", " ", text.lower())
-        words.update(w for w in cleaned.split() if len(w) >= 4)
+        # Fold plurals with the guardrail's own ``_singular`` so "avoid squats"
+        # collides with the "Box Squat" candidate here, exactly as it would in
+        # ``validation`` — otherwise the fake proposes a swap the downstream
+        # guardrail rejects, and the batch quietly loses its headline edit.
+        words.update(_singular(w) for w in cleaned.split() if len(w) >= 4)
     return words
 
 
@@ -106,9 +111,12 @@ def _pick_swap_row(rows):
 
 def _pick_swap_name(current_name, forbidden_words):
     """The first candidate alternative that doesn't collide with ``forbidden_words``."""
-    current_words = set(re.sub(r"[^a-z\s]", " ", (current_name or "").lower()).split())
+    current_words = {
+        _singular(w)
+        for w in re.sub(r"[^a-z\s]", " ", (current_name or "").lower()).split()
+    }
     for candidate in _SWAP_ALTERNATIVES:
-        candidate_words = set(candidate.lower().split())
+        candidate_words = {_singular(w) for w in candidate.lower().split()}
         if candidate_words & current_words:
             continue  # not a real swap — same movement family as the current name
         if candidate_words & forbidden_words:
@@ -117,20 +125,28 @@ def _pick_swap_name(current_name, forbidden_words):
     return _FALLBACK_SWAP
 
 
-def _trimmed_sets(session):
-    """``(current, trimmed)`` set counts for a one-set volume trim on ``session``.
+def _pick_trim_row(rows, swap_session, used_ids):
+    """``(session, exercise, current_sets)`` for an honest one-set volume trim.
 
-    Reads the day's first row (the volume edit sets every row in the session,
-    but one honest number reads better on the review card than none); an
-    unparsable count falls back to ``(None, 3)`` so the card still shows a sane
-    target.
+    Targets ONE row (``prescription_id``), never the whole day: a day-wide
+    ``new_sets`` derived from one row would silently *increase* any row that
+    trains fewer sets (``apply._apply_volume`` writes the same count to every
+    row in a session). Wants a row not already edited by the swap/progress,
+    with a parseable count of 2+; rows outside the swap's day are preferred so
+    the batch visibly spans the week.
     """
-    raw = ((session.get("exercises") or [{}])[0].get("sets") or "").strip()
-    try:
-        current = int(raw)
-    except ValueError:
-        return None, 3
-    return current, max(current - 1, 2)
+    ordered = [r for r in rows if r[0].get("id") != swap_session.get("id")]
+    ordered += [r for r in rows if r[0].get("id") == swap_session.get("id")]
+    for session, exercise in ordered:
+        if exercise.get("id") in used_ids:
+            continue
+        try:
+            current = int((exercise.get("sets") or "").strip())
+        except ValueError:
+            continue
+        if current >= 2:
+            return session, exercise, current
+    return None
 
 
 def _bump_load(load_type, current_load):
@@ -238,23 +254,22 @@ class FakeDemoClient:
                 }
             )
 
-        # 3) A volume tweak on a different session, if the plan has another with rows.
-        volume_session = next(
-            (
-                s
-                for s in program
-                if s.get("id") != swap_session.get("id") and (s.get("exercises") or [])
-            ),
-            None,
-        )
-        if volume_session is not None:
-            current_sets, new_sets = _trimmed_sets(volume_session)
+        # 3) A one-set volume trim on a third row, elsewhere in the week if possible.
+        used_ids = {swap_exercise.get("id")}
+        if progress_row is not None:
+            used_ids.add(progress_row[1].get("id"))
+        trim = _pick_trim_row(rows, swap_session, used_ids)
+        if trim is not None:
+            trim_session, trim_exercise, current_sets = trim
+            trim_name = trim_exercise.get("name") or "Exercise"
+            new_sets = current_sets - 1
             changes.append(
                 {
                     "kind": "volume",
-                    "session_id": volume_session.get("id"),
-                    "title": f"{volume_session.get('name') or 'This day'} → trim a set",
-                    "before": f"{current_sets} sets" if current_sets else "",
+                    "prescription_id": trim_exercise.get("id"),
+                    "day_label": trim_session.get("name") or "",
+                    "title": f"{trim_name} → {new_sets} sets",
+                    "before": f"{current_sets} sets",
                     "after": f"{new_sets} sets",
                     "rationale": (
                         "Fatigue has been creeping up, so pulling back one set "

--- a/app/store_project/meso/agent/fake.py
+++ b/app/store_project/meso/agent/fake.py
@@ -57,12 +57,15 @@ def _contraindication_words(context):
     return words
 
 
-def _honors_note(context):
+def _honors_note(context, instruction):
     """The rule the swap honors, straight from the plan's own grounding.
 
-    The first contraindication text (athlete's, else the group's folded list) —
+    A real contraindication text (athlete's, else the group's folded list) —
     the same line the coach sees on the athlete card, so the review gate reads
-    "this respects *her* flag", not boilerplate. Truncated to the model column
+    "this respects *her* flag", not boilerplate. Prefer the flag the coach's
+    ``instruction`` is actually about (word overlap — "her knee is cranky"
+    picks the knee flag over an unrelated first-in-list one); ties and
+    no-overlap fall back to the first. Truncated to the model column
     (``validation._LIMITS``); a plan with no contraindications gets a generic
     coaching-rule note instead of an empty honors line.
     """
@@ -70,9 +73,21 @@ def _honors_note(context):
     group = context.get("group") or {}
     texts = list(athlete.get("contraindications") or [])
     texts += list(group.get("contraindications") or [])
-    if texts:
-        return texts[0][:255]
-    return "the plan's movement preferences"
+    if not texts:
+        return "the plan's movement preferences"
+    instruction_words = {
+        w
+        for w in re.sub(r"[^a-z\s]", " ", (instruction or "").lower()).split()
+        if len(w) >= 4
+    }
+
+    def overlap(text):
+        text_words = {
+            w for w in re.sub(r"[^a-z\s]", " ", text.lower()).split() if len(w) >= 4
+        }
+        return len(text_words & instruction_words)
+
+    return max(texts, key=overlap)[:255]
 
 
 def _pick_swap_row(rows):
@@ -100,6 +115,22 @@ def _pick_swap_name(current_name, forbidden_words):
             continue  # would reintroduce a flagged movement
         return candidate
     return _FALLBACK_SWAP
+
+
+def _trimmed_sets(session):
+    """``(current, trimmed)`` set counts for a one-set volume trim on ``session``.
+
+    Reads the day's first row (the volume edit sets every row in the session,
+    but one honest number reads better on the review card than none); an
+    unparsable count falls back to ``(None, 3)`` so the card still shows a sane
+    target.
+    """
+    raw = ((session.get("exercises") or [{}])[0].get("sets") or "").strip()
+    try:
+        current = int(raw)
+    except ValueError:
+        return None, 3
+    return current, max(current - 1, 2)
 
 
 def _bump_load(load_type, current_load):
@@ -171,7 +202,7 @@ class FakeDemoClient:
                     "forgiving range of motion — the work stays hard without "
                     "aggravating anything."
                 ),
-                "honors": _honors_note(context),
+                "honors": _honors_note(context, instruction),
                 "introduces_exercise": swap_name,
                 "new_name": swap_name,
             }
@@ -186,13 +217,19 @@ class FakeDemoClient:
             _, progress_exercise = progress_row
             progress_name = progress_exercise.get("name") or "Exercise"
             load_type = progress_exercise.get("load_type") or LoadType.ABSOLUTE
-            new_load = _bump_load(load_type, progress_exercise.get("load"))
+            current_load = progress_exercise.get("load") or ""
+            new_load = _bump_load(load_type, current_load)
             suffix = "%" if load_type == LoadType.PERCENT else ""
             changes.append(
                 {
                     "kind": "progress",
                     "prescription_id": progress_exercise.get("id"),
                     "title": f"{progress_name} → {new_load}{suffix}",
+                    # before/after are display-only, but the review card renders
+                    # its strikethrough → arrow row unconditionally — leaving
+                    # them empty shows a dangling arrow on camera.
+                    "before": f"{current_load}{suffix}" if current_load else "",
+                    "after": f"{new_load}{suffix}",
                     "rationale": (
                         "A small, defensible step up from loads already handled "
                         "comfortably the last couple of sessions."
@@ -201,21 +238,29 @@ class FakeDemoClient:
                 }
             )
 
-        # 3) A volume tweak on a different session, if the plan has more than one.
+        # 3) A volume tweak on a different session, if the plan has another with rows.
         volume_session = next(
-            (s for s in program if s.get("id") != swap_session.get("id")), None
+            (
+                s
+                for s in program
+                if s.get("id") != swap_session.get("id") and (s.get("exercises") or [])
+            ),
+            None,
         )
         if volume_session is not None:
+            current_sets, new_sets = _trimmed_sets(volume_session)
             changes.append(
                 {
                     "kind": "volume",
                     "session_id": volume_session.get("id"),
                     "title": f"{volume_session.get('name') or 'This day'} → trim a set",
+                    "before": f"{current_sets} sets" if current_sets else "",
+                    "after": f"{new_sets} sets",
                     "rationale": (
                         "Fatigue has been creeping up, so pulling back one set "
                         "keeps the stimulus without digging the hole any deeper."
                     ),
-                    "new_sets": "3",
+                    "new_sets": str(new_sets),
                 }
             )
 

--- a/app/store_project/meso/agent/fake.py
+++ b/app/store_project/meso/agent/fake.py
@@ -1,0 +1,226 @@
+"""Demo/sandbox mode: a pre-baked agent client with no Anthropic call (#388/#389).
+
+``FakeDemoClient`` stands in for ``MesoAgentClient`` when ``MESO_AGENT_FAKE`` is
+set — for a re-recordable walkthrough video or a public sandbox, where a curated,
+repeatable proposal reads better on camera than whatever a live model happens to
+return, and where no real API key should be required (or spent) at all.
+
+Like ``evals.ScriptedEvalClient``, it reads the plan context
+(``agent.service.build_context``) to target real rows so the downstream
+guardrail (``agent.validation.clean_change``) accepts the batch end-to-end; unlike
+the eval client it aims for polish — a small, curated batch with coach-voiced
+copy, since this is exactly what a prospective coach sees in the review gate on
+camera. No randomness, no network, no ``anthropic`` import.
+"""
+
+import re
+
+from ..models import LoadType
+
+# Candidate swap targets, roughly ordered by how often they're a safe alternative
+# to a common lower-body/posterior-chain lift. Picked by elimination against the
+# plan's contraindication words, so the demo never has to rely on the
+# (real, still-enforced) validation guardrail rejecting an unsafe suggestion.
+_SWAP_ALTERNATIVES = [
+    "Box Squat",
+    "Hip Thrust",
+    "Trap Bar Deadlift",
+    "Chest-Supported Row",
+    "Goblet Squat",
+    "Supported Split Squat",
+]
+
+# A generic, low-risk fallback if every candidate above collides with the plan's
+# contraindications (an unlikely, but not impossible, demo plan).
+_FALLBACK_SWAP = "Coach's Choice Alternative"
+
+
+def _contraindication_words(context):
+    """Movement words the demo must not reintroduce.
+
+    Reads the same contraindication texts the real client is grounded on — an
+    individual plan's ``athlete.contraindications`` or a group plan's folded
+    ``group.contraindications`` (``agent.service.build_context``) — and pulls out
+    plain lowercase words. Deliberately loose (no stemming, no stopword list, a
+    shorter minimum length than ``validation._significant_words``) since this is a
+    *pre-filter* to keep the demo tasteful; the real guardrail
+    (``validation.clean_change``) is still the enforced backstop.
+    """
+    athlete = context.get("athlete") or {}
+    group = context.get("group") or {}
+    texts = list(athlete.get("contraindications") or [])
+    texts += list(group.get("contraindications") or [])
+    words = set()
+    for text in texts:
+        cleaned = re.sub(r"[^a-z\s]", " ", text.lower())
+        words.update(w for w in cleaned.split() if len(w) >= 4)
+    return words
+
+
+def _honors_note(context):
+    """The rule the swap honors, straight from the plan's own grounding.
+
+    The first contraindication text (athlete's, else the group's folded list) —
+    the same line the coach sees on the athlete card, so the review gate reads
+    "this respects *her* flag", not boilerplate. Truncated to the model column
+    (``validation._LIMITS``); a plan with no contraindications gets a generic
+    coaching-rule note instead of an empty honors line.
+    """
+    athlete = context.get("athlete") or {}
+    group = context.get("group") or {}
+    texts = list(athlete.get("contraindications") or [])
+    texts += list(group.get("contraindications") or [])
+    if texts:
+        return texts[0][:255]
+    return "the plan's movement preferences"
+
+
+def _pick_swap_row(rows):
+    """The row a joint-sparing swap tells the best story on.
+
+    Prefer the first row *not* already tagged as a curated-safe pick (e.g.
+    ``knee-safe``): swapping the one exercise the coach already made safe
+    undercuts the honors line right next to it. Falls back to the first row.
+    """
+    for session, exercise in rows:
+        tag = (exercise.get("tag") or "").lower()
+        if "safe" not in tag:
+            return session, exercise
+    return rows[0]
+
+
+def _pick_swap_name(current_name, forbidden_words):
+    """The first candidate alternative that doesn't collide with ``forbidden_words``."""
+    current_words = set(re.sub(r"[^a-z\s]", " ", (current_name or "").lower()).split())
+    for candidate in _SWAP_ALTERNATIVES:
+        candidate_words = set(candidate.lower().split())
+        if candidate_words & current_words:
+            continue  # not a real swap — same movement family as the current name
+        if candidate_words & forbidden_words:
+            continue  # would reintroduce a flagged movement
+        return candidate
+    return _FALLBACK_SWAP
+
+
+def _bump_load(load_type, current_load):
+    """A small, defensible progression on ``current_load``, respecting its type.
+
+    A ``pct`` row is a bare percentage of 1RM — bumped by a couple of points and
+    capped near 100; an ``abs`` row is a plate-loadable weight — bumped by 2.5.
+    Both stay **bare numbers**: ``apply`` writes ``new_load`` verbatim into the
+    prescription's ``load`` column, and every existing row stores loads unitless
+    (the unit lives on the plan) — a suffixed "62.5 kg" would render as the one
+    inconsistent cell in the designer grid. Falls back to a sane default when the
+    current value isn't a plain number (e.g. "BW"), so the demo never emits an
+    unparsable load.
+    """
+    if load_type == LoadType.PERCENT:
+        try:
+            current = float((current_load or "").rstrip("%").strip())
+        except ValueError:
+            return "80"
+        bumped = min(current + 2, 100)
+        return str(int(bumped)) if bumped == int(bumped) else str(bumped)
+    try:
+        current = float((current_load or "").strip())
+    except ValueError:
+        return "62.5"
+    bumped = current + 2.5
+    return str(int(bumped)) if bumped == int(bumped) else str(bumped)
+
+
+class FakeDemoClient:
+    """No-network stand-in for ``MesoAgentClient`` (demo/sandbox mode)."""
+
+    model = "meso-fake-demo"
+
+    def propose(self, *, context, instruction):
+        program = (context.get("plan") or {}).get("program") or []
+        rows = [
+            (session, exercise)
+            for session in program
+            for exercise in (session.get("exercises") or [])
+        ]
+
+        if not rows:
+            return {
+                "summary": (
+                    "This week doesn't have any exercises yet — build out the "
+                    "days and I'll take it from there."
+                ),
+                "changes": [],
+            }
+
+        forbidden = _contraindication_words(context)
+        changes = []
+
+        # 1) A joint-friendly swap — on the row that isn't already the safe pick.
+        swap_session, swap_exercise = _pick_swap_row(rows)
+        current_name = swap_exercise.get("name") or "Exercise"
+        swap_name = _pick_swap_name(current_name, forbidden)
+        changes.append(
+            {
+                "kind": "swap",
+                "prescription_id": swap_exercise.get("id"),
+                "day_label": swap_session.get("name") or "",
+                "title": f"{current_name} → {swap_name}",
+                "before": current_name,
+                "after": swap_name,
+                "rationale": (
+                    f"{swap_name} trains the same pattern through a shorter, more "
+                    "forgiving range of motion — the work stays hard without "
+                    "aggravating anything."
+                ),
+                "honors": _honors_note(context),
+                "introduces_exercise": swap_name,
+                "new_name": swap_name,
+            }
+        )
+
+        # 2) A small, load-type-aware progression on a different row, if there is one.
+        progress_row = next(
+            ((s, e) for s, e in rows if e.get("id") != swap_exercise.get("id")),
+            None,
+        )
+        if progress_row is not None:
+            _, progress_exercise = progress_row
+            progress_name = progress_exercise.get("name") or "Exercise"
+            load_type = progress_exercise.get("load_type") or LoadType.ABSOLUTE
+            new_load = _bump_load(load_type, progress_exercise.get("load"))
+            suffix = "%" if load_type == LoadType.PERCENT else ""
+            changes.append(
+                {
+                    "kind": "progress",
+                    "prescription_id": progress_exercise.get("id"),
+                    "title": f"{progress_name} → {new_load}{suffix}",
+                    "rationale": (
+                        "A small, defensible step up from loads already handled "
+                        "comfortably the last couple of sessions."
+                    ),
+                    "new_load": new_load,
+                }
+            )
+
+        # 3) A volume tweak on a different session, if the plan has more than one.
+        volume_session = next(
+            (s for s in program if s.get("id") != swap_session.get("id")), None
+        )
+        if volume_session is not None:
+            changes.append(
+                {
+                    "kind": "volume",
+                    "session_id": volume_session.get("id"),
+                    "title": f"{volume_session.get('name') or 'This day'} → trim a set",
+                    "rationale": (
+                        "Fatigue has been creeping up, so pulling back one set "
+                        "keeps the stimulus without digging the hole any deeper."
+                    ),
+                    "new_sets": "3",
+                }
+            )
+
+        summary = (
+            "Swapped in a joint-friendly alternative, nudged a load forward "
+            "where it's been earned, and trimmed a set where fatigue is building."
+        )
+        return {"summary": summary, "changes": changes}

--- a/app/store_project/meso/management/commands/seed_demo_recording.py
+++ b/app/store_project/meso/management/commands/seed_demo_recording.py
@@ -14,9 +14,12 @@ command is that command's deterministic sibling:
 - the coach is **comped** (``CoachSubscription.comp``) — the demo workspace (5
   athletes + a group) would otherwise trip the free-tier seat/agent gates and
   freeze the designer/agent mid-recording;
-- the full demo workspace is loaded via ``meso.demo.load_demo`` (the same 5
-  athletes + Maya's built/delivered/logged plan + the demo group), so the
-  recording has real, populated screens to show;
+- the demo workspace is **reset** (``clear_demo`` → ``load_demo``) rather than
+  topped up: ``load_demo`` alone upserts rows but keeps whatever a previous
+  recording added on top (applied agent batches, their designer chat history,
+  logged sets), and run N's video would show N-1 stale agent threads on
+  camera. Every recording starts from the same pristine workspace (the same 5
+  athletes + Maya's built/delivered/logged plan + the demo group);
 - Maya Okonkwo — the demo's "hero" athlete — additionally gets a **usable**
   password (the same as the coach's) so an optional athlete-phone-view shot in
   the storyboard can log in as her too; her four demo siblings keep their
@@ -36,6 +39,7 @@ from django.core.management.base import CommandError
 from django.core.management.base import CommandParser
 from django.db import transaction
 
+from store_project.meso.demo import clear_demo
 from store_project.meso.demo import demo_email
 from store_project.meso.demo import load_demo
 from store_project.meso.models import CoachProfile
@@ -110,6 +114,10 @@ class Command(BaseCommand):
         coach = self._ensure_coach(email, password)
         CoachProfile.objects.get_or_create(user=coach)
         CoachSubscription.comp(coach)
+        # Reset, don't top up: drop whatever a previous recording layered onto
+        # the workspace (applied batches + their designer chat thread, logged
+        # sets) so every video starts from the identical pristine state.
+        clear_demo(coach)
         load_demo(coach)
         athlete_email = self._ensure_maya_login(coach, password)
 

--- a/app/store_project/meso/management/commands/seed_demo_recording.py
+++ b/app/store_project/meso/management/commands/seed_demo_recording.py
@@ -1,0 +1,165 @@
+"""Seed a deterministic demo coach with known credentials for video recording.
+
+Issue #388 (Level-1 demo): the automated, re-recordable walkthrough video drives
+a real browser through the real allauth login form, so the recorder needs a
+coach whose credentials are **known in advance** — not ``seed_meso_demo``'s
+coach, whose password is a ``get_random_string(16)`` throwaway printed once to
+stdout (fine for a human skimming it, useless for an unattended script). This
+command is that command's deterministic sibling:
+
+- the coach's email + password are **known** (``--email``/``--password`` →
+  ``MESO_DEMO_COACH_EMAIL``/``MESO_DEMO_COACH_PASSWORD`` → a fixed default),
+  and the password is **(re)set on every run** — a stale/rotated password from
+  a prior recording session can never lock the recorder out;
+- the coach is **comped** (``CoachSubscription.comp``) — the demo workspace (5
+  athletes + a group) would otherwise trip the free-tier seat/agent gates and
+  freeze the designer/agent mid-recording;
+- the full demo workspace is loaded via ``meso.demo.load_demo`` (the same 5
+  athletes + Maya's built/delivered/logged plan + the demo group), so the
+  recording has real, populated screens to show;
+- Maya Okonkwo — the demo's "hero" athlete — additionally gets a **usable**
+  password (the same as the coach's) so an optional athlete-phone-view shot in
+  the storyboard can log in as her too; her four demo siblings keep their
+  unusable passwords (nobody needs to log in as them).
+
+Guardrail: this creates (or overwrites) a **known-password, comped** account —
+harmless on a throwaway dev/staging box, a real liability anywhere real. It
+refuses to run unless ``settings.DEBUG`` is on, or ``--force`` is passed.
+"""
+
+import json
+import os
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.core.management.base import CommandError
+from django.core.management.base import CommandParser
+from django.db import transaction
+
+from store_project.meso.demo import demo_email
+from store_project.meso.demo import load_demo
+from store_project.meso.models import CoachProfile
+from store_project.meso.models import CoachSubscription
+from store_project.users.models import User
+
+DEFAULT_COACH_EMAIL = "demo-coach@demo.invalid"
+DEFAULT_COACH_PASSWORD = "meso-demo-recording"
+DEFAULT_COACH_NAME = "Demo Coach"
+
+#: The demo's "hero" athlete (``seed_meso_demo.ATHLETES``'s ``"maya"`` slug) —
+#: the one demo athlete given a usable, known password for the optional
+#: athlete-phone-view recording step.
+MAYA_SLUG = "maya"
+
+
+class Command(BaseCommand):
+    help = (
+        "Seed a deterministic, known-password demo coach + full demo workspace "
+        "for the demo-video recorder (dev/staging only; pass --force elsewhere)."
+    )
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument(
+            "--email",
+            default=None,
+            help=(
+                "Coach email (default: $MESO_DEMO_COACH_EMAIL, else "
+                f"{DEFAULT_COACH_EMAIL})."
+            ),
+        )
+        parser.add_argument(
+            "--password",
+            default=None,
+            help=(
+                "Coach password, (re)set on every run (default: "
+                "$MESO_DEMO_COACH_PASSWORD, else a fixed known default)."
+            ),
+        )
+        parser.add_argument(
+            "--json",
+            action="store_true",
+            help="Print the result as a single JSON object instead of text lines.",
+        )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Allow running with settings.DEBUG off (never do this on prod).",
+        )
+
+    @transaction.atomic
+    def handle(self, *args, **options):
+        if not settings.DEBUG and not options["force"]:
+            raise CommandError(
+                "Refusing to seed a known-password, comped demo coach with "
+                "DEBUG off — this would create/overwrite that account "
+                "wherever it runs. Pass --force if you really mean it (e.g. a "
+                "disposable staging box)."
+            )
+
+        email = (
+            options["email"]
+            or os.environ.get("MESO_DEMO_COACH_EMAIL")
+            or DEFAULT_COACH_EMAIL
+        )
+        password = (
+            options["password"]
+            or os.environ.get("MESO_DEMO_COACH_PASSWORD")
+            or DEFAULT_COACH_PASSWORD
+        )
+
+        coach = self._ensure_coach(email, password)
+        CoachProfile.objects.get_or_create(user=coach)
+        CoachSubscription.comp(coach)
+        load_demo(coach)
+        athlete_email = self._ensure_maya_login(coach, password)
+
+        result = {"coach_email": coach.email, "athlete_email": athlete_email}
+        if options["json"]:
+            self.stdout.write(json.dumps(result))
+            return
+
+        self.stdout.write(self.style.SUCCESS(f"✓ Demo coach ready: {coach.email}"))
+        if athlete_email:
+            self.stdout.write(f"  - Maya (athlete) login: {athlete_email}")
+        else:
+            self.stdout.write(
+                self.style.WARNING(
+                    "  - Maya's demo athlete row was not found; her login was "
+                    "not set up."
+                )
+            )
+
+    # -- coach ----------------------------------------------------------------
+
+    def _ensure_coach(self, email, password):
+        """The demo coach, with a **known, always-current** password + name."""
+        coach, _created = User.objects.get_or_create(
+            email=email, defaults={"username": email, "name": DEFAULT_COACH_NAME}
+        )
+        coach.name = DEFAULT_COACH_NAME
+        coach.set_password(password)
+        coach.save()
+        return coach
+
+    # -- Maya's athlete login ---------------------------------------------------
+
+    def _ensure_maya_login(self, coach, password):
+        """Give Maya's demo athlete a usable, known password.
+
+        Non-fatal if her row is somehow absent (e.g. ``load_demo`` changes
+        shape underneath this command) — the recorder can still shoot the
+        coach-side flows; only the optional athlete-phone-view step needs her.
+        """
+        maya_email = demo_email(coach, MAYA_SLUG)
+        maya = User.objects.filter(email=maya_email).first()
+        if maya is None:
+            self.stderr.write(
+                self.style.WARNING(
+                    f"Maya's demo athlete row ({maya_email}) was not found "
+                    "(did load_demo run?) — skipping her login setup."
+                )
+            )
+            return None
+        maya.set_password(password)
+        maya.save(update_fields=["password"])
+        return maya.email

--- a/app/store_project/meso/tests/test_agent_fake.py
+++ b/app/store_project/meso/tests/test_agent_fake.py
@@ -198,6 +198,60 @@ class TestFakeDemoClientPropose:
         assert volume["after"] == "3 sets"
         assert volume["new_sets"] == "3"
 
+    def test_swap_respects_plural_contraindication_wording(self):
+        # "avoid squats" must collide with the "Box Squat" candidate the same
+        # way validation's singular-folded guardrail sees it — otherwise the
+        # fake proposes a swap the downstream guardrail rejects and the batch
+        # quietly loses its headline edit.
+        context = {
+            "plan": {
+                "program": [
+                    {
+                        "id": 1,
+                        "name": "Lower",
+                        "exercises": [{"id": 11, "name": "Leg Press"}],
+                    }
+                ]
+            },
+            "athlete": {"contraindications": ["Avoid heavy squats and deadlifts"]},
+        }
+        result = FakeDemoClient().propose(context=context, instruction="go")
+        swap = next(c for c in result["changes"] if c["kind"] == "swap")
+        assert "squat" not in swap["introduces_exercise"].lower()
+        assert "deadlift" not in swap["introduces_exercise"].lower()
+
+    def test_volume_trim_targets_one_row_never_the_whole_day(self):
+        # A day-wide new_sets derived from one row would silently *increase*
+        # any row training fewer sets (apply writes the same count to every
+        # row in a session) — the trim must target a single prescription.
+        context = {
+            "plan": {
+                "program": [
+                    {
+                        "id": 1,
+                        "name": "Lower",
+                        "exercises": [{"id": 11, "name": "Back Squat"}],
+                    },
+                    {
+                        "id": 2,
+                        "name": "Upper",
+                        "exercises": [
+                            {"id": 21, "name": "Bench Press", "sets": "4"},
+                            {"id": 22, "name": "Seated Row", "sets": "2"},
+                        ],
+                    },
+                ]
+            }
+        }
+        result = FakeDemoClient().propose(context=context, instruction="go")
+        volume = next(c for c in result["changes"] if c["kind"] == "volume")
+        # Bench (21) is taken by the progression; the trim lands on the row's
+        # own count (2 → 1), not a day-wide value that would bump it to 3.
+        assert volume["prescription_id"] == 22
+        assert "session_id" not in volume
+        assert volume["new_sets"] == "1"
+        assert volume["before"] == "2 sets"
+
     def test_abs_progression_stays_a_bare_number(self):
         # ``apply`` writes new_load verbatim into the load column, where every
         # existing row is unitless — a "kg" suffix would be the one odd cell in

--- a/app/store_project/meso/tests/test_agent_fake.py
+++ b/app/store_project/meso/tests/test_agent_fake.py
@@ -139,6 +139,65 @@ class TestFakeDemoClientPropose:
         progress = next(c for c in result["changes"] if c["kind"] == "progress")
         assert progress["prescription_id"] == 11
 
+    def test_honors_picks_the_contraindication_the_instruction_is_about(self):
+        # Maya's demo card lists an unrelated flag first; the coach's knee-themed
+        # instruction should pull the knee flag into the honors chip, not
+        # whatever happens to be first in the list.
+        context = {
+            "plan": {
+                "program": [
+                    {
+                        "id": 1,
+                        "name": "Lower",
+                        "exercises": [{"id": 11, "name": "Bulgarian Split Squat"}],
+                    }
+                ]
+            },
+            "athlete": {
+                "contraindications": [
+                    "No max-effort jumping / impact",
+                    "L knee — avoid deep knee flexion under load",
+                ]
+            },
+        }
+        result = FakeDemoClient().propose(
+            context=context,
+            instruction="Her left knee has been cranky — keep this week knee-friendly.",
+        )
+        swap = next(c for c in result["changes"] if c["kind"] == "swap")
+        assert swap["honors"] == "L knee — avoid deep knee flexion under load"
+
+    def test_every_change_fills_the_before_after_row(self):
+        # The review card renders its strikethrough → arrow row unconditionally;
+        # an empty pair shows a dangling arrow on camera.
+        context = {
+            "plan": {
+                "program": [
+                    {
+                        "id": 1,
+                        "name": "Lower",
+                        "exercises": [
+                            {"id": 11, "name": "Back Squat", "load": "100"},
+                            {"id": 12, "name": "Leg Press", "load": "110"},
+                        ],
+                    },
+                    {
+                        "id": 2,
+                        "name": "Upper",
+                        "exercises": [{"id": 21, "name": "Bench Press", "sets": "4"}],
+                    },
+                ]
+            }
+        }
+        result = FakeDemoClient().propose(context=context, instruction="go")
+        assert len(result["changes"]) == 3
+        for change in result["changes"]:
+            assert change["after"], change
+        volume = next(c for c in result["changes"] if c["kind"] == "volume")
+        assert volume["before"] == "4 sets"
+        assert volume["after"] == "3 sets"
+        assert volume["new_sets"] == "3"
+
     def test_abs_progression_stays_a_bare_number(self):
         # ``apply`` writes new_load verbatim into the load column, where every
         # existing row is unitless — a "kg" suffix would be the one odd cell in

--- a/app/store_project/meso/tests/test_agent_fake.py
+++ b/app/store_project/meso/tests/test_agent_fake.py
@@ -1,0 +1,194 @@
+"""Demo/sandbox mode (#388/#389) — a pre-baked agent client, no Anthropic call.
+
+``MESO_AGENT_FAKE`` swaps ``get_default_client`` for ``agent.fake.FakeDemoClient``
+so a recorded walkthrough video / a public sandbox never needs a real API key and
+never touches the network. It runs through the exact same pipeline as the real
+client (``service.run_proposal_job`` → ``validation.clean_change`` → the review
+gate), so these tests exercise it end-to-end rather than mocking the seams.
+"""
+
+import json
+
+import pytest
+from django.test import override_settings
+from django.urls import reverse
+
+from store_project.meso.agent import client as client_module
+from store_project.meso.agent import service
+from store_project.meso.agent.fake import FakeDemoClient
+from store_project.meso.factories import ContraindicationFactory
+from store_project.meso.models import AgentProposalBatch
+from store_project.meso.tests.test_agent_validation import make_plan
+
+pytestmark = pytest.mark.django_db
+
+
+# -- get_default_client wiring ----------------------------------------------
+
+
+class TestGetDefaultClientFake:
+    @override_settings(MESO_AGENT_FAKE=True, ANTHROPIC_API_KEY="")
+    def test_fake_setting_wins_even_with_no_api_key(self):
+        client = client_module.get_default_client()
+        assert isinstance(client, FakeDemoClient)
+
+    @override_settings(MESO_AGENT_FAKE=True, ANTHROPIC_API_KEY="sk-ant-real-key")
+    def test_fake_setting_wins_over_a_real_api_key(self):
+        # The demo mode must not accidentally spend real API credits.
+        client = client_module.get_default_client()
+        assert isinstance(client, FakeDemoClient)
+
+    @override_settings(MESO_AGENT_FAKE=False, ANTHROPIC_API_KEY="")
+    def test_default_behavior_unchanged_no_key_no_client(self):
+        assert client_module.get_default_client() is None
+
+    @override_settings(MESO_AGENT_FAKE=False, ANTHROPIC_API_KEY="sk-ant-real-key")
+    def test_default_behavior_unchanged_with_key_returns_real_client(self):
+        client = client_module.get_default_client()
+        assert type(client).__name__ == "MesoAgentClient"
+        assert not isinstance(client, FakeDemoClient)
+
+
+# -- FakeDemoClient.propose ---------------------------------------------------
+
+
+class TestFakeDemoClientPropose:
+    def test_targets_real_ids_and_passes_validation_end_to_end(self):
+        plan, session, presc = make_plan()
+        fake = FakeDemoClient()
+
+        batch, rejected = service.propose_changes(
+            plan, "Draft something for this week.", coach=plan.coach, client=fake
+        )
+
+        assert rejected == []
+        assert batch.status == AgentProposalBatch.Status.PENDING
+        assert batch.changes.count() > 0
+        assert batch.model == "meso-fake-demo"
+        # No network call happened, so the usage ledger is honestly empty.
+        assert batch.input_tokens == 0
+        assert batch.output_tokens == 0
+        assert batch.api_calls == 0
+        for change in batch.changes.all():
+            if change.kind in ("swap", "progress"):
+                assert change.prescription_id == presc.pk
+            if change.kind == "volume":
+                assert change.session_id is not None
+
+    def test_no_targets_yields_empty_changes(self):
+        context = {"plan": {"program": []}}
+        result = FakeDemoClient().propose(context=context, instruction="go")
+        assert result["changes"] == []
+        assert result["summary"]
+
+    def test_contraindication_case_still_yields_a_persisted_change(self):
+        plan, session, presc = make_plan()
+        ContraindicationFactory(
+            athlete=plan.athlete,
+            text="L knee — avoid deep knee flexion under load",
+        )
+        fake = FakeDemoClient()
+
+        batch, rejected = service.propose_changes(
+            plan, "Draft something for this week.", coach=plan.coach, client=fake
+        )
+
+        assert batch.changes.count() >= 1
+        # The demo never proposes the forbidden movement in the first place.
+        for change in batch.changes.all():
+            assert "flexion" not in (change.after or "").lower()
+            assert "flexion" not in (change.introduces_exercise or "").lower()
+            assert "flexion" not in change.payload.get("name", "").lower()
+
+    def test_summary_reads_like_a_coach_not_a_test_fixture(self):
+        plan, _, _ = make_plan()
+        result = FakeDemoClient().propose(
+            context=service.build_context(plan), instruction="go"
+        )
+        summary = result["summary"].lower()
+        assert "scripted" not in summary
+        assert "fake" not in summary
+
+    def test_swap_skips_the_row_already_tagged_safe(self):
+        # The demo data's day 1 leads with a curated knee-safe row; swapping THAT
+        # row would undercut the honors line beside it. The swap should land on
+        # the first untagged row instead (the one the contraindication is about).
+        context = {
+            "plan": {
+                "program": [
+                    {
+                        "id": 1,
+                        "name": "Lower",
+                        "exercises": [
+                            {"id": 11, "name": "Box Squat", "tag": "knee-safe"},
+                            {"id": 12, "name": "Bulgarian Split Squat"},
+                        ],
+                    }
+                ]
+            },
+            "athlete": {
+                "contraindications": ["L knee — avoid deep knee flexion under load"]
+            },
+        }
+        result = FakeDemoClient().propose(context=context, instruction="go")
+        swap = next(c for c in result["changes"] if c["kind"] == "swap")
+        assert swap["prescription_id"] == 12
+        # …and the honors line quotes the plan's real contraindication, not a stub.
+        assert swap["honors"] == "L knee — avoid deep knee flexion under load"
+        # The progression then targets a row other than the swapped one.
+        progress = next(c for c in result["changes"] if c["kind"] == "progress")
+        assert progress["prescription_id"] == 11
+
+    def test_abs_progression_stays_a_bare_number(self):
+        # ``apply`` writes new_load verbatim into the load column, where every
+        # existing row is unitless — a "kg" suffix would be the one odd cell in
+        # the on-camera designer grid.
+        context = {
+            "plan": {
+                "program": [
+                    {
+                        "id": 1,
+                        "name": "Lower",
+                        "exercises": [
+                            {"id": 11, "name": "Hip Thrust"},
+                            {"id": 12, "name": "Leg Press", "load": "110"},
+                        ],
+                    }
+                ]
+            }
+        }
+        result = FakeDemoClient().propose(context=context, instruction="go")
+        progress = next(c for c in result["changes"] if c["kind"] == "progress")
+        assert progress["new_load"] == "112.5"
+
+
+# -- end-to-end view test -----------------------------------------------------
+
+
+class TestAgentProposeEndpointFake:
+    @override_settings(
+        MESO_AGENT_FAKE=True, ANTHROPIC_API_KEY="", MESO_AGENT_RUN_SYNC=True
+    )
+    def test_propose_endpoint_resolves_to_a_reviewable_pending_batch(self, client):
+        plan, _, _ = make_plan()
+        client.force_login(plan.coach)
+
+        resp = client.post(
+            reverse("meso:api_plan_agent", kwargs={"plan_id": plan.pk}),
+            data=json.dumps({"instruction": "Draft this week."}),
+            content_type="application/json",
+        )
+
+        assert resp.status_code == 202
+        data = resp.json()
+        batch = AgentProposalBatch.objects.get(pk=data["batch_id"])
+        assert batch.status == AgentProposalBatch.Status.PENDING
+        assert batch.changes.count() > 0
+
+        status_resp = client.get(
+            reverse("meso:api_batch_status", kwargs={"batch_id": batch.pk})
+        )
+        status_data = status_resp.json()
+        assert status_data["status"] == AgentProposalBatch.Status.PENDING
+        assert len(status_data["changes"]) > 0
+        assert "review_url" in status_data

--- a/app/store_project/meso/tests/test_seed_demo_recording.py
+++ b/app/store_project/meso/tests/test_seed_demo_recording.py
@@ -1,0 +1,194 @@
+"""Issue #388 (Level-1 demo) — the automated-recording seed command.
+
+``seed_demo_recording`` is the deterministic sibling of ``seed_meso_demo``: the
+demo-video recorder drives a real browser through the real allauth login form,
+so it needs a coach whose credentials are **known in advance**, not a
+random throwaway password printed once to stdout. These tests pin its
+contract:
+
+- a coach exists with a known, usable password (+ ``CoachProfile`` + a
+  **comped** ``CoachSubscription`` — the demo workspace would otherwise trip
+  the free-tier seat/agent gates mid-recording);
+- the full demo workspace (``meso.demo.load_demo``) is loaded;
+- Maya Okonkwo's demo athlete additionally gets a usable, known password (the
+  same as the coach's) for the optional athlete-phone-view shot;
+- reruns are idempotent and always converge the password back to the known
+  value, even if something changed it since the last run;
+- ``--json`` prints exactly ``{"coach_email": ..., "athlete_email": ...}`` and
+  never the password;
+- it refuses to run with ``settings.DEBUG`` off unless ``--force`` is passed.
+"""
+
+import json
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from store_project.meso.demo import demo_email
+from store_project.meso.demo import has_demo
+from store_project.meso.management.commands.seed_demo_recording import (
+    DEFAULT_COACH_PASSWORD,
+)
+from store_project.meso.management.commands.seed_demo_recording import Command
+from store_project.meso.models import CoachProfile
+from store_project.meso.models import CoachSubscription
+from store_project.users.factories import UserFactory
+from store_project.users.models import User
+
+pytestmark = pytest.mark.django_db
+
+COACH_EMAIL = "demo-coach@demo.invalid"
+
+
+@pytest.fixture(autouse=True)
+def _debug_on(settings):
+    """Most of this suite needs DEBUG on; ``TestDebugGuard`` flips it off itself."""
+    settings.DEBUG = True
+
+
+def seed(**options):
+    call_command("seed_demo_recording", **options)
+
+
+class TestSeedsCoach:
+    def test_creates_coach_with_known_usable_password(self):
+        seed()
+        coach = User.objects.get(email=COACH_EMAIL)
+        assert coach.check_password(DEFAULT_COACH_PASSWORD)
+        assert coach.has_usable_password()
+        assert coach.name  # presentable on camera
+
+    def test_creates_coach_profile(self):
+        seed()
+        coach = User.objects.get(email=COACH_EMAIL)
+        assert CoachProfile.objects.filter(user=coach).exists()
+
+    def test_comps_the_subscription(self):
+        seed()
+        coach = User.objects.get(email=COACH_EMAIL)
+        sub = CoachSubscription.objects.get(coach=coach)
+        assert sub.status == CoachSubscription.Status.COMPED
+        assert sub.is_active
+
+    def test_custom_email_and_password_args(self):
+        seed(email="custom-coach@demo.invalid", password="a-different-pw")
+        coach = User.objects.get(email="custom-coach@demo.invalid")
+        assert coach.check_password("a-different-pw")
+
+    def test_env_vars_override_defaults(self, monkeypatch):
+        monkeypatch.setenv("MESO_DEMO_COACH_EMAIL", "env-coach@demo.invalid")
+        monkeypatch.setenv("MESO_DEMO_COACH_PASSWORD", "env-password")
+        seed()
+        coach = User.objects.get(email="env-coach@demo.invalid")
+        assert coach.check_password("env-password")
+
+    def test_cli_args_win_over_env_vars(self, monkeypatch):
+        monkeypatch.setenv("MESO_DEMO_COACH_EMAIL", "env-coach@demo.invalid")
+        seed(email="cli-coach@demo.invalid")
+        assert User.objects.filter(email="cli-coach@demo.invalid").exists()
+        assert not User.objects.filter(email="env-coach@demo.invalid").exists()
+
+
+class TestLoadsDemoWorkspace:
+    def test_loads_demo_data(self):
+        seed()
+        coach = User.objects.get(email=COACH_EMAIL)
+        assert has_demo(coach) is True
+
+    def test_maya_gets_a_usable_known_password(self):
+        seed()
+        coach = User.objects.get(email=COACH_EMAIL)
+        maya = User.objects.get(email=demo_email(coach, "maya"))
+        assert maya.has_usable_password()
+        assert maya.check_password(DEFAULT_COACH_PASSWORD)
+
+    def test_maya_can_authenticate_through_the_real_backend(self, client):
+        seed()
+        coach = User.objects.get(email=COACH_EMAIL)
+        maya_email = demo_email(coach, "maya")
+        assert client.login(email=maya_email, password=DEFAULT_COACH_PASSWORD)
+
+    def test_coach_can_authenticate_through_the_real_backend(self, client):
+        seed()
+        assert client.login(email=COACH_EMAIL, password=DEFAULT_COACH_PASSWORD)
+
+    def test_other_demo_athletes_keep_unusable_passwords(self):
+        seed()
+        coach = User.objects.get(email=COACH_EMAIL)
+        devon = User.objects.get(email=demo_email(coach, "devon"))
+        assert not devon.has_usable_password()
+
+
+class TestMayaLoginIsNonFatalWhenMissing:
+    """White-box: the helper is graceful when the demo athlete row is absent."""
+
+    def test_returns_none_and_does_not_raise(self):
+        coach = UserFactory()  # no demo loaded — Maya's row doesn't exist
+        cmd = Command()
+        cmd.stderr = StringIO()
+        result = cmd._ensure_maya_login(coach, "some-password")
+        assert result is None
+
+
+class TestIdempotent:
+    def test_rerun_does_not_duplicate(self):
+        seed()
+        seed()
+        assert User.objects.filter(email=COACH_EMAIL).count() == 1
+        coach = User.objects.get(email=COACH_EMAIL)
+        assert CoachProfile.objects.filter(user=coach).count() == 1
+        assert CoachSubscription.objects.filter(coach=coach).count() == 1
+        assert has_demo(coach) is True
+
+    def test_rerun_restores_the_known_password_if_changed(self):
+        seed()
+        coach = User.objects.get(email=COACH_EMAIL)
+        coach.set_password("someone-changed-it")
+        coach.save(update_fields=["password"])
+
+        seed()
+        coach.refresh_from_db()
+        assert coach.check_password(DEFAULT_COACH_PASSWORD)
+
+    def test_rerun_restores_mayas_password_if_changed(self):
+        seed()
+        coach = User.objects.get(email=COACH_EMAIL)
+        maya = User.objects.get(email=demo_email(coach, "maya"))
+        maya.set_password("someone-changed-it")
+        maya.save(update_fields=["password"])
+
+        seed()
+        maya.refresh_from_db()
+        assert maya.check_password(DEFAULT_COACH_PASSWORD)
+
+
+class TestJsonOutput:
+    def test_json_shape_and_no_password_leak(self):
+        out = StringIO()
+        call_command("seed_demo_recording", json=True, stdout=out)
+        payload = json.loads(out.getvalue().strip())
+        coach = User.objects.get(email=COACH_EMAIL)
+        maya_email = demo_email(coach, "maya")
+        assert payload == {"coach_email": COACH_EMAIL, "athlete_email": maya_email}
+        assert DEFAULT_COACH_PASSWORD not in out.getvalue()
+
+    def test_human_readable_output_has_no_password_either(self):
+        out = StringIO()
+        call_command("seed_demo_recording", stdout=out)
+        assert DEFAULT_COACH_PASSWORD not in out.getvalue()
+        assert COACH_EMAIL in out.getvalue()
+
+
+class TestDebugGuard:
+    def test_refuses_without_force(self, settings):
+        settings.DEBUG = False
+        with pytest.raises(CommandError):
+            call_command("seed_demo_recording")
+        assert not User.objects.filter(email=COACH_EMAIL).exists()
+
+    def test_allows_with_force(self, settings):
+        settings.DEBUG = False
+        seed(force=True)
+        assert User.objects.filter(email=COACH_EMAIL).exists()

--- a/app/store_project/meso/tests/test_seed_demo_recording.py
+++ b/app/store_project/meso/tests/test_seed_demo_recording.py
@@ -14,6 +14,9 @@ contract:
   same as the coach's) for the optional athlete-phone-view shot;
 - reruns are idempotent and always converge the password back to the known
   value, even if something changed it since the last run;
+- reruns **reset** the workspace (``clear_demo`` → ``load_demo``): whatever a
+  previous recording layered on top (applied agent batches and their designer
+  chat history) is gone, so run N's video never shows run N-1's chat thread;
 - ``--json`` prints exactly ``{"coach_email": ..., "athlete_email": ...}`` and
   never the password;
 - it refuses to run with ``settings.DEBUG`` off unless ``--force`` is passed.
@@ -32,8 +35,10 @@ from store_project.meso.management.commands.seed_demo_recording import (
     DEFAULT_COACH_PASSWORD,
 )
 from store_project.meso.management.commands.seed_demo_recording import Command
+from store_project.meso.models import AgentProposalBatch
 from store_project.meso.models import CoachProfile
 from store_project.meso.models import CoachSubscription
+from store_project.meso.models import Plan
 from store_project.users.factories import UserFactory
 from store_project.users.models import User
 
@@ -160,8 +165,32 @@ class TestIdempotent:
         maya.save(update_fields=["password"])
 
         seed()
-        maya.refresh_from_db()
+        # The rerun reset the workspace, so Maya is a *fresh* row (same
+        # deterministic email) — re-fetch rather than refresh the deleted one.
+        maya = User.objects.get(email=demo_email(coach, "maya"))
         assert maya.check_password(DEFAULT_COACH_PASSWORD)
+
+    def test_rerun_resets_prior_agent_batches(self):
+        # ``load_demo`` alone would top up and keep run N-1's applied batches —
+        # whose designer chat thread would then replay on camera in run N. The
+        # command must reset (clear_demo → load_demo) to a pristine workspace.
+        seed()
+        coach = User.objects.get(email=COACH_EMAIL)
+        maya = User.objects.get(email=demo_email(coach, "maya"))
+        plan = Plan.objects.filter(
+            relationship__coach=coach, relationship__athlete=maya
+        ).first()
+        assert plan is not None
+        AgentProposalBatch.objects.create(
+            plan=plan,
+            coach=coach,
+            instruction="a previous recording's run",
+            status=AgentProposalBatch.Status.APPLIED,
+        )
+
+        seed()
+        assert not AgentProposalBatch.objects.filter(coach=coach).exists()
+        assert has_demo(coach) is True
 
 
 class TestJsonOutput:

--- a/app/store_project/templates/meso/athlete_session.html
+++ b/app/store_project/templates/meso/athlete_session.html
@@ -91,7 +91,7 @@
               <span class="meso-row-meta meso-mono" style="white-space:nowrap;" x-show="setImpliedOneRm(r)" x-cloak x-text="'1RM ≈ ' + setImpliedOneRm(r)"></span>
             </template>
             <div class="meso-spacer"></div>
-            <button type="button" @click="toggle(r)" :aria-pressed="r.done" aria-label="Mark set done"
+            <button type="button" data-testid="set-toggle" @click="toggle(r)" :aria-pressed="r.done" aria-label="Mark set done"
                     style="appearance:none;border:0;background:none;cursor:pointer;padding:0;flex:0 0 auto;">
               <template x-if="r.done"><div style="width:26px;height:26px;border-radius:50%;background:var(--accent);display:flex;align-items:center;justify-content:center;color:var(--accent-ink);font-size:13px;">&#10003;</div></template>
               <template x-if="!r.done"><div style="width:26px;height:26px;border-radius:50%;border:1.5px solid var(--line);background:var(--surface);"></div></template>
@@ -107,7 +107,7 @@
       <span class="meso-row-meta" style="color:var(--ok);" x-show="saved" x-cloak>Saved &#10003;</span>
       <span class="meso-row-meta" style="color:var(--dim);" x-show="queued" x-cloak>Saved offline — will sync when you&#8217;re back.</span>
       <span class="meso-row-meta" style="color:var(--warn);" x-show="error" x-cloak>Couldn&#8217;t save — try again.</span>
-      <button type="button" class="meso-btn" @click="save(false)" :disabled="saving">Save progress</button>
+      <button type="button" data-testid="session-save" class="meso-btn" @click="save(false)" :disabled="saving">Save progress</button>
       <button type="button" class="meso-btn meso-btn--primary" @click="save(true)" :disabled="saving" x-text="saving ? 'Saving…' : 'Log session'">Log session</button>
     </div>
   </div>

--- a/app/store_project/templates/meso/deliver.html
+++ b/app/store_project/templates/meso/deliver.html
@@ -132,7 +132,7 @@
         <a class="meso-btn" href="{% url 'meso:review' %}">← Back to changes</a>
         <div class="meso-spacer"></div>
         <span x-show="error" x-cloak style="font-size:12.5px;color:var(--warn);">Delivery failed — try again.</span>
-        <button class="meso-btn meso-btn--primary" @click="deliver()" :disabled="sending" style="font-size:13.5px;padding:10px 18px;">
+        <button data-testid="deliver-send" class="meso-btn meso-btn--primary" @click="deliver()" :disabled="sending" style="font-size:13.5px;padding:10px 18px;">
           <span x-text="sending ? 'Delivering…' : 'Deliver to {{ athlete.name }}'"></span>
         </button>
       </div>

--- a/app/store_project/templates/meso/designer.html
+++ b/app/store_project/templates/meso/designer.html
@@ -253,7 +253,7 @@
                             </div>
                           </div>
                         </template>
-                        <a :href="m.reviewUrl" data-hover="brighten" style="align-self:flex-start;text-decoration:none;font-size:12px;font-weight:650;color:var(--accent-ink);background:var(--accent);border-radius:8px;padding:7px 12px;">
+                        <a data-testid="agent-review-link" :href="m.reviewUrl" data-hover="brighten" style="align-self:flex-start;text-decoration:none;font-size:12px;font-weight:650;color:var(--accent-ink);background:var(--accent);border-radius:8px;padding:7px 12px;">
                           Review <span x-text="m.changes.length"></span> <span x-text="m.changes.length === 1 ? 'change' : 'changes'"></span> &#8594;
                         </a>
                       </div>
@@ -282,8 +282,8 @@
                 </template>
               </div>
               <div class="meso-composer" style="display:flex;align-items:flex-end;gap:8px;background:var(--rail);border:1px solid var(--line);border-radius:11px;padding:7px 7px 7px 12px;">
-                <input x-model="inputText" @keydown="onInputKey($event)" placeholder="Ask the agent to adjust the program&#8230;" style="flex:1;appearance:none;border:0;background:transparent;outline:none;font:inherit;font-size:13px;color:var(--ink);padding:5px 0;" />
-                <button data-hover="brighten" @click="onSend()" :disabled="agentTyping" :style="agentTyping ? 'opacity:0.55;cursor:default;' : ''" style="appearance:none;cursor:pointer;border:0;width:32px;height:32px;border-radius:8px;background:var(--accent);color:var(--accent-ink);display:flex;align-items:center;justify-content:center;flex:0 0 auto;font-size:15px;">&#8593;</button>
+                <input data-testid="agent-composer-input" x-model="inputText" @keydown="onInputKey($event)" placeholder="Ask the agent to adjust the program&#8230;" style="flex:1;appearance:none;border:0;background:transparent;outline:none;font:inherit;font-size:13px;color:var(--ink);padding:5px 0;" />
+                <button data-testid="agent-composer-send" data-hover="brighten" @click="onSend()" :disabled="agentTyping" :style="agentTyping ? 'opacity:0.55;cursor:default;' : ''" style="appearance:none;cursor:pointer;border:0;width:32px;height:32px;border-radius:8px;background:var(--accent);color:var(--accent-ink);display:flex;align-items:center;justify-content:center;flex:0 0 auto;font-size:15px;">&#8593;</button>
               </div>
               {% if agent_allowance.metered %}
               <!-- Agent meter (S6 Phase 5; flat plan D14): every tier gets a monthly

--- a/app/store_project/templates/meso/review.html
+++ b/app/store_project/templates/meso/review.html
@@ -73,7 +73,7 @@
       <div class="meso-row-meta">Rejected edits are discarded — the program keeps its current values.</div>
       <div class="meso-spacer"></div>
       <button class="meso-btn" @click="dismiss()" :disabled="!pending || busy">Discard</button>
-      <button class="meso-btn meso-btn--primary" @click="apply()" :disabled="!pending || busy">
+      <button data-testid="review-apply" class="meso-btn meso-btn--primary" @click="apply()" :disabled="!pending || busy">
         Apply <span x-text="approved"></span> &amp; deliver →
       </button>
     </div>

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -1,0 +1,108 @@
+# Meso walkthrough demo video
+
+`just record-demo` regenerates a short screen recording of the real Meso
+product — no manual steps, no editing. It's the "level 1" demo for issue
+[#388](https://github.com/lancegoyke/fitness-store/issues/388): plan at
+[`docs/meso/demo-walkthrough-video-plan.md`](../meso/demo-walkthrough-video-plan.md).
+
+## Prerequisites
+
+```bash
+just services                        # Postgres :5434 / Redis :6334
+uv sync                              # installs Playwright as a dev dep
+uv run playwright install chromium   # downloads a headless-capable Chromium
+```
+
+## Run it
+
+```bash
+just record-demo
+```
+
+That's the whole interface. Under the hood (`scripts/record_demo.py`) it:
+
+1. Runs `migrate --no-input` then `seed_demo_recording --json` — a
+   deterministic, known-password demo coach + Maya's built/delivered/logged
+   plan (idempotent; safe to re-run).
+2. Starts `runserver 8035 --noreload` in the background with
+   `MESO_AGENT_FAKE=1` + `MESO_AGENT_RUN_SYNC=1` (and the Anthropic/VAPID env
+   vars explicitly blanked) — the agent step is the curated, no-network
+   `FakeDemoClient` proposal, never a real Anthropic/push call. Always
+   terminated (own process group) when the script exits, success or failure.
+3. Drives the storyboard below in headless Chromium via Playwright, recording
+   video the whole time.
+4. Writes `docs/demo/out/meso-walkthrough.mp4` (falls back to `.webm` if no
+   ffmpeg is found — system `ffmpeg` is preferred; else Playwright's own
+   bundled copy under `~/Library/Caches/ms-playwright/ffmpeg-*/` (macOS) /
+   `~/.cache/ms-playwright/ffmpeg-*/` (Linux) is used automatically).
+
+`docs/demo/out/` is git-ignored — **commit the tool, never the binary**; host
+the produced video wherever it's shown, and regenerate it whenever the UI
+changes enough to make the old one stale.
+
+## The storyboard-step editing model
+
+Each step is a small, labelled function in `scripts/record_demo.py`
+(`step_roster`, `step_athlete_profile`, `step_designer`,
+`step_agent_proposal`, `step_review`, `step_deliver`,
+`step_athlete_logs_a_set`) — one step, one function, so a UI change is a
+one-line/one-function edit, not a re-shoot:
+
+1. **Roster** — land on `/meso/`; Maya Okonkwo's row is visible.
+2. **Athlete profile** — open Maya; her delivered program + logged session.
+3. **Designer** — open her plan; the current week's grid + agent composer.
+4. **Agent proposal** — type a coach instruction, send it, follow the
+   resolved batch's review link (the pre-baked `MESO_AGENT_FAKE` proposal —
+   see below).
+5. **Review** — the proposed changes are visible; click "Apply … & deliver".
+6. **Deliver** — click "Deliver to Maya …"; wait for the confirmation card.
+7. **Athlete view** — log out, log back in as Maya (same recorded browser
+   context/viewport — a second `record_video_dir` context would produce a
+   *second* video file), open a not-yet-logged session, toggle a set, "Save
+   progress".
+
+Synchronization is always a Playwright auto-wait on a selector
+(`expect(...)`/`wait_for_*`) — never a sleep. `pause(page, seconds)` exists
+only to hold a screen long enough to read on camera; it's never load-bearing.
+
+## The pre-baked agent step
+
+The agent turn (`MESO_AGENT_FAKE=1`) never calls Anthropic — it grounds a
+small, curated `FakeDemoClient` proposal on the plan's own real rows (a
+knee-safe swap honoring Maya's contraindication, a load progression, a volume
+trim), so it's deterministic, free, and still passes the real review-gate
+validation. See `app/store_project/meso/agent/fake.py`.
+
+## Enumerated `data-testid`s
+
+Added only where role/text selectors were brittle or ambiguous (role/text
+selectors were kept everywhere else — e.g. the "Sign In" button, "Open in
+designer" link, and Maya's roster row, scoped to `a.meso-row` since her name
+also appears as a plain link in the roster's "Recent activity" rail):
+
+| `data-testid` | Element | Template |
+|---|---|---|
+| `agent-composer-input` | Agent chat message input | `meso/designer.html` |
+| `agent-composer-send` | Agent chat send button | `meso/designer.html` |
+| `agent-review-link` | "Review N changes →" link on a resolved agent turn | `meso/designer.html` |
+| `review-apply` | "Apply … & deliver →" button | `meso/review.html` |
+| `deliver-send` | "Deliver to {athlete} …" button | `meso/deliver.html` |
+| `set-toggle` | Per-set "mark done" circle (one per set row) | `meso/athlete_session.html` |
+| `session-save` | "Save progress" button | `meso/athlete_session.html` |
+
+Two selector gotchas worth knowing if a future edit touches these flows:
+
+- **`agent-review-link` is not unique.** The designer restores a plan's
+  *persisted* chat history on load (`hydrateThread` in `static/js/meso.js`),
+  and `seed_demo_recording` reseeds the demo workspace without clearing old
+  `AgentProposalBatch` rows — so every past recording run leaves another
+  review link in that history. The script always takes `.last` (the newest
+  turn, appended at the end of the thread).
+- **The Django Debug Toolbar silently eats clicks.** `config/settings/local.py`
+  turns it on whenever `DEBUG` is on (required for `seed_demo_recording`),
+  and its floating handle sits on top of real controls (e.g. "Open in
+  designer"), intercepting the click rather than just looking ugly. The
+  script hides `#djDebug` via a `context.add_init_script` scoped to the
+  *recorded* browser context only (not a settings change, so `just dev` is
+  unaffected) — deferred to `DOMContentLoaded`, since an init script runs
+  before the HTML parser creates `document.documentElement`.

--- a/docs/meso/demo-walkthrough-video-plan.md
+++ b/docs/meso/demo-walkthrough-video-plan.md
@@ -1,6 +1,6 @@
 # Meso — Level-1 walkthrough demo video (automated, re-recordable)
 
-Status: **PLANNED** — not started. Tracking issue: [#388](https://github.com/lancegoyke/fitness-store/issues/388).
+Status: **SHIPPED** — issue [#388](https://github.com/lancegoyke/fitness-store/issues/388) is done. `just record-demo` (`scripts/record_demo.py`) seeds deterministic demo data, drives the full storyboard below in headless Chromium via Playwright, and writes `docs/demo/out/meso-walkthrough.mp4` — zero manual steps, re-recordable after any UI change. See `docs/demo/README.md` for prerequisites, the enumerated `data-testid`s, and the storyboard-step editing model.
 
 ## Why
 

--- a/justfile
+++ b/justfile
@@ -97,5 +97,8 @@ db-shell:
 # Regenerate the Meso walkthrough video (docs/demo/README.md) — seeds demo
 # data, drives the real coach + athlete flow in headless Chromium, and writes
 # docs/demo/out/meso-walkthrough.mp4. Zero manual steps; safe to re-run.
-record-demo: services
+# `--wait` blocks on the DB/Redis healthchecks (a plain `up -d` returns before
+# Postgres accepts connections, and a cold run's first `migrate` would fail).
+record-demo:
+    docker compose up -d --wait
     uv run python scripts/record_demo.py

--- a/justfile
+++ b/justfile
@@ -93,3 +93,9 @@ stop-services:
 # Database shell (connects to local PostgreSQL)
 db-shell:
     docker exec -it fitness_store_postgres psql -U postgres
+
+# Regenerate the Meso walkthrough video (docs/demo/README.md) — seeds demo
+# data, drives the real coach + athlete flow in headless Chromium, and writes
+# docs/demo/out/meso-walkthrough.mp4. Zero manual steps; safe to re-run.
+record-demo: services
+    uv run python scripts/record_demo.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
   "pytest-sugar",
   "pytest-django",
   "ruff",
+  "playwright>=1.61.0",
 ]
 
 [tool.ruff]

--- a/scripts/record_demo.py
+++ b/scripts/record_demo.py
@@ -1,0 +1,581 @@
+#!/usr/bin/env python3
+"""Regenerate the Meso walkthrough demo video (issue #388).
+
+Standalone driver script — not a Django management command, not part of the
+pytest suite. Zero manual steps: seed deterministic demo data, drive the real
+coach + athlete flow in a headless, screen-recorded Chromium via Playwright,
+and write ``docs/demo/out/meso-walkthrough.mp4``.
+
+Run via ``just record-demo`` (``uv run python scripts/record_demo.py``), with
+the dev Postgres/Redis containers already up (``just services``).
+
+Storyboard (docs/meso/demo-walkthrough-video-plan.md), one step = one small,
+labelled function below — the intended unit of edit when a UI change breaks a
+selector:
+
+    1. Roster           — the coach's athlete list.
+    2. Athlete profile  — Maya's delivered program + logged session.
+    3. Designer         — the current week's grid + agent chat.
+    4. Agent proposal   — a coach instruction resolves to the pre-baked
+                           ``MESO_AGENT_FAKE`` batch; follow the review link.
+    5. Review           — apply the batch (redirects to deliver).
+    6. Deliver          — send the week to Maya.
+    7. Athlete view     — log in as Maya, toggle a set, save progress.
+
+Synchronization is always a Playwright auto-wait on a selector
+(``expect``/``wait_for``); ``pause()`` only slows the recording for
+legibility and is never load-bearing for correctness.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from playwright.sync_api import Page
+from playwright.sync_api import expect
+from playwright.sync_api import sync_playwright
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANAGE_PY = REPO_ROOT / "app" / "manage.py"
+OUT_DIR = REPO_ROOT / "docs" / "demo" / "out"
+VIDEO_BASENAME = "meso-walkthrough"
+SERVER_LOG_PATH = OUT_DIR / "record_demo.server.log"
+
+# Kept a constant, dedicated port (not the dev-server's :8034) so a stray
+# `just dev` running alongside this script never collides with it.
+PORT = 8035
+BASE_URL = f"http://127.0.0.1:{PORT}"
+SERVER_READY_TIMEOUT = 40  # seconds
+
+VIEWPORT = {"width": 1280, "height": 720}
+
+# Legibility pauses — cosmetic pacing only, see the module docstring.
+BEAT = 1.0  # seconds
+LONG_BEAT = 2.0  # seconds; used where a screen most needs to "read" on camera
+
+# The coach instruction typed into the agent composer (STEP 4). Chosen to echo
+# Maya's seeded contraindication so the pre-baked FakeDemoClient's swap +
+# honors line read as a direct response to it on camera.
+AGENT_INSTRUCTION = (
+    "Her left knee has been cranky — keep this week knee-friendly but keep "
+    "her progressing."
+)
+
+# Server env for the recording: MESO_AGENT_FAKE + MESO_AGENT_RUN_SYNC make the
+# agent step a fast, deterministic, no-network call; the Anthropic/VAPID vars
+# are explicitly blanked (even though a real .env may set them) so a bug in
+# the fake-client gate can never fire a real network call during an
+# unattended recording. `load_dotenv()` (config/settings/base.py) never
+# overrides already-exported vars, so these win over `.env`.
+SERVER_ENV_OVERRIDES = {
+    "MESO_AGENT_FAKE": "1",
+    "MESO_AGENT_RUN_SYNC": "1",
+    "ANTHROPIC_API_KEY": "",
+    "MESO_VAPID_PUBLIC_KEY": "",
+    "MESO_VAPID_PRIVATE_KEY": "",
+}
+
+# Hides the Django Debug Toolbar (config/settings/local.py, on whenever DEBUG
+# is on) inside the *recorded* browser context only — a purely cosmetic fix
+# scoped to this script, not a settings change that would affect `just dev`.
+# Its floating handle also sits on top of real controls (e.g. "Open in
+# designer"), silently eating clicks — so this is load-bearing, not just
+# cosmetic. Deferred to DOMContentLoaded: an init script runs *before* the
+# HTML parser creates `document.documentElement`, so appending to it (or
+# `document.head`) any earlier throws (caught, but the style never lands).
+HIDE_DEBUG_TOOLBAR_CSS = """
+document.addEventListener("DOMContentLoaded", () => {
+  const style = document.createElement("style");
+  style.textContent = "#djDebug{display:none !important;}";
+  document.head.appendChild(style);
+});
+"""
+
+
+class StepError(RuntimeError):
+    """A storyboard step failed; carries the step name for a clear exit message."""
+
+    def __init__(self, step: str, original: BaseException) -> None:
+        super().__init__(f"{step}: {original}")
+        self.step = step
+        self.original = original
+
+
+def log(message: str) -> None:
+    print(message, flush=True)
+
+
+def run_step(name, fn, *args, **kwargs):
+    """Run one storyboard step, tagging any failure with its label."""
+    log(f"\n=== {name} ===")
+    try:
+        result = fn(*args, **kwargs)
+    except Exception as exc:
+        raise StepError(name, exc) from exc
+    log("    ok")
+    return result
+
+
+def pause(page: Page, seconds: float = BEAT) -> None:
+    """Hold the current screen for ``seconds`` — legibility only, never sync."""
+    page.wait_for_timeout(seconds * 1000)
+
+
+# ---------------------------------------------------------------------------
+# Setup: migrate + seed (plain subprocess calls, not the long-running server)
+# ---------------------------------------------------------------------------
+
+
+def run_management_command(args, env):
+    cmd = ["uv", "run", "python", str(MANAGE_PY), *args]
+    log(f"$ {' '.join(cmd)}")
+    result = subprocess.run(cmd, cwd=REPO_ROOT, env=env, capture_output=True, text=True)
+    if result.returncode != 0:
+        sys.stderr.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        raise RuntimeError(f"`{' '.join(args)}` exited {result.returncode}")
+    return result.stdout
+
+
+def seed_demo_data(env):
+    run_management_command(["migrate", "--no-input"], env)
+    stdout = run_management_command(["seed_demo_recording", "--json"], env)
+    data = None
+    for line in stdout.splitlines():
+        candidate = line.strip()
+        if candidate.startswith("{"):
+            data = json.loads(candidate)
+            break
+    if not data:
+        raise RuntimeError(
+            f"seed_demo_recording --json printed no JSON object:\n{stdout}"
+        )
+    coach_email = data["coach_email"]
+    athlete_email = data.get("athlete_email")
+    if not athlete_email:
+        raise RuntimeError(
+            "seed_demo_recording didn't return an athlete_email — Maya's demo "
+            "row wasn't found (see its stderr warning above)."
+        )
+    log(f"    coach email:   {coach_email}")
+    log(f"    athlete email: {athlete_email}")
+    return coach_email, athlete_email
+
+
+# ---------------------------------------------------------------------------
+# Dev server subprocess (own process group so it can never outlive this script)
+# ---------------------------------------------------------------------------
+
+
+def start_server(env):
+    cmd = ["uv", "run", "python", str(MANAGE_PY), "runserver", str(PORT), "--noreload"]
+    log(f"$ {' '.join(cmd)}")
+    log_file = open(SERVER_LOG_PATH, "w")
+    proc = subprocess.Popen(
+        cmd,
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    proc._log_file = log_file  # keep the handle open; closed in stop_server()
+    return proc
+
+
+def wait_for_server(proc, url, timeout=SERVER_READY_TIMEOUT):
+    deadline = time.time() + timeout
+    last_error = None
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(
+                f"dev server exited early (code {proc.returncode}) — see {SERVER_LOG_PATH}"
+            )
+        try:
+            with urllib.request.urlopen(url, timeout=2) as response:
+                if response.status < 500:
+                    return
+        except (urllib.error.URLError, ConnectionError, TimeoutError) as exc:
+            last_error = exc
+        time.sleep(0.3)
+    raise TimeoutError(f"dev server never answered {url} ({last_error})")
+
+
+def stop_server(proc):
+    if proc is None:
+        return
+    log_file = getattr(proc, "_log_file", None)
+    if proc.poll() is None:
+        log("\n=== stopping dev server ===")
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+            proc.wait(timeout=10)
+        except (ProcessLookupError, subprocess.TimeoutExpired):
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+    if log_file:
+        log_file.close()
+
+
+# ---------------------------------------------------------------------------
+# Off-camera login (STEP 0 — not part of the recorded video)
+# ---------------------------------------------------------------------------
+
+
+def offcamera_login(browser, email, password):
+    """Log in through the real allauth form in an unrecorded context.
+
+    Returns the resulting ``storage_state`` so the recorded context can start
+    already authenticated — the login form itself never appears on camera.
+    """
+    context = browser.new_context(viewport=VIEWPORT)
+    page = context.new_page()
+    page.goto(f"{BASE_URL}/accounts/login/")
+    page.locator('input[name="login"]').fill(email)
+    page.locator('input[name="password"]').fill(password)
+    with page.expect_navigation(
+        url=lambda u: "/accounts/login/" not in u, timeout=15000
+    ):
+        page.get_by_role("button", name="Sign In").click()
+    state = context.storage_state()
+    context.close()
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Storyboard steps (recorded)
+# ---------------------------------------------------------------------------
+
+
+def step_roster(page: Page):
+    """STEP 1 ROSTER — land on the coach's athlete list.
+
+    Scoped to ``a.meso-row`` (not just role+name) because "Maya Okonkwo" also
+    appears as a plain link in the roster's "Recent activity" rail — role/text
+    alone resolves to both and Playwright's strict mode rejects the ambiguity.
+    """
+    page.goto(f"{BASE_URL}/meso/")
+    maya_row = page.locator("a.meso-row", has_text="Maya Okonkwo")
+    expect(maya_row).to_be_visible()
+    pause(page, LONG_BEAT)
+    with page.expect_navigation(url=re.compile(r"/meso/athlete/")):
+        maya_row.click()
+
+
+def step_athlete_profile(page: Page):
+    """STEP 2 ATHLETE PROFILE — Maya's delivered program + logged session."""
+    expect(page.get_by_role("heading", name="Maya Okonkwo")).to_be_visible()
+    open_designer = page.get_by_role("link", name="Open in designer")
+    expect(open_designer).to_be_visible()
+    pause(page, LONG_BEAT)
+    with page.expect_navigation(url=re.compile(r"/meso/designer/")):
+        open_designer.click()
+
+
+def step_designer(page: Page):
+    """STEP 3 DESIGNER — the periodized current week + agent composer."""
+    expect(page.get_by_test_id("agent-composer-input")).to_be_visible()
+    pause(page, LONG_BEAT)
+
+
+def step_agent_proposal(page: Page, instruction: str):
+    """STEP 4 AGENT PROPOSAL — a coach instruction resolves to a review link.
+
+    ``seed_demo_recording`` resets the workspace (``clear_demo`` →
+    ``load_demo``), so the designer's persisted chat thread starts empty and
+    this run's proposal is the only ``agent-review-link`` on the page.
+    ``.last`` is kept as belt-and-braces: the designer restores persisted
+    history on load (``hydrateThread``/``serialize_chat_thread``), and the
+    freshest turn is always appended at the end of the thread.
+    """
+    composer = page.get_by_test_id("agent-composer-input")
+    composer.fill(instruction)
+    pause(page, BEAT)
+    page.get_by_test_id("agent-composer-send").click()
+    # MESO_AGENT_RUN_SYNC resolves the batch inline, but this still crosses two
+    # HTTP round-trips (POST + one status poll) plus Alpine's render — a
+    # generous timeout costs nothing on a fast, deterministic fake client.
+    review_link = page.get_by_test_id("agent-review-link").last
+    expect(review_link).to_be_visible(timeout=30000)
+    pause(page, LONG_BEAT)
+    with page.expect_navigation(url=re.compile(r"/meso/review/")):
+        review_link.click()
+
+
+def step_review(page: Page):
+    """STEP 5 REVIEW — let the proposal read, then apply & deliver."""
+    apply_button = page.get_by_test_id("review-apply")
+    expect(apply_button).to_be_visible()
+    expect(apply_button).to_be_enabled()
+    pause(page, LONG_BEAT)
+    with page.expect_navigation(url=re.compile(r"/meso/deliver/")):
+        apply_button.click()
+
+
+def step_deliver(page: Page):
+    """STEP 6 DELIVER — send the week to Maya; wait for the confirmation card."""
+    deliver_button = page.get_by_test_id("deliver-send")
+    expect(deliver_button).to_be_visible()
+    pause(page, LONG_BEAT)
+    deliver_button.click()
+    expect(
+        page.get_by_role("heading", name=re.compile(r"Delivered to Maya"))
+    ).to_be_visible()
+    pause(page, LONG_BEAT)
+
+
+def step_athlete_logs_a_set(page: Page, athlete_email: str, password: str):
+    """STEP 7 ATHLETE LOGS A SET — same recorded context/viewport, new identity.
+
+    ``ACCOUNT_LOGOUT_ON_GET`` is on, so a bare GET drops the coach's session;
+    logging back in as Maya in the *same* page/context keeps this in one
+    recorded video (a second ``browser.new_context(record_video_dir=...)``
+    would produce a second file).
+    """
+    page.goto(f"{BASE_URL}/accounts/logout/")
+    page.goto(f"{BASE_URL}/accounts/login/")
+    page.locator('input[name="login"]').fill(athlete_email)
+    page.locator('input[name="password"]').fill(password)
+    with page.expect_navigation(
+        url=lambda u: "/accounts/login/" not in u, timeout=15000
+    ):
+        page.get_by_role("button", name="Sign In").click()
+
+    page.goto(f"{BASE_URL}/meso/me/")
+    # The already-logged "Lower" day shows "Logged"; pick a not-yet-logged day
+    # so the toggle below is a real unchecked → checked flip on camera.
+    todo_session = page.locator("a.meso-row", has_text="To do").first
+    expect(todo_session).to_be_visible()
+    pause(page, BEAT)
+    with page.expect_navigation(url=re.compile(r"/meso/me/session/")):
+        todo_session.click()
+
+    toggle = page.get_by_test_id("set-toggle").first
+    expect(toggle).to_be_visible()
+    pause(page, BEAT)
+    toggle.click()
+    pause(page, BEAT)
+
+    page.get_by_test_id("session-save").click()
+    # Exact text: "Saved offline — will sync…" (the queued/offline state) also
+    # starts with "Saved", which a substring match would ambiguously resolve.
+    expect(page.get_by_text("Saved ✓", exact=True)).to_be_visible()
+    pause(page, LONG_BEAT)
+
+
+# ---------------------------------------------------------------------------
+# Video post-processing
+# ---------------------------------------------------------------------------
+
+
+def find_ffmpeg():
+    """System ``ffmpeg`` if on PATH, else Playwright's own bundled binary.
+
+    Playwright's ffmpeg is *not* under the pip package's ``driver/`` dir (that
+    only holds the Node driver) — it's under the same per-OS cache directory
+    ``playwright install`` downloads browsers into (``ms-playwright``), as
+    ``ffmpeg-<rev>/ffmpeg-<platform>``.
+    """
+    system_ffmpeg = shutil.which("ffmpeg")
+    if system_ffmpeg:
+        return system_ffmpeg
+    candidates = []
+    browsers_path = os.environ.get("PLAYWRIGHT_BROWSERS_PATH")
+    if browsers_path and browsers_path != "0":
+        candidates.append(Path(browsers_path))
+    candidates += [
+        Path.home() / "Library" / "Caches" / "ms-playwright",  # macOS
+        Path.home() / ".cache" / "ms-playwright",  # Linux
+    ]
+    for base in candidates:
+        if not base.is_dir():
+            continue
+        for path in sorted(base.glob("ffmpeg-*/ffmpeg*")):
+            if path.is_file() and os.access(path, os.X_OK):
+                return str(path)
+    return None
+
+
+def probe_duration_seconds(ffmpeg_path, media_path):
+    ffprobe_path = shutil.which("ffprobe")
+    if not ffprobe_path and ffmpeg_path:
+        candidate = Path(ffmpeg_path).with_name(
+            Path(ffmpeg_path).name.replace("ffmpeg", "ffprobe")
+        )
+        if candidate.is_file():
+            ffprobe_path = str(candidate)
+    if not ffprobe_path:
+        return None
+    try:
+        result = subprocess.run(
+            [
+                ffprobe_path,
+                "-v",
+                "error",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "default=noprint_wrappers=1:nokey=1",
+                str(media_path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        return round(float(result.stdout.strip()), 1)
+    except (subprocess.SubprocessError, ValueError, OSError):
+        return None
+
+
+def finalize_video(raw_webm_path: Path):
+    """Move the recorded webm into place, then convert to mp4 if possible."""
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    final_webm = OUT_DIR / f"{VIDEO_BASENAME}.webm"
+    shutil.move(str(raw_webm_path), final_webm)
+
+    ffmpeg_path = find_ffmpeg()
+    if not ffmpeg_path:
+        log(
+            "\nNOTE: no ffmpeg found (system PATH or Playwright's bundled copy) — "
+            f"kept the raw {final_webm.name}. Install ffmpeg and re-run to get the "
+            "target .mp4 artifact."
+        )
+        return final_webm, probe_duration_seconds(None, final_webm)
+
+    final_mp4 = OUT_DIR / f"{VIDEO_BASENAME}.mp4"
+    cmd = [
+        ffmpeg_path,
+        "-y",
+        "-i",
+        str(final_webm),
+        "-c:v",
+        "libx264",
+        "-pix_fmt",
+        "yuv420p",
+        "-movflags",
+        "+faststart",
+        str(final_mp4),
+    ]
+    log(f"$ {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr)
+        log(f"\nNOTE: ffmpeg conversion failed — kept the raw {final_webm.name}.")
+        return final_webm, probe_duration_seconds(ffmpeg_path, final_webm)
+
+    final_webm.unlink(missing_ok=True)
+    return final_mp4, probe_duration_seconds(ffmpeg_path, final_mp4)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def build_env():
+    env = os.environ.copy()
+    env.update(SERVER_ENV_OVERRIDES)
+    return env
+
+
+def main():
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    for stray in OUT_DIR.glob("*.webm"):
+        if stray.name != f"{VIDEO_BASENAME}.webm":
+            stray.unlink()
+
+    env = build_env()
+    server_proc = None
+    exit_code = 0
+    video_result = None
+
+    try:
+        coach_email, athlete_email = run_step("SEED DEMO DATA", seed_demo_data, env)
+        server_proc = start_server(env)
+        run_step(
+            "WAIT FOR DEV SERVER",
+            wait_for_server,
+            server_proc,
+            f"{BASE_URL}/accounts/login/",
+        )
+
+        with sync_playwright() as pw:
+            browser = pw.chromium.launch(headless=True)
+            try:
+                password = env.get("MESO_DEMO_COACH_PASSWORD", "meso-demo-recording")
+                storage_state = run_step(
+                    "OFF-CAMERA LOGIN", offcamera_login, browser, coach_email, password
+                )
+
+                context = browser.new_context(
+                    storage_state=storage_state,
+                    viewport=VIEWPORT,
+                    record_video_dir=str(OUT_DIR),
+                    record_video_size=VIEWPORT,
+                )
+                context.add_init_script(HIDE_DEBUG_TOOLBAR_CSS)
+                page = context.new_page()
+
+                run_step("STEP 1 ROSTER", step_roster, page)
+                run_step("STEP 2 ATHLETE PROFILE", step_athlete_profile, page)
+                run_step("STEP 3 DESIGNER", step_designer, page)
+                run_step(
+                    "STEP 4 AGENT PROPOSAL",
+                    step_agent_proposal,
+                    page,
+                    AGENT_INSTRUCTION,
+                )
+                run_step("STEP 5 REVIEW", step_review, page)
+                run_step("STEP 6 DELIVER", step_deliver, page)
+                run_step(
+                    "STEP 7 ATHLETE LOGS A SET",
+                    step_athlete_logs_a_set,
+                    page,
+                    athlete_email,
+                    password,
+                )
+
+                video = page.video
+                context.close()
+                raw_webm_path = Path(video.path())
+            finally:
+                browser.close()
+
+        video_result = run_step("FINALIZE VIDEO", finalize_video, raw_webm_path)
+
+    except StepError as exc:
+        log(f"\nFAILED at step: {exc.step}\n{exc.original}")
+        exit_code = 1
+    except Exception as exc:  # setup/server-lifecycle failures, no step label
+        log(f"\nFAILED (setup): {exc}")
+        exit_code = 1
+    finally:
+        stop_server(server_proc)
+
+    if exit_code:
+        sys.exit(exit_code)
+
+    final_path, duration = video_result
+    size_kb = final_path.stat().st_size / 1024
+    duration_note = (
+        f"{duration} seconds" if duration is not None else "duration unknown"
+    )
+    log(
+        f"\nwrote {final_path.relative_to(REPO_ROOT)} ({duration_note}, {size_kb:.0f} KB)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/record_demo.py
+++ b/scripts/record_demo.py
@@ -41,6 +41,7 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
+from dotenv import dotenv_values
 from playwright.sync_api import Page
 from playwright.sync_api import expect
 from playwright.sync_api import sync_playwright
@@ -62,6 +63,9 @@ VIEWPORT = {"width": 1280, "height": 720}
 # Legibility pauses — cosmetic pacing only, see the module docstring.
 BEAT = 1.0  # seconds
 LONG_BEAT = 2.0  # seconds; used where a screen most needs to "read" on camera
+
+# ``seed_demo_recording``'s fixed default (kept in sync with the command).
+DEFAULT_DEMO_PASSWORD = "meso-demo-recording"
 
 # The coach instruction typed into the agent composer (STEP 4). Chosen to echo
 # Maya's seeded contraindication so the pre-baked FakeDemoClient's swap +
@@ -147,9 +151,31 @@ def run_management_command(args, env):
     return result.stdout
 
 
-def seed_demo_data(env):
+def resolve_demo_password():
+    """The password the demo accounts will use, resolved where the seed reads it.
+
+    ``seed_demo_recording`` (a child ``manage.py`` process) resolves its
+    password as CLI → process env → ``.env`` (Django's ``load_dotenv()``) →
+    fixed default — but this parent script never loads ``.env``, so a password
+    set only there would seed the accounts with one value while the recorder
+    logs in with another (and times out at the off-camera login). Resolve from
+    the same sources here and pass it back to the command explicitly
+    (``--password``), making this script the single source of truth.
+    """
+    from_env = os.environ.get("MESO_DEMO_COACH_PASSWORD")
+    if from_env:
+        return from_env
+    from_dotenv = dotenv_values(REPO_ROOT / ".env").get("MESO_DEMO_COACH_PASSWORD")
+    if from_dotenv:
+        return from_dotenv
+    return DEFAULT_DEMO_PASSWORD
+
+
+def seed_demo_data(env, password):
     run_management_command(["migrate", "--no-input"], env)
-    stdout = run_management_command(["seed_demo_recording", "--json"], env)
+    stdout = run_management_command(
+        ["seed_demo_recording", "--json", "--password", password], env
+    )
     data = None
     for line in stdout.splitlines():
         candidate = line.strip()
@@ -502,7 +528,10 @@ def main():
     video_result = None
 
     try:
-        coach_email, athlete_email = run_step("SEED DEMO DATA", seed_demo_data, env)
+        password = resolve_demo_password()
+        coach_email, athlete_email = run_step(
+            "SEED DEMO DATA", seed_demo_data, env, password
+        )
         server_proc = start_server(env)
         run_step(
             "WAIT FOR DEV SERVER",
@@ -514,7 +543,6 @@ def main():
         with sync_playwright() as pw:
             browser = pw.chromium.launch(headless=True)
             try:
-                password = env.get("MESO_DEMO_COACH_PASSWORD", "meso-demo-recording")
                 storage_state = run_step(
                     "OFF-CAMERA LOGIN", offcamera_login, browser, coach_email, password
                 )

--- a/uv.lock
+++ b/uv.lock
@@ -783,6 +783,7 @@ dev = [
     { name = "factory-boy" },
     { name = "ipdb" },
     { name = "ipython" },
+    { name = "playwright" },
     { name = "pylint-django" },
     { name = "pytest" },
     { name = "pytest-django" },
@@ -829,6 +830,7 @@ dev = [
     { name = "factory-boy" },
     { name = "ipdb" },
     { name = "ipython" },
+    { name = "playwright", specifier = ">=1.61.0" },
     { name = "pylint-django" },
     { name = "pytest" },
     { name = "pytest-django" },
@@ -946,6 +948,63 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/34/c03bcbc759d67ac3d96077838cdc1eac85417de6ea3b65b313fe53043eee/google_genai-1.59.0.tar.gz", hash = "sha256:0b7a2dc24582850ae57294209d8dfc2c4f5fcfde0a3f11d81dc5aca75fb619e2", size = 487374, upload-time = "2026-01-15T20:29:46.619Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/53/6d00692fe50d73409b3406ae90c71bc4499c8ae7fac377ba16e283da917c/google_genai-1.59.0-py3-none-any.whl", hash = "sha256:59fc01a225d074fe9d1e626c3433da292f33249dadce4deb34edea698305a6df", size = 719099, upload-time = "2026-01-15T20:29:44.604Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/f1/fbbfef6af0bad0548f09bc28948ea3c275b4edb19e17fc5ca9900a6a634d/greenlet-3.5.3.tar.gz", hash = "sha256:a61efc018fd3eb317eeca31aba90ee9e7f26f22884a79b6c6ec715bf71bb62f1", size = 200270, upload-time = "2026-06-26T19:28:24.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/ff/a620267401db30a50cc8450ee90730e2d4a85658c055c0e760d4ed47fb13/greenlet-3.5.3-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:c8d87c2134d871df96ecdea9cec7cbaab286dadab0f56476e57aaf9e8ac11550", size = 287609, upload-time = "2026-06-26T18:21:14.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fa/5401ac78021c826a25b6dde0c705e0a8f29b617509f9185a31dac15fbe1b/greenlet-3.5.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2d185dd1621757e70c3861cceffd5317ab4e7ed7eb09c82994828468527ade5", size = 607435, upload-time = "2026-06-26T19:07:11.412Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/76/1dc144a2e56e65d36405078ed774224375ea520a1870a6e46e08bb4ac7bf/greenlet-3.5.3-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1c514a468149bf8fbbab874188a3535cd8a48a3e353eb53a3d424296f8dbacd3", size = 619787, upload-time = "2026-06-26T19:10:08.396Z" },
+    { url = "https://files.pythonhosted.org/packages/57/61/2f5b1adf256d039f5dab8005de8d3d7ad2b0070a3219c0e036b3fbfeb440/greenlet-3.5.3-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9ad04dd75458c6300b047c61b8639092433d205a25a14e310d6582a480efcca1", size = 625580, upload-time = "2026-06-26T19:24:18.344Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/87/c298cee62df1de4ad7fec32abda73526cff347fd143a6ed4ac369246668a/greenlet-3.5.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:915f887cf2682b66419b879423a2e072634aa7b7dce6f3ada4957cfced3f1e9a", size = 616786, upload-time = "2026-06-26T18:32:19.128Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d9/ab7fc9e543e44d6879b0a6ef9a4b2188940fd180cc65d6f646883ddf7201/greenlet-3.5.3-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:afaabdd554cd7ae9bbb3ca070b0d7fdfd207dbf1d16865f7233837709d354bda", size = 427933, upload-time = "2026-06-26T19:25:38.219Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/2e/e6f009885ed0705ccf33fe0583c117cfd03cde77e31a596dd5785a30762b/greenlet-3.5.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:766cfd421c13e450feb340cd472a3ed9957d438727b7b4593ad7c76c5d2b0deb", size = 1574316, upload-time = "2026-06-26T19:09:04.273Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fe/43fd110b01e40da0adb7c90ac7ea744bef2d43dca00de5095fd2351c2a68/greenlet-3.5.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2ecda9ec22edf38fa389369eaed8c3d37c05f3c54e69f69438dbb2cc1de1458b", size = 1638614, upload-time = "2026-06-26T18:31:46.297Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/7c/062447147a61f8b4337b156fe70d32a165fcf2f89d7ca6255e572806705c/greenlet-3.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:c82304750f057167ff60d188df1d0cc1764ce9567eadf03e6a7443bcedd0b30b", size = 239850, upload-time = "2026-06-26T18:21:54.613Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7e/220a7f5824a64a60443fc03b39dfac4ea63a7fb6d481efa27eafa928e7f4/greenlet-3.5.3-cp313-cp313-win_arm64.whl", hash = "sha256:dc133a1569ee667b2a6ef56ce551084aeefd87a5acbc4736d336d1e2edc6cfc4", size = 238141, upload-time = "2026-06-26T18:22:48.507Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/93/43e116ee114b28737ba7e12952a0d4e2f55944d0f84e42bc91ba7192a3c9/greenlet-3.5.3-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:fd2e02fa07485778536a036222d616ab957b1d533f36b3ed98ce725d9c9d3117", size = 288202, upload-time = "2026-06-26T18:23:49.604Z" },
+    { url = "https://files.pythonhosted.org/packages/82/2f/146d218299046a43d1f029fd544b3d110d0f175a09c715c7e8da4a4a345d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df0a0628d1597eb0897b62f55d1343f772405fd25f3b2a796c76874b0c2e22e8", size = 654096, upload-time = "2026-06-26T19:07:12.71Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/cc/04738cafb3f45fa991ea44f9de94c47dcec964f5a972300988a6751f49d9/greenlet-3.5.3-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ebd933a6adabc298bab47731a130fe6bfb888bd934eee37810f151159544540d", size = 666304, upload-time = "2026-06-26T19:10:09.503Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a9/73fa62893d5b84b4205544e6b673c654cc43aa5b9899bac00f04d64af73d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8d19fe6c39ebff9259f07bcc685d3290f8fa4ea2278e51dd0008e4d6b0f2d814", size = 670657, upload-time = "2026-06-26T19:24:19.967Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/aa/4e0dad5e605c270c784ab911c43da6adb136ccd4d81180f763ca429a723d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b9d501b40e80b70e32323c799dd9b420a5577a9601469d362ae1ffb690f3a7c", size = 663635, upload-time = "2026-06-26T18:32:20.802Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7e/2ffce64929fb3cab7b65d5a0b20aaf9764e227681d731b041077fc9a525a/greenlet-3.5.3-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:962c5df2db8cb446da51edf1ca5296c389d93b99c9d8aa2ee4c7d0d8f1218260", size = 473497, upload-time = "2026-06-26T19:25:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/50/13efdbea246fe3d3b735e191fec08fb50809f53cd2383ebe123d0809e44b/greenlet-3.5.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a1fad1d11e7d6aab184107baa8e4ece11ccba3ec9599cd7efa5ff4d70d43256a", size = 1621252, upload-time = "2026-06-26T19:09:05.647Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/22/c0a336ae4a1410fd5f5121098e5bfbf1865f64c5ef80b4b5412886c4a332/greenlet-3.5.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fad5aec764399f1b5cc347ad250a59660f20c8f8888ea6bae1f93b769cce1154", size = 1684824, upload-time = "2026-06-26T18:31:47.738Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/94/91aec0030bea75c4b3244251d0de60a1f3432d1ecb53ab6c437fb5c3ba61/greenlet-3.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:7669aa24cf2a1041d6f7899575b494a3ab4cf68bfcc8609b1dc0be7272db835e", size = 240754, upload-time = "2026-06-26T18:22:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/06/68d0983e79e02138f64b4d303c500c27ddb48e5e77f3debb80888a921eae/greenlet-3.5.3-cp314-cp314-win_arm64.whl", hash = "sha256:5b4807c4082c9d1b6d9eed56fcd041863e37f2228106eef24c30ca096e238605", size = 239549, upload-time = "2026-06-26T18:22:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/91/95/3e161213d7f1d378d15aa9e792093e9bfe01844680d04b7fd6e0107c9098/greenlet-3.5.3-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:271a8ea7c1024e8a0d7dd2be66dd66dda8a07193f41a17b9e924f7600f5b62be", size = 296389, upload-time = "2026-06-26T18:22:20.657Z" },
+    { url = "https://files.pythonhosted.org/packages/00/92/715c44721abe2b4d1ae9abde4179411868a5bff312479f54e105d372f131/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19131729ae0ddc3c2e1ef85e650169b5e37ee32e400f215f78b94d7b0d567310", size = 653382, upload-time = "2026-06-26T19:07:14.209Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/83/37a10372a1090a6624cca8e74c12df1a36c2dc36429ed0255b7fb1aeee23/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1540dd8e5fc2a5aec40fbb98ef8e149fa47c89a4b4a1cf2575a14d3d1869d7a8", size = 659401, upload-time = "2026-06-26T19:10:10.876Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/73/8faec206b851c22b1733545fda900829a1f3f5b1c78ae7e0fb3dba57d9f4/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b897d97759425953f69a9c0fac67f8fe333ec0ce7377ef186fb2b0c3ad5e354d", size = 659582, upload-time = "2026-06-26T19:24:21.357Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e2/d1509cad4207da559cc42986ecdd8fc67ad0d1bba2bf03023c467fd5e0f3/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e81fa194a1d20967877bdf9c7794db2bc99063e5be36aee710c08f04c5bb087f", size = 656969, upload-time = "2026-06-26T18:32:22.272Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/55/50c19e49f8045834ada71ef12f8ad048eba8517c6aa41161bed676328fae/greenlet-3.5.3-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:3236754d423955ea08e9bb5f6c04a7895f9e22c290b66aa7653fcb922d839eb0", size = 491037, upload-time = "2026-06-26T19:25:40.672Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7d/eaf70de20aadca3a5884aec58362861c64ce45e7b277f47ed026926a3b89/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:55cf4d777485d43110e47133cbba6d74a8885a87ec1227ef0267f9ee80c5aa21", size = 1617822, upload-time = "2026-06-26T19:09:06.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f9/414d38fc400ae4350d4185eaad1827676f7cf5287b9136e0ed1cbbe20a7f/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:12a248ba75f6a9a236375f52296c498c89ff1d8badf32deb9eca7abd5853f7da", size = 1677983, upload-time = "2026-06-26T18:31:49.396Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/15/7edb977e08f9bff702fe42d6c902702786ff6b9694058b4e6a2a6ac90e57/greenlet-3.5.3-cp314-cp314t-win_amd64.whl", hash = "sha256:efc6bd60ea02e085862c74a3ef64b147ffc6f1a5ea7d9f26e7a939943f68c1e3", size = 243626, upload-time = "2026-06-26T18:24:41.485Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8a/93928dce91e6b3598b5e779e8d1fd6576a504640c58e78627077f6a7a91a/greenlet-3.5.3-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:ea03f2f04367845d6b58eeed276e1e56e51f0b97d8ad5a88a7d20a91dc9056cc", size = 288860, upload-time = "2026-06-26T18:22:48.07Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ca/69db42d447a1378043e2c8f19c09cbbd1263371505053c496b49066d3d16/greenlet-3.5.3-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78dbef602fda6d97d957eb7937f70c9ce9e9527330347f8f6b6f9e554a9e7a47", size = 659747, upload-time = "2026-06-26T19:07:15.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/0b/af7ac2ef8dd41e3da1a40dda6305c23b9a03e13ba975ec916357b50f8575/greenlet-3.5.3-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f73857adb8fee13fa56c172bd11262f888c0c648f9fea113e777bb2c7904a81", size = 670419, upload-time = "2026-06-26T19:10:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/25/aa/952cf28c2ff949a8c971134fb43854dd7eaa737218723aaef758f8c9aead/greenlet-3.5.3-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cefa9cef4b371f9844c6053db71f1138bc6807bab1578b0dae5149c1f1141357", size = 674261, upload-time = "2026-06-26T19:24:22.79Z" },
+    { url = "https://files.pythonhosted.org/packages/51/1e/1d51640cacbfc455dbe9f9a9f594c49e4e244f63b9971a2f4764e46cc53d/greenlet-3.5.3-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:232fec92e823addaf02d9472cf7381e24a1d046a6ced1103c5caa4c21b9dfc1d", size = 668787, upload-time = "2026-06-26T18:32:24.298Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/f2/b00d6f5e63e531a93562b2ec1a4c320fbee91f580fc42e6417af69d706e5/greenlet-3.5.3-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:6219b6d04dbf6ba6084d77dc609e8473060dc55f759cbf626d512122781fa128", size = 480322, upload-time = "2026-06-26T19:25:41.852Z" },
+    { url = "https://files.pythonhosted.org/packages/21/66/4030d5b0b5894500023f003bb054d9bb354dfbd1e186c3a296759172f5f5/greenlet-3.5.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:2421c3564da9429d5586d46ca31ebb26516b5498a802cf65c041a8e8a8980d34", size = 1626305, upload-time = "2026-06-26T19:09:08.281Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/50/5221371c7550108dfa3c378debc41d032aa9c78e89abb01d8011cfc93289/greenlet-3.5.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e0f0d160f0b2e558e6c75f7930967183255dc9735e5f5b8cae58ee09c9576d8b", size = 1688631, upload-time = "2026-06-26T18:31:51.278Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5d/00d469daae3c65d2bf620b10eee82eb022127d483c6bc8c69fae6f3fbf17/greenlet-3.5.3-cp315-cp315-win_amd64.whl", hash = "sha256:dd99329bbc15ca78dcc583dba05d0b1b0bae01ab6c2174989f5aaee3e41ac930", size = 241027, upload-time = "2026-06-26T18:22:38.203Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e8/883785b44c5780ed71e83d3e4437e710470be17a2e181e8b601e2da0dc4a/greenlet-3.5.3-cp315-cp315-win_arm64.whl", hash = "sha256:499fef2acede88c1864a57bb586b4bf533c81e1b82df7ab93451cdb47dfec227", size = 240085, upload-time = "2026-06-26T18:23:54.217Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/da/4f4a8450962fad137c1c8981a3f1b8919d06c829993d4d476f9c525d5173/greenlet-3.5.3-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:176bc16a721fa5fc294d70b87b4dfa5fbdd251b3da5d5372735ecef9bd7d6d0c", size = 297221, upload-time = "2026-06-26T18:23:27.176Z" },
+    { url = "https://files.pythonhosted.org/packages/57/66/b3bfae3e220a9b63ea539a0eea681800c69ab1aada757eae8789f183e7ce/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:629b614d2b786e89c50440e246f33eea78f58a962d0bdbbcc809e6d13605903f", size = 657221, upload-time = "2026-06-26T19:07:16.973Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/81/b6d4d73a709684fc77e7fa034d7c2fe82cffa9fc920fadcaa659c2626213/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2b2e857ae16f5f72142edf75f9f176fe7526ba19a2841df1420516f83831c9f2", size = 663226, upload-time = "2026-06-26T19:10:13.723Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/39/0e0938a75115b939d42733a2a12e1d349653c9531fe6fe563e8a681f04e6/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:16d192579ed281051396dddd7f7754dac6259e6b1fb26378c87b66622f8e3f91", size = 663706, upload-time = "2026-06-26T19:24:24.312Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/07/e210b02b589f16e74ff48b730690e4a34ffe984219fce4f3c1a0e7ec8545/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e515757e2e36bcbf1fad09a46e1557e8b1ae1797d4b44d09da7deed88ad28608", size = 660802, upload-time = "2026-06-26T18:32:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/41/35d1c678cdb3c3b9e6bee691728e563cfb294202b23c7a4c3c2ccc343589/greenlet-3.5.3-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:4399eb8d041f20b68d943918bc55502a93d6fdc0a37c14da7881c04139acee9d", size = 498803, upload-time = "2026-06-26T19:25:43.063Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/2e/5303eb3fa06bca089060f479707182a93e360683bc252acf846c3090d34e/greenlet-3.5.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:b363d46ed1ea431825fdb01471bb024fc08399bad1572a616e853c7684415adb", size = 1622157, upload-time = "2026-06-26T19:09:09.527Z" },
+    { url = "https://files.pythonhosted.org/packages/54/70/50de47a488f14df260b50ae34fb5d56016e308b098eab02c878b5223c26a/greenlet-3.5.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:e44da2f5bbdaabaf7d80b73dbb430c7035771e9f244e3c8b769715c9d8fa0a16", size = 1681159, upload-time = "2026-06-26T18:31:52.986Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/13/1055e1dda7882073eda533e2b96c62e55bbd2db7fda6d5ece992febc7071/greenlet-3.5.3-cp315-cp315t-win_amd64.whl", hash = "sha256:8ff8bed3e3baa20a3ea261ce00526f1898ad4801d4886fd2220580ee0ad8fadf", size = 244007, upload-time = "2026-06-26T18:22:04.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0d/ca7d15afbdc397e3401134c9e1800d51d12b829661786187a4ad08fe484f/greenlet-3.5.3-cp315-cp315t-win_arm64.whl", hash = "sha256:b7068bd09f761f3f5b4d214c2bed063186b2a86148c740b3873e3f56d79bac31", size = 242586, upload-time = "2026-06-26T18:23:37.93Z" },
 ]
 
 [[package]]
@@ -1419,6 +1478,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.61.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/ee/31e4e0db36588b817a10b299a0285082545fde7d36543c2abe498bb3d61a/playwright-1.61.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:ff138c3a604f69911e9d42fd036e55c2a171e5616edf04c1e7f60a2a285540b0", size = 43421877, upload-time = "2026-06-29T10:32:48.428Z" },
+    { url = "https://files.pythonhosted.org/packages/42/35/71395dd3ecc798965be4a3ef8c443217d4abca168e7cb34536304f9489e6/playwright-1.61.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:009588c2a7e499bc5a8b425b61fa65490968bbda9cd69e0cf2cff10f8304659a", size = 42205016, upload-time = "2026-06-29T10:32:52.104Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/44/323164cf5cd1647bdefce76ffce27651aadb959d089b48f53ea40918276e/playwright-1.61.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:9f7de4536088d12037c13a52b7ea34b59270b78926bb56935070597ffac6b1af", size = 43421884, upload-time = "2026-06-29T10:32:55.773Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f8/a35bf179e4ba2522c1893635094a64e407572547bd61528820fc0abc87fe/playwright-1.61.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:54f3b39f6eab832e33458c1dd7da0b5682aedab3b09ae731b5c59fa12fd2024e", size = 47421381, upload-time = "2026-06-29T10:32:59.903Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/eb/e3f922348ec17c315f98c463f72faa1181a1c3de0bfe31a8d2edf6561723/playwright-1.61.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93454322ade8c11d5d6c211bfd91bdfb9ffb4810e3e026371bcbc4bec1b7ee4c", size = 47120545, upload-time = "2026-06-29T10:33:03.574Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a6/5be4e52b40a9c0c8a073e7c5b0785c05cf5a9ea8f8a7b5b260e32d970342/playwright-1.61.0-py3-none-win32.whl", hash = "sha256:372d55a6f1248fa1dd47599686980cb8fb5bbe6fcda59eab793eb657c11d8a9b", size = 37844841, upload-time = "2026-06-29T10:33:07.361Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fd/2b78036e5fbe9d5f5645bbe08a1eac7160c51243c0093963edbcf67c35d9/playwright-1.61.0-py3-none-win_amd64.whl", hash = "sha256:35c6cc4589a5d00964a59d7b3e59641e0aac0c02f15479a7af77d20f6bc79597", size = 37844846, upload-time = "2026-06-29T10:33:10.637Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/1b0f3c4ee4eb0514bc805b5c2f9a223e5b6de4f11a926f5235d51d0fc81b/playwright-1.61.0-py3-none-win_arm64.whl", hash = "sha256:e9fcbffcf557a8620fdedd92491eb59a32d18e23d6f3b4f6214b952be324fe51", size = 33955127, upload-time = "2026-06-29T10:33:14.008Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1688,6 +1766,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
     { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
     { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #388

## Summary
Builds the level-1 Meso demo as a **tool, not a recording**: `just record-demo` seeds deterministic demo data, drives the full coach + athlete storyboard through a real headless Chromium (Playwright), and writes `docs/demo/out/meso-walkthrough.mp4` (~22s, 1280×720) — zero manual steps, no Anthropic/Stripe/email/push calls, re-recordable after any UI change by editing one labelled storyboard step.

## Changes
- **`MESO_AGENT_FAKE` setting + `agent/fake.py`** — demo/sandbox mode (shared with #389): `get_default_client()` returns a curated, deterministic, no-network `FakeDemoClient` before the API-key gate. It grounds its batch in the real plan context (tag-aware swap target, honors chip quoting the contraindication the coach's instruction is about, load_type-aware progressions, a one-row volume trim that can never increase another row) and runs the unchanged real pipeline: drafting batch → validation guardrail → review gate.
- **`seed_demo_recording` management command** — idempotent known-credentials seeding: comped Demo Coach (`demo-coach@demo.invalid`), `CoachProfile`, a **pristine reset** (`clear_demo` → `load_demo`) so run N never replays run N-1's designer chat, and a usable login for Maya (athlete phone-view step). DEBUG-only unless `--force`; `--json` emits the emails, never the password.
- **`scripts/record_demo.py`** — the recorder: migrate + seed → dedicated `:8035` server with a curated env (fake agent on, Anthropic/VAPID blanked) → off-camera allauth login via `storage_state` → 7 labelled storyboard steps (roster → athlete → designer → agent proposes → review/apply → deliver → Maya logs a set) → webm → mp4 via ffmpeg. Sync is always selector auto-waits; pauses are cosmetic pacing only.
- **7 `data-testid`s** on the storyboard's brittle click targets (enumerated in `docs/demo/README.md`); everything else uses role/text selectors.
- **Plumbing/docs** — Playwright as a dev dep, `record-demo` recipe (`docker compose up -d --wait` for cold starts), git-ignored `docs/demo/out/`, `docs/demo/README.md`, plan doc flipped to SHIPPED, `.env.example` entries.

## Testing
- 34 new tests (fake client wiring/grounding/guardrail cases end-to-end through the real propose endpoint; seed command contract incl. pristine reset + DEBUG guard). Full suite: **1675 passed**; ruff + pre-commit clean.
- `just record-demo` run end-to-end repeatedly (including twice back-to-back for re-recordability); output frames visually verified — pristine chat thread, honors chip quotes Maya's knee flag, 72% → 74% progression, no debug toolbar.
- `/codex-review-loop` converged: iter 1 → 1×P2 fixed (password source of truth), iter 2 → 2×P2+1×P3 fixed (one-row trim, cold-start wait, plural fold), iter 3 → **CLEAN**.

https://claude.ai/code/session_01JX2o56d7pu41ZAJgMA3TR2