### PR TITLE
refactor(meso): extract deliver Alpine component to static/js under vitest

### DIFF
--- a/app/store_project/static/js/meso_deliver.js
+++ b/app/store_project/static/js/meso_deliver.js
@@ -1,0 +1,56 @@
+/* Meso — deliver screen state. The "Deliver" button POSTs the real action
+ * (stamp the target week + snapshot). `weekId` is the week the screen targets
+ * (the current week, or the ?week= the coach picked); sending it lets a coach
+ * deliver a built-ahead week without first making it current. Scheduling and
+ * push/email notifications arrive with the athlete app.
+ */
+function createMesoDeliver(planId, csrf, weekId) {
+  return {
+    planId: planId,
+    csrf: csrf,
+    weekId: weekId,
+    delivered: false,
+    sending: false,
+    error: false,
+    async deliver() {
+      this.sending = true;
+      this.error = false;
+      try {
+        const res = await fetch(`/meso/api/plan/${this.planId}/deliver/`, {
+          method: "POST",
+          headers: {
+            "X-CSRFToken": this.csrf,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(
+            this.weekId != null ? { week_id: this.weekId } : {},
+          ),
+        });
+        if (!res.ok) throw new Error("Request failed: " + res.status);
+        this.delivered = true;
+      } catch (e) {
+        this.error = true;
+        console.error("Deliver failed", e);
+      } finally {
+        this.sending = false;
+      }
+    },
+  };
+}
+
+// Register the Alpine component in the browser. Loaded as a classic <script>,
+// so `document` exists here but no module system does.
+if (
+  typeof document !== "undefined" &&
+  typeof document.addEventListener === "function"
+) {
+  document.addEventListener("alpine:init", () => {
+    Alpine.data("mesoDeliver", createMesoDeliver);
+  });
+}
+
+// Test hook: expose the factory to Node-based runners (vitest). Skipped in the
+// browser, where `module` is undefined.
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = { createMesoDeliver };
+}

--- a/app/store_project/templates/meso/deliver.html
+++ b/app/store_project/templates/meso/deliver.html
@@ -4,6 +4,7 @@
 {% block title %}Deliver · Meso{% endblock %}
 
 {% block head_extra %}
+  <script defer src="{% static 'js/meso_deliver.js' %}"></script>
   <script defer src="{% static 'js/alpine.min.js' %}"></script>
 {% endblock %}
 
@@ -152,44 +153,4 @@
 {% endblock %}
 {% block scripts %}
   <style>[x-cloak]{display:none !important;}</style>
-  <script>
-    // Deliver screen state. The "Deliver" button POSTs the real action (stamp
-    // the target week + snapshot). `weekId` is the week the screen targets (the
-    // current week, or the ?week= the coach picked); sending it lets a coach
-    // deliver a built-ahead week without first making it current. Scheduling and
-    // push/email notifications arrive with the athlete app.
-    document.addEventListener("alpine:init", () => {
-      Alpine.data("mesoDeliver", (planId, csrf, weekId) => ({
-        planId: planId,
-        csrf: csrf,
-        weekId: weekId,
-        delivered: false,
-        sending: false,
-        error: false,
-        async deliver() {
-          this.sending = true;
-          this.error = false;
-          try {
-            const res = await fetch(`/meso/api/plan/${this.planId}/deliver/`, {
-              method: "POST",
-              headers: {
-                "X-CSRFToken": this.csrf,
-                "Content-Type": "application/json",
-              },
-              body: JSON.stringify(
-                this.weekId != null ? { week_id: this.weekId } : {},
-              ),
-            });
-            if (!res.ok) throw new Error("Request failed: " + res.status);
-            this.delivered = true;
-          } catch (e) {
-            this.error = true;
-            console.error("Deliver failed", e);
-          } finally {
-            this.sending = false;
-          }
-        },
-      }));
-    });
-  </script>
 {% endblock %}

--- a/frontend/meso_deliver.test.js
+++ b/frontend/meso_deliver.test.js
@@ -1,0 +1,135 @@
+// Tests for the deliver screen (app/store_project/static/js/meso_deliver.js).
+//
+// Focus: deliver() — the one POST this screen makes. It stamps the target week
+// (or none, for "current") on the plan's deliver endpoint and flips delivered /
+// sending / error. No offline queue or retry logic here (unlike the athlete
+// logger) — a failed send just re-arms the button.
+
+import { createMesoDeliver } from "../app/store_project/static/js/meso_deliver.js";
+
+const PLAN_ID = 7;
+const CSRF = "tok";
+
+// Build a fetch Response stub. Deliver only ever checks `.ok` / `.status`.
+function res({ ok = true, status = 200 } = {}) {
+  return { ok, status };
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("createMesoDeliver: initial state", () => {
+  it("hydrates planId/csrf/weekId from the constructor args", () => {
+    const c = createMesoDeliver(PLAN_ID, CSRF, 42);
+    expect(c.planId).toBe(PLAN_ID);
+    expect(c.csrf).toBe(CSRF);
+    expect(c.weekId).toBe(42);
+  });
+
+  it("starts not delivered, not sending, no error", () => {
+    const c = createMesoDeliver(PLAN_ID, CSRF, null);
+    expect(c.delivered).toBe(false);
+    expect(c.sending).toBe(false);
+    expect(c.error).toBe(false);
+  });
+});
+
+describe("deliver", () => {
+  it("POSTs to the plan's deliver endpoint with CSRF + JSON headers", async () => {
+    const c = createMesoDeliver(PLAN_ID, CSRF, null);
+    global.fetch = vi.fn().mockResolvedValue(res());
+    await c.deliver();
+    expect(global.fetch).toHaveBeenCalledWith(
+      `/meso/api/plan/${PLAN_ID}/deliver/`,
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          "X-CSRFToken": CSRF,
+          "Content-Type": "application/json",
+        },
+      }),
+    );
+  });
+
+  it("sends the targeted week id in the body when weekId is set", async () => {
+    const c = createMesoDeliver(PLAN_ID, CSRF, 42);
+    global.fetch = vi.fn().mockResolvedValue(res());
+    await c.deliver();
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(body).toEqual({ week_id: 42 });
+  });
+
+  it("sends an empty body when weekId is null (deliver the current week)", async () => {
+    const c = createMesoDeliver(PLAN_ID, CSRF, null);
+    global.fetch = vi.fn().mockResolvedValue(res());
+    await c.deliver();
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(body).toEqual({});
+  });
+
+  it("sets sending true while the request is in flight, false after", async () => {
+    const c = createMesoDeliver(PLAN_ID, CSRF, null);
+    let sendingDuringFetch;
+    global.fetch = vi.fn().mockImplementation(async () => {
+      sendingDuringFetch = c.sending;
+      return res();
+    });
+    await c.deliver();
+    expect(sendingDuringFetch).toBe(true);
+    expect(c.sending).toBe(false);
+  });
+
+  it("marks delivered on success", async () => {
+    const c = createMesoDeliver(PLAN_ID, CSRF, null);
+    global.fetch = vi.fn().mockResolvedValue(res());
+    await c.deliver();
+    expect(c.delivered).toBe(true);
+    expect(c.error).toBe(false);
+  });
+
+  it("clears a previous error at the start of a fresh attempt", async () => {
+    const c = createMesoDeliver(PLAN_ID, CSRF, null);
+    c.error = true;
+    global.fetch = vi.fn().mockResolvedValue(res());
+    await c.deliver();
+    expect(c.error).toBe(false);
+  });
+
+  it("surfaces an HTTP error and does not mark delivered", async () => {
+    const c = createMesoDeliver(PLAN_ID, CSRF, null);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    global.fetch = vi.fn().mockResolvedValue(res({ ok: false, status: 500 }));
+    await c.deliver();
+    expect(c.error).toBe(true);
+    expect(c.delivered).toBe(false);
+    expect(c.sending).toBe(false);
+    expect(console.error).toHaveBeenCalledWith(
+      "Deliver failed",
+      expect.any(Error),
+    );
+  });
+
+  it("surfaces a network failure the same way as an HTTP error", async () => {
+    const c = createMesoDeliver(PLAN_ID, CSRF, null);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    global.fetch = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"));
+    await c.deliver();
+    expect(c.error).toBe(true);
+    expect(c.delivered).toBe(false);
+    expect(c.sending).toBe(false);
+  });
+
+  it("leaves an earlier successful delivery marked delivered if a redelivery fails", async () => {
+    const c = createMesoDeliver(PLAN_ID, CSRF, null);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    global.fetch = vi.fn().mockResolvedValue(res());
+    await c.deliver();
+    expect(c.delivered).toBe(true);
+
+    global.fetch = vi.fn().mockResolvedValue(res({ ok: false, status: 500 }));
+    await c.deliver();
+    expect(c.error).toBe(true);
+    expect(c.delivered).toBe(true); // failure doesn't unset a prior success
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -12,7 +12,7 @@ export default defineConfig({
     include: ["frontend/**/*.test.js"],
     coverage: {
       provider: "v8",
-      include: ["app/store_project/static/js/meso.js", "app/store_project/static/js/meso_athlete.js", "app/store_project/static/js/meso_onboarding.js"],
+      include: ["app/store_project/static/js/meso.js", "app/store_project/static/js/meso_athlete.js", "app/store_project/static/js/meso_onboarding.js", "app/store_project/static/js/meso_deliver.js"],
       reporter: ["text", "html"],
     },
   },


### PR DESCRIPTION
## Summary

Phase 0 (part 2) of the designer framework plan (#403, plan doc `docs/meso/designer-framework-plan.md`): extract the inline `Alpine.data("mesoDeliver", …)` component from `templates/meso/deliver.html` into `static/js/meso_deliver.js` and bring it under the vitest suite. Deliver stays Alpine indefinitely, so this cleanup keeps its value regardless of the Phase 2 island.

Built red→green: the failing spec commit lands first, the extraction makes it pass.

## Changes

- **New module** `app/store_project/static/js/meso_deliver.js` — `createMesoDeliver(planId, csrf, weekId)` factory, moved verbatim from the template; browser registration via `alpine:init` + `module.exports` test hook, mirroring `meso_athlete.js`.
- **`deliver.html`** — inline `<script>` component removed; module loaded via `{% static %}` before `alpine.min.js` (same ordering as `athlete_session.html`). The `x-data="mesoDeliver(...)"` call site is untouched — behavior-identical.
- **New tests** `frontend/meso_deliver.test.js` — 11 specs: hydration, request shape/headers/body (with and without `week_id`), in-flight `sending` transition, success/error/network-failure paths, failed-redeliver keeps `delivered`.
- **`vitest.config.js`** — coverage include extended with the new module.

No CI filter changes needed (`frontend.yml` already globs `static/js/**` and `frontend/**`).

## Test plan

- [x] `npx vitest run` — 4 files, 126 tests pass (11 new)
- [x] `uv run pytest app/store_project/meso/ -k deliver` — 145 passed

Noted, deliberately unchanged (behavior-identical rule): `deliver()` has no re-entrancy guard — pre-existing, candidate for later hardening.

Part of #403.