### PR TITLE
fix(meso): consolidate redundant agent-area guidance in the designer

### DIFF
--- a/app/store_project/meso/tests/test_designer_onboarding.py
+++ b/app/store_project/meso/tests/test_designer_onboarding.py
@@ -10,12 +10,15 @@ column is the athlete's real view.
 
 Phase 5 fixes both:
 
-- **Coachmarks.** Three dismissible first-run notes anchor the designer's
-  regions (week grid · agent · phone preview). They show until dismissed; the
+- **Coachmarks.** Two dismissible first-run notes anchor the designer's
+  regions (week grid · phone preview). They show until dismissed; the
   dismissal persists client-side (``meso.js`` localStorage), like the athlete
   onboarding chrome. No server "seen" flag, no migration.
 - **Agent self-explanation.** A persistent propose → review → apply note makes
-  the review gate explicit for everyone (not just first-timers).
+  the review gate explicit for everyone (not just first-timers). The agent
+  column originally also had its own dismissible coachmark and a chat greeting
+  that both repeated this guidance — consolidated into this one note plus the
+  greeting, which now just carries the "ask in plain words" examples.
 - **Real chrome.** The fabricated left-rail athlete/programming-style/macrocycle
   is replaced with the *real* plan: the athlete's name + active
   contraindications (now carried in the serialized payload) and the real
@@ -63,19 +66,18 @@ def render_designer(client, plan):
 
 
 class TestCoachmarksRender:
-    """The three dismissible region coachmarks render for a real plan."""
+    """The two dismissible region coachmarks render for a real plan."""
 
-    def test_designer_renders_all_three_coachmarks(self, client):
+    def test_designer_renders_both_coachmarks(self, client):
         plan, _, _ = seed_plan()
         body = render_designer(client, plan)
         assert "The week grid" in body  # grid coachmark
-        assert "Talk to the agent" in body  # agent coachmark
         assert "Preview as your athlete" in body  # phone-preview coachmark
 
     def test_each_coachmark_has_a_dismiss_control(self, client):
         plan, _, _ = seed_plan()
         body = render_designer(client, plan)
-        for key in ("grid", "agent", "phone"):
+        for key in ("grid", "phone"):
             assert f"dismissCoachmark('{key}')" in body
 
 
@@ -85,7 +87,7 @@ class TestAgentSelfExplanation:
     def test_designer_renders_review_gate_note(self, client):
         plan, _, _ = seed_plan()
         body = render_designer(client, plan)
-        assert "you review" in body
+        assert "You review" in body
         assert "until you approve" in body
 
 
@@ -133,7 +135,6 @@ class TestCoachmarkSource:
     def test_template_wires_coachmark_visibility(self):
         html = read_designer_template()
         assert "coachmarkVisible('grid')" in html
-        assert "coachmarkVisible('agent')" in html
         assert "coachmarkVisible('phone')" in html
 
     def test_template_drops_fabricated_left_rail(self):

--- a/app/store_project/static/js/meso.js
+++ b/app/store_project/static/js/meso.js
@@ -38,12 +38,15 @@ function createMeso() {
     exSeq: 1,
 
     // ---- first-run coachmarks (first-time UX Phase 5) ----
-    // Three dismissible region notes (week grid / agent / phone preview) orient a
+    // Two dismissible region notes (week grid / phone preview) orient a
     // first-time coach. They show until dismissed; the dismissal persists in
     // localStorage so a coach who waved one away never sees it again (no server
     // "seen" flag — the persistence lives client-side, like the athlete onboarding
     // chrome). The reactive map drives `x-show`; init() hydrates it from storage.
-    coachmarkKeys: ["grid", "agent", "phone"],
+    // (The agent column previously had a third coachmark repeating the same
+    // guidance as the persistent review-gate note and the chat greeting —
+    // dropped; its examples now live in the greeting below.)
+    coachmarkKeys: ["grid", "phone"],
     coachmarksDismissed: {},
 
     // Group mode only: the open per-athlete override editor (one shared row),
@@ -83,7 +86,7 @@ function createMeso() {
       {
         id: 1,
         role: "agent",
-        text: "Tell me how you'd like to adjust this plan — swap a lift, change a day's volume, progress loads, or add a deload. I'll propose changes for you to review before anything touches the program.",
+        text: "Tell me how you'd like to adjust this plan — try “lighten Friday” or “add a deload week.”",
       },
     ],
 

--- a/app/store_project/templates/meso/designer.html
+++ b/app/store_project/templates/meso/designer.html
@@ -207,27 +207,19 @@
             <div x-show="agentTyping" class="meso-flex" style="align-items:center;gap:5px;font-size:11px;color:var(--dim);"><div style="width:6px;height:6px;border-radius:50%;background:var(--accent);"></div>drafting&#8230;</div>
             <div x-show="!agentTyping" class="meso-flex" style="align-items:center;gap:5px;font-size:11px;color:var(--dim);"><div style="width:6px;height:6px;border-radius:50%;background:var(--ok);"></div>ready</div>
             <div style="flex:1;"></div>
-            <div style="font-size:11px;color:var(--dim);" x-text="isGroup ? 'grounded on the group' : 'grounded on profile + logs'"></div>
           </div>
 
           <!-- How the agent works (Phase 5): a persistent note making the review
                gate explicit — a first-timer won't expect the agent to only
                *propose*. Shown in both modes: the group agent (groups Phase 1)
-               edits the shared program behind the same review gate. -->
-          <div style="flex:0 0 auto;display:flex;align-items:flex-start;gap:7px;padding:8px 16px;border-bottom:1px solid var(--line-2);background:var(--rail);font-size:11px;line-height:1.4;color:var(--dim);">
-            <span style="font-weight:700;color:var(--accent-deep);white-space:nowrap;">Propose &#8594; review &#8594; apply</span>
-            <span>The agent proposes; you review every change before it touches the program — nothing applies until you approve.</span>
-          </div>
-
-          <!-- Agent coachmark (Phase 5): dismissible first-run orientation for the
-               agent column. Shown in both modes — the agent is live for groups
-               too (groups Phase 1, the shared program). -->
-          <div x-show="coachmarkVisible('agent')" class="meso-flex" style="flex:0 0 auto;align-items:flex-start;gap:9px;margin:12px 14px 0;padding:11px 12px;background:var(--soft);border:1px solid var(--soft-line);border-left:3px solid var(--accent);border-radius:9px;">
-            <div style="flex:1;min-width:0;line-height:1.4;">
-              <div style="font-size:12.5px;font-weight:700;color:var(--accent-deep);">Talk to the agent</div>
-              <div style="font-size:11.5px;color:var(--accent-deep);opacity:0.85;">Ask in plain words &#8212; &#8220;lighten Friday,&#8221; &#8220;add a deload week.&#8221; It drafts changes you can review.</div>
-            </div>
-            <button @click="dismissCoachmark('agent')" data-hover="rail" aria-label="Dismiss tip" style="appearance:none;cursor:pointer;border:0;background:transparent;font:inherit;font-size:15px;line-height:1;color:var(--dim);padding:2px 4px;flex:0 0 auto;">&times;</button>
+               edits the shared program behind the same review gate. Consolidated
+               with the (now-removed) dismissible "Talk to the agent" coachmark and
+               the chat greeting, which previously repeated this same guidance in
+               three places; the greeting now carries the "ask in plain words"
+               examples and this note is the single explanation of the review gate. -->
+          <div style="flex:0 0 auto;display:flex;flex-direction:column;gap:3px;padding:9px 16px;border-bottom:1px solid var(--line-2);background:var(--rail);font-size:11px;line-height:1.45;color:var(--dim);">
+            <span style="font-weight:700;color:var(--accent-deep);letter-spacing:0.01em;">Propose &#8594; review &#8594; apply</span>
+            <span>You review every change before it touches the program. Nothing applies until you approve.</span>
           </div>
 
           <div x-ref="thread" style="flex:1;overflow-y:auto;padding:16px;display:flex;flex-direction:column;gap:13px;">
@@ -279,7 +271,7 @@
                capability the demo holds back — clone of the exhausted-allowance
                upgrade card below, pointed at signup instead of billing. -->
             <div style="flex:0 0 auto;border-top:1px solid var(--line-2);padding:13px 14px 15px;">
-              <p style="margin:0 0 9px;font-size:12px;color:var(--dim);line-height:1.4;">The AI agent is the one thing the demo holds back. Create a free account to draft with AI.</p>
+              <p style="margin:0 0 9px;font-size:12px;color:var(--dim);line-height:1.4;">Let AI draft the whole program for you &#8212; free to start.</p>
               <a href="{% url 'meso:sandbox_signup' %}" data-hover="brighten" style="display:inline-block;text-decoration:none;font:inherit;font-size:12.5px;font-weight:650;color:var(--accent-ink);background:var(--accent);border-radius:8px;padding:8px 14px;">Create a free account</a>
             </div>
           {% elif can_use_agent %}

--- a/frontend/meso.test.js
+++ b/frontend/meso.test.js
@@ -550,11 +550,14 @@ describe("addDay", () => {
 
 // ---- first-run coachmarks (first-time UX Phase 5) ----
 //
-// Three dismissible region notes (grid / agent / phone) orient a first-time
-// coach. They show until dismissed; the dismissal persists in localStorage so a
-// coach who waved one away never sees it again. The reactive `coachmarksDismissed`
-// map drives `x-show` in the template; here we cover the pure key helper and the
-// load/dismiss/visibility round-trip (jsdom gives us a real localStorage).
+// Two dismissible region notes (grid / phone) orient a first-time coach (the
+// former "agent" coachmark was folded into the persistent review-gate note and
+// the chat greeting — see meso.js). They show until dismissed; the dismissal
+// persists in localStorage so a coach who waved one away never sees it again.
+// The reactive `coachmarksDismissed` map drives `x-show` in the template; here
+// we cover the pure key helper — it's generic over any key string, so "agent"
+// below still exercises the dismiss/visibility round-trip even though it's no
+// longer a template-driven coachmark (jsdom gives us a real localStorage).
 describe("designer coachmarks", () => {
   beforeEach(() => {
     window.localStorage.clear();


### PR DESCRIPTION
## Summary
- The agent chat column repeated the same "talk in plain words, changes wait for review" guidance in three places: a persistent header note, a dismissible coachmark, and the first chat greeting. Dropped the coachmark, folded its concrete examples ("lighten Friday," "add a deload week") into the greeting, and kept the persistent note as the single explanation of the review gate.
- Removed the leftover "grounded on the group" / "grounded on profile + logs" status label from the Agent panel header — dead UI chrome with no clear purpose.
- Refreshed the sandbox signup CTA copy from "The AI agent is the one thing the demo holds back. Create a free account to draft with AI." to "Let AI draft the whole program for you — free to start."
- Updated `coachmarkKeys` (now `["grid", "phone"]`, was `["grid", "agent", "phone"]`) and the affected Python/JS tests + docs to match.

## Test plan
- [x] `uv run pytest store_project/meso/` — 1504 passed
- [x] `npm test` (vitest) — 115 passed
- [x] `just lint` — clean

https://claude.ai/code/session_01JX2o56d7pu41ZAJgMA3TR2