### PR TITLE
fix(meso): align sandbox banner and messages with page gutter

### DIFF
--- a/app/store_project/templates/meso/_meso_base.html
+++ b/app/store_project/templates/meso/_meso_base.html
@@ -60,24 +60,29 @@
         {% block topnav_avatar %}{% if request.user.is_authenticated %}<a class="meso-avatar meso-avatar--sm meso-avatar--accent meso-avatar--link" href="{% url 'users:profile' %}" title="Signed in as {{ request.user.display_name }} — account">{{ request.user.display_name|initials }}</a>{% endif %}{% endblock %}
       </nav>
 
-      {% if is_sandbox %}
-        {% comment %}
-          Persistent sandbox banner (issue #389, Phase 1): a slim strip, not a
-          card, so it reads as chrome rather than page content — every screen
-          in the throwaway workspace carries it.
-        {% endcomment %}
-        <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;padding:10px 14px;margin:14px 0 0;background:var(--soft);border:1px solid var(--soft-line);border-left:3px solid var(--accent);border-radius:9px;font-size:13px;color:var(--accent-deep);">
-          {# No "keep your work" promise — carry-over at signup is deferred (S6). #}
-          <span style="flex:1;min-width:0;">You're in a live demo — your work here is temporary. <strong>Create a free account</strong> to run the AI agent.</span>
-          <a class="meso-btn meso-btn--primary" href="{% url 'meso:sandbox_signup' %}">Create a free account</a>
-        </div>
-      {% endif %}
+      {% if is_sandbox or messages %}
+        {# Matches .meso-page's gutter (max-width:1120px, 24px side padding) so these strips align with the content below instead of bleeding to the viewport edges. #}
+        <div style="max-width:1120px;margin:0 auto;padding:0 24px;">
+          {% if is_sandbox %}
+            {% comment %}
+              Persistent sandbox banner (issue #389, Phase 1): a slim strip, not a
+              card, so it reads as chrome rather than page content — every screen
+              in the throwaway workspace carries it.
+            {% endcomment %}
+            <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;padding:10px 14px;margin:14px 0 0;background:var(--soft);border:1px solid var(--soft-line);border-left:3px solid var(--accent);border-radius:9px;font-size:13px;color:var(--accent-deep);">
+              {# No "keep your work" promise — carry-over at signup is deferred (S6). #}
+              <span style="flex:1;min-width:0;">You're in a live demo — your work here is temporary. <strong>Create a free account</strong> to run the AI agent.</span>
+              <a class="meso-btn meso-btn--primary" href="{% url 'meso:sandbox_signup' %}">Create a free account</a>
+            </div>
+          {% endif %}
 
-      {% if messages %}
-        <div style="display:flex;flex-direction:column;gap:8px;margin:14px 0 0;">
-          {% for message in messages %}
-            <div class="meso-card meso-card--pad" style="padding:11px 14px;font-size:13px;color:var(--ink);border-left:3px solid {% if message.tags == 'error' %}var(--warn){% else %}var(--accent-ink){% endif %};">{{ message }}</div>
-          {% endfor %}
+          {% if messages %}
+            <div style="display:flex;flex-direction:column;gap:8px;margin:14px 0 0;">
+              {% for message in messages %}
+                <div class="meso-card meso-card--pad" style="padding:11px 14px;font-size:13px;color:var(--ink);border-left:3px solid {% if message.tags == 'error' %}var(--warn){% else %}var(--accent-ink){% endif %};">{{ message }}</div>
+              {% endfor %}
+            </div>
+          {% endif %}
         </div>
       {% endif %}
 


### PR DESCRIPTION
## Summary
- Sandbox demo banner and flash-message strip in `_meso_base.html` sat directly under `.meso-app` (no horizontal padding), so they spanned edge-to-edge while page content is inset via `.meso-page`'s 24px gutter — reported as "not well formatted, no space on the sides" in the live demo.
- Wrapped both blocks in a `max-width:1120px; margin:0 auto; padding:0 24px` container matching `.meso-page`'s gutter so they now align with the content below.

## Test plan
- [x] `uv run pytest app/store_project/meso -q -k "roster or sandbox"` — 131 passed
- [x] Verified visually in Chrome at `/meso/demo/` — banner now lines up with page content instead of touching viewport edges

https://claude.ai/code/session_01JX2o56d7pu41ZAJgMA3TR2