### PR TITLE
fix(meso): replace the dead hard-coded avatar with a real identity chip (#387)

### DIFF
--- a/app/store_project/meso/templatetags/meso_extras.py
+++ b/app/store_project/meso/templatetags/meso_extras.py
@@ -1,0 +1,11 @@
+from django import template
+
+from ..serializers import initials as _initials
+
+register = template.Library()
+
+
+@register.filter
+def initials(name):
+    """Two-letter monogram for an avatar ("Maya Okonkwo" → "MO")."""
+    return _initials(str(name))

--- a/app/store_project/meso/tests/test_topnav_identity.py
+++ b/app/store_project/meso/tests/test_topnav_identity.py
@@ -62,11 +62,17 @@ class TestCoachTopnavIdentity:
         assert 'title="Coach">LG<' not in body
 
 
-class TestAnonymousDefaultBlock:
-    def test_offline_page_renders_no_avatar(self, client):
-        # offline.html inherits the default block anonymously (it suppresses
-        # the site nav but not the avatar) — an identity chip for nobody, or a
-        # link into a login-gated page from the offline shell, would be wrong.
+class TestOfflineShellStaysGeneric:
+    def test_offline_page_renders_no_avatar_anonymously(self, client):
+        body = client.get(reverse("meso:offline")).content.decode()
+        assert "meso-avatar" not in body
+        assert reverse("users:profile") not in body
+
+    def test_offline_page_renders_no_avatar_when_authenticated(self, client):
+        # The service worker precaches /meso/offline/ with the athlete's
+        # credentials — an inherited identity chip would bake their initials
+        # and a dead /users/profile/ link into the cached offline shell.
+        client.force_login(make_coach(name="Maya Okonkwo"))
         body = client.get(reverse("meso:offline")).content.decode()
         assert "meso-avatar" not in body
         assert reverse("users:profile") not in body

--- a/app/store_project/meso/tests/test_topnav_identity.py
+++ b/app/store_project/meso/tests/test_topnav_identity.py
@@ -1,0 +1,72 @@
+"""The Meso top bar's identity corner (issue #387).
+
+The coach shell used to render a hard-coded, non-interactive "LG" monogram in
+the ``.meso-topnav`` corner — wrong initials for every coach but one (and for
+every sandbox demo visitor), and dead UI sitting right under the site nav's
+real Account/Logout links. The corner's job is *identity*: show who is signed
+in (which the site nav's text links don't) and link to the account page. When
+Meso grows its own settings surface, this avatar is its natural entry point.
+
+The athlete PWA and public landing overrides of ``topnav_avatar`` are out of
+scope here — they already render the right thing (athlete initials / a Log in
+button).
+"""
+
+import pytest
+from django.urls import reverse
+
+from store_project.meso.models import CoachProfile
+from store_project.users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+# The default topnav_avatar block in _meso_base.html — one line, so the whole
+# anchor is assertable as a stable snippet.
+AVATAR_CLASS = (
+    'class="meso-avatar meso-avatar--sm meso-avatar--accent meso-avatar--link"'
+)
+
+
+def make_coach(name="Maya Okonkwo"):
+    coach = UserFactory(name=name)
+    CoachProfile.objects.create(user=coach)
+    return coach
+
+
+class TestCoachTopnavIdentity:
+    def test_avatar_shows_the_signed_in_coachs_real_initials(self, client):
+        client.force_login(make_coach(name="Maya Okonkwo"))
+        body = client.get(reverse("meso:roster")).content.decode()
+        assert AVATAR_CLASS in body
+        assert ">MO</a>" in body
+
+    def test_avatar_links_to_the_account_page(self, client):
+        client.force_login(make_coach())
+        body = client.get(reverse("meso:roster")).content.decode()
+        assert f'{AVATAR_CLASS} href="{reverse("users:profile")}"' in body
+
+    def test_avatar_tooltip_names_the_signed_in_coach(self, client):
+        client.force_login(make_coach(name="Maya Okonkwo"))
+        body = client.get(reverse("meso:roster")).content.decode()
+        assert 'title="Signed in as Maya Okonkwo' in body
+
+    def test_hardcoded_lg_monogram_is_gone(self, client):
+        client.force_login(make_coach(name="Maya Okonkwo"))
+        body = client.get(reverse("meso:roster")).content.decode()
+        assert 'title="Coach">LG<' not in body
+
+    def test_sandbox_demo_coach_sees_demo_initials_not_lg(self, client):
+        # A sandbox visitor is logged in as a throwaway "Demo Coach" → DC.
+        body = client.get(reverse("meso:sandbox_enter"), follow=True).content.decode()
+        assert ">DC</a>" in body
+        assert 'title="Coach">LG<' not in body
+
+
+class TestAnonymousDefaultBlock:
+    def test_offline_page_renders_no_avatar(self, client):
+        # offline.html inherits the default block anonymously (it suppresses
+        # the site nav but not the avatar) — an identity chip for nobody, or a
+        # link into a login-gated page from the offline shell, would be wrong.
+        body = client.get(reverse("meso:offline")).content.decode()
+        assert "meso-avatar" not in body
+        assert reverse("users:profile") not in body

--- a/app/store_project/static/css/meso.css
+++ b/app/store_project/static/css/meso.css
@@ -134,6 +134,7 @@ a.meso-row,
 button.meso-row,
 a.meso-card,
 button.meso-card,
+.meso-avatar--link,
 .meso [data-hover] {
   transition:
     background-color 0.15s ease,
@@ -152,6 +153,7 @@ button.meso-card,
   button.meso-row,
   a.meso-card,
   button.meso-card,
+  .meso-avatar--link,
   .meso [data-hover] {
     transition: none;
   }
@@ -580,6 +582,18 @@ button.meso-card:hover {
   height: 48px;
   border-radius: 13px;
   font-size: 16px;
+}
+/* The topnav identity chip (issue #387) — the one avatar that's a link, so it
+   must read as clickable where the decorative list monograms don't. */
+.meso-avatar--link {
+  text-decoration: none;
+  cursor: pointer;
+}
+.meso-avatar--link:hover,
+.meso-avatar--link:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+  box-shadow: 0 1px 6px rgba(49, 117, 157, 0.25);
 }
 
 /* --- athlete rows / list --- */

--- a/app/store_project/templates/meso/_meso_base.html
+++ b/app/store_project/templates/meso/_meso_base.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load static meso_extras %}
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -50,7 +50,14 @@
         </div>
         <div class="meso-spacer"></div>
         {% block topnav_actions %}{% endblock %}
-        {% block topnav_avatar %}<div class="meso-avatar meso-avatar--sm meso-avatar--accent" title="Coach">LG</div>{% endblock %}
+        {% comment %}
+          The corner's job is identity (issue #387): show *who* is signed in —
+          the one thing the site nav's Account/Logout links above don't. It
+          links to the account page; when Meso grows its own settings surface,
+          this chip becomes its entry point. Anonymous shell pages (offline)
+          render nothing here.
+        {% endcomment %}
+        {% block topnav_avatar %}{% if request.user.is_authenticated %}<a class="meso-avatar meso-avatar--sm meso-avatar--accent meso-avatar--link" href="{% url 'users:profile' %}" title="Signed in as {{ request.user.display_name }} — account">{{ request.user.display_name|initials }}</a>{% endif %}{% endblock %}
       </nav>
 
       {% if is_sandbox %}

--- a/app/store_project/templates/meso/offline.html
+++ b/app/store_project/templates/meso/offline.html
@@ -12,6 +12,13 @@ for an anonymous fetch rather than a useless cached login redirect.
 {# Phone-first PWA offline fallback — no marketing site nav. #}
 {% block site_nav %}{% endblock %}
 
+{% comment %}
+No identity chip either: the service worker precaches this page with the
+athlete's credentials, so the inherited authenticated default (#387) would bake
+their initials and a dead /users/profile/ link into the cached offline shell.
+{% endcomment %}
+{% block topnav_avatar %}{% endblock %}
+
 {% block navlinks %}
   <a class="meso-navlink" href="{% url 'meso:athlete_home' %}">Training</a>
 {% endblock %}


### PR DESCRIPTION
Fixes #387

## Summary
The Meso coach shell's top-bar corner rendered a mock-era leftover: a hard-coded, non-interactive **"LG"** monogram (`title="Coach"`) for every coach — including sandbox demo visitors — sitting right under the site nav's working Account/Logout links. Two account icons, one of them dead and wrong.

The corner now renders the **signed-in user's real initials as an interactive identity chip**: it links to the account page (`users:profile`) with a `Signed in as {name} — account` tooltip, and gets a hover/focus ring following the #385 interactive-feedback conventions.

## Design rationale (the issue's open questions)
- **Why keep something there at all?** The corner's job is *identity* — showing **who** is signed in, which the site nav's Account/Logout text links don't do. This matches the athlete-PWA precedent, where the initials avatar is the identity marker (those pages have no site nav).
- **Where do Meso settings live?** Nothing settings-shaped exists in Meso yet, so this PR deliberately builds no settings page or dropdown. When Meso settings land, this chip is their natural entry point (grow the link into a small account menu, GitHub-style) — rather than folding Meso settings into the store profile page.

## Changes
- `_meso_base.html`: default `topnav_avatar` block → real monogram linked to `users:profile`, guarded by `is_authenticated`; hard-coded "LG" removed. Athlete-PWA (`athlete_home`/`athlete_session`), landing, invite-claim, and unsubscribe overrides untouched.
- New `meso/templatetags/meso_extras.py` with an `initials` filter reusing the existing `serializers.initials()` monogram helper.
- `meso.css`: `.meso-avatar--link` modifier (hover/focus ring, wired into the #385 transition + reduced-motion blocks). Decorative list monograms keep no hover.
- `offline.html`: explicitly empties the avatar block — the service worker precaches `/meso/offline/` with the athlete's credentials, so the inherited chip would bake stale identity and a dead `/users/profile/` link into the cached offline shell (Codex review catch).
- New `meso/tests/test_topnav_identity.py`: real initials + account link + tooltip on coach pages, hard-coded LG gone, sandbox demo coach shows "DC", offline shell stays identity-free both anonymous and authenticated.

## Testing
- `just check` — 1758 passed, lint clean.
- `/codex-review-loop` converged CLEAN in 2 iterations (iteration 1 caught the offline-precache identity leak, fixed in `20a1671`).

https://claude.ai/code/session_01JX2o56d7pu41ZAJgMA3TR2