### PR TITLE
build(meso): Vite + React 19 designer-island scaffolding (Phase 2, PR A)

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -6,13 +6,15 @@ on:
     paths-ignore:
       - "**.md"
       - "docs/**"
-      # Front-end test scaffold only — these never affect the Django app, so
-      # they should not run Django CI (and thus never trigger a deploy). The
-      # served JS under static/js/** is deliberately NOT ignored: changing it
-      # ships via collectstatic and must deploy. See .github/workflows/frontend.yml.
-      - "frontend/**"
-      - "package.json"
-      - "package-lock.json"
+      # Front-end TEST scaffold only — these never reach the production image,
+      # so they should not run Django CI (and thus never trigger a deploy).
+      # Everything that DOES ship must stay un-ignored: static/js/** (served
+      # via collectstatic), frontend/designer/** and package*.json (inputs to
+      # the Dockerfile's island build stage — a designer change with no Python
+      # diff still needs a deploy to rebuild the bundle into the image). See
+      # .github/workflows/frontend.yml.
+      - "frontend/*.test.js"
+      - "frontend/README.md"
       - "vitest.config.js"
       - ".github/workflows/frontend.yml"
   pull_request:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,9 +1,13 @@
 name: Frontend CI
 
-# Runs the meso front-end unit tests (vitest). This is a SEPARATE workflow from
-# "Django CI" on purpose: the production deploy keys off "Django CI" succeeding,
-# so front-end-test-only changes run here, gate the PR, and never trigger a
-# deploy. Only fires when JS/test files actually change.
+# Runs the meso front-end unit tests (vitest) plus the designer island's
+# typecheck and production build (Decision 3,
+# docs/meso/designer-framework-plan.md). This is a SEPARATE workflow from
+# "Django CI" on purpose: the production deploy keys off "Django CI"
+# succeeding, so front-end-test-only changes run here, gate the PR, and never
+# trigger a deploy — the build here only verifies the bundle compiles; the
+# Dockerfile's node stage is what actually ships it. Only fires when JS/TS/
+# test/build-config files actually change.
 
 on:
   push:
@@ -14,6 +18,9 @@ on:
       - "package.json"
       - "package-lock.json"
       - "vitest.config.js"
+      - "tsconfig*.json"
+      - "vite.config.*"
+      - ".nvmrc"
       - ".github/workflows/frontend.yml"
   pull_request:
     branches: ["main"]
@@ -23,6 +30,9 @@ on:
       - "package.json"
       - "package-lock.json"
       - "vitest.config.js"
+      - "tsconfig*.json"
+      - "vite.config.*"
+      - ".nvmrc"
       - ".github/workflows/frontend.yml"
 
 concurrency:
@@ -47,3 +57,9 @@ jobs:
 
       - name: Run front-end tests
         run: npm test
+
+      - name: Typecheck the designer island
+        run: npm run typecheck
+
+      - name: Build the designer island
+        run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,11 @@ repomix-output.*
 node_modules/
 coverage/
 
+# Designer island build output (Decision 3, docs/meso/designer-framework-plan.md):
+# built by Vite everywhere it's needed (Dockerfile node stage, frontend.yml CI,
+# `just frontend-build`/`frontend-watch` in dev) — never committed.
+app/store_project/static/js/dist/
+
 # Meso demo-video recorder output (issue #388) — commit the tool
 # (scripts/record_demo.py), never the generated binary; `just record-demo`
 # regenerates it on demand. See docs/demo/README.md.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,17 @@
 # syntax=docker/dockerfile:1
 
+# Builds the designer React island (Decision 3,
+# docs/meso/designer-framework-plan.md) to STABLE, un-hashed filenames; the
+# python stage below copies dist/ into the static tree before collectstatic
+# (which re-hashes it via WhiteNoise's manifest storage) runs at container
+# start. A broken frontend build fails here, so it can never reach prod.
+FROM node:22-slim AS frontend-builder
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY frontend/designer/ ./frontend/designer/
+RUN npm run build
+
 # Production image for Mastering Fitness, built on the Hetzner box by the
 # `deploy` tool (docker compose build). Build context is the repo root.
 # WhiteNoise serves static files from this image; media lives on S3.
@@ -27,6 +39,11 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 # Application source.
 COPY . .
+
+# Designer island build output, in place before the entrypoint's
+# `collectstatic` (WhiteNoise re-hashes it into the manifest at container
+# start — see the frontend-builder stage above).
+COPY --from=frontend-builder /app/app/store_project/static/js/dist/ /app/app/store_project/static/js/dist/
 
 # Non-root runtime user; staticfiles dir must be writable for collectstatic.
 RUN chmod +x /app/docker-entrypoint.sh \

--- a/docs/meso/designer-framework-plan.md
+++ b/docs/meso/designer-framework-plan.md
@@ -149,13 +149,23 @@ session should treat these as part of the soft-delete contract:
   the deliver screen (selector, `?week=`, session count) is live-only;
   `applyPlanData` disarms a pending index-anchored delete confirm.
 
-### Phase 1 — undo/redo backend + minimal UI — 🔴 red suites committed
+### Phase 1 — undo/redo backend + minimal UI — ✅ shipped (#407)
 
-> Status (2026-07-02): the failing contract suites are committed on branch
-> `meso-designer-phase-1-undo` (`test_designer_undo.py` +
-> `frontend/meso_undo.test.js`); the full spec they encode is a comment on
-> #403 ("Phase 1 spec"). Implement to green against them without modifying
-> them; rebase the branch onto main first (it was cut pre-#405-squash).
+**Outcome (2026-07-02):** shipped as #407 — a `PlanAction` snapshot op-log
+(migration 0032) + `history.py` (`serialize_plan_snapshot` /
+`restore_plan_snapshot`) + recording in nine endpoints
+(`prescription_patch`, `session_add_exercise`, `session_add`, `week_add`,
+`week_set_current`, `prescription_override`, the three Phase 0 deletes, and
+`batch_apply` as a single undoable step) + `history`
+(`can_undo`/`can_redo`/labels) on both the full plan envelope and row-level
+autosave/add/override payloads. Built red→green against the pre-committed 33
+pytest + 17 vitest specs, unmodified. A 3-round local Codex review loop found
+five fixes, all shipped: row-level replies now refresh `history`;
+`record_plan_action` row-locks the plan against concurrent autosaves; labels
+clamp to 255 chars (Postgres column limit); `session_add`/`week_add` take the
+plan lock before child locks, fixing a lock-order inversion against
+undo/deletes; and snapshot restore skips overrides whose `GroupMembership`
+has since been removed instead of 500ing on the dead FK.
 
 - `deleted_at` migration + `PlanAction` model, snapshot serializer/restorer,
   action recording in the endpoints listed in Decision 2, `undo`/`redo`
@@ -167,7 +177,7 @@ session should treat these as part of the soft-delete contract:
 - Tests: pytest round-trips — edit/undo/redo, delete-day/undo (logs intact!),
   batch_apply/undo, redo-stack cleared by a fresh edit, history cap.
 
-### Phase 2 — the island (behavior-identical migration)
+### Phase 2 — the island (behavior-identical migration) — 🚧 in progress (PR A: scaffolding)
 
 - Vite + React app in `frontend/designer/`; entry reads the same
   `meso-plan-data` / `meso-chat-thread` / `meso-csrf` elements; template

--- a/frontend/designer/src/DesignerRoot.test.tsx
+++ b/frontend/designer/src/DesignerRoot.test.tsx
@@ -1,0 +1,16 @@
+// Smoke test for the Phase 2 build toolchain (docs/meso/designer-framework-plan.md,
+// Phase 2 / Decision 3): proves jsdom + React Testing Library + TSX compile and
+// render through vitest before any real component-port work starts. PR A only
+// needs the pipeline to work end-to-end; PR B replaces DesignerRoot with the
+// ported island.
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { DesignerRoot } from "./DesignerRoot";
+
+describe("DesignerRoot", () => {
+  it("mounts and renders the scaffold placeholder", () => {
+    render(<DesignerRoot />);
+
+    expect(screen.getByTestId("designer-root-placeholder")).toBeInTheDocument();
+  });
+});

--- a/frontend/designer/src/DesignerRoot.tsx
+++ b/frontend/designer/src/DesignerRoot.tsx
@@ -1,0 +1,8 @@
+// Placeholder mount target for the Phase 2 island port
+// (docs/meso/designer-framework-plan.md, Phase 2). This PR (PR A) only proves
+// the Vite + React 19 + TypeScript build and test pipeline end-to-end; PR B
+// replaces this with the real ported designer UI (TopBar, WeekStrip,
+// WeekGrid, ChatPanel, ...) and wires designer.html to mount it.
+export function DesignerRoot() {
+  return <div data-testid="designer-root-placeholder">Designer island scaffold</div>;
+}

--- a/frontend/designer/src/main.tsx
+++ b/frontend/designer/src/main.tsx
@@ -1,0 +1,14 @@
+import { createRoot } from "react-dom/client";
+import { DesignerRoot } from "./DesignerRoot";
+
+// Entry for the designer island bundle (dist/designer.js). No-ops on every
+// page that doesn't render the mount point — which, in this PR, is every
+// page: designer.html still renders the Alpine UI and doesn't load this
+// script yet. PR B swaps designer.html's markup for
+// `<div id="meso-designer-root">` and the module <script> tag; this file is
+// what mounts into it.
+const container = document.getElementById("meso-designer-root");
+
+if (container) {
+  createRoot(container).render(<DesignerRoot />);
+}

--- a/frontend/designer/tsconfig.json
+++ b/frontend/designer/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "moduleDetection": "force",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "vite.config.ts", "vitest-setup.ts"]
+}

--- a/frontend/designer/vite.config.ts
+++ b/frontend/designer/vite.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+// Resolve paths from this config file's own location, not the shell's cwd,
+// so `npm run build` behaves the same run from the repo root (the normal
+// case, via `just frontend-build`) or anywhere else. Uses the global `URL`
+// instead of `node:path`/`node:url` so the island doesn't need @types/node.
+const here = new URL(".", import.meta.url).pathname;
+const outDir = `${here}../../app/store_project/static/js/dist`;
+
+// Builds the designer React island to STABLE, un-hashed filenames in the
+// Django static tree (Decision 3, docs/meso/designer-framework-plan.md).
+// WhiteNoise's manifest storage content-hashes everything again at
+// `collectstatic`, so Vite doesn't need to — and a hashed filename here would
+// have nowhere to update the `{% static %}` reference in designer.html.
+export default defineConfig({
+  root: here,
+  plugins: [react()],
+  build: {
+    outDir,
+    emptyOutDir: true,
+    // Flatten output: dist/designer.js + dist/designer.css, no assets/ dir.
+    assetsDir: ".",
+    cssCodeSplit: false,
+    modulePreload: false,
+    target: "es2022",
+    rollupOptions: {
+      input: `${here}src/main.tsx`,
+      output: {
+        format: "es",
+        // No code-split hashes: one entry, no dynamic imports, so there is
+        // exactly one JS chunk and (if any component imports CSS) one
+        // stylesheet — both land under these fixed names every build.
+        entryFileNames: "designer.js",
+        chunkFileNames: "designer.js",
+        assetFileNames: "designer[extname]",
+        codeSplitting: false,
+      },
+    },
+  },
+});

--- a/frontend/designer/vitest-setup.ts
+++ b/frontend/designer/vitest-setup.ts
@@ -1,0 +1,5 @@
+// Extends vitest's `expect` with jest-dom matchers (toBeInTheDocument, etc.)
+// for the designer island's React Testing Library specs. Loaded for every
+// frontend/**/*.test.{js,ts,tsx} file via vitest.config.js's `setupFiles` —
+// harmless no-op for the plain-JS meso*.test.js suites, which don't use it.
+import "@testing-library/jest-dom/vitest";

--- a/justfile
+++ b/justfile
@@ -41,6 +41,19 @@ test-coverage:
 test-js:
     npm test
 
+# Rebuild the designer React island (frontend/designer/) on every save. Run
+# this alongside `just dev` if you're touching the designer page — there's no
+# HMR yet (Decision 3), and `just dev` alone won't build it: the page will
+# 404 on dist/designer.js in DEBUG until this (or `frontend-build`) has run.
+frontend-watch:
+    npm run watch
+
+# One-shot production build of the designer island to
+# app/store_project/static/js/dist/ (also runs in the Dockerfile node stage
+# and in Frontend CI to catch a broken build before it ships).
+frontend-build:
+    npm run build
+
 lint:
     uv run ruff check
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,14 +7,33 @@
     "": {
       "name": "fitness-store-frontend",
       "version": "0.0.0",
+      "dependencies": {
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0"
+      },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/react": "^19.2.2",
+        "@types/react-dom": "^19.2.1",
+        "@vitejs/plugin-react": "^6.0.3",
         "@vitest/coverage-v8": "^4.1.9",
         "jsdom": "^29.1.1",
+        "typescript": "^5.9.3",
+        "vite": "^8.1.2",
         "vitest": "^4.1.9"
       },
       "engines": {
         "node": ">=22"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.1.11",
@@ -67,6 +86,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
@@ -101,6 +144,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
@@ -660,6 +713,96 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -670,6 +813,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -695,6 +846,52 @@
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
+      "integrity": "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.1.9",
@@ -840,6 +1037,41 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -903,6 +1135,20 @@
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/data-urls": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -924,6 +1170,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -933,6 +1189,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/entities": {
       "version": "8.0.0",
@@ -1036,6 +1300,16 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
@@ -1402,6 +1676,17 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1446,6 +1731,16 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.15",
@@ -1549,6 +1844,22 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -1557,6 +1868,49 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-from-string": {
@@ -1616,6 +1970,12 @@
         "node": ">=v12.22.7"
       }
     },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -1659,6 +2019,19 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -1777,6 +2150,20 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/undici": {
       "version": "7.28.0",

--- a/package.json
+++ b/package.json
@@ -9,11 +9,26 @@
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "build": "vite build --config frontend/designer/vite.config.ts",
+    "watch": "vite build --watch --config frontend/designer/vite.config.ts",
+    "typecheck": "tsc --noEmit -p frontend/designer/tsconfig.json"
+  },
+  "dependencies": {
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/react": "^19.2.2",
+    "@types/react-dom": "^19.2.1",
+    "@vitejs/plugin-react": "^6.0.3",
     "@vitest/coverage-v8": "^4.1.9",
     "jsdom": "^29.1.1",
+    "typescript": "^5.9.3",
+    "vite": "^8.1.2",
     "vitest": "^4.1.9"
   }
 }

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,15 +1,21 @@
 import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
 
 // Front-end unit tests for the meso app's hand-written JS (the only place in
 // the repo with non-trivial client-side logic: the athlete's offline log queue
-// and the designer's agent poll loop). Tests live under frontend/ — kept out of
-// app/store_project/static/ so they are never collected/served by Django, and
-// so test-only changes can be excluded from the deploy-triggering Django CI.
+// and the designer's agent poll loop) AND the Phase 2 designer island under
+// frontend/designer/ (React + TSX, built separately by
+// frontend/designer/vite.config.ts — see Decision 3 in
+// docs/meso/designer-framework-plan.md). Tests live under frontend/ — kept out
+// of app/store_project/static/ so they are never collected/served by Django,
+// and so test-only changes can be excluded from the deploy-triggering Django CI.
 export default defineConfig({
+  plugins: [react()],
   test: {
     globals: true,
     environment: "jsdom",
-    include: ["frontend/**/*.test.js"],
+    include: ["frontend/**/*.test.{js,ts,tsx}"],
+    setupFiles: ["frontend/designer/vitest-setup.ts"],
     coverage: {
       provider: "v8",
       include: ["app/store_project/static/js/meso.js", "app/store_project/static/js/meso_athlete.js", "app/store_project/static/js/meso_onboarding.js", "app/store_project/static/js/meso_deliver.js"],


### PR DESCRIPTION
## Summary

Phase 2 PR A of the designer framework plan (#403, plan doc Decision 3): the build scaffolding for the React island, with **no user-visible change** — `designer.html` and `meso.js` are untouched; the island mounts nowhere in prod yet. PR B (the behavior-identical port + template swap) lands on top of this.

Built toolchain-first-red: an RTL smoke spec for the placeholder island component lands first, the scaffolding makes it pass.

## What's here

- **`frontend/designer/`** — strict-TS Vite + React 19 island source: entry (`main.tsx`, no-ops unless `#meso-designer-root` exists), placeholder `DesignerRoot`, RTL smoke spec, jest-dom setup.
- **Stable output names** — `vite.config.ts` builds a single un-hashed `app/store_project/static/js/dist/designer.js` (+`designer.css` once styles exist); WhiteNoise's manifest storage does the hashing at collectstatic, so plain `{% static %}` will reference it. `dist/` is gitignored — built everywhere it's needed:
- **Dockerfile** — new `node:22-slim` `frontend-builder` stage (`npm ci` + `npm run build`); its `dist/` is `COPY --from`'d into the python stage before the entrypoint's collectstatic. A broken frontend build fails the image build. Verified end-to-end locally: `docker build` succeeds and the bundle lands in the image with correct ownership.
- **Frontend CI** — `npm run typecheck` + `npm run build` steps; path filters grow the TS/vite config paths. Django CI (the deploy gate) untouched.
- **justfile** — `frontend-watch` / `frontend-build` recipes (no HMR by design; the recipe comment documents that `just dev` alone won't build the island).
- **package.json** — react/react-dom as the first real `dependencies`; typescript/vite/@vitejs/plugin-react/RTL as devDeps. `@vitejs/plugin-react@^6` because the existing `vitest@4` already resolves `vite@8`, which older plugin majors don't peer with.
- **Plan doc** — Phase 1 annotated shipped (#407) with its outcome paragraph; Phase 2 marked in progress.

## Test plan

- [x] `npm run typecheck` clean · `npm run build` → `dist/designer.js` (190 kB, 60 kB gzip)
- [x] `npx vitest run` — 168 passed (167 existing + smoke)
- [x] `uv run pytest` — 1839 passed (docs-only Django-side)
- [x] `docker build .` — full image build green; bundle present in container

Part of #403 (Phase 2, PR A of two).

## Review hardening

`da20adb` (local Codex review catch): with the bundle now built into the production image, a main push touching only `frontend/designer/**` or `package*.json` would have run Frontend CI but skipped Django CI — and the deploy keys off Django CI, so prod would silently keep the old bundle. `django.yml`'s push `paths-ignore` now excludes only the true test scaffold; every shipped build input triggers the deploy gate.
