### PR TITLE
feat(meso): grid keyboard navigation + cell accessibility (Phase 3)

### DIFF
--- a/frontend/designer/src/DesignerRoot.test.tsx
+++ b/frontend/designer/src/DesignerRoot.test.tsx
@@ -4,7 +4,8 @@
 // flags json_script elements the same way designer.html's `init()` did, then
 // composes every hook and renders the tree. Absent/malformed payload is the
 // no-op-without-a-plan guard ported from init()'s early return.
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen, cleanup, waitFor, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { DesignerRoot } from "./DesignerRoot";
 
 function jsonScript(id: string, data: unknown) {
@@ -137,5 +138,138 @@ describe("hydration: missing or malformed payload", () => {
 
     expect(spy).toHaveBeenCalled();
     expect(container).toBeEmptyDOMElement();
+  });
+});
+
+// === Phase 3: grid keyboard navigation — RED (../hooks/useGridNav does not
+// exist; WeekGrid does not call it yet). DesignerRoot.tsx itself needs NO
+// code changes for this PR (useGridNav is instantiated inside WeekGrid,
+// which already receives `program` from usePlanData) — these specs mount
+// the full app because focus-restoration-across-applyPlanData needs a real
+// undo() round trip (usePlanData + useUndoRedo), and the undo-key
+// regression needs the real window keydown listener (useUndoRedo).
+//
+// Restoration tiers tested here are ONLY the three FALLBACKS (spec: "else
+// focus the first cell of the same day ... else the grid's first cell ...
+// else nothing") — tier 1 ("re-focus the same prescriptionId+column")
+// is deliberately NOT pinned at this level: React's keyed reconciliation
+// already keeps the same <input> DOM node (and thus its native focus)
+// across a same-shape program swap with no restoration code involved, so
+// an integration spec for it can't fail today for the right reason (it's
+// covered, and IS discriminating, at the hook level in
+// hooks/useGridNav.test.tsx). Tiers 2/3 genuinely unmount the previously-
+// focused input (its row/day disappears from the array), which drops
+// focus to <body> today with nothing to restore it — that's what makes
+// them real red specs here.
+function twoDayGridProgram() {
+  return [
+    {
+      id: 1,
+      n: 1,
+      name: "Lower",
+      exercises: [
+        { id: 9, name: "Box Squat", sets: "3", reps: "5", load: "100", load_type: "abs" },
+        { id: 10, name: "RDL", sets: "3", reps: "8", load: "80", load_type: "abs" },
+      ],
+    },
+    {
+      id: 2,
+      n: 2,
+      name: "Upper",
+      exercises: [{ id: 11, name: "Bench", sets: "3", reps: "5", load: "70", load_type: "abs" }],
+    },
+  ];
+}
+
+function mountGridPlan() {
+  jsonScript(
+    "meso-plan-data",
+    planPayload({
+      program: twoDayGridProgram(),
+      history: { can_undo: true, can_redo: false, undo_label: "Edited Box Squat", redo_label: null },
+    }),
+  );
+  jsonScript("meso-chat-thread", []);
+  csrfSpan("tok123");
+  jsonScript("meso-designer-flags", flagsPayload());
+  render(<DesignerRoot />);
+}
+
+function mockUndoReply(program: unknown[]) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      ok: true,
+      program,
+      weeks: [{ id: 1, index: 1, label: "Wk 1", current: true }],
+      phases: [{ name: "Hypertrophy", weeks: "4 wk", state: "current" }],
+      viewing: 1,
+      history: { can_undo: false, can_redo: true, undo_label: null, redo_label: "Edited Box Squat" },
+    }),
+  }) as unknown as typeof fetch;
+}
+
+describe("Phase 3: grid focus restoration across an applyPlanData swap (undo)", () => {
+  it("tier: falls back to the day's first cell when the focused prescription is gone but its day survives", async () => {
+    const user = userEvent.setup();
+    mountGridPlan();
+    await user.click(screen.getByTestId("exercise-sets-9"));
+
+    // Exercise 9 is gone from day 1 (undone); exercise 10 remains.
+    mockUndoReply([
+      { id: 1, n: 1, name: "Lower", exercises: [{ id: 10, name: "RDL", sets: "3", reps: "8", load: "80", load_type: "abs" }] },
+      { id: 2, n: 2, name: "Upper", exercises: [{ id: 11, name: "Bench", sets: "3", reps: "5", load: "70", load_type: "abs" }] },
+    ]);
+    await user.click(screen.getByTestId("undo-button"));
+
+    await waitFor(() => expect(screen.getByTestId("exercise-name-10")).toHaveFocus());
+  });
+
+  it("tier: falls back to the grid's first cell when the focused day itself is gone; a further swap that empties the grid does not crash", async () => {
+    const user = userEvent.setup();
+    mountGridPlan();
+    await user.click(screen.getByTestId("exercise-sets-11")); // day 2's only exercise
+
+    // Day 2 is gone entirely (undone); only day 1 remains.
+    mockUndoReply([
+      {
+        id: 1,
+        n: 1,
+        name: "Lower",
+        exercises: [
+          { id: 9, name: "Box Squat", sets: "3", reps: "5", load: "100", load_type: "abs" },
+          { id: 10, name: "RDL", sets: "3", reps: "8", load: "80", load_type: "abs" },
+        ],
+      },
+    ]);
+    await user.click(screen.getByTestId("undo-button"));
+
+    await waitFor(() => expect(screen.getByTestId("exercise-name-9")).toHaveFocus());
+
+    // A further swap that empties the whole grid: "else nothing" — must not
+    // throw (an uncaught error here would fail this test), and must not
+    // leave a stale reference to a removed element.
+    mockUndoReply([]);
+    await user.click(screen.getByTestId("undo-button"));
+    await waitFor(() => expect(screen.queryByTestId("exercise-name-9")).not.toBeInTheDocument());
+  });
+});
+
+describe("Phase 3 regression: grid inputs still suppress global undo (handleUndoKey)", () => {
+  it("once a cell has its own keydown wiring, Ctrl+Z there still leaves native field undo alone (no undo POST)", async () => {
+    const user = userEvent.setup();
+    mountGridPlan();
+    await user.click(screen.getByTestId("exercise-sets-9"));
+    // Sanity: this proves the cell truly has Phase 3's own keydown handling
+    // active (not just "nothing is wired so nothing could intercept
+    // anything") before trusting the negative assertion below.
+    await user.keyboard("{ArrowDown}");
+    expect(screen.getByTestId("exercise-sets-10")).toHaveFocus();
+
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    fireEvent.keyDown(screen.getByTestId("exercise-sets-10"), { key: "z", ctrlKey: true });
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });

--- a/frontend/designer/src/DesignerRoot.test.tsx
+++ b/frontend/designer/src/DesignerRoot.test.tsx
@@ -205,7 +205,10 @@ function mockUndoReply(program: unknown[]) {
       weeks: [{ id: 1, index: 1, label: "Wk 1", current: true }],
       phases: [{ name: "Hypertrophy", weeks: "4 wk", state: "current" }],
       viewing: 1,
-      history: { can_undo: false, can_redo: true, undo_label: null, redo_label: "Edited Box Squat" },
+      // can_undo stays true: the multi-undo restoration specs click the undo
+      // button repeatedly, and a can_undo:false reply would disable it after
+      // the first click (userEvent.click on a disabled button never fires).
+      history: { can_undo: true, can_redo: true, undo_label: "Edited RDL", redo_label: "Edited Box Squat" },
     }),
   }) as unknown as typeof fetch;
 }

--- a/frontend/designer/src/components/DayCard.tsx
+++ b/frontend/designer/src/components/DayCard.tsx
@@ -5,6 +5,7 @@ import { ExerciseRow } from "./ExerciseRow";
 import type { Day, Exercise } from "../lib/api";
 import type { PendingDelete } from "../hooks/usePlanData";
 import type { OneRmEditorState } from "../hooks/useOneRmEditor";
+import type { UseGridNavResult } from "../hooks/useGridNav";
 
 export interface DayCardProps {
   day: Day;
@@ -17,6 +18,10 @@ export interface DayCardProps {
   onConfirmPendingDelete(): void;
   onCancelPendingDelete(): void;
   onAddExercise(dayIndex: number): void;
+  // Phase 3: optional passthrough from WeekGrid, forwarded straight to every
+  // ExerciseRow. Optional so DayCard.test.tsx's existing fixtures (which
+  // never set it) keep passing untouched.
+  gridNav?: UseGridNavResult;
   onFieldChange(dayIndex: number, exIndex: number, field: keyof Exercise, value: string): void;
   onCommit(dayIndex: number, exIndex: number): void;
   onRemoveExercise(dayIndex: number, exIndex: number): void;
@@ -42,6 +47,7 @@ export function DayCard(props: DayCardProps) {
     onConfirmPendingDelete,
     onCancelPendingDelete,
     onAddExercise,
+    gridNav,
     onFieldChange,
     onCommit,
     onRemoveExercise,
@@ -122,6 +128,7 @@ export function DayCard(props: DayCardProps) {
           isGroup={isGroup}
           unit={unit}
           deleting={deleting}
+          gridNav={gridNav}
           oneRmOpenForRow={oneRmOpenForRow(ex)}
           oneRmEditorState={oneRmEditorState}
           onFieldChange={(field, value) => onFieldChange(dayIndex, xi, field, value)}

--- a/frontend/designer/src/components/ExerciseRow.test.tsx
+++ b/frontend/designer/src/components/ExerciseRow.test.tsx
@@ -5,6 +5,10 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ExerciseRow } from "./ExerciseRow";
 import type { Exercise } from "../lib/api";
+// Phase 3 (grid keyboard navigation) — type-only import, safely erased at
+// build time (verbatimModuleSyntax) even before ../hooks/useGridNav exists,
+// so it can't break this file's EXISTING specs while useGridNav is red.
+import type { GridColumn, UseGridNavResult, GridCellCallbacks } from "../hooks/useGridNav";
 
 function ex(overrides: Partial<Exercise> = {}): Exercise {
   return { id: 9, name: "Squat", sets: "3", reps: "5", load: "100", load_type: "abs", rpe: "8", note: "", ...overrides };
@@ -249,5 +253,154 @@ describe("1RM editor keyboard", () => {
     await user.click(screen.getByTestId("one-rm-input-9"));
     await user.keyboard("{Escape}");
     expect(onOneRmCancel).toHaveBeenCalledTimes(1);
+  });
+});
+
+// === Phase 3: grid keyboard navigation — RED (frontend/designer/CONTRACT.md
+// has no useGridNav section yet; ../hooks/useGridNav does not exist). See
+// useGridNav.test.tsx's header for the full API contract. Additions below,
+// existing specs above are untouched.
+//
+// Design decisions pinned here (ExerciseRow's side of the contract):
+// - `ExerciseRowProps` gains an OPTIONAL `gridNav?: UseGridNavResult` prop
+//   (threaded WeekGrid -> DayCard -> ExerciseRow, both hops optional) so
+//   DayCard.test.tsx's existing fixtures — out of scope for this PR — never
+//   need to change: DayCard forwards `gridNav` straight through, and
+//   ExerciseRow falls back to a harmless no-op (tabIndex -1, inert
+//   onFocus/onKeyDown) when the prop is absent, exactly as these specs
+//   exercise via `baseProps()` (which never sets it).
+// - `aria-label` and `data-grid-cell` are unconditional — pure functions of
+//   (ex.name, ex.id, column) — so they're correct even in that no-gridNav
+//   fallback path (a11y must never depend on the nav feature being wired).
+describe("Phase 3: cell aria-labels (a11y, unconditional)", () => {
+  it("labels every one of the six cells '<exercise name> — <column label>'", () => {
+    render(<ExerciseRow {...baseProps({ ex: ex({ name: "Box Squat" }) })} />);
+    expect(screen.getByTestId("exercise-name-9")).toHaveAttribute("aria-label", "Box Squat — exercise name");
+    expect(screen.getByTestId("exercise-sets-9")).toHaveAttribute("aria-label", "Box Squat — sets");
+    expect(screen.getByTestId("exercise-reps-9")).toHaveAttribute("aria-label", "Box Squat — reps");
+    expect(screen.getByTestId("exercise-load-9")).toHaveAttribute("aria-label", "Box Squat — load");
+    expect(screen.getByTestId("exercise-rpe-9")).toHaveAttribute("aria-label", "Box Squat — RPE");
+    expect(screen.getByTestId("exercise-note-9")).toHaveAttribute("aria-label", "Box Squat — note");
+  });
+
+  it("falls back to 'exercise' in the label when the row has no name yet", () => {
+    render(<ExerciseRow {...baseProps({ ex: ex({ name: "" }) })} />);
+    expect(screen.getByTestId("exercise-sets-9")).toHaveAttribute("aria-label", "exercise — sets");
+  });
+});
+
+describe("Phase 3: grid-cell DOM identity (unconditional)", () => {
+  it("tags every cell input data-grid-cell='<prescriptionId>:<column>'", () => {
+    render(<ExerciseRow {...baseProps()} />);
+    expect(screen.getByTestId("exercise-name-9")).toHaveAttribute("data-grid-cell", "9:name");
+    expect(screen.getByTestId("exercise-sets-9")).toHaveAttribute("data-grid-cell", "9:sets");
+    expect(screen.getByTestId("exercise-reps-9")).toHaveAttribute("data-grid-cell", "9:reps");
+    expect(screen.getByTestId("exercise-load-9")).toHaveAttribute("data-grid-cell", "9:load");
+    expect(screen.getByTestId("exercise-rpe-9")).toHaveAttribute("data-grid-cell", "9:rpe");
+    expect(screen.getByTestId("exercise-note-9")).toHaveAttribute("data-grid-cell", "9:note");
+  });
+});
+
+describe("Phase 3: roving tabIndex wiring (gridNav prop)", () => {
+  function gridNavAnchoredOn(column: GridColumn): UseGridNavResult {
+    return {
+      anchor: { prescriptionId: 9, column },
+      cellProps: vi.fn((_id: number | string, c: GridColumn) => ({
+        tabIndex: c === column ? (0 as const) : (-1 as const),
+        onFocus: vi.fn(),
+        onKeyDown: vi.fn(),
+      })),
+    };
+  }
+
+  it("sets tabIndex=0 only on the gridNav-anchored column, -1 on the rest", () => {
+    render(<ExerciseRow {...baseProps({ gridNav: gridNavAnchoredOn("load") })} />);
+    expect(screen.getByTestId("exercise-name-9")).toHaveAttribute("tabindex", "-1");
+    expect(screen.getByTestId("exercise-sets-9")).toHaveAttribute("tabindex", "-1");
+    expect(screen.getByTestId("exercise-load-9")).toHaveAttribute("tabindex", "0");
+    expect(screen.getByTestId("exercise-note-9")).toHaveAttribute("tabindex", "-1");
+  });
+
+  it("without a gridNav prop, cells fall back to a non-tabbable -1 rather than crashing", () => {
+    render(<ExerciseRow {...baseProps()} />);
+    expect(screen.getByTestId("exercise-name-9")).toHaveAttribute("tabindex", "-1");
+    expect(screen.getByTestId("exercise-sets-9")).toHaveAttribute("tabindex", "-1");
+  });
+
+  it("calls gridNav.cellProps with this row's prescription id and each cell's column", () => {
+    const gridNav = gridNavAnchoredOn("name");
+    render(<ExerciseRow {...baseProps({ gridNav })} />);
+    expect(gridNav.cellProps).toHaveBeenCalledWith(9, "name", expect.anything());
+    expect(gridNav.cellProps).toHaveBeenCalledWith(9, "sets", expect.anything());
+    expect(gridNav.cellProps).toHaveBeenCalledWith(9, "reps", expect.anything());
+    expect(gridNav.cellProps).toHaveBeenCalledWith(9, "load", expect.anything());
+    expect(gridNav.cellProps).toHaveBeenCalledWith(9, "rpe", expect.anything());
+    expect(gridNav.cellProps).toHaveBeenCalledWith(9, "note", expect.anything());
+  });
+});
+
+describe("Phase 3: cellProps callback wiring (Enter-commit / Escape-revert contract)", () => {
+  // ExerciseRow must hand useGridNav's cellProps() a callbacks object whose
+  // onCommit IS the row's existing dirty-gated commit (spec: "the existing
+  // dirty-gated commit — no-op when clean") and whose onRevert writes
+  // through the RAW onFieldChange prop (bypassing the dirtying `changed()`
+  // wrapper) and clears the dirty flag — this is what lets Escape suppress
+  // a subsequent blur-commit. We capture the real callbacks ExerciseRow
+  // passes and invoke them directly, rather than re-deriving useGridNav's
+  // own key-decision logic here (that's useGridNav.test.tsx's job).
+  function captureCallbacks(column: GridColumn) {
+    let captured: GridCellCallbacks | undefined;
+    const gridNav: UseGridNavResult = {
+      anchor: { prescriptionId: 9, column },
+      cellProps: vi.fn((_id: number | string, c: GridColumn, callbacks: GridCellCallbacks) => {
+        if (c === column) captured = callbacks;
+        return { tabIndex: c === column ? (0 as const) : (-1 as const), onFocus: vi.fn(), onKeyDown: vi.fn() };
+      }),
+    };
+    return { gridNav, getCallbacks: () => captured };
+  }
+
+  it("onCommit is a no-op on a clean cell (existing dirty gate)", () => {
+    const onCommit = vi.fn();
+    const { gridNav, getCallbacks } = captureCallbacks("load");
+    render(<ExerciseRow {...baseProps({ gridNav, onCommit })} />);
+    expect(gridNav.cellProps).toHaveBeenCalled();
+    getCallbacks()!.onCommit();
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it("onCommit fires the row's onCommit prop once the cell has actually been changed", async () => {
+    const user = userEvent.setup();
+    const onCommit = vi.fn();
+    const { gridNav, getCallbacks } = captureCallbacks("load");
+    render(<ExerciseRow {...baseProps({ gridNav, onCommit })} />);
+    await user.type(screen.getByTestId("exercise-load-9"), "5");
+    expect(gridNav.cellProps).toHaveBeenCalled();
+    getCallbacks()!.onCommit();
+    expect(onCommit).toHaveBeenCalledTimes(1);
+  });
+
+  it("onRevert calls the raw onFieldChange with the given value and suppresses the next blur commit", async () => {
+    const user = userEvent.setup();
+    const onFieldChange = vi.fn();
+    const onCommit = vi.fn();
+    const { gridNav, getCallbacks } = captureCallbacks("load");
+    render(<ExerciseRow {...baseProps({ gridNav, onFieldChange, onCommit })} />);
+    await user.type(screen.getByTestId("exercise-load-9"), "5"); // dirties the row
+    expect(gridNav.cellProps).toHaveBeenCalled();
+    getCallbacks()!.onRevert("100");
+    expect(onFieldChange).toHaveBeenCalledWith("load", "100");
+    await user.click(screen.getByTestId("exercise-load-9"));
+    await user.tab();
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it("onChange marks the row dirty and forwards to onFieldChange, same as typing", () => {
+    const onFieldChange = vi.fn();
+    const { gridNav, getCallbacks } = captureCallbacks("note");
+    render(<ExerciseRow {...baseProps({ gridNav, onFieldChange })} />);
+    expect(gridNav.cellProps).toHaveBeenCalled();
+    getCallbacks()!.onChange("left knee sore");
+    expect(onFieldChange).toHaveBeenCalledWith("note", "left knee sore");
   });
 });

--- a/frontend/designer/src/components/ExerciseRow.tsx
+++ b/frontend/designer/src/components/ExerciseRow.tsx
@@ -6,6 +6,14 @@ import { useRef } from "react";
 import { loadSuffix } from "../lib/grid";
 import type { Exercise } from "../lib/api";
 import type { OneRmEditorState } from "../hooks/useOneRmEditor";
+import { cellAriaLabel, gridCellDomKey } from "../hooks/useGridNav";
+import type { GridCellBindings, GridCellCallbacks, GridColumn, UseGridNavResult } from "../hooks/useGridNav";
+
+// Phase 3 (grid keyboard navigation): a cell with no gridNav wired up (or no
+// gridNav prop at all) falls back to a harmless, non-tabbable, inert
+// binding — never crashes, never intercepts a key. a11y (data-grid-cell /
+// aria-label) stays unconditional regardless (see below).
+const INERT_GRID_BINDINGS: GridCellBindings = { tabIndex: -1, onFocus: () => {}, onKeyDown: () => {} };
 
 export interface ExerciseRowProps {
   ex: Exercise;
@@ -21,6 +29,9 @@ export interface ExerciseRowProps {
   // source: ExerciseRow takes a `deleting` prop (see ExerciseRow.test.tsx's
   // note).
   deleting: boolean;
+  // Phase 3: optional passthrough from WeekGrid (via DayCard). Absent in
+  // DayCard.test.tsx's existing fixtures — see useGridNav.test.tsx's header.
+  gridNav?: UseGridNavResult;
   onFieldChange(field: keyof Exercise, value: string): void;
   onCommit(): void;
   onRemove(): void;
@@ -40,6 +51,7 @@ export function ExerciseRow(props: ExerciseRowProps) {
     oneRmOpenForRow,
     oneRmEditorState,
     deleting,
+    gridNav,
     onFieldChange,
     onCommit,
     onRemove,
@@ -66,6 +78,25 @@ export function ExerciseRow(props: ExerciseRowProps) {
     dirtySinceFocus.current = false;
     onCommit();
   };
+  // Phase 3 Escape: revert writes through the RAW onFieldChange (bypassing
+  // `changed`'s dirtying) and clears the dirty flag, so a subsequent blur
+  // doesn't re-commit the draft the coach just backed out of.
+  const revert = (field: keyof Exercise, value: string) => {
+    dirtySinceFocus.current = false;
+    onFieldChange(field, value);
+  };
+
+  // Every grid cell's gridNav wiring: same callback shape, keyed by column.
+  // `column` doubles as the Exercise field name (GridColumn's members are a
+  // subset of keyof Exercise by construction).
+  function gridCellBindings(column: GridColumn): GridCellBindings {
+    const callbacks: GridCellCallbacks = {
+      onChange: (value) => changed(column, value),
+      onCommit: commitIfDirty,
+      onRevert: (value) => revert(column, value),
+    };
+    return gridNav ? gridNav.cellProps(ex.id, column, callbacks) : INERT_GRID_BINDINGS;
+  }
 
   return (
     <div className="meso-ex-row">
@@ -73,9 +104,12 @@ export function ExerciseRow(props: ExerciseRowProps) {
         <input
           className="meso-cell meso-ex-name-input"
           data-testid={`exercise-name-${ex.id}`}
+          data-grid-cell={gridCellDomKey(ex.id, "name")}
+          aria-label={cellAriaLabel(ex.name, "name")}
           value={ex.name}
           onChange={(e) => changed("name", e.target.value)}
           onBlur={commitIfDirty}
+          {...gridCellBindings("name")}
         />
         <div className="meso-ex-tags">
           {ex.tag && <span className="meso-tag-chip">{ex.tag}</span>}
@@ -184,17 +218,23 @@ export function ExerciseRow(props: ExerciseRowProps) {
         <input
           className="meso-cell meso-num-input meso-num-input--sets"
           data-testid={`exercise-sets-${ex.id}`}
+          data-grid-cell={gridCellDomKey(ex.id, "sets")}
+          aria-label={cellAriaLabel(ex.name, "sets")}
           value={ex.sets}
           onChange={(e) => changed("sets", e.target.value)}
           onBlur={commitIfDirty}
+          {...gridCellBindings("sets")}
         />
         <span className="meso-x-sep">×</span>
         <input
           className="meso-cell meso-num-input meso-num-input--reps"
           data-testid={`exercise-reps-${ex.id}`}
+          data-grid-cell={gridCellDomKey(ex.id, "reps")}
+          aria-label={cellAriaLabel(ex.name, "reps")}
           value={ex.reps}
           onChange={(e) => changed("reps", e.target.value)}
           onBlur={commitIfDirty}
+          {...gridCellBindings("reps")}
         />
       </div>
 
@@ -202,9 +242,12 @@ export function ExerciseRow(props: ExerciseRowProps) {
         <input
           className="meso-cell meso-num-input meso-num-input--load"
           data-testid={`exercise-load-${ex.id}`}
+          data-grid-cell={gridCellDomKey(ex.id, "load")}
+          aria-label={cellAriaLabel(ex.name, "load")}
           value={ex.load}
           onChange={(e) => changed("load", e.target.value)}
           onBlur={commitIfDirty}
+          {...gridCellBindings("load")}
         />
         <button
           type="button"
@@ -222,9 +265,12 @@ export function ExerciseRow(props: ExerciseRowProps) {
         <input
           className="meso-cell meso-num-input meso-num-input--rpe"
           data-testid={`exercise-rpe-${ex.id}`}
+          data-grid-cell={gridCellDomKey(ex.id, "rpe")}
+          aria-label={cellAriaLabel(ex.name, "rpe")}
           value={ex.rpe ?? ""}
           onChange={(e) => changed("rpe", e.target.value)}
           onBlur={commitIfDirty}
+          {...gridCellBindings("rpe")}
         />
       </div>
 
@@ -232,10 +278,13 @@ export function ExerciseRow(props: ExerciseRowProps) {
         <input
           className="meso-note"
           data-testid={`exercise-note-${ex.id}`}
+          data-grid-cell={gridCellDomKey(ex.id, "note")}
+          aria-label={cellAriaLabel(ex.name, "note")}
           value={ex.note ?? ""}
           placeholder="—"
           onChange={(e) => changed("note", e.target.value)}
           onBlur={commitIfDirty}
+          {...gridCellBindings("note")}
         />
       </div>
     </div>

--- a/frontend/designer/src/components/WeekGrid.test.tsx
+++ b/frontend/designer/src/components/WeekGrid.test.tsx
@@ -14,10 +14,10 @@
 // coachmark hook slice (coachmarkVisible, dismissCoachmark) its own prose
 // says are wired in. Resolved by including them — WeekGrid must have them to
 // render DayCard/ExerciseRow and the coachmark at all.
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { WeekGrid } from "./WeekGrid";
-import type { Day, Week, HistoryState } from "../lib/api";
+import type { Day, Week, HistoryState, Exercise } from "../lib/api";
 import type { PendingDelete } from "../hooks/usePlanData";
 
 function day(overrides: Partial<Day> = {}): Day {
@@ -107,5 +107,132 @@ describe("WeekGrid", () => {
     render(<WeekGrid {...baseProps({ onAddDay })} />);
     await user.click(screen.getByTestId("add-day-button"));
     expect(onAddDay).toHaveBeenCalledTimes(1);
+  });
+});
+
+// === Phase 3: grid keyboard navigation — RED. WeekGrid is where useGridNav
+// (../hooks/useGridNav, does not exist yet) gets instantiated internally —
+// it's called ONCE inside WeekGrid (which already receives `program`), so
+// WeekGrid's own prop signature does NOT change; no new required prop shows
+// up in baseProps() above, and none of the existing specs needed touching.
+// These specs render real multi-day/multi-exercise programs and drive real
+// keyboard events through RTL — no mock gridNav is needed or possible here
+// (it isn't an externally-injectable prop).
+//
+// A generic negative ("key X does nothing") is NOT useful as a red spec:
+// with nothing wired up today, "nothing moves" is already trivially true.
+// Every spec below is built so at least one assertion is false against
+// today's (unmodified) WeekGrid — see inline notes where that isn't obvious.
+function exercise(id: number, overrides: Partial<Exercise> = {}): Exercise {
+  return { id, name: `Ex ${id}`, sets: "3", reps: "5", load: "100", load_type: "abs", rpe: "8", note: "", ...overrides };
+}
+
+// day 1 (id 1): ex 9 "Box Squat", ex 10 "RDL" — day 2 (id 2): ex 11 "Bench".
+const NAV_PROGRAM: Day[] = [
+  day({ id: 1, n: 1, name: "Lower", exercises: [exercise(9, { name: "Box Squat" }), exercise(10, { name: "RDL" })] }),
+  day({ id: 2, n: 2, name: "Upper", exercises: [exercise(11, { name: "Bench" })] }),
+];
+
+describe("Phase 3: ArrowDown / ArrowUp navigate rows across day-card boundaries", () => {
+  it("ArrowDown moves focus to the same column on the next row within a day", async () => {
+    const user = userEvent.setup();
+    render(<WeekGrid {...baseProps({ program: NAV_PROGRAM })} />);
+    await user.click(screen.getByTestId("exercise-sets-9"));
+    await user.keyboard("{ArrowDown}");
+    expect(screen.getByTestId("exercise-sets-10")).toHaveFocus();
+  });
+
+  it("ArrowDown crosses a day-card boundary (last row of day 1 -> first row of day 2)", async () => {
+    const user = userEvent.setup();
+    render(<WeekGrid {...baseProps({ program: NAV_PROGRAM })} />);
+    await user.click(screen.getByTestId("exercise-load-10"));
+    await user.keyboard("{ArrowDown}");
+    expect(screen.getByTestId("exercise-load-11")).toHaveFocus();
+  });
+
+  it("ArrowUp mirrors ArrowDown, crossing day boundaries upward", async () => {
+    const user = userEvent.setup();
+    render(<WeekGrid {...baseProps({ program: NAV_PROGRAM })} />);
+    await user.click(screen.getByTestId("exercise-rpe-11"));
+    await user.keyboard("{ArrowUp}");
+    expect(screen.getByTestId("exercise-rpe-10")).toHaveFocus();
+  });
+});
+
+describe("Phase 3: ArrowRight / ArrowLeft move columns only at caret extremes", () => {
+  it("ArrowRight at the end of the text moves to the next column", () => {
+    render(<WeekGrid {...baseProps({ program: NAV_PROGRAM })} />);
+    const setsInput = screen.getByTestId("exercise-sets-9") as HTMLInputElement;
+    setsInput.focus();
+    setsInput.setSelectionRange(setsInput.value.length, setsInput.value.length);
+    fireEvent.keyDown(setsInput, { key: "ArrowRight" });
+    expect(screen.getByTestId("exercise-reps-9")).toHaveFocus();
+  });
+
+  it("ArrowLeft at the start of the text moves to the previous column", () => {
+    render(<WeekGrid {...baseProps({ program: NAV_PROGRAM })} />);
+    const repsInput = screen.getByTestId("exercise-reps-9") as HTMLInputElement;
+    repsInput.focus();
+    repsInput.setSelectionRange(0, 0);
+    fireEvent.keyDown(repsInput, { key: "ArrowLeft" });
+    expect(screen.getByTestId("exercise-sets-9")).toHaveFocus();
+  });
+});
+
+describe("Phase 3: Enter commits / Escape reverts (integrated)", () => {
+  it("Enter commits only when the cell is dirty, and keeps focus in place", async () => {
+    const user = userEvent.setup();
+    const onCommit = vi.fn();
+    render(<WeekGrid {...baseProps({ program: NAV_PROGRAM, onCommit })} />);
+    const loadInput = screen.getByTestId("exercise-load-9");
+    await user.click(loadInput);
+    await user.keyboard("{Enter}"); // clean cell: no-op (existing dirty gate)
+    expect(onCommit).not.toHaveBeenCalled();
+    await user.keyboard("5"); // dirties the cell
+    await user.keyboard("{Enter}");
+    expect(onCommit).toHaveBeenCalledWith(0, 0);
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(loadInput).toHaveFocus();
+  });
+
+  it("Escape reverts to the focus-time value via onFieldChange and suppresses the next blur commit", async () => {
+    const user = userEvent.setup();
+    const onFieldChange = vi.fn();
+    const onCommit = vi.fn();
+    render(<WeekGrid {...baseProps({ program: NAV_PROGRAM, onFieldChange, onCommit })} />);
+    const loadInput = screen.getByTestId("exercise-load-9");
+    await user.click(loadInput);
+    await user.keyboard("999"); // undoes nothing yet — just a draft
+    await user.keyboard("{Escape}");
+    // The focus-time value was "100" (exercise(9)'s default load) — never
+    // re-typed, so this exact call can only come from the revert path.
+    expect(onFieldChange).toHaveBeenCalledWith(0, 0, "load", "100");
+    await user.tab();
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+});
+
+describe("Phase 3: roving tabIndex across multiple rendered rows/days", () => {
+  it("exactly one cell (the grid's first) is tabbable on initial render", () => {
+    render(<WeekGrid {...baseProps({ program: NAV_PROGRAM })} />);
+    expect(screen.getByTestId("exercise-name-9")).toHaveAttribute("tabindex", "0");
+    expect(screen.getByTestId("exercise-sets-9")).toHaveAttribute("tabindex", "-1");
+    expect(screen.getByTestId("exercise-name-10")).toHaveAttribute("tabindex", "-1");
+    expect(screen.getByTestId("exercise-name-11")).toHaveAttribute("tabindex", "-1");
+  });
+
+  it("focusing another cell moves the roving tabIndex to it", async () => {
+    const user = userEvent.setup();
+    render(<WeekGrid {...baseProps({ program: NAV_PROGRAM })} />);
+    await user.click(screen.getByTestId("exercise-rpe-10"));
+    expect(screen.getByTestId("exercise-rpe-10")).toHaveAttribute("tabindex", "0");
+    expect(screen.getByTestId("exercise-name-9")).toHaveAttribute("tabindex", "-1");
+  });
+});
+
+describe("Phase 3: aria-labels flow through to rendered cells", () => {
+  it("labels a rendered cell with its exercise name and column", () => {
+    render(<WeekGrid {...baseProps({ program: NAV_PROGRAM })} />);
+    expect(screen.getByTestId("exercise-sets-9")).toHaveAttribute("aria-label", "Box Squat — sets");
   });
 });

--- a/frontend/designer/src/components/WeekGrid.tsx
+++ b/frontend/designer/src/components/WeekGrid.tsx
@@ -10,6 +10,7 @@ import { WeekStrip } from "./WeekStrip";
 import type { Day, Exercise, HistoryState, Week } from "../lib/api";
 import type { Id, PendingDelete } from "../hooks/usePlanData";
 import type { OneRmEditorState } from "../hooks/useOneRmEditor";
+import { useGridNav } from "../hooks/useGridNav";
 
 export interface WeekGridProps {
   program: Day[];
@@ -92,6 +93,11 @@ export function WeekGrid(props: WeekGridProps) {
     onRedo,
   } = props;
 
+  // Phase 3: instantiated ONCE here (WeekGrid already receives `program`) —
+  // DayCard/ExerciseRow only ever see the result as an optional passthrough
+  // prop (see useGridNav.test.tsx's header).
+  const gridNav = useGridNav({ program });
+
   return (
     <div>
       <WeekStrip
@@ -154,6 +160,7 @@ export function WeekGrid(props: WeekGridProps) {
           onConfirmPendingDelete={onConfirmPendingDelete}
           onCancelPendingDelete={onCancelPendingDelete}
           onAddExercise={onAddExercise ?? (() => {})}
+          gridNav={gridNav}
           onFieldChange={onFieldChange}
           onCommit={onCommit}
           onRemoveExercise={onRemoveExercise}

--- a/frontend/designer/src/components/WeekStrip.tsx
+++ b/frontend/designer/src/components/WeekStrip.tsx
@@ -57,6 +57,7 @@ export function WeekStrip(props: WeekStripProps) {
           key={w.id}
           type="button"
           data-testid={`week-chip-${w.id}`}
+          data-grid-restore=""
           data-hover="rail"
           className={`meso-week-chip${w.id === viewedWeekId ? " is-viewed" : ""}`}
           title={w.current ? "Live week — delivery sends this one" : "View " + w.label}
@@ -69,6 +70,7 @@ export function WeekStrip(props: WeekStripProps) {
       <button
         type="button"
         data-testid="add-week-button"
+          data-grid-restore=""
         data-hover="add"
         className="meso-week-strip-btn meso-week-strip-btn--dashed"
         onClick={onAddWeek}
@@ -79,6 +81,7 @@ export function WeekStrip(props: WeekStripProps) {
         <button
           type="button"
           data-testid="make-current-button"
+          data-grid-restore=""
           data-hover="brighten"
           className="meso-week-strip-btn meso-week-strip-btn--accent"
           title="Make this the live week — delivery will send it"
@@ -91,6 +94,7 @@ export function WeekStrip(props: WeekStripProps) {
         <button
           type="button"
           data-testid="remove-week-button"
+          data-grid-restore=""
           data-hover="rail"
           className="meso-week-strip-btn"
           disabled={deleting}
@@ -106,6 +110,7 @@ export function WeekStrip(props: WeekStripProps) {
           <button
             type="button"
             data-testid="confirm-remove-week-button"
+          data-grid-restore=""
             data-hover="brighten"
             className="meso-week-strip-btn meso-week-strip-btn--confirm"
             disabled={deleting}
@@ -117,6 +122,7 @@ export function WeekStrip(props: WeekStripProps) {
           <button
             type="button"
             data-testid="cancel-remove-week-button"
+          data-grid-restore=""
             data-hover="rail"
             className="meso-week-strip-btn"
             disabled={deleting}
@@ -131,6 +137,7 @@ export function WeekStrip(props: WeekStripProps) {
         <button
           type="button"
           data-testid="undo-button"
+          data-grid-restore=""
           data-hover="rail"
           className="meso-week-strip-btn"
           disabled={undoing || !history.can_undo}
@@ -143,6 +150,7 @@ export function WeekStrip(props: WeekStripProps) {
         <button
           type="button"
           data-testid="redo-button"
+          data-grid-restore=""
           data-hover="rail"
           className="meso-week-strip-btn"
           disabled={undoing || !history.can_redo}

--- a/frontend/designer/src/hooks/useGridNav.test.tsx
+++ b/frontend/designer/src/hooks/useGridNav.test.tsx
@@ -557,3 +557,34 @@ describe("review hardening: Escape baseline + focus-steal guard", () => {
     expect(document.activeElement).toBe(composer);
   });
 });
+
+describe("review hardening: modified arrows stay native", () => {
+  // Shift+Arrow extends a selection; Ctrl/Alt/Cmd+Arrow are native text
+  // navigation. None of them may move grid focus or preventDefault.
+  it("Shift+ArrowDown is not intercepted", () => {
+    const cells = mountCells(PROGRAM);
+    cells["9:sets"]!.focus();
+    const { result } = renderHook(() => useGridNav({ program: PROGRAM }));
+    const event = keyEvent("ArrowDown", cells["9:sets"]!, { shiftKey: true });
+    act(() => {
+      result.current.cellProps(9, "sets", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(cells["9:sets"]);
+  });
+
+  it("Ctrl+ArrowLeft at the caret boundary is not intercepted", () => {
+    const cells = mountCells(PROGRAM);
+    const input = cells["9:sets"]!;
+    input.value = "3";
+    input.focus();
+    input.setSelectionRange(0, 0);
+    const { result } = renderHook(() => useGridNav({ program: PROGRAM }));
+    const event = keyEvent("ArrowLeft", input, { ctrlKey: true });
+    act(() => {
+      result.current.cellProps(9, "sets", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(input);
+  });
+});

--- a/frontend/designer/src/hooks/useGridNav.test.tsx
+++ b/frontend/designer/src/hooks/useGridNav.test.tsx
@@ -1,0 +1,508 @@
+// Specs for useGridNav (Phase 3, docs/meso/designer-framework-plan.md +
+// scratchpad phase3-spec.md) — the grid's roving-tabindex + keyboard-nav +
+// focus-restoration hook. Does NOT exist yet; this file is RED until a
+// later agent implements `../hooks/useGridNav`.
+//
+// === API decisions this file pins (spec left these open) ===
+// 1. Hook lives at frontend/designer/src/hooks/useGridNav.ts, called ONCE
+//    inside WeekGrid (has `program` already; DesignerRoot needs no change).
+// 2. Cell DOM identity: every grid `<input>` carries
+//    `data-grid-cell="{prescriptionId}:{column}"` (see `gridCellDomKey`
+//    below) so the hook can locate + `.focus()` siblings via
+//    `document.querySelector` instead of ref-plumbing through
+//    DayCard/ExerciseRow. `cellProps()` itself returns only
+//    `{ tabIndex, onFocus, onKeyDown }` — NOT the data-attribute or the
+//    aria-label; those are the caller's job (ExerciseRow sets
+//    `data-grid-cell={gridCellDomKey(...)}` and
+//    `aria-label={cellAriaLabel(...)}` directly) so aria-labels stay a
+//    pure, hook-independent a11y guarantee (present even if a row is
+//    somehow rendered without a wired-up gridNav).
+// 3. `cellProps(prescriptionId, column, callbacks)` — `callbacks` is
+//    `{ onChange(value), onCommit(), onRevert(value) }`, supplied fresh
+//    per render by ExerciseRow: `onCommit` IS the row's existing
+//    dirty-gated `commitIfDirty` (so Enter's "existing dirty-gated
+//    commit" requirement is satisfied by construction, no duplicate dirty
+//    tracking inside the hook); `onRevert` is a NEW ExerciseRow-side
+//    function that calls the raw (non-dirtying) `onFieldChange` prop and
+//    clears the row's `dirtySinceFocus` ref — this is how Escape avoids
+//    re-arming a commit-on-blur after reverting.
+// 4. Focus-time value capture (needed for Escape) lives INSIDE the hook:
+//    `onFocus` records `event.currentTarget.value` keyed by cell id, and
+//    ALSO updates `anchor` (roving tabindex follows real focus, mouse or
+//    keyboard). Arrow-key moves set `anchor` directly (not via a focus
+//    event round-trip) so the hook works identically whether or not
+//    React's synthetic event system is attached (true in these
+//    hook-only specs, which build fake event objects and never mount
+//    real DOM via React).
+// 5. ArrowLeft/Right at a ROW extreme (no column to wrap to): the spec
+//    only says "no wrap"; resolved here as "well, no preventDefault
+//    either" — there's no browser default to suppress at a boundary
+//    caret position, so the native no-op is harmless.
+// 6. Restoration tiers apply on every `program` reference change
+//    (rerender), gated on "the grid had focus before this change" (a
+//    ref flipped true by any cell's onFocus) — the spec's documented
+//    simpler alternative to a call-site "pending restore" flag. Tier-1
+//    (same prescriptionId+column) calling `.focus()` on an
+//    already-focused node is a no-op in real browsers, so this cannot
+//    disturb an in-progress keystroke during ordinary per-field edits.
+// 7. `cellAriaLabel(exerciseName, column)` is exported as a pure
+//    function (no hook state needed) — testable standalone, and usable
+//    unconditionally by ExerciseRow even before/without a live gridNav.
+
+import { act, renderHook } from "@testing-library/react";
+import type { FocusEvent, KeyboardEvent } from "react";
+import {
+  useGridNav,
+  cellAriaLabel,
+  gridCellDomKey,
+  GRID_COLUMNS,
+} from "./useGridNav";
+import type { Day, Exercise } from "../lib/api";
+
+function ex(id: number, overrides: Partial<Exercise> = {}): Exercise {
+  return { id, name: `Ex ${id}`, sets: "3", reps: "5", load: "100", load_type: "abs", rpe: "8", note: "", ...overrides };
+}
+
+function day(id: number, exercises: Exercise[], overrides: Partial<Day> = {}): Day {
+  return { id, n: id, name: `Day ${id}`, exercises, ...overrides };
+}
+
+// day 1 (id 1): ex 9, ex 10 — day 2 (id 2): ex 11. Flattened row order
+// (per spec, day-major/exercise-minor): (9), (10), (11).
+const PROGRAM: Day[] = [day(1, [ex(9), ex(10)]), day(2, [ex(11)])];
+
+const NOOP_CALLBACKS = { onChange: vi.fn(), onCommit: vi.fn(), onRevert: vi.fn() };
+
+/** Mounts one real `<input>` per (prescriptionId, column) in `program`, so
+ * the hook's `document.querySelector`-based focus moves have somewhere
+ * real to land — mirrors what ExerciseRow would render, without needing a
+ * full React render of the grid tree. */
+function mountCells(program: Day[]) {
+  const nodes: Record<string, HTMLInputElement> = {};
+  for (const d of program) {
+    for (const e of d.exercises) {
+      for (const column of GRID_COLUMNS) {
+        const input = document.createElement("input");
+        input.type = "text";
+        input.value = String((e as unknown as Record<string, unknown>)[column] ?? "");
+        input.setAttribute("data-grid-cell", gridCellDomKey(e.id, column));
+        document.body.appendChild(input);
+        nodes[gridCellDomKey(e.id, column)] = input;
+      }
+    }
+  }
+  return nodes;
+}
+
+/** Simulates the DOM swap a real applyPlanData-driven re-render performs:
+ * tear down every existing grid cell and mount fresh ones for the new
+ * program (see decision 6 — the hook's own effect runs against whatever
+ * `document.querySelector` finds after this). */
+function resyncCells(program: Day[]) {
+  document.querySelectorAll("[data-grid-cell]").forEach((n) => n.remove());
+  return mountCells(program);
+}
+
+function keyEvent(
+  key: string,
+  target: HTMLInputElement,
+  extra: Partial<{ ctrlKey: boolean; metaKey: boolean; shiftKey: boolean }> = {},
+): KeyboardEvent<HTMLInputElement> {
+  return {
+    key,
+    currentTarget: target,
+    target,
+    preventDefault: vi.fn(),
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    ...extra,
+  } as unknown as KeyboardEvent<HTMLInputElement>;
+}
+
+function focusEvent(target: HTMLInputElement): FocusEvent<HTMLInputElement> {
+  return { currentTarget: target, target } as unknown as FocusEvent<HTMLInputElement>;
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("anchor + roving tabindex", () => {
+  it("starts anchored on the first cell (first exercise, name column)", () => {
+    mountCells(PROGRAM);
+    const { result } = renderHook(() => useGridNav({ program: PROGRAM }));
+    expect(result.current.anchor).toEqual({ prescriptionId: 9, column: "name" });
+  });
+
+  it("exactly one cell is tabbable (0) initially — every other cell is -1", () => {
+    mountCells(PROGRAM);
+    const { result } = renderHook(() => useGridNav({ program: PROGRAM }));
+    expect(result.current.cellProps(9, "name", NOOP_CALLBACKS).tabIndex).toBe(0);
+    expect(result.current.cellProps(9, "sets", NOOP_CALLBACKS).tabIndex).toBe(-1);
+    expect(result.current.cellProps(10, "name", NOOP_CALLBACKS).tabIndex).toBe(-1);
+    expect(result.current.cellProps(11, "note", NOOP_CALLBACKS).tabIndex).toBe(-1);
+  });
+
+  it("focusing another cell moves the roving 0 to it", () => {
+    const cells = mountCells(PROGRAM);
+    const { result } = renderHook(() => useGridNav({ program: PROGRAM }));
+    act(() => {
+      result.current.cellProps(10, "load", NOOP_CALLBACKS).onFocus(focusEvent(cells["10:load"]!));
+    });
+    expect(result.current.anchor).toEqual({ prescriptionId: 10, column: "load" });
+    expect(result.current.cellProps(10, "load", NOOP_CALLBACKS).tabIndex).toBe(0);
+    expect(result.current.cellProps(9, "name", NOOP_CALLBACKS).tabIndex).toBe(-1);
+  });
+
+  it("cell identity is (prescriptionId, column), never an index — a same-column cell on a different exercise is a different cell", () => {
+    mountCells(PROGRAM);
+    const { result } = renderHook(() => useGridNav({ program: PROGRAM }));
+    // Two different exercises' "name" cells must be distinguishable even
+    // though both are "column 0 of their row".
+    expect(result.current.cellProps(9, "name", NOOP_CALLBACKS).tabIndex).toBe(0);
+    expect(result.current.cellProps(10, "name", NOOP_CALLBACKS).tabIndex).toBe(-1);
+  });
+});
+
+describe("ArrowDown / ArrowUp", () => {
+  it("ArrowDown moves focus to the same column on the next exercise row within a day", () => {
+    const cells = mountCells(PROGRAM);
+    const { result } = renderHook(() => useGridNav({ program: PROGRAM }));
+    const event = keyEvent("ArrowDown", cells["9:sets"]!);
+    act(() => {
+      result.current.cellProps(9, "sets", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(cells["10:sets"]);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(result.current.anchor).toEqual({ prescriptionId: 10, column: "sets" });
+  });
+
+  it("ArrowDown crosses a day-card boundary (last row of day N -> first row of day N+1)", () => {
+    const cells = mountCells(PROGRAM);
+    const { result } = renderHook(() => useGridNav({ program: PROGRAM }));
+    const event = keyEvent("ArrowDown", cells["10:load"]!);
+    act(() => {
+      result.current.cellProps(10, "load", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(cells["11:load"]);
+  });
+
+  it("ArrowDown at the very last row is a no-op but still preventDefault", () => {
+    const cells = mountCells(PROGRAM);
+    const { result } = renderHook(() => useGridNav({ program: PROGRAM }));
+    const event = keyEvent("ArrowDown", cells["11:note"]!);
+    act(() => {
+      result.current.cellProps(11, "note", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(result.current.anchor).toEqual({ prescriptionId: 11, column: "note" });
+  });
+
+  it("ArrowUp mirrors ArrowDown, crossing day boundaries upward", () => {
+    const cells = mountCells(PROGRAM);
+    const { result } = renderHook(() => useGridNav({ program: PROGRAM }));
+    const event = keyEvent("ArrowUp", cells["11:rpe"]!);
+    act(() => {
+      result.current.cellProps(11, "rpe", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(cells["10:rpe"]);
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it("ArrowUp at the very first row is a no-op but still preventDefault", () => {
+    const cells = mountCells(PROGRAM);
+    const { result } = renderHook(() => useGridNav({ program: PROGRAM }));
+    const event = keyEvent("ArrowUp", cells["9:name"]!);
+    act(() => {
+      result.current.cellProps(9, "name", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+});
+
+describe("ArrowRight / ArrowLeft (caret-conditional)", () => {
+  it("ArrowRight at the end of the text moves to the next column and preventDefaults", () => {
+    const cells = mountCells(PROGRAM);
+    const setsInput = cells["9:sets"]!;
+    setsInput.value = "42";
+    setsInput.setSelectionRange(2, 2); // caret at end (value.length === 2)
+    const { result } = renderHook(() => useGridNav({ program: PROGRAM }));
+    const event = keyEvent("ArrowRight", setsInput);
+    act(() => {
+      result.current.cellProps(9, "sets", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(cells["9:reps"]);
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it("ArrowLeft at the start of the text moves to the previous column and preventDefaults", () => {
+    const cells = mountCells(PROGRAM);
+    const repsInput = cells["9:reps"]!;
+    repsInput.value = "5";
+    repsInput.setSelectionRange(0, 0); // caret at start
+    const { result } = renderHook(() => useGridNav({ program: PROGRAM }));
+    const event = keyEvent("ArrowLeft", repsInput);
+    act(() => {
+      result.current.cellProps(9, "reps", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(cells["9:sets"]);
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it("ArrowRight mid-text does NOT move focus or preventDefault (native caret move wins)", () => {
+    const cells = mountCells(PROGRAM);
+    const setsInput = cells["9:sets"]!;
+    setsInput.value = "4200";
+    setsInput.setSelectionRange(2, 2); // caret in the middle
+    setsInput.focus(); // must actually hold focus for "stays put" to mean anything
+    const { result } = renderHook(() => useGridNav({ program: PROGRAM }));
+    const event = keyEvent("ArrowRight", setsInput);
+    act(() => {
+      result.current.cellProps(9, "sets", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(setsInput);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("ArrowLeft with a non-collapsed selection does NOT move focus (selectionStart !== selectionEnd)", () => {
+    const cells = mountCells(PROGRAM);
+    const repsInput = cells["9:reps"]!;
+    repsInput.value = "5";
+    repsInput.setSelectionRange(0, 1); // a selection, not a collapsed caret
+    repsInput.focus();
+    const { result } = renderHook(() => useGridNav({ program: PROGRAM }));
+    const event = keyEvent("ArrowLeft", repsInput);
+    act(() => {
+      result.current.cellProps(9, "reps", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(repsInput);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("no wrap at a row extreme: ArrowLeft at the start of the first column (name) is a pure no-op", () => {
+    const cells = mountCells(PROGRAM);
+    const nameInput = cells["9:name"]!;
+    nameInput.setSelectionRange(0, 0);
+    nameInput.focus();
+    const { result } = renderHook(() => useGridNav({ program: PROGRAM }));
+    const event = keyEvent("ArrowLeft", nameInput);
+    act(() => {
+      result.current.cellProps(9, "name", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(nameInput);
+    // Decision 5: nothing to prevent at a boundary caret, so no preventDefault.
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("no wrap at a row extreme: ArrowRight at the end of the last column (note) is a pure no-op", () => {
+    const cells = mountCells(PROGRAM);
+    const noteInput = cells["9:note"]!;
+    noteInput.value = "";
+    noteInput.setSelectionRange(0, 0); // empty value: start === end === length === 0
+    noteInput.focus();
+    const { result } = renderHook(() => useGridNav({ program: PROGRAM }));
+    const event = keyEvent("ArrowRight", noteInput);
+    act(() => {
+      result.current.cellProps(9, "note", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(noteInput);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+});
+
+describe("Enter (commit) / Escape (revert)", () => {
+  it("Enter calls the cell's onCommit, preventDefaults, and does not move focus", () => {
+    const cells = mountCells(PROGRAM);
+    cells["9:load"]!.focus(); // must actually hold focus for "does not move" to mean anything
+    const { result } = renderHook(() => useGridNav({ program: PROGRAM }));
+    const onCommit = vi.fn();
+    const event = keyEvent("Enter", cells["9:load"]!);
+    act(() => {
+      result.current.cellProps(9, "load", { ...NOOP_CALLBACKS, onCommit }).onKeyDown(event);
+    });
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(document.activeElement).toBe(cells["9:load"]);
+  });
+
+  it("Escape reverts to the focus-time value via onRevert, preventDefaults, and keeps focus", () => {
+    const cells = mountCells(PROGRAM);
+    const loadInput = cells["9:load"]!;
+    loadInput.value = "100";
+    const { result } = renderHook(() => useGridNav({ program: PROGRAM }));
+    const onRevert = vi.fn();
+    const callbacks = { ...NOOP_CALLBACKS, onRevert };
+    // Focus first (captures the focus-time value: "100")...
+    loadInput.focus();
+    act(() => {
+      result.current.cellProps(9, "load", callbacks).onFocus(focusEvent(loadInput));
+    });
+    // ...then the coach types a draft the row hasn't committed yet.
+    loadInput.value = "999";
+    const event = keyEvent("Escape", loadInput);
+    act(() => {
+      result.current.cellProps(9, "load", callbacks).onKeyDown(event);
+    });
+    expect(onRevert).toHaveBeenCalledWith("100");
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(document.activeElement).toBe(loadInput);
+  });
+
+  it("Escape without a prior focus call reverts to the DOM value at keydown time (no captured value yet)", () => {
+    // Open API question the spec doesn't resolve: what's the "focus-time
+    // value" if onKeyDown fires before this cell's own onFocus ever ran
+    // (e.g. a synthetic/test harness quirk)? Decision: fall back to the
+    // current DOM value, i.e. a same-value no-op revert — never throw.
+    const cells = mountCells(PROGRAM);
+    const rpeInput = cells["9:rpe"]!;
+    rpeInput.value = "8";
+    const { result } = renderHook(() => useGridNav({ program: PROGRAM }));
+    const onRevert = vi.fn();
+    const event = keyEvent("Escape", rpeInput);
+    act(() => {
+      result.current.cellProps(9, "rpe", { ...NOOP_CALLBACKS, onRevert }).onKeyDown(event);
+    });
+    expect(onRevert).toHaveBeenCalledWith("8");
+  });
+});
+
+describe("regression: undo/redo keys are left alone", () => {
+  it("Ctrl+Z / Cmd+Z / Shift+Ctrl+Z on a cell are NOT intercepted (no preventDefault, no callback) — bubbles to the window-level undo listener", () => {
+    const cells = mountCells(PROGRAM);
+    const { result } = renderHook(() => useGridNav({ program: PROGRAM }));
+    for (const extra of [{ ctrlKey: true }, { metaKey: true }, { ctrlKey: true, shiftKey: true }]) {
+      const event = keyEvent("z", cells["9:name"]!, extra);
+      act(() => {
+        result.current.cellProps(9, "name", NOOP_CALLBACKS).onKeyDown(event);
+      });
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    }
+    expect(NOOP_CALLBACKS.onCommit).not.toHaveBeenCalled();
+    expect(NOOP_CALLBACKS.onRevert).not.toHaveBeenCalled();
+  });
+});
+
+describe("native keys pass through untouched", () => {
+  it.each(["Home", "End", "PageUp", "PageDown", "a", "Tab"])("%s is not preventDefault'd", (key) => {
+    const cells = mountCells(PROGRAM);
+    const { result } = renderHook(() => useGridNav({ program: PROGRAM }));
+    const event = keyEvent(key, cells["9:sets"]!);
+    act(() => {
+      result.current.cellProps(9, "sets", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+});
+
+describe("cellAriaLabel (pure helper, decision 7)", () => {
+  it("builds '<name> — <column label>' for a non-name column", () => {
+    expect(cellAriaLabel("Box Squat", "sets")).toBe("Box Squat — sets");
+    expect(cellAriaLabel("Box Squat", "reps")).toBe("Box Squat — reps");
+    expect(cellAriaLabel("Box Squat", "load")).toBe("Box Squat — load");
+    expect(cellAriaLabel("Box Squat", "rpe")).toBe("Box Squat — RPE");
+    expect(cellAriaLabel("Box Squat", "note")).toBe("Box Squat — note");
+  });
+
+  it("labels the name cell as '<name> — exercise name'", () => {
+    expect(cellAriaLabel("Box Squat", "name")).toBe("Box Squat — exercise name");
+  });
+
+  it("falls back to 'exercise' when the row has no name yet", () => {
+    expect(cellAriaLabel("", "sets")).toBe("exercise — sets");
+  });
+});
+
+describe("gridCellDomKey (pure helper, decision 2)", () => {
+  it("joins prescriptionId and column with a colon", () => {
+    expect(gridCellDomKey(9, "sets")).toBe("9:sets");
+    expect(gridCellDomKey("abc", "name")).toBe("abc:name");
+  });
+});
+
+describe("focus restoration across a program swap (applyPlanData), decision 6", () => {
+  function focus(result: ReturnType<typeof useGridNav>, cells: Record<string, HTMLInputElement>, id: number, column: "name" | "sets") {
+    act(() => {
+      result.cellProps(id, column, NOOP_CALLBACKS).onFocus(focusEvent(cells[gridCellDomKey(id, column)]!));
+    });
+  }
+
+  it("tier 1: re-focuses the same (prescriptionId, column) when it survives the swap", () => {
+    let cells = mountCells(PROGRAM);
+    const { result, rerender } = renderHook(({ program }) => useGridNav({ program }), {
+      initialProps: { program: PROGRAM },
+    });
+    focus(result.current, cells, 9, "sets");
+
+    const NEXT: Day[] = [day(1, [ex(9, { load: "105" }), ex(10)]), day(2, [ex(11)])];
+    cells = resyncCells(NEXT);
+    act(() => rerender({ program: NEXT }));
+
+    expect(document.activeElement).toBe(cells["9:sets"]);
+    expect(result.current.anchor).toEqual({ prescriptionId: 9, column: "sets" });
+  });
+
+  it("tier 2: falls back to the first cell of the same day when the prescription is gone but the day survives", () => {
+    let cells = mountCells(PROGRAM);
+    const { result, rerender } = renderHook(({ program }) => useGridNav({ program }), {
+      initialProps: { program: PROGRAM },
+    });
+    focus(result.current, cells, 9, "sets");
+
+    // Day 1 survives (id 1) but exercise 9 is gone; exercise 10 remains.
+    const NEXT: Day[] = [day(1, [ex(10)]), day(2, [ex(11)])];
+    cells = resyncCells(NEXT);
+    act(() => rerender({ program: NEXT }));
+
+    expect(document.activeElement).toBe(cells["10:name"]);
+    expect(result.current.anchor).toEqual({ prescriptionId: 10, column: "name" });
+  });
+
+  it("tier 3: falls back to the grid's first cell when the day itself is gone", () => {
+    let cells = mountCells(PROGRAM);
+    const { result, rerender } = renderHook(({ program }) => useGridNav({ program }), {
+      initialProps: { program: PROGRAM },
+    });
+    focus(result.current, cells, 11, "sets"); // day 2's exercise
+
+    // Day 2 (id 2) is gone entirely; only day 1 remains.
+    const NEXT: Day[] = [day(1, [ex(9), ex(10)])];
+    cells = resyncCells(NEXT);
+    act(() => rerender({ program: NEXT }));
+
+    expect(document.activeElement).toBe(cells["9:name"]);
+    expect(result.current.anchor).toEqual({ prescriptionId: 9, column: "name" });
+  });
+
+  it("tier 4: does nothing (no throw, no focus) when the whole grid is emptied", () => {
+    const cells = mountCells(PROGRAM);
+    const { result, rerender } = renderHook(({ program }) => useGridNav({ program }), {
+      initialProps: { program: PROGRAM },
+    });
+    focus(result.current, cells, 9, "name");
+
+    resyncCells([]);
+    expect(() => act(() => rerender({ program: [] }))).not.toThrow();
+
+    expect(result.current.anchor).toBe(null);
+  });
+
+  it("does NOT steal focus on a program swap when the grid was never focused", () => {
+    let cells = mountCells(PROGRAM);
+    const { rerender } = renderHook(({ program }) => useGridNav({ program }), {
+      initialProps: { program: PROGRAM },
+    });
+    // No onFocus call at all — the coach has been typing in the chat panel,
+    // not the grid, when e.g. another tab's undo swaps the program.
+    const NEXT: Day[] = [day(1, [ex(9), ex(10)]), day(2, [ex(11)])];
+    cells = resyncCells(NEXT);
+    act(() => rerender({ program: NEXT }));
+
+    expect(document.activeElement).toBe(document.body);
+    expect(cells["9:name"]).not.toBe(document.activeElement);
+  });
+});

--- a/frontend/designer/src/hooks/useGridNav.test.tsx
+++ b/frontend/designer/src/hooks/useGridNav.test.tsx
@@ -588,3 +588,49 @@ describe("review hardening: modified arrows stay native", () => {
     expect(document.activeElement).toBe(input);
   });
 });
+
+describe("review hardening: row patches don't steal focus from controls", () => {
+  // Clicking a control that mutates `program` but stays mounted (the
+  // load-type toggle patches the exercise) must keep focus on that control —
+  // only grid cells, orphaned focus (body), or controls explicitly marked
+  // data-grid-restore (undo/redo, week chips — swap initiators whose result
+  // SHOULD return the coach to the grid) allow restoration to move focus.
+  it("an unmarked button keeps focus across a program identity change", () => {
+    let cells = mountCells(PROGRAM);
+    const toggle = document.createElement("button");
+    document.body.appendChild(toggle);
+    const { result, rerender } = renderHook(({ program }) => useGridNav({ program }), {
+      initialProps: { program: PROGRAM },
+    });
+    act(() => {
+      result.current.cellProps(9, "sets", NOOP_CALLBACKS).onFocus(focusEvent(cells[gridCellDomKey(9, "sets")]!));
+    });
+    toggle.focus();
+
+    const NEXT: Day[] = [day(1, [ex(9, { load_type: "pct" }), ex(10)]), day(2, [ex(11)])];
+    cells = resyncCells(NEXT);
+    act(() => rerender({ program: NEXT }));
+
+    expect(document.activeElement).toBe(toggle);
+  });
+
+  it("a data-grid-restore control still hands focus back to the grid", () => {
+    let cells = mountCells(PROGRAM);
+    const undoButton = document.createElement("button");
+    undoButton.setAttribute("data-grid-restore", "");
+    document.body.appendChild(undoButton);
+    const { result, rerender } = renderHook(({ program }) => useGridNav({ program }), {
+      initialProps: { program: PROGRAM },
+    });
+    act(() => {
+      result.current.cellProps(9, "sets", NOOP_CALLBACKS).onFocus(focusEvent(cells[gridCellDomKey(9, "sets")]!));
+    });
+    undoButton.focus();
+
+    const NEXT: Day[] = [day(1, [ex(10)]), day(2, [ex(11)])];
+    cells = resyncCells(NEXT);
+    act(() => rerender({ program: NEXT }));
+
+    expect(document.activeElement).toBe(cells["10:name"]);
+  });
+});

--- a/frontend/designer/src/hooks/useGridNav.test.tsx
+++ b/frontend/designer/src/hooks/useGridNav.test.tsx
@@ -506,3 +506,54 @@ describe("focus restoration across a program swap (applyPlanData), decision 6", 
     expect(cells["9:name"]).not.toBe(document.activeElement);
   });
 });
+
+describe("review hardening: Escape baseline + focus-steal guard", () => {
+  it("Enter resets the Escape baseline to the committed value", () => {
+    // Without the reset, an Enter-commit followed by a fresh draft and Escape
+    // would roll the UI back PAST the committed value, desyncing it from the
+    // server (which kept the Enter-committed state).
+    const cells = mountCells(PROGRAM);
+    const loadInput = cells["9:load"]!;
+    loadInput.value = "100";
+    const { result } = renderHook(() => useGridNav({ program: PROGRAM }));
+    const onCommit = vi.fn();
+    const onRevert = vi.fn();
+    const callbacks = { ...NOOP_CALLBACKS, onCommit, onRevert };
+    loadInput.focus();
+    act(() => {
+      result.current.cellProps(9, "load", callbacks).onFocus(focusEvent(loadInput));
+    });
+    loadInput.value = "150";
+    act(() => {
+      result.current.cellProps(9, "load", callbacks).onKeyDown(keyEvent("Enter", loadInput));
+    });
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    loadInput.value = "175";
+    act(() => {
+      result.current.cellProps(9, "load", callbacks).onKeyDown(keyEvent("Escape", loadInput));
+    });
+    expect(onRevert).toHaveBeenCalledWith("150");
+  });
+
+  it("restoration never steals focus from a non-grid form field", () => {
+    // A program swap landing while the coach types in e.g. the chat composer
+    // must not yank focus back into the grid — restoration only fires when a
+    // grid cell held focus (or the swap just orphaned it).
+    let cells = mountCells(PROGRAM);
+    const composer = document.createElement("input");
+    document.body.appendChild(composer);
+    const { result, rerender } = renderHook(({ program }) => useGridNav({ program }), {
+      initialProps: { program: PROGRAM },
+    });
+    act(() => {
+      result.current.cellProps(9, "sets", NOOP_CALLBACKS).onFocus(focusEvent(cells[gridCellDomKey(9, "sets")]!));
+    });
+    composer.focus();
+
+    const NEXT: Day[] = [day(1, [ex(10)]), day(2, [ex(11)])];
+    cells = resyncCells(NEXT);
+    act(() => rerender({ program: NEXT }));
+
+    expect(document.activeElement).toBe(composer);
+  });
+});

--- a/frontend/designer/src/hooks/useGridNav.ts
+++ b/frontend/designer/src/hooks/useGridNav.ts
@@ -149,7 +149,21 @@ export function useGridNav(options: UseGridNavOptions): UseGridNavResult {
       next = firstOfDay !== undefined ? { prescriptionId: firstOfDay, column: "name" } : firstCellOf(flat);
     }
 
-    commitAnchor(next, flat, focusedOnceRef.current);
+    // Never steal focus from a non-grid form field (e.g. the chat composer):
+    // restoration fires only when a grid cell holds focus, when the swap just
+    // orphaned it (focus fell to body), or when focus sits on a plain control
+    // (undo/redo buttons, week chips — grid operations whose swap SHOULD
+    // return the coach to the grid).
+    const active = document.activeElement as HTMLElement | null;
+    const activeIsGridCell = !!active && active.hasAttribute("data-grid-cell");
+    const activeIsForeignField =
+      !activeIsGridCell &&
+      !!active &&
+      (active.tagName === "INPUT" ||
+        active.tagName === "TEXTAREA" ||
+        active.tagName === "SELECT" ||
+        active.isContentEditable);
+    commitAnchor(next, flat, focusedOnceRef.current && !activeIsForeignField);
     // program is the only externally-driven trigger for restoration; flat is
     // derived from it in lockstep, and the anchor/ref reads are intentionally
     // "current value at effect time", not reactive dependencies.
@@ -203,10 +217,16 @@ export function useGridNav(options: UseGridNavOptions): UseGridNavResult {
           commitAnchor({ prescriptionId, column: nextColumn }, flat, true);
           return;
         }
-        case "Enter":
+        case "Enter": {
           event.preventDefault();
           callbacks.onCommit();
+          // The committed value is the new Escape baseline — without this, a
+          // fresh draft + Escape would roll the UI back PAST the commit,
+          // desyncing it from the server.
+          focusValuesRef.current[gridCellDomKey(prescriptionId, column)] =
+            event.currentTarget.value;
           return;
+        }
         case "Escape": {
           event.preventDefault();
           const key = gridCellDomKey(prescriptionId, column);

--- a/frontend/designer/src/hooks/useGridNav.ts
+++ b/frontend/designer/src/hooks/useGridNav.ts
@@ -1,0 +1,226 @@
+// useGridNav — grid keyboard navigation + cell a11y (Phase 3, docs/meso/
+// designer-framework-plan.md + scratchpad phase3-spec.md). Owns the roving-
+// tabindex anchor, arrow/Enter/Escape key handling on the six per-exercise
+// cells (name, sets, reps, load, rpe, note), and focus restoration across a
+// full-envelope program swap (undo/redo/week switch/add/delete/confirm).
+// Instantiated ONCE inside WeekGrid (see useGridNav.test.tsx's header) —
+// DayCard/ExerciseRow receive the result as an optional passthrough prop and
+// never call this hook themselves.
+//
+// Cell identity is always (prescriptionId, column) — NEVER an index — so a
+// day/exercise reorder or delete can't silently point the anchor at the
+// wrong row. DOM lookups go through `document.querySelector` against a
+// `data-grid-cell` attribute (see `gridCellDomKey`) rather than ref-plumbing
+// through DayCard/ExerciseRow, so arrow-key moves and focus restoration work
+// identically for a hook-only unit test (no React DOM at all) and the real
+// mounted app.
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { FocusEvent, KeyboardEvent } from "react";
+import type { Day } from "../lib/api";
+
+type Id = number | string;
+
+export type GridColumn = "name" | "sets" | "reps" | "load" | "rpe" | "note";
+
+export const GRID_COLUMNS: readonly GridColumn[] = ["name", "sets", "reps", "load", "rpe", "note"];
+
+export const GRID_COLUMN_LABELS: Record<GridColumn, string> = {
+  name: "exercise name",
+  sets: "sets",
+  reps: "reps",
+  load: "load",
+  rpe: "RPE",
+  note: "note",
+};
+
+export interface GridCellId {
+  prescriptionId: Id;
+  column: GridColumn;
+}
+
+export interface GridCellCallbacks {
+  onChange(value: string): void;
+  onCommit(): void;
+  onRevert(value: string): void;
+}
+
+export interface GridCellBindings {
+  tabIndex: 0 | -1;
+  onFocus(event: FocusEvent<HTMLInputElement>): void;
+  onKeyDown(event: KeyboardEvent<HTMLInputElement>): void;
+}
+
+export interface UseGridNavResult {
+  anchor: GridCellId | null;
+  cellProps(prescriptionId: Id, column: GridColumn, callbacks: GridCellCallbacks): GridCellBindings;
+}
+
+export interface UseGridNavOptions {
+  program: Day[];
+}
+
+/** "<exercise name or 'exercise'> — <column label>" (spec's a11y section). */
+export function cellAriaLabel(exerciseName: string, column: GridColumn): string {
+  return `${exerciseName || "exercise"} — ${GRID_COLUMN_LABELS[column]}`;
+}
+
+/** DOM identity for a cell's `data-grid-cell` attribute / querySelector key. */
+export function gridCellDomKey(prescriptionId: Id, column: GridColumn): string {
+  return `${prescriptionId}:${column}`;
+}
+
+interface FlatProgram {
+  /** Every exercise id, day-major/exercise-minor (spec's flattened row order). */
+  order: Id[];
+  dayIdByExercise: Map<Id, Id>;
+  firstExerciseByDay: Map<Id, Id>;
+}
+
+function flattenProgram(program: Day[]): FlatProgram {
+  const order: Id[] = [];
+  const dayIdByExercise = new Map<Id, Id>();
+  const firstExerciseByDay = new Map<Id, Id>();
+  for (const day of program) {
+    for (const ex of day.exercises) {
+      order.push(ex.id);
+      dayIdByExercise.set(ex.id, day.id);
+      if (!firstExerciseByDay.has(day.id)) firstExerciseByDay.set(day.id, ex.id);
+    }
+  }
+  return { order, dayIdByExercise, firstExerciseByDay };
+}
+
+function firstCellOf(flat: FlatProgram): GridCellId | null {
+  const id = flat.order[0];
+  return id === undefined ? null : { prescriptionId: id, column: "name" };
+}
+
+function focusCell(id: Id, column: GridColumn) {
+  const selector = `[data-grid-cell="${gridCellDomKey(id, column)}"]`;
+  document.querySelector<HTMLElement>(selector)?.focus();
+}
+
+const HANDLED_KEYS = new Set(["ArrowDown", "ArrowUp", "ArrowLeft", "ArrowRight", "Enter", "Escape"]);
+
+export function useGridNav(options: UseGridNavOptions): UseGridNavResult {
+  const { program } = options;
+  const flat = useMemo(() => flattenProgram(program), [program]);
+
+  const [anchor, setAnchor] = useState<GridCellId | null>(() => firstCellOf(flat));
+  const anchorRef = useRef<GridCellId | null>(anchor);
+  const lastDayIdRef = useRef<Id | null>(
+    anchor ? (flat.dayIdByExercise.get(anchor.prescriptionId) ?? null) : null,
+  );
+  // Flips true the first time any cell actually receives focus — gates
+  // whether restoration is allowed to steal DOM focus (spec: "the anchor
+  // (roving tabIndex) always tracks whatever was restored" but a program
+  // swap that happens while the grid was never focused must not yank focus
+  // away from e.g. the chat panel).
+  const focusedOnceRef = useRef(false);
+  // Cell key -> value captured at focus time, for Escape's revert target.
+  const focusValuesRef = useRef<Record<string, string>>({});
+
+  function commitAnchor(next: GridCellId | null, flatForLookup: FlatProgram, shouldFocus: boolean) {
+    anchorRef.current = next;
+    lastDayIdRef.current = next ? (flatForLookup.dayIdByExercise.get(next.prescriptionId) ?? null) : null;
+    setAnchor(next);
+    if (next && shouldFocus) focusCell(next.prescriptionId, next.column);
+  }
+
+  // Restoration (spec "Focus restoration across applyPlanData"): recompute
+  // the anchor on EVERY program identity change so tabIndex stays valid even
+  // when the grid never had focus, but only call .focus() when it did.
+  useEffect(() => {
+    const prev = anchorRef.current;
+    if (prev === null) {
+      commitAnchor(firstCellOf(flat), flat, false);
+      return;
+    }
+
+    let next: GridCellId | null;
+    if (flat.order.includes(prev.prescriptionId)) {
+      // Tier 1: same (prescriptionId, column) survives.
+      next = { prescriptionId: prev.prescriptionId, column: prev.column };
+    } else {
+      const dayId = lastDayIdRef.current;
+      const firstOfDay = dayId === null ? undefined : flat.firstExerciseByDay.get(dayId);
+      // Tier 2: first cell of the same day, else Tier 3: grid's first cell
+      // (firstCellOf returns null for Tier 4 — the whole grid is empty).
+      next = firstOfDay !== undefined ? { prescriptionId: firstOfDay, column: "name" } : firstCellOf(flat);
+    }
+
+    commitAnchor(next, flat, focusedOnceRef.current);
+    // program is the only externally-driven trigger for restoration; flat is
+    // derived from it in lockstep, and the anchor/ref reads are intentionally
+    // "current value at effect time", not reactive dependencies.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [program]);
+
+  function cellProps(prescriptionId: Id, column: GridColumn, callbacks: GridCellCallbacks): GridCellBindings {
+    const tabIndex: 0 | -1 =
+      anchor && anchor.prescriptionId === prescriptionId && anchor.column === column ? 0 : -1;
+
+    const onFocus = (event: FocusEvent<HTMLInputElement>) => {
+      focusedOnceRef.current = true;
+      focusValuesRef.current[gridCellDomKey(prescriptionId, column)] = event.currentTarget.value;
+      commitAnchor({ prescriptionId, column }, flat, false);
+    };
+
+    const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "z") return; // undo/redo: untouched.
+      if (!HANDLED_KEYS.has(event.key)) return;
+
+      // Any handled keydown implies this cell currently holds focus — keep
+      // the anchor synced even if no onFocus round-trip preceded it (a
+      // hook-only test building a raw keydown event, or a real keydown that
+      // arrives before its own focus event settles).
+      commitAnchor({ prescriptionId, column }, flat, false);
+
+      switch (event.key) {
+        case "ArrowDown":
+        case "ArrowUp": {
+          event.preventDefault();
+          const idx = flat.order.indexOf(prescriptionId);
+          if (idx === -1) return;
+          const nextIdx = idx + (event.key === "ArrowDown" ? 1 : -1);
+          const targetId = flat.order[nextIdx];
+          if (targetId === undefined) return; // extreme: no-op, preventDefault already fired.
+          commitAnchor({ prescriptionId: targetId, column }, flat, true);
+          return;
+        }
+        case "ArrowRight":
+        case "ArrowLeft": {
+          const el = event.currentTarget;
+          const collapsed = el.selectionStart === el.selectionEnd;
+          const atBoundary =
+            event.key === "ArrowRight" ? el.selectionStart === el.value.length : el.selectionStart === 0;
+          if (!collapsed || !atBoundary) return; // let the caret move natively.
+          const colIdx = GRID_COLUMNS.indexOf(column);
+          const nextColIdx = colIdx + (event.key === "ArrowRight" ? 1 : -1);
+          const nextColumn = GRID_COLUMNS[nextColIdx];
+          if (nextColumn === undefined) return; // row extreme: nothing to prevent either.
+          event.preventDefault();
+          commitAnchor({ prescriptionId, column: nextColumn }, flat, true);
+          return;
+        }
+        case "Enter":
+          event.preventDefault();
+          callbacks.onCommit();
+          return;
+        case "Escape": {
+          event.preventDefault();
+          const key = gridCellDomKey(prescriptionId, column);
+          const value = focusValuesRef.current[key] ?? event.currentTarget.value;
+          callbacks.onRevert(value);
+          return;
+        }
+        default:
+          return;
+      }
+    };
+
+    return { tabIndex, onFocus, onKeyDown };
+  }
+
+  return { anchor, cellProps };
+}

--- a/frontend/designer/src/hooks/useGridNav.ts
+++ b/frontend/designer/src/hooks/useGridNav.ts
@@ -183,6 +183,9 @@ export function useGridNav(options: UseGridNavOptions): UseGridNavResult {
     const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
       if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "z") return; // undo/redo: untouched.
       if (!HANDLED_KEYS.has(event.key)) return;
+      // Modified keys are native text editing (Shift+Arrow selection,
+      // Ctrl/Alt/Cmd+Arrow word- and line-navigation) — never grid moves.
+      if (event.shiftKey || event.ctrlKey || event.metaKey || event.altKey) return;
 
       // Any handled keydown implies this cell currently holds focus — keep
       // the anchor synced even if no onFocus round-trip preceded it (a

--- a/frontend/designer/src/hooks/useGridNav.ts
+++ b/frontend/designer/src/hooks/useGridNav.ts
@@ -149,21 +149,19 @@ export function useGridNav(options: UseGridNavOptions): UseGridNavResult {
       next = firstOfDay !== undefined ? { prescriptionId: firstOfDay, column: "name" } : firstCellOf(flat);
     }
 
-    // Never steal focus from a non-grid form field (e.g. the chat composer):
-    // restoration fires only when a grid cell holds focus, when the swap just
-    // orphaned it (focus fell to body), or when focus sits on a plain control
-    // (undo/redo buttons, week chips — grid operations whose swap SHOULD
-    // return the coach to the grid).
+    // Restoration may move focus ONLY when it won't steal it: the active
+    // element is a grid cell, focus was orphaned by the swap (fell to body),
+    // or the coach is on a control explicitly marked data-grid-restore
+    // (undo/redo, week chips, add/remove week — swap initiators whose result
+    // should return them to the grid). Anything else — the chat composer, the
+    // load-type toggle re-rendering under focus on a row patch — keeps focus.
     const active = document.activeElement as HTMLElement | null;
-    const activeIsGridCell = !!active && active.hasAttribute("data-grid-cell");
-    const activeIsForeignField =
-      !activeIsGridCell &&
-      !!active &&
-      (active.tagName === "INPUT" ||
-        active.tagName === "TEXTAREA" ||
-        active.tagName === "SELECT" ||
-        active.isContentEditable);
-    commitAnchor(next, flat, focusedOnceRef.current && !activeIsForeignField);
+    const allowFocusMove =
+      !active ||
+      active === document.body ||
+      active.hasAttribute("data-grid-cell") ||
+      active.closest("[data-grid-restore]") !== null;
+    commitAnchor(next, flat, focusedOnceRef.current && allowFocusMove);
     // program is the only externally-driven trigger for restoration; flat is
     // derived from it in lockstep, and the anchor/ref reads are intentionally
     // "current value at effect time", not reactive dependencies.

--- a/frontend/designer/src/styles/designer-grid.css
+++ b/frontend/designer/src/styles/designer-grid.css
@@ -131,6 +131,16 @@
   border-radius: 5px;
   outline: none;
 }
+/* Phase 3 a11y: a visible ring for keyboard-driven grid cell focus, on all
+   six cells (name/sets/reps/load/rpe/note — `data-grid-cell` is set
+   unconditionally, so this doesn't depend on `.meso-cell` specifically,
+   which the note input doesn't carry). Deliberately :focus-visible only —
+   a mouse click into a cell should not show the ring. Overrides the
+   `outline: none` above/on `.meso-note`. */
+[data-grid-cell]:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 .meso-ex-tags {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary

Phase 3 of the designer framework plan (#403): the island grid becomes keyboard-first, and the a11y debts deferred from #401's review (unlabeled inputs, missing focus rings) are paid. Island-only — no backend changes. Full spec is a comment on #403 ("Phase 3 spec"); built red→green (57 failing specs first, now 379 total green).

## What a coach can do now

- **Roving tabindex**: one Tab stop for the whole grid; Tab/Shift+Tab pass through to the surrounding controls; the grid remembers its cell.
- **Arrow navigation**: Up/Down move between rows (crossing day cards) staying in the same column; Left/Right move columns only when the caret sits at the text boundary — mid-text they move the caret, and **modified arrows (Shift-select, Ctrl/Alt/Cmd word-nav) always stay native**.
- **Enter commits** the cell (the dirty-gated autosave — a clean cell is a no-op) and keeps focus; **Escape reverts** the draft to its focus-time value (re-baselined after each Enter commit) and suppresses the blur autosave.
- **Focus survives `applyPlanData`** (undo/redo/week ops/deletes): re-anchored by prescription id + column, falling back to the same day's first cell, then the grid's first cell. Restoration never steals focus — it moves focus only when a grid cell held it, the swap orphaned it, or the coach was on an explicitly marked swap control (`data-grid-restore`: undo/redo, week chips, add/make-current/remove).
- **a11y**: every cell has an aria-label ("Box Squat — sets"); keyboard focus draws a visible `:focus-visible` ring in the accent color.

## Architecture

One new hook, `useGridNav` (instantiated inside WeekGrid; DayCard/ExerciseRow take an optional passthrough prop and degrade gracefully without it). Cell identity is always `(prescriptionId, column)` — never an index — with DOM lookup via `data-grid-cell` attributes, so reorders/deletes can't mis-anchor. `data-grid-cell` and aria-labels are unconditional: a11y never depends on the nav wiring.

## Review hardening (local Codex loop, 3 iterations, every finding fixed + spec-pinned)

- `4ad9bb9` — Enter re-baselines Escape (no rollback past a committed value); restoration skips non-grid form fields (chat composer).
- `66232b9` — modified arrow keys bail before grid handling.
- `9a40ae9` — restoration allowlist tightened to grid cells / orphaned focus / `data-grid-restore` controls (a load-type-toggle row patch no longer steals focus from the button).
- Plus a fixture fix (`1f49292`): the multi-undo restoration mock disabled the undo button after one click, making its own second click inert.

## Verification

- [x] `npx vitest run` — 379 passed (66 new Phase 3 specs) · typecheck clean · build green (245 kB)
- [x] `uv run pytest` — 1853 passed · ruff clean (no Python changes)
- [x] **Real-browser walkthrough** on local dev: arrow movement with visible focus rings, day-boundary crossing, caret-conditional column moves, Escape-revert with zero spurious autosave requests, Tab correctly skipping `tabIndex=-1` cells to the next control.

Part of #403 (Phase 3). Phase 4 (dnd-kit reordering) is next and last — its keyboard sensors build on this focus system.