### PR TITLE
feat(meso): drag-and-drop reordering for exercises and days (Phase 4)

### DIFF
--- a/app/store_project/meso/history.py
+++ b/app/store_project/meso/history.py
@@ -197,6 +197,12 @@ def restore_plan_snapshot(plan, snapshot):
 
     for presc in models.ExercisePrescription.objects.filter(pk__in=prescription_pks):
         row = prescription_rows[presc.pk]
+        # ``session_id`` is restored too (Phase 4, #403): before
+        # ``prescription_move``, no endpoint ever re-pointed a prescription's
+        # session, so this was captured in the snapshot but never needed
+        # writing back. A move's undo must put the row back in its source
+        # session, not just its old order within whatever session it's in now.
+        presc.session_id = row["session_id"]
         presc.exercise_id = row["exercise_id"]
         presc.name = row["name"]
         presc.order = row["order"]

--- a/app/store_project/meso/tests/test_designer_reorder.py
+++ b/app/store_project/meso/tests/test_designer_reorder.py
@@ -1,0 +1,872 @@
+"""Phase 4 — dnd-kit reorder endpoints (RED, designer framework Phase 4, #403).
+
+The designer's drag-and-drop needs three write endpoints, built on Phase 0's
+soft delete + Phase 1's undo op-log (``docs/meso/designer-framework-plan.md``
+Phase 4):
+
+- ``api_session_reorder`` — reorder the exercise rows within one session
+  (``Session.prescriptions``), by posting the session's full live prescription
+  id set in the new order;
+- ``api_week_reorder_sessions`` — reorder the training days within one week
+  (``Week.sessions``), by posting the week's full live session id set in the
+  new order;
+- ``api_prescription_move`` — move one exercise row to a different session
+  **within the same week** (cross-day drag), re-pointing ``session`` and
+  densely renumbering both the source and target session's live rows.
+
+All three follow the established designer-write shape: ``@login_required
+@require_POST``, ``_editable_plan_or_response`` (302/403/402), live-row
+scoping on the URL target and its ancestors (404), ``record_plan_action``
+before the write (undo-able), ``_touch_plan``, and a
+``{"ok": true, **serialize_plan(plan, week=...)}`` envelope. ``Session.order``/
+``ExercisePrescription.order`` are 0-based, matching the scaffold's
+``order=0`` convention (``Plan.scaffold``, ``Mesocycle.append_week``).
+
+Covers, per the Phase 4 spec's pytest paragraph:
+
+- per-endpoint happy path (DB order values + serialized ``program`` order +
+  envelope keys + ``history.can_undo``), an idempotent repost, the id-set
+  validation matrix (missing/extra/duplicate/foreign-plan/soft-deleted id,
+  malformed JSON, non-int entries), the shared auth matrix (302/405/403/404),
+  soft-deleted target/ancestor 404s, exactly one ``PlanAction`` per call with
+  a loosely-pinned label, and an undo round trip;
+- ``api_prescription_move``'s own rules: cross-week moves are a 400, the
+  index clamps into range, a target-equals-source move behaves like a plain
+  reorder, and a moved row's ``LoggedSet`` history keeps pointing at the same
+  prescription pk untouched.
+
+Where the spec is silent, decisions taken here (noted inline at the relevant
+test): malformed-JSON/non-list/non-int-entry failures are asserted as a bare
+400 (no JSON-body shape pinned) — mirroring ``prescription_patch``'s
+``HttpResponseBadRequest`` convention for structurally-invalid bodies, as
+opposed to the *semantic* id-set mismatches (missing/extra/duplicate/foreign/
+deleted), which the spec explicitly promises as ``{"ok": false, "error": ...}``
+and so are asserted as such here. ``api_prescription_move``'s ``session_id``
+referencing a foreign/soft-deleted/nonexistent session is likewise asserted as
+a 400 (a body-referenced id failing validation), mirroring
+``prescription_override``'s ``_group_member_or_none`` 400-on-bad-reference
+convention rather than the URL-segment 404 convention.
+"""
+
+import json
+
+import pytest
+from django.urls import reverse
+
+from store_project.meso.factories import CoachAthleteFactory
+from store_project.meso.factories import ExercisePrescriptionFactory
+from store_project.meso.factories import LoggedSetFactory
+from store_project.meso.factories import MesocycleFactory
+from store_project.meso.factories import PlanFactory
+from store_project.meso.factories import SessionFactory
+from store_project.meso.factories import SessionLogFactory
+from store_project.meso.factories import WeekFactory
+from store_project.meso.models import Plan
+from store_project.meso.models import PlanAction
+from store_project.meso.serializers import serialize_plan
+from store_project.users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def seed_session(n=3, coach=None, athlete=None):
+    """A plan w/ one current week -> one session holding ``n`` live rows, order 0..n-1."""
+    rel = CoachAthleteFactory(
+        coach=coach or UserFactory(), athlete=athlete or UserFactory()
+    )
+    plan = PlanFactory(
+        relationship=rel, title="Hypertrophy Block", status=Plan.Status.ACTIVE
+    )
+    meso = MesocycleFactory(plan=plan, name="Hypertrophy", order=0)
+    week = WeekFactory(mesocycle=meso, index=1, is_current=True)
+    session = SessionFactory(week=week, day_number=1, name="Lower", order=0)
+    prescs = [
+        ExercisePrescriptionFactory(session=session, name=f"Exercise {i}", order=i)
+        for i in range(n)
+    ]
+    return plan, week, session, prescs
+
+
+def seed_week_with_sessions(n=3, coach=None, athlete=None):
+    """A plan w/ one current week holding ``n`` live sessions, order 0..n-1."""
+    rel = CoachAthleteFactory(
+        coach=coach or UserFactory(), athlete=athlete or UserFactory()
+    )
+    plan = PlanFactory(
+        relationship=rel, title="Hypertrophy Block", status=Plan.Status.ACTIVE
+    )
+    meso = MesocycleFactory(plan=plan, name="Hypertrophy", order=0)
+    week = WeekFactory(mesocycle=meso, index=1, is_current=True)
+    sessions = [
+        SessionFactory(week=week, day_number=i + 1, name=f"Day {i + 1}", order=i)
+        for i in range(n)
+    ]
+    return plan, week, sessions
+
+
+def seed_two_sessions(coach=None, athlete=None):
+    """One current week: ``session_a`` (2 rows: p0, p1), ``session_b`` (1 row: q0)."""
+    plan, week, sessions = seed_week_with_sessions(n=2, coach=coach, athlete=athlete)
+    session_a, session_b = sessions
+    p0 = ExercisePrescriptionFactory(session=session_a, name="Box Squat", order=0)
+    p1 = ExercisePrescriptionFactory(session=session_a, name="RDL", order=1)
+    q0 = ExercisePrescriptionFactory(session=session_b, name="Bench", order=0)
+    return plan, week, session_a, session_b, p0, p1, q0
+
+
+def _two_week_plan():
+    """A plan with ``week1`` (current) and ``week2`` (non-current), scaffold each."""
+    link = CoachAthleteFactory()
+    plan = link.create_plan()
+    meso = plan.mesocycles.get()
+    week1 = meso.weeks.get(index=1)
+    week2 = meso.append_week()
+    return link, plan, week1, week2
+
+
+def post_json(client, url, payload):
+    return client.post(url, data=json.dumps(payload), content_type="application/json")
+
+
+def undo_url(plan):
+    return reverse("meso:api_plan_undo", kwargs={"plan_id": plan.pk})
+
+
+def undo_actions(plan):
+    return PlanAction.objects.filter(plan=plan, stack=PlanAction.Stack.UNDO)
+
+
+def _envelope_keys(body):
+    return {"program", "weeks", "viewing", "phases"}.issubset(body.keys())
+
+
+def _session_order_url(plan, session):
+    return reverse(
+        "meso:api_session_reorder", kwargs={"plan_id": plan.pk, "pk": session.pk}
+    )
+
+
+def _week_order_url(plan, week):
+    return reverse(
+        "meso:api_week_reorder_sessions",
+        kwargs={"plan_id": plan.pk, "week_id": week.pk},
+    )
+
+
+def _move_url(plan, presc):
+    return reverse(
+        "meso:api_prescription_move", kwargs={"plan_id": plan.pk, "pk": presc.pk}
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /meso/api/plan/<id>/session/<pk>/reorder/
+# ---------------------------------------------------------------------------
+
+
+class TestSessionReorderEndpoint:
+    def test_happy_path_writes_db_order_and_serializes_new_order(self, client):
+        plan, week, session, (p0, p1, p2) = seed_session(n=3)
+        client.force_login(plan.relationship.coach)
+        resp = post_json(
+            client, _session_order_url(plan, session), {"order": [p2.pk, p0.pk, p1.pk]}
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert _envelope_keys(body)
+        assert body["history"]["can_undo"] is True
+
+        p0.refresh_from_db()
+        p1.refresh_from_db()
+        p2.refresh_from_db()
+        assert (p2.order, p0.order, p1.order) == (0, 1, 2)
+
+        data = serialize_plan(plan, week=week)
+        day = next(d for d in data["program"] if d["id"] == session.pk)
+        assert [e["id"] for e in day["exercises"]] == [p2.pk, p0.pk, p1.pk]
+
+    def test_idempotent_repost_is_a_200_noop_that_still_records_one_action(
+        self, client
+    ):
+        plan, week, session, (p0, p1, p2) = seed_session(n=3)
+        client.force_login(plan.relationship.coach)
+        url = _session_order_url(plan, session)
+        current_order = [p0.pk, p1.pk, p2.pk]
+        resp = post_json(client, url, {"order": current_order})
+        assert resp.status_code == 200
+        assert undo_actions(plan).count() == 1
+
+        resp = post_json(client, url, {"order": current_order})
+        assert resp.status_code == 200
+        assert undo_actions(plan).count() == 2
+        p0.refresh_from_db()
+        p1.refresh_from_db()
+        p2.refresh_from_db()
+        assert (p0.order, p1.order, p2.order) == (0, 1, 2)
+
+    def test_missing_id_400(self, client):
+        plan, week, session, (p0, p1, p2) = seed_session(n=3)
+        client.force_login(plan.relationship.coach)
+        resp = post_json(
+            client, _session_order_url(plan, session), {"order": [p0.pk, p1.pk]}
+        )
+        assert resp.status_code == 400
+        assert resp.json()["ok"] is False
+
+    def test_extra_id_from_a_sibling_session_400(self, client):
+        plan, week, session, (p0, p1, p2) = seed_session(n=3)
+        other_session = SessionFactory(week=week, day_number=2, name="Upper", order=1)
+        other_presc = ExercisePrescriptionFactory(session=other_session, name="Bench")
+        client.force_login(plan.relationship.coach)
+        resp = post_json(
+            client,
+            _session_order_url(plan, session),
+            {"order": [p0.pk, p1.pk, p2.pk, other_presc.pk]},
+        )
+        assert resp.status_code == 400
+        assert resp.json()["ok"] is False
+
+    def test_duplicate_id_400(self, client):
+        plan, week, session, (p0, p1, p2) = seed_session(n=3)
+        client.force_login(plan.relationship.coach)
+        resp = post_json(
+            client, _session_order_url(plan, session), {"order": [p0.pk, p0.pk, p1.pk]}
+        )
+        assert resp.status_code == 400
+        assert resp.json()["ok"] is False
+
+    def test_foreign_plans_id_400(self, client):
+        plan, week, session, (p0, p1, p2) = seed_session(n=3)
+        _, _, _, (other_presc, *_rest) = seed_session(n=1)  # a different coach's plan
+        client.force_login(plan.relationship.coach)
+        resp = post_json(
+            client,
+            _session_order_url(plan, session),
+            {"order": [p0.pk, p1.pk, other_presc.pk]},
+        )
+        assert resp.status_code == 400
+        assert resp.json()["ok"] is False
+
+    def test_soft_deleted_id_in_list_400(self, client):
+        plan, week, session, (p0, p1, p2) = seed_session(n=3)
+        client.force_login(plan.relationship.coach)
+        del_resp = client.post(
+            reverse(
+                "meso:api_prescription_delete", kwargs={"plan_id": plan.pk, "pk": p2.pk}
+            )
+        )
+        assert del_resp.status_code == 200
+        # The live set is now just {p0, p1} — posting all three (including the
+        # now-deleted p2) is an "extra" id relative to the live set.
+        resp = post_json(
+            client, _session_order_url(plan, session), {"order": [p0.pk, p1.pk, p2.pk]}
+        )
+        assert resp.status_code == 400
+        assert resp.json()["ok"] is False
+
+    def test_malformed_json_400(self, client):
+        plan, week, session, (p0, p1, p2) = seed_session(n=3)
+        client.force_login(plan.relationship.coach)
+        resp = client.post(
+            _session_order_url(plan, session),
+            data="not json",
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+
+    def test_non_list_order_400(self, client):
+        plan, week, session, (p0, p1, p2) = seed_session(n=3)
+        client.force_login(plan.relationship.coach)
+        resp = post_json(client, _session_order_url(plan, session), {"order": "abc"})
+        assert resp.status_code == 400
+
+    def test_non_int_entries_400(self, client):
+        plan, week, session, (p0, p1, p2) = seed_session(n=3)
+        client.force_login(plan.relationship.coach)
+        resp = post_json(
+            client,
+            _session_order_url(plan, session),
+            {"order": [p0.pk, "not-an-id", p2.pk]},
+        )
+        assert resp.status_code == 400
+
+    def test_requires_login(self, client):
+        plan, week, session, prescs = seed_session(n=1)
+        resp = post_json(client, _session_order_url(plan, session), {"order": []})
+        assert resp.status_code == 302
+        assert "/accounts/login/" in resp.url
+
+    def test_get_not_allowed(self, client):
+        plan, week, session, prescs = seed_session(n=1)
+        client.force_login(plan.relationship.coach)
+        resp = client.get(_session_order_url(plan, session))
+        assert resp.status_code == 405
+
+    def test_non_owner_forbidden(self, client):
+        plan, week, session, (p0,) = seed_session(n=1)
+        client.force_login(UserFactory())
+        resp = post_json(client, _session_order_url(plan, session), {"order": [p0.pk]})
+        assert resp.status_code == 403
+
+    def test_unknown_session_pk_404(self, client):
+        plan, week, session, prescs = seed_session(n=1)
+        client.force_login(plan.relationship.coach)
+        resp = post_json(
+            client,
+            reverse(
+                "meso:api_session_reorder",
+                kwargs={"plan_id": plan.pk, "pk": 999999},
+            ),
+            {"order": []},
+        )
+        assert resp.status_code == 404
+
+    def test_soft_deleted_session_404(self, client):
+        plan, week, session, (p0,) = seed_session(n=1)
+        client.force_login(plan.relationship.coach)
+        del_resp = client.post(
+            reverse(
+                "meso:api_session_delete", kwargs={"plan_id": plan.pk, "pk": session.pk}
+            )
+        )
+        assert del_resp.status_code == 200
+        resp = post_json(client, _session_order_url(plan, session), {"order": [p0.pk]})
+        assert resp.status_code == 404
+
+    def test_soft_deleted_ancestor_week_404(self, client):
+        link, plan, week1, week2 = _two_week_plan()
+        session2 = week2.sessions.first()
+        presc2 = session2.prescriptions.first()
+        client.force_login(link.coach)
+        del_resp = client.post(
+            reverse(
+                "meso:api_week_delete", kwargs={"plan_id": plan.pk, "week_id": week2.pk}
+            )
+        )
+        assert del_resp.status_code == 200
+        resp = post_json(
+            client, _session_order_url(plan, session2), {"order": [presc2.pk]}
+        )
+        assert resp.status_code == 404
+
+    def test_records_exactly_one_plan_action_with_loosely_pinned_label(self, client):
+        plan, week, session, (p0, p1, p2) = seed_session(n=3)
+        client.force_login(plan.relationship.coach)
+        resp = post_json(
+            client, _session_order_url(plan, session), {"order": [p2.pk, p0.pk, p1.pk]}
+        )
+        assert resp.status_code == 200
+        actions = list(undo_actions(plan))
+        assert len(actions) == 1
+        assert actions[0].label == "Reordered exercises"
+
+    def test_undo_round_trip_restores_original_order_values(self, client):
+        plan, week, session, (p0, p1, p2) = seed_session(n=3)
+        client.force_login(plan.relationship.coach)
+        resp = post_json(
+            client, _session_order_url(plan, session), {"order": [p2.pk, p0.pk, p1.pk]}
+        )
+        assert resp.status_code == 200
+
+        resp = client.post(undo_url(plan))
+        assert resp.status_code == 200
+        p0.refresh_from_db()
+        p1.refresh_from_db()
+        p2.refresh_from_db()
+        assert (p0.order, p1.order, p2.order) == (0, 1, 2)
+
+
+# ---------------------------------------------------------------------------
+# POST /meso/api/plan/<id>/week/<week_id>/reorder/
+# ---------------------------------------------------------------------------
+
+
+class TestWeekReorderSessionsEndpoint:
+    def test_happy_path_writes_db_order_and_serializes_new_order(self, client):
+        plan, week, (s0, s1, s2) = seed_week_with_sessions(n=3)
+        client.force_login(plan.relationship.coach)
+        resp = post_json(
+            client, _week_order_url(plan, week), {"order": [s2.pk, s0.pk, s1.pk]}
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert _envelope_keys(body)
+        assert body["history"]["can_undo"] is True
+
+        s0.refresh_from_db()
+        s1.refresh_from_db()
+        s2.refresh_from_db()
+        assert (s2.order, s0.order, s1.order) == (0, 1, 2)
+        # day_number/name stay untouched — order is presentation order only.
+        assert s0.day_number == 1 and s0.name == "Day 1"
+
+        data = serialize_plan(plan, week=week)
+        assert [d["id"] for d in data["program"]] == [s2.pk, s0.pk, s1.pk]
+
+    def test_idempotent_repost_is_a_200_noop_that_still_records_one_action(
+        self, client
+    ):
+        plan, week, (s0, s1, s2) = seed_week_with_sessions(n=3)
+        client.force_login(plan.relationship.coach)
+        url = _week_order_url(plan, week)
+        current_order = [s0.pk, s1.pk, s2.pk]
+        resp = post_json(client, url, {"order": current_order})
+        assert resp.status_code == 200
+        assert undo_actions(plan).count() == 1
+
+        resp = post_json(client, url, {"order": current_order})
+        assert resp.status_code == 200
+        assert undo_actions(plan).count() == 2
+        s0.refresh_from_db()
+        s1.refresh_from_db()
+        s2.refresh_from_db()
+        assert (s0.order, s1.order, s2.order) == (0, 1, 2)
+
+    def test_missing_id_400(self, client):
+        plan, week, (s0, s1, s2) = seed_week_with_sessions(n=3)
+        client.force_login(plan.relationship.coach)
+        resp = post_json(client, _week_order_url(plan, week), {"order": [s0.pk, s1.pk]})
+        assert resp.status_code == 400
+        assert resp.json()["ok"] is False
+
+    def test_extra_id_from_a_sibling_week_400(self, client):
+        link, plan, week1, week2 = _two_week_plan()
+        session2 = week2.sessions.first()
+        sessions1 = list(week1.sessions.all())
+        client.force_login(link.coach)
+        resp = post_json(
+            client,
+            _week_order_url(plan, week1),
+            {"order": [s.pk for s in sessions1] + [session2.pk]},
+        )
+        assert resp.status_code == 400
+        assert resp.json()["ok"] is False
+
+    def test_duplicate_id_400(self, client):
+        plan, week, (s0, s1, s2) = seed_week_with_sessions(n=3)
+        client.force_login(plan.relationship.coach)
+        resp = post_json(
+            client, _week_order_url(plan, week), {"order": [s0.pk, s0.pk, s1.pk]}
+        )
+        assert resp.status_code == 400
+        assert resp.json()["ok"] is False
+
+    def test_foreign_plans_id_400(self, client):
+        plan, week, (s0, s1, s2) = seed_week_with_sessions(n=3)
+        _, _, (other_session,) = seed_week_with_sessions(n=1)  # a different coach
+        client.force_login(plan.relationship.coach)
+        resp = post_json(
+            client,
+            _week_order_url(plan, week),
+            {"order": [s0.pk, s1.pk, other_session.pk]},
+        )
+        assert resp.status_code == 400
+        assert resp.json()["ok"] is False
+
+    def test_soft_deleted_id_in_list_400(self, client):
+        plan, week, (s0, s1, s2) = seed_week_with_sessions(n=3)
+        client.force_login(plan.relationship.coach)
+        del_resp = client.post(
+            reverse("meso:api_session_delete", kwargs={"plan_id": plan.pk, "pk": s2.pk})
+        )
+        assert del_resp.status_code == 200
+        resp = post_json(
+            client, _week_order_url(plan, week), {"order": [s0.pk, s1.pk, s2.pk]}
+        )
+        assert resp.status_code == 400
+        assert resp.json()["ok"] is False
+
+    def test_malformed_json_400(self, client):
+        plan, week, (s0,) = seed_week_with_sessions(n=1)
+        client.force_login(plan.relationship.coach)
+        resp = client.post(
+            _week_order_url(plan, week),
+            data="not json",
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+
+    def test_non_list_order_400(self, client):
+        plan, week, (s0,) = seed_week_with_sessions(n=1)
+        client.force_login(plan.relationship.coach)
+        resp = post_json(client, _week_order_url(plan, week), {"order": "abc"})
+        assert resp.status_code == 400
+
+    def test_non_int_entries_400(self, client):
+        plan, week, (s0, s1, s2) = seed_week_with_sessions(n=3)
+        client.force_login(plan.relationship.coach)
+        resp = post_json(
+            client,
+            _week_order_url(plan, week),
+            {"order": [s0.pk, "not-an-id", s2.pk]},
+        )
+        assert resp.status_code == 400
+
+    def test_requires_login(self, client):
+        plan, week, (s0,) = seed_week_with_sessions(n=1)
+        resp = post_json(client, _week_order_url(plan, week), {"order": []})
+        assert resp.status_code == 302
+        assert "/accounts/login/" in resp.url
+
+    def test_get_not_allowed(self, client):
+        plan, week, (s0,) = seed_week_with_sessions(n=1)
+        client.force_login(plan.relationship.coach)
+        resp = client.get(_week_order_url(plan, week))
+        assert resp.status_code == 405
+
+    def test_non_owner_forbidden(self, client):
+        plan, week, (s0,) = seed_week_with_sessions(n=1)
+        client.force_login(UserFactory())
+        resp = post_json(client, _week_order_url(plan, week), {"order": [s0.pk]})
+        assert resp.status_code == 403
+
+    def test_unknown_week_id_404(self, client):
+        plan, week, (s0,) = seed_week_with_sessions(n=1)
+        client.force_login(plan.relationship.coach)
+        resp = post_json(
+            client,
+            reverse(
+                "meso:api_week_reorder_sessions",
+                kwargs={"plan_id": plan.pk, "week_id": 999999},
+            ),
+            {"order": []},
+        )
+        assert resp.status_code == 404
+
+    def test_soft_deleted_week_404(self, client):
+        link, plan, week1, week2 = _two_week_plan()
+        session2 = week2.sessions.first()
+        client.force_login(link.coach)
+        del_resp = client.post(
+            reverse(
+                "meso:api_week_delete", kwargs={"plan_id": plan.pk, "week_id": week2.pk}
+            )
+        )
+        assert del_resp.status_code == 200
+        resp = post_json(client, _week_order_url(plan, week2), {"order": [session2.pk]})
+        assert resp.status_code == 404
+
+    def test_records_exactly_one_plan_action_with_loosely_pinned_label(self, client):
+        plan, week, (s0, s1, s2) = seed_week_with_sessions(n=3)
+        client.force_login(plan.relationship.coach)
+        resp = post_json(
+            client, _week_order_url(plan, week), {"order": [s2.pk, s0.pk, s1.pk]}
+        )
+        assert resp.status_code == 200
+        actions = list(undo_actions(plan))
+        assert len(actions) == 1
+        assert actions[0].label == "Reordered days"
+
+    def test_undo_round_trip_restores_original_order_values(self, client):
+        plan, week, (s0, s1, s2) = seed_week_with_sessions(n=3)
+        client.force_login(plan.relationship.coach)
+        resp = post_json(
+            client, _week_order_url(plan, week), {"order": [s2.pk, s0.pk, s1.pk]}
+        )
+        assert resp.status_code == 200
+
+        resp = client.post(undo_url(plan))
+        assert resp.status_code == 200
+        s0.refresh_from_db()
+        s1.refresh_from_db()
+        s2.refresh_from_db()
+        assert (s0.order, s1.order, s2.order) == (0, 1, 2)
+
+
+# ---------------------------------------------------------------------------
+# POST /meso/api/plan/<id>/prescription/<pk>/move/
+# ---------------------------------------------------------------------------
+
+
+class TestPrescriptionMoveEndpoint:
+    def test_happy_path_moves_row_and_densely_renumbers_both_sessions(self, client):
+        plan, week, session_a, session_b, p0, p1, q0 = seed_two_sessions()
+        client.force_login(plan.relationship.coach)
+        resp = post_json(
+            client,
+            _move_url(plan, p0),
+            {"session_id": session_b.pk, "index": 0},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert _envelope_keys(body)
+        assert body["history"]["can_undo"] is True
+
+        p0.refresh_from_db()
+        p1.refresh_from_db()
+        q0.refresh_from_db()
+        assert p0.session_id == session_b.pk
+        assert p0.order == 0
+        assert q0.order == 1
+        # session_a's remaining row renumbers densely (was order=1, now 0).
+        assert p1.session_id == session_a.pk
+        assert p1.order == 0
+
+        data = serialize_plan(plan, week=week)
+        day_a = next(d for d in data["program"] if d["id"] == session_a.pk)
+        day_b = next(d for d in data["program"] if d["id"] == session_b.pk)
+        assert [e["id"] for e in day_a["exercises"]] == [p1.pk]
+        assert [e["id"] for e in day_b["exercises"]] == [p0.pk, q0.pk]
+
+    def test_idempotent_repost_of_the_same_move_is_a_200_noop(self, client):
+        plan, week, session_a, session_b, p0, p1, q0 = seed_two_sessions()
+        client.force_login(plan.relationship.coach)
+        url = _move_url(plan, p0)
+        resp = post_json(client, url, {"session_id": session_b.pk, "index": 0})
+        assert resp.status_code == 200
+        assert undo_actions(plan).count() == 1
+
+        # p0 is now IN session_b at index 0 — reposting the identical move is a
+        # target-equals-source no-op, still recording one action.
+        resp = post_json(client, url, {"session_id": session_b.pk, "index": 0})
+        assert resp.status_code == 200
+        assert undo_actions(plan).count() == 2
+        p0.refresh_from_db()
+        assert p0.session_id == session_b.pk
+        assert p0.order == 0
+
+    def test_target_equals_source_behaves_like_a_reorder(self, client):
+        plan, week, session_a, session_b, p0, p1, q0 = seed_two_sessions()
+        client.force_login(plan.relationship.coach)
+        resp = post_json(
+            client, _move_url(plan, p0), {"session_id": session_a.pk, "index": 1}
+        )
+        assert resp.status_code == 200
+        p0.refresh_from_db()
+        p1.refresh_from_db()
+        q0.refresh_from_db()
+        # p0 moved past p1 within the SAME session — a plain within-day reorder.
+        assert p0.session_id == session_a.pk
+        assert p1.session_id == session_a.pk
+        assert (p1.order, p0.order) == (0, 1)
+        # session_b is untouched.
+        assert q0.session_id == session_b.pk
+        assert q0.order == 0
+
+    def test_cross_week_move_400(self, client):
+        link, plan, week1, week2 = _two_week_plan()
+        presc1 = week1.sessions.first().prescriptions.first()
+        session2 = week2.sessions.first()
+        client.force_login(link.coach)
+        resp = post_json(
+            client, _move_url(plan, presc1), {"session_id": session2.pk, "index": 0}
+        )
+        assert resp.status_code == 400
+        body = resp.json()
+        assert body["ok"] is False
+        assert body["error"] == "Move within one week."
+        presc1.refresh_from_db()
+        assert presc1.session_id == week1.sessions.first().pk
+
+    def test_index_clamps_above_range_to_the_end(self, client):
+        plan, week, session_a, session_b, p0, p1, q0 = seed_two_sessions()
+        client.force_login(plan.relationship.coach)
+        resp = post_json(
+            client, _move_url(plan, p0), {"session_id": session_b.pk, "index": 999}
+        )
+        assert resp.status_code == 200
+        p0.refresh_from_db()
+        q0.refresh_from_db()
+        assert p0.session_id == session_b.pk
+        assert p0.order == 1  # clamped to the end (after q0)
+        assert q0.order == 0
+
+    def test_index_clamps_below_range_to_zero(self, client):
+        plan, week, session_a, session_b, p0, p1, q0 = seed_two_sessions()
+        client.force_login(plan.relationship.coach)
+        resp = post_json(
+            client, _move_url(plan, p0), {"session_id": session_b.pk, "index": -5}
+        )
+        assert resp.status_code == 200
+        p0.refresh_from_db()
+        q0.refresh_from_db()
+        assert p0.session_id == session_b.pk
+        assert p0.order == 0
+        assert q0.order == 1
+
+    def test_missing_session_id_400(self, client):
+        plan, week, session_a, session_b, p0, p1, q0 = seed_two_sessions()
+        client.force_login(plan.relationship.coach)
+        resp = post_json(client, _move_url(plan, p0), {"index": 0})
+        assert resp.status_code == 400
+
+    def test_non_int_session_id_400(self, client):
+        plan, week, session_a, session_b, p0, p1, q0 = seed_two_sessions()
+        client.force_login(plan.relationship.coach)
+        resp = post_json(client, _move_url(plan, p0), {"session_id": "abc", "index": 0})
+        assert resp.status_code == 400
+
+    def test_missing_index_400(self, client):
+        plan, week, session_a, session_b, p0, p1, q0 = seed_two_sessions()
+        client.force_login(plan.relationship.coach)
+        resp = post_json(client, _move_url(plan, p0), {"session_id": session_b.pk})
+        assert resp.status_code == 400
+
+    def test_non_int_index_400(self, client):
+        plan, week, session_a, session_b, p0, p1, q0 = seed_two_sessions()
+        client.force_login(plan.relationship.coach)
+        resp = post_json(
+            client,
+            _move_url(plan, p0),
+            {"session_id": session_b.pk, "index": "abc"},
+        )
+        assert resp.status_code == 400
+
+    def test_malformed_json_400(self, client):
+        plan, week, session_a, session_b, p0, p1, q0 = seed_two_sessions()
+        client.force_login(plan.relationship.coach)
+        resp = client.post(
+            _move_url(plan, p0), data="not json", content_type="application/json"
+        )
+        assert resp.status_code == 400
+
+    def test_foreign_session_id_400(self, client):
+        # A decision where the spec is silent: a session_id that doesn't
+        # resolve to a live session of THIS plan is a 400 (a body-referenced
+        # id failing validation), mirroring prescription_override's
+        # _group_member_or_none 400-on-bad-reference convention — not the
+        # URL-segment 404 convention used for the endpoint's own `pk`.
+        plan, week, session_a, session_b, p0, p1, q0 = seed_two_sessions()
+        client.force_login(plan.relationship.coach)
+        resp = post_json(
+            client, _move_url(plan, p0), {"session_id": 999999, "index": 0}
+        )
+        assert resp.status_code == 400
+
+    def test_soft_deleted_target_session_id_400(self, client):
+        plan, week, session_a, session_b, p0, p1, q0 = seed_two_sessions()
+        client.force_login(plan.relationship.coach)
+        del_resp = client.post(
+            reverse(
+                "meso:api_session_delete",
+                kwargs={"plan_id": plan.pk, "pk": session_b.pk},
+            )
+        )
+        assert del_resp.status_code == 200
+        resp = post_json(
+            client, _move_url(plan, p0), {"session_id": session_b.pk, "index": 0}
+        )
+        assert resp.status_code == 400
+
+    def test_requires_login(self, client):
+        plan, week, session_a, session_b, p0, p1, q0 = seed_two_sessions()
+        resp = post_json(
+            client, _move_url(plan, p0), {"session_id": session_b.pk, "index": 0}
+        )
+        assert resp.status_code == 302
+        assert "/accounts/login/" in resp.url
+
+    def test_get_not_allowed(self, client):
+        plan, week, session_a, session_b, p0, p1, q0 = seed_two_sessions()
+        client.force_login(plan.relationship.coach)
+        resp = client.get(_move_url(plan, p0))
+        assert resp.status_code == 405
+
+    def test_non_owner_forbidden(self, client):
+        plan, week, session_a, session_b, p0, p1, q0 = seed_two_sessions()
+        client.force_login(UserFactory())
+        resp = post_json(
+            client, _move_url(plan, p0), {"session_id": session_b.pk, "index": 0}
+        )
+        assert resp.status_code == 403
+
+    def test_unknown_prescription_pk_404(self, client):
+        plan, week, session_a, session_b, p0, p1, q0 = seed_two_sessions()
+        client.force_login(plan.relationship.coach)
+        resp = post_json(
+            client,
+            reverse(
+                "meso:api_prescription_move",
+                kwargs={"plan_id": plan.pk, "pk": 999999},
+            ),
+            {"session_id": session_b.pk, "index": 0},
+        )
+        assert resp.status_code == 404
+
+    def test_soft_deleted_prescription_404(self, client):
+        plan, week, session_a, session_b, p0, p1, q0 = seed_two_sessions()
+        client.force_login(plan.relationship.coach)
+        del_resp = client.post(
+            reverse(
+                "meso:api_prescription_delete", kwargs={"plan_id": plan.pk, "pk": p0.pk}
+            )
+        )
+        assert del_resp.status_code == 200
+        resp = post_json(
+            client, _move_url(plan, p0), {"session_id": session_b.pk, "index": 0}
+        )
+        assert resp.status_code == 404
+
+    def test_soft_deleted_ancestor_week_404(self, client):
+        link, plan, week1, week2 = _two_week_plan()
+        session2a = week2.sessions.first()
+        session2b = SessionFactory(week=week2, day_number=2, name="Upper", order=1)
+        presc2 = session2a.prescriptions.first()
+        client.force_login(link.coach)
+        del_resp = client.post(
+            reverse(
+                "meso:api_week_delete", kwargs={"plan_id": plan.pk, "week_id": week2.pk}
+            )
+        )
+        assert del_resp.status_code == 200
+        resp = post_json(
+            client, _move_url(plan, presc2), {"session_id": session2b.pk, "index": 0}
+        )
+        assert resp.status_code == 404
+
+    def test_records_exactly_one_plan_action_with_loosely_pinned_label(self, client):
+        plan, week, session_a, session_b, p0, p1, q0 = seed_two_sessions()
+        client.force_login(plan.relationship.coach)
+        resp = post_json(
+            client, _move_url(plan, p0), {"session_id": session_b.pk, "index": 0}
+        )
+        assert resp.status_code == 200
+        actions = list(undo_actions(plan))
+        assert len(actions) == 1
+        assert "Moved" in actions[0].label
+        assert "Box Squat" in actions[0].label
+
+    def test_undo_round_trip_puts_the_row_back_in_source_session_at_old_order(
+        self, client
+    ):
+        plan, week, session_a, session_b, p0, p1, q0 = seed_two_sessions()
+        client.force_login(plan.relationship.coach)
+        resp = post_json(
+            client, _move_url(plan, p0), {"session_id": session_b.pk, "index": 0}
+        )
+        assert resp.status_code == 200
+
+        resp = client.post(undo_url(plan))
+        assert resp.status_code == 200
+        p0.refresh_from_db()
+        p1.refresh_from_db()
+        q0.refresh_from_db()
+        assert p0.session_id == session_a.pk
+        assert p0.order == 0
+        assert p1.session_id == session_a.pk
+        assert p1.order == 1
+        assert q0.session_id == session_b.pk
+        assert q0.order == 0
+
+    def test_logged_set_survives_the_move_pointing_at_the_same_prescription(
+        self, client
+    ):
+        plan, week, session_a, session_b, p0, p1, q0 = seed_two_sessions()
+        log = SessionLogFactory(session=session_a, athlete=plan.athlete)
+        logged_set = LoggedSetFactory(session_log=log, prescription=p0)
+        client.force_login(plan.relationship.coach)
+        resp = post_json(
+            client, _move_url(plan, p0), {"session_id": session_b.pk, "index": 0}
+        )
+        assert resp.status_code == 200
+
+        logged_set.refresh_from_db()
+        assert logged_set.prescription_id == p0.pk
+        assert logged_set.session_log_id == log.pk
+        # The log itself keeps pointing at the (untouched) session it was
+        # logged against — moving the prescription never touches SessionLog.
+        log.refresh_from_db()
+        assert log.session_id == session_a.pk

--- a/app/store_project/meso/urls.py
+++ b/app/store_project/meso/urls.py
@@ -163,6 +163,12 @@ urlpatterns = [
         views.session_delete,
         name="api_session_delete",
     ),
+    # Reorder a session's exercise rows (dnd-kit designer, Phase 4, #403).
+    path(
+        "api/plan/<int:plan_id>/session/<int:pk>/reorder/",
+        views.session_reorder,
+        name="api_session_reorder",
+    ),
     # Multi-week designer: view any week (read), add the next week (write), and
     # set the live/deliver-target week. ``week/<id>/`` GET views; POST sets current.
     path(
@@ -186,6 +192,12 @@ urlpatterns = [
         views.week_delete,
         name="api_week_delete",
     ),
+    # Reorder a week's training days (dnd-kit designer, Phase 4, #403).
+    path(
+        "api/plan/<int:plan_id>/week/<int:week_id>/reorder/",
+        views.week_reorder_sessions,
+        name="api_week_reorder_sessions",
+    ),
     # Plan-wide undo/redo op-log (designer framework Phase 1, issue #401).
     path(
         "api/plan/<int:plan_id>/undo/",
@@ -208,6 +220,13 @@ urlpatterns = [
         "api/plan/<int:plan_id>/prescription/<int:pk>/one-rm/",
         views.coach_set_one_rm,
         name="api_coach_set_one_rm",
+    ),
+    # Move an exercise row to a different session, within the same week
+    # (dnd-kit designer cross-day drag, Phase 4, #403).
+    path(
+        "api/plan/<int:plan_id>/prescription/<int:pk>/move/",
+        views.prescription_move,
+        name="api_prescription_move",
     ),
     path(
         "api/plan/<int:plan_id>/deliver/",

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -2192,6 +2192,85 @@ def session_delete(request, plan_id, pk):
     return JsonResponse({"ok": True, **serialize_plan(plan, week=week)})
 
 
+def _parse_id_list(request):
+    """A designer reorder POST's ``{"order": [...]}`` body, or a bare 400.
+
+    Structural failures — malformed JSON, a non-object body, a missing/non-list
+    ``order``, or a non-int entry — are asserted as a bare 400 (mirrors
+    ``prescription_patch``'s ``HttpResponseBadRequest`` convention for
+    structurally-invalid bodies), as opposed to the *semantic* id-set mismatch
+    a caller checks afterward against the live rows it's reordering (which the
+    spec promises as ``{"ok": false, "error": ...}``). ``bool`` is an ``int``
+    subclass, so it's excluded explicitly — the same guard ``_body_week_id`` uses.
+    """
+    try:
+        payload = json.loads(request.body or "{}")
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None, HttpResponseBadRequest("Malformed JSON.")
+    if not isinstance(payload, dict):
+        return None, HttpResponseBadRequest("Expected a JSON object.")
+    order = payload.get("order")
+    if not isinstance(order, list) or not all(
+        isinstance(item, int) and not isinstance(item, bool) for item in order
+    ):
+        return None, HttpResponseBadRequest("order must be a list of integers.")
+    return order, None
+
+
+@login_required
+@require_POST
+def session_reorder(request, plan_id, pk):
+    """Reorder one session's exercise rows (dnd-kit designer, Phase 4, #403).
+
+    Body ``{"order": [<prescription ids>]}`` must be EXACTLY the session's live
+    prescription id set — one entry per live row, no missing/extra/duplicate/
+    foreign/soft-deleted id — in the new order; any mismatch is a 400
+    ``{"ok": false, "error": ...}`` (see ``_parse_id_list`` for the structural-
+    vs-semantic 400 split). Writes dense 0-based ``ExercisePrescription.order``
+    values matching the posted order. Idempotent: posting the current order is
+    a 200 no-op that still records one action (the client never sends a no-op
+    post, so this is the simplest contract rather than a special case).
+    """
+    plan, forbidden = _editable_plan_or_response(request, plan_id)
+    if forbidden is not None:
+        return forbidden
+    session = get_object_or_404(
+        Session,
+        pk=pk,
+        week__mesocycle__plan=plan,
+        deleted_at__isnull=True,
+        week__deleted_at__isnull=True,
+    )
+    order, bad = _parse_id_list(request)
+    if bad is not None:
+        return bad
+
+    week = session.week
+    with transaction.atomic():
+        # Lock ordering: plan first (see session_add) — the live id set is read
+        # under this lock so a concurrent write to the same session's rows
+        # can't slip in between the read and this reorder's write.
+        Plan.objects.select_for_update().filter(pk=plan.pk).first()
+        live_ids = list(
+            session.prescriptions.filter(deleted_at__isnull=True).values_list(
+                "pk", flat=True
+            )
+        )
+        if len(order) != len(live_ids) or set(order) != set(live_ids):
+            return JsonResponse(
+                {
+                    "ok": False,
+                    "error": "order must be exactly the session's exercises.",
+                },
+                status=400,
+            )
+        record_plan_action(plan, "Reordered exercises")
+        for index, prescription_id in enumerate(order):
+            ExercisePrescription.objects.filter(pk=prescription_id).update(order=index)
+        _touch_plan(plan)
+    return JsonResponse({"ok": True, **serialize_plan(plan, week=week)})
+
+
 @login_required
 @require_GET
 def week_view(request, plan_id, week_id):
@@ -2346,6 +2425,46 @@ def week_delete(request, plan_id, week_id):
         week.save(update_fields=["deleted_at"])
         _touch_plan(plan)
     return JsonResponse({"ok": True, **serialize_plan(plan)})
+
+
+@login_required
+@require_POST
+def week_reorder_sessions(request, plan_id, week_id):
+    """Reorder one week's training days (dnd-kit designer, Phase 4, #403).
+
+    Body ``{"order": [<session ids>]}`` must be EXACTLY the week's live session
+    id set, in the new order — validation mirrors ``session_reorder`` (see
+    ``_parse_id_list`` for the structural-vs-semantic 400 split). Writes dense
+    0-based ``Session.order`` values only; ``day_number``/``name`` stay
+    untouched — "Day 1" keeps its label, since ``order`` is presentation order,
+    not the day's identity (``Session.Meta.ordering = ["order", "day_number"]``).
+    """
+    plan, forbidden = _editable_plan_or_response(request, plan_id)
+    if forbidden is not None:
+        return forbidden
+    week = get_object_or_404(
+        Week, pk=week_id, mesocycle__plan=plan, deleted_at__isnull=True
+    )
+    order, bad = _parse_id_list(request)
+    if bad is not None:
+        return bad
+
+    with transaction.atomic():
+        # Lock ordering: plan first (see session_add).
+        Plan.objects.select_for_update().filter(pk=plan.pk).first()
+        live_ids = list(
+            week.sessions.filter(deleted_at__isnull=True).values_list("pk", flat=True)
+        )
+        if len(order) != len(live_ids) or set(order) != set(live_ids):
+            return JsonResponse(
+                {"ok": False, "error": "order must be exactly the week's days."},
+                status=400,
+            )
+        record_plan_action(plan, "Reordered days")
+        for index, session_id in enumerate(order):
+            Session.objects.filter(pk=session_id).update(order=index)
+        _touch_plan(plan)
+    return JsonResponse({"ok": True, **serialize_plan(plan, week=week)})
 
 
 def _undo_redo_week_response(plan, week_id):
@@ -2612,6 +2731,116 @@ def prescription_override(request, plan_id, pk):
         # matches the membership; this stays defensive against future drift.
         return HttpResponseBadRequest("The prescription is not in this program.")
     return _override_response(plan, prescription)
+
+
+def _live_session_in_plan_or_none(plan, session_id):
+    """A live ``Session`` of ``plan`` by pk, or ``None`` (a bad body reference).
+
+    Mirrors ``_group_member_or_none``'s convention: a body-referenced id that
+    doesn't resolve to a live row of this plan answers 400, not the URL-segment
+    404 used for the endpoint's own ``pk``.
+    """
+    return Session.objects.filter(
+        pk=session_id,
+        week__mesocycle__plan=plan,
+        deleted_at__isnull=True,
+        week__deleted_at__isnull=True,
+    ).first()
+
+
+@login_required
+@require_POST
+def prescription_move(request, plan_id, pk):
+    """Move one exercise row to a different session, within the same week (Phase 4, #403).
+
+    The designer's cross-day drag: re-points ``prescription.session`` to the
+    posted ``session_id`` and densely renumbers (0-based) BOTH the source and
+    target session's live rows, with the moved row landing at the posted
+    ``index`` (clamped into ``[0, len(target's live rows)]`` — a drop past
+    either end just lands at that end). A target session equal to the source
+    behaves like a plain within-day reorder (the row never leaves, only the
+    one session's rows are renumbered). Cross-*week* moves — a target session
+    in a different week than the source — are a 400
+    ``{"ok": false, "error": "Move within one week."}``; the designer's grid
+    has no cross-week drag gesture. ``LoggedSet.prescription`` rows are left
+    untouched — a move only ever changes ``session``/``order``, never touches
+    an athlete's logged history, so it keeps pointing at the same pk.
+
+    Body ``{"session_id": <int>, "index": <int>}``; malformed JSON, a non-object
+    body, or a missing/non-int field is a bare 400 (mirrors ``prescription_patch``).
+    A ``session_id`` that doesn't resolve to a live session of THIS plan is also
+    a 400 (``_live_session_in_plan_or_none``, mirroring ``prescription_override``'s
+    ``_group_member_or_none`` bad-reference convention) rather than a 404 — only
+    the URL-segment ``pk`` gets the 404 treatment.
+    """
+    plan, forbidden = _editable_plan_or_response(request, plan_id)
+    if forbidden is not None:
+        return forbidden
+    prescription = get_object_or_404(
+        ExercisePrescription,
+        pk=pk,
+        session__week__mesocycle__plan=plan,
+        deleted_at__isnull=True,
+        session__deleted_at__isnull=True,
+        session__week__deleted_at__isnull=True,
+    )
+    try:
+        payload = json.loads(request.body or "{}")
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return HttpResponseBadRequest("Malformed JSON.")
+    if not isinstance(payload, dict):
+        return HttpResponseBadRequest("Expected a JSON object.")
+
+    session_id = payload.get("session_id")
+    if not isinstance(session_id, int) or isinstance(session_id, bool):
+        return HttpResponseBadRequest("session_id must be an integer.")
+    index = payload.get("index")
+    if not isinstance(index, int) or isinstance(index, bool):
+        return HttpResponseBadRequest("index must be an integer.")
+
+    target_session = _live_session_in_plan_or_none(plan, session_id)
+    if target_session is None:
+        return HttpResponseBadRequest("session_id must be a live session of this plan.")
+    source_session = prescription.session
+    if target_session.week_id != source_session.week_id:
+        return JsonResponse({"ok": False, "error": "Move within one week."}, status=400)
+
+    week = source_session.week
+    with transaction.atomic():
+        # Lock ordering: plan first (see session_add).
+        Plan.objects.select_for_update().filter(pk=plan.pk).first()
+        record_plan_action(plan, f"Moved {prescription.name or 'exercise'}")
+        if target_session.pk == source_session.pk:
+            siblings = list(
+                source_session.prescriptions.filter(deleted_at__isnull=True)
+                .exclude(pk=prescription.pk)
+                .order_by("order")
+            )
+            clamped = max(0, min(index, len(siblings)))
+            siblings.insert(clamped, prescription)
+            for new_order, row in enumerate(siblings):
+                ExercisePrescription.objects.filter(pk=row.pk).update(order=new_order)
+        else:
+            target_rows = list(
+                target_session.prescriptions.filter(deleted_at__isnull=True).order_by(
+                    "order"
+                )
+            )
+            clamped = max(0, min(index, len(target_rows)))
+            target_rows.insert(clamped, prescription)
+            for new_order, row in enumerate(target_rows):
+                ExercisePrescription.objects.filter(pk=row.pk).update(
+                    order=new_order, session_id=target_session.pk
+                )
+            source_rows = list(
+                source_session.prescriptions.filter(deleted_at__isnull=True)
+                .exclude(pk=prescription.pk)
+                .order_by("order")
+            )
+            for new_order, row in enumerate(source_rows):
+                ExercisePrescription.objects.filter(pk=row.pk).update(order=new_order)
+        _touch_plan(plan)
+    return JsonResponse({"ok": True, **serialize_plan(plan, week=week)})
 
 
 @login_required

--- a/frontend/designer/src/DesignerRoot.tsx
+++ b/frontend/designer/src/DesignerRoot.tsx
@@ -221,6 +221,7 @@ export function DesignerRoot() {
     planId,
     csrf,
     viewedWeekId: planData.viewedWeekId,
+    setPendingDelete: planData.setPendingDelete,
     program: planData.program,
     setProgram: planData.setProgram,
     applyPlanData: planData.applyPlanData,

--- a/frontend/designer/src/DesignerRoot.tsx
+++ b/frontend/designer/src/DesignerRoot.tsx
@@ -23,6 +23,7 @@ import { useDeletes } from "./hooks/useDeletes";
 import { useUndoRedo } from "./hooks/useUndoRedo";
 import { useOverrideEditor } from "./hooks/useOverrideEditor";
 import { useOneRmEditor } from "./hooks/useOneRmEditor";
+import { useReorder } from "./hooks/useReorder";
 import { useAgentChat } from "./hooks/useAgentChat";
 import type { ChatMessage } from "./hooks/useAgentChat";
 import { useCoachmarks } from "./hooks/useCoachmarks";
@@ -216,6 +217,14 @@ export function DesignerRoot() {
     adoptHistory: planData.adoptHistory,
     patchExercise: planData.patchExercise,
   });
+  const reorder = useReorder({
+    planId,
+    csrf,
+    viewedWeekId: planData.viewedWeekId,
+    program: planData.program,
+    setProgram: planData.setProgram,
+    applyPlanData: planData.applyPlanData,
+  });
   const agentChat = useAgentChat({
     planId,
     csrf,
@@ -341,6 +350,8 @@ export function DesignerRoot() {
                   onRequestRemoveWeek={deletes.requestRemoveWeek}
                   onUndo={undoRedo.undo}
                   onRedo={undoRedo.redo}
+                  onDragEnd={reorder.onDragEnd}
+                  reordering={reorder.reordering}
                 />
               </div>
             )}

--- a/frontend/designer/src/components/DayCard.test.tsx
+++ b/frontend/designer/src/components/DayCard.test.tsx
@@ -101,3 +101,32 @@ describe("DayCard", () => {
     expect(onAddExercise).toHaveBeenCalledWith(0);
   });
 });
+
+// === Phase 4 (dnd-kit reordering) — RED. DayCard does not render a day-strip
+// drag handle yet; these specs are appended (existing specs above are
+// untouched). Per scratchpad/phase4-spec.md: "each DayCard header gets one
+// [handle] (`data-testid="day-drag-${id}"`, aria-label "Reorder <day
+// name>")". The spec's own example phrase is "<day name or 'Day N'>" — this
+// block resolves the fallback as "Day <day.n>" (the same badge number the
+// header already renders in `.meso-day-badge`), not the array index, so the
+// label stays correct after a day reorder (`n` is the day's own identity;
+// `dayIndex` is presentation position and changes on every drag).
+describe("drag handle (Phase 4, dnd-kit reordering)", () => {
+  it("renders a day-strip drag-handle button with the reorder testid/aria-label", () => {
+    render(<DayCard {...baseProps()} />);
+    const handle = screen.getByTestId("day-drag-1");
+    expect(handle.tagName).toBe("BUTTON");
+    expect(handle).toHaveAttribute("type", "button");
+    expect(handle).toHaveAttribute("aria-label", "Reorder Lower");
+  });
+
+  it("falls back to 'Reorder Day <n>' when the day has no name", () => {
+    render(<DayCard {...baseProps({ day: day({ name: "" }) })} />);
+    expect(screen.getByTestId("day-drag-1")).toHaveAttribute("aria-label", "Reorder Day 1");
+  });
+
+  it("is NOT a grid-nav restoration target", () => {
+    render(<DayCard {...baseProps()} />);
+    expect(screen.getByTestId("day-drag-1")).not.toHaveAttribute("data-grid-restore");
+  });
+});

--- a/frontend/designer/src/components/DayCard.tsx
+++ b/frontend/designer/src/components/DayCard.tsx
@@ -1,11 +1,14 @@
 // DayCard (CONTRACT.md "DayCard") — ported 1:1 from designer.html's day card
 // (lines ~391-461): day header (name/bias/count + remove-day arm/confirm/
 // cancel), column headers, one ExerciseRow per exercise, "+ Add exercise".
+import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { ExerciseRow } from "./ExerciseRow";
 import type { Day, Exercise } from "../lib/api";
 import type { PendingDelete } from "../hooks/usePlanData";
 import type { OneRmEditorState } from "../hooks/useOneRmEditor";
 import type { UseGridNavResult } from "../hooks/useGridNav";
+import type { ReorderDragData } from "../hooks/useReorder";
 
 export interface DayCardProps {
   day: Day;
@@ -63,9 +66,41 @@ export function DayCard(props: DayCardProps) {
 
   const armed = !!pendingDelete && pendingDelete.type === "day" && pendingDelete.di === dayIndex;
 
+  // Phase 4 (dnd-kit reordering): DayCard is itself a sortable item in
+  // WeekGrid's day-strip SortableContext, AND a SortableContext provider
+  // for its own exercise rows below — the standard nested-containers dnd-kit
+  // pattern. Drag listeners are bound only to the day handle in the header.
+  const dragData: ReorderDragData = { type: "day", sessionId: day.id };
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: `day-${day.id}`, data: dragData });
+  const cardStyle = { transform: CSS.Transform.toString(transform), transition };
+  const dayHandleLabel = `Reorder ${day.name || `Day ${day.n}`}`;
+
   return (
-    <div className="meso-day-card">
+    <div
+      className={`meso-day-card${isDragging ? " is-dragging" : ""}`}
+      ref={setNodeRef}
+      style={cardStyle}
+    >
       <div className="meso-day-header">
+        <button
+          type="button"
+          ref={setActivatorNodeRef}
+          data-testid={`day-drag-${day.id}`}
+          className="meso-drag-handle meso-drag-handle--day"
+          aria-label={dayHandleLabel}
+          {...attributes}
+          {...listeners}
+        >
+          ⠿
+        </button>
         <div className="meso-day-badge">{day.n}</div>
         <div className="meso-day-name">{day.name}</div>
         {day.bias && <div className="meso-day-bias">{day.bias}</div>}
@@ -119,29 +154,35 @@ export function DayCard(props: DayCardProps) {
         <div className="meso-col-center">RPE</div>
         <div>Notes</div>
       </div>
-      {day.exercises.map((ex, xi) => (
-        <ExerciseRow
-          key={ex.id}
-          ex={ex}
-          dayIndex={dayIndex}
-          exIndex={xi}
-          isGroup={isGroup}
-          unit={unit}
-          deleting={deleting}
-          gridNav={gridNav}
-          oneRmOpenForRow={oneRmOpenForRow(ex)}
-          oneRmEditorState={oneRmEditorState}
-          onFieldChange={(field, value) => onFieldChange(dayIndex, xi, field, value)}
-          onCommit={() => onCommit(dayIndex, xi)}
-          onRemove={() => onRemoveExercise(dayIndex, xi)}
-          onToggleLoadType={() => onToggleLoadType(ex)}
-          onOpenOverride={() => onOpenOverride(ex)}
-          onOpenOneRm={() => onOpenOneRm(ex)}
-          onOneRmChange={onOneRmChange}
-          onOneRmSave={onOneRmSave}
-          onOneRmCancel={onOneRmCancel}
-        />
-      ))}
+      <SortableContext
+        items={day.exercises.map((ex) => `ex-${ex.id}`)}
+        strategy={verticalListSortingStrategy}
+      >
+        {day.exercises.map((ex, xi) => (
+          <ExerciseRow
+            key={ex.id}
+            ex={ex}
+            dayIndex={dayIndex}
+            exIndex={xi}
+            isGroup={isGroup}
+            unit={unit}
+            deleting={deleting}
+            gridNav={gridNav}
+            dayId={day.id}
+            oneRmOpenForRow={oneRmOpenForRow(ex)}
+            oneRmEditorState={oneRmEditorState}
+            onFieldChange={(field, value) => onFieldChange(dayIndex, xi, field, value)}
+            onCommit={() => onCommit(dayIndex, xi)}
+            onRemove={() => onRemoveExercise(dayIndex, xi)}
+            onToggleLoadType={() => onToggleLoadType(ex)}
+            onOpenOverride={() => onOpenOverride(ex)}
+            onOpenOneRm={() => onOpenOneRm(ex)}
+            onOneRmChange={onOneRmChange}
+            onOneRmSave={onOneRmSave}
+            onOneRmCancel={onOneRmCancel}
+          />
+        ))}
+      </SortableContext>
       <button
         type="button"
         data-hover="add"

--- a/frontend/designer/src/components/ExerciseRow.test.tsx
+++ b/frontend/designer/src/components/ExerciseRow.test.tsx
@@ -256,42 +256,6 @@ describe("1RM editor keyboard", () => {
   });
 });
 
-// === Phase 4 (dnd-kit reordering) — RED. ExerciseRow does not render a drag
-// handle yet; these specs are appended (existing specs above are untouched).
-// Per scratchpad/phase4-spec.md's "Drag handles, not draggable cells": each
-// row gets a grip BUTTON (not the whole cell) so dnd-kit's PointerSensor
-// only starts a drag from that control, and so the handle can double as a
-// KeyboardSensor target riding the Phase 3 tab order without colliding with
-// grid-nav's own cell keydown handling. Two decisions this block pins:
-// - aria-label falls back to "Reorder exercise" for a nameless row, matching
-//   ../hooks/useGridNav's existing `cellAriaLabel` fallback convention
-//   (`exerciseName || "exercise"`) rather than inventing a new one.
-// - the handle is explicitly `type="button"` (never relying on a bare
-//   <button>'s implicit "submit" default) — the same convention every other
-//   testid'd button in this file already follows.
-describe("drag handle (Phase 4, dnd-kit reordering)", () => {
-  it("renders a drag-handle button with the reorder testid/aria-label, before the name cell", () => {
-    render(<ExerciseRow {...baseProps()} />);
-    const handle = screen.getByTestId("exercise-drag-9");
-    expect(handle.tagName).toBe("BUTTON");
-    expect(handle).toHaveAttribute("type", "button");
-    expect(handle).toHaveAttribute("aria-label", "Reorder Squat");
-    const nameInput = screen.getByTestId("exercise-name-9");
-    // DOCUMENT_POSITION_FOLLOWING (4): nameInput comes after handle in the DOM.
-    expect(handle.compareDocumentPosition(nameInput) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-  });
-
-  it("falls back to 'Reorder exercise' when the row has no name", () => {
-    render(<ExerciseRow {...baseProps({ ex: ex({ name: "" }) })} />);
-    expect(screen.getByTestId("exercise-drag-9")).toHaveAttribute("aria-label", "Reorder exercise");
-  });
-
-  it("is NOT a grid-nav restoration target (data-grid-restore is for undo/redo/week controls, not drag handles)", () => {
-    render(<ExerciseRow {...baseProps()} />);
-    expect(screen.getByTestId("exercise-drag-9")).not.toHaveAttribute("data-grid-restore");
-  });
-});
-
 // === Phase 3: grid keyboard navigation — RED (frontend/designer/CONTRACT.md
 // has no useGridNav section yet; ../hooks/useGridNav does not exist). See
 // useGridNav.test.tsx's header for the full API contract. Additions below,
@@ -438,5 +402,41 @@ describe("Phase 3: cellProps callback wiring (Enter-commit / Escape-revert contr
     expect(gridNav.cellProps).toHaveBeenCalled();
     getCallbacks()!.onChange("left knee sore");
     expect(onFieldChange).toHaveBeenCalledWith("note", "left knee sore");
+  });
+});
+
+// === Phase 4 (dnd-kit reordering) — RED. ExerciseRow does not render a drag
+// handle yet; these specs are appended (existing specs above are untouched).
+// Per scratchpad/phase4-spec.md's "Drag handles, not draggable cells": each
+// row gets a grip BUTTON (not the whole cell) so dnd-kit's PointerSensor
+// only starts a drag from that control, and so the handle can double as a
+// KeyboardSensor target riding the Phase 3 tab order without colliding with
+// grid-nav's own cell keydown handling. Two decisions this block pins:
+// - aria-label falls back to "Reorder exercise" for a nameless row, matching
+//   ../hooks/useGridNav's existing `cellAriaLabel` fallback convention
+//   (`exerciseName || "exercise"`) rather than inventing a new one.
+// - the handle is explicitly `type="button"` (never relying on a bare
+//   <button>'s implicit "submit" default) — the same convention every other
+//   testid'd button in this file already follows.
+describe("drag handle (Phase 4, dnd-kit reordering)", () => {
+  it("renders a drag-handle button with the reorder testid/aria-label, before the name cell", () => {
+    render(<ExerciseRow {...baseProps()} />);
+    const handle = screen.getByTestId("exercise-drag-9");
+    expect(handle.tagName).toBe("BUTTON");
+    expect(handle).toHaveAttribute("type", "button");
+    expect(handle).toHaveAttribute("aria-label", "Reorder Squat");
+    const nameInput = screen.getByTestId("exercise-name-9");
+    // DOCUMENT_POSITION_FOLLOWING (4): nameInput comes after handle in the DOM.
+    expect(handle.compareDocumentPosition(nameInput) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("falls back to 'Reorder exercise' when the row has no name", () => {
+    render(<ExerciseRow {...baseProps({ ex: ex({ name: "" }) })} />);
+    expect(screen.getByTestId("exercise-drag-9")).toHaveAttribute("aria-label", "Reorder exercise");
+  });
+
+  it("is NOT a grid-nav restoration target (data-grid-restore is for undo/redo/week controls, not drag handles)", () => {
+    render(<ExerciseRow {...baseProps()} />);
+    expect(screen.getByTestId("exercise-drag-9")).not.toHaveAttribute("data-grid-restore");
   });
 });

--- a/frontend/designer/src/components/ExerciseRow.test.tsx
+++ b/frontend/designer/src/components/ExerciseRow.test.tsx
@@ -256,6 +256,42 @@ describe("1RM editor keyboard", () => {
   });
 });
 
+// === Phase 4 (dnd-kit reordering) — RED. ExerciseRow does not render a drag
+// handle yet; these specs are appended (existing specs above are untouched).
+// Per scratchpad/phase4-spec.md's "Drag handles, not draggable cells": each
+// row gets a grip BUTTON (not the whole cell) so dnd-kit's PointerSensor
+// only starts a drag from that control, and so the handle can double as a
+// KeyboardSensor target riding the Phase 3 tab order without colliding with
+// grid-nav's own cell keydown handling. Two decisions this block pins:
+// - aria-label falls back to "Reorder exercise" for a nameless row, matching
+//   ../hooks/useGridNav's existing `cellAriaLabel` fallback convention
+//   (`exerciseName || "exercise"`) rather than inventing a new one.
+// - the handle is explicitly `type="button"` (never relying on a bare
+//   <button>'s implicit "submit" default) — the same convention every other
+//   testid'd button in this file already follows.
+describe("drag handle (Phase 4, dnd-kit reordering)", () => {
+  it("renders a drag-handle button with the reorder testid/aria-label, before the name cell", () => {
+    render(<ExerciseRow {...baseProps()} />);
+    const handle = screen.getByTestId("exercise-drag-9");
+    expect(handle.tagName).toBe("BUTTON");
+    expect(handle).toHaveAttribute("type", "button");
+    expect(handle).toHaveAttribute("aria-label", "Reorder Squat");
+    const nameInput = screen.getByTestId("exercise-name-9");
+    // DOCUMENT_POSITION_FOLLOWING (4): nameInput comes after handle in the DOM.
+    expect(handle.compareDocumentPosition(nameInput) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("falls back to 'Reorder exercise' when the row has no name", () => {
+    render(<ExerciseRow {...baseProps({ ex: ex({ name: "" }) })} />);
+    expect(screen.getByTestId("exercise-drag-9")).toHaveAttribute("aria-label", "Reorder exercise");
+  });
+
+  it("is NOT a grid-nav restoration target (data-grid-restore is for undo/redo/week controls, not drag handles)", () => {
+    render(<ExerciseRow {...baseProps()} />);
+    expect(screen.getByTestId("exercise-drag-9")).not.toHaveAttribute("data-grid-restore");
+  });
+});
+
 // === Phase 3: grid keyboard navigation — RED (frontend/designer/CONTRACT.md
 // has no useGridNav section yet; ../hooks/useGridNav does not exist). See
 // useGridNav.test.tsx's header for the full API contract. Additions below,

--- a/frontend/designer/src/components/ExerciseRow.tsx
+++ b/frontend/designer/src/components/ExerciseRow.tsx
@@ -3,11 +3,15 @@
 // onFieldChange, onBlur -> onCommit), load-type toggle, group adjust badge,
 // individual %1RM badge/inline editor, remove ×.
 import { useRef } from "react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { loadSuffix } from "../lib/grid";
 import type { Exercise } from "../lib/api";
+import type { Id } from "../hooks/usePlanData";
 import type { OneRmEditorState } from "../hooks/useOneRmEditor";
 import { cellAriaLabel, gridCellDomKey } from "../hooks/useGridNav";
 import type { GridCellBindings, GridCellCallbacks, GridColumn, UseGridNavResult } from "../hooks/useGridNav";
+import type { ReorderDragData } from "../hooks/useReorder";
 
 // Phase 3 (grid keyboard navigation): a cell with no gridNav wired up (or no
 // gridNav prop at all) falls back to a harmless, non-tabbable, inert
@@ -23,6 +27,12 @@ export interface ExerciseRowProps {
   unit: string;
   oneRmOpenForRow: boolean;
   oneRmEditorState: OneRmEditorState | null;
+  // Phase 4 (dnd-kit reordering): the owning day's id, carried by the drag
+  // handle's sortable data so useReorder's cross-day move can find the
+  // source day without re-deriving it from `program`. Optional so
+  // ExerciseRow.test.tsx's existing fixtures (rendered standalone, with no
+  // parent DayCard) keep passing untouched.
+  dayId?: Id;
   // CONTRACT.md's prop list omits `deleting`, but its own prose says the
   // remove × is `disabled={deleting}` — and the source (designer.html line
   // ~440) binds `:disabled="deleting"` on that button. Resolved toward the
@@ -52,6 +62,7 @@ export function ExerciseRow(props: ExerciseRowProps) {
     oneRmEditorState,
     deleting,
     gridNav,
+    dayId,
     onFieldChange,
     onCommit,
     onRemove,
@@ -64,6 +75,23 @@ export function ExerciseRow(props: ExerciseRowProps) {
   } = props;
 
   const showOneRm = !isGroup && ex.load_type === "pct";
+
+  // Phase 4 (dnd-kit reordering): the row itself is a sortable item (so
+  // dragging it repositions via CSS.Transform), but the drag LISTENERS are
+  // bound only to the handle button below — dnd-kit's documented "drag
+  // handle" pattern — so a click/drag anywhere else in the row (a cell
+  // input, a badge) never starts a drag.
+  const dragData: ReorderDragData = { type: "exercise", dayId: (dayId ?? "") as Id, prescriptionId: ex.id };
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: `ex-${ex.id}`, data: dragData });
+  const rowStyle = { transform: CSS.Transform.toString(transform), transition };
 
   // Native @change parity: commit on blur only if the coach actually typed in
   // a cell since focusing it — an unconditional blur commit would autosave
@@ -99,18 +127,35 @@ export function ExerciseRow(props: ExerciseRowProps) {
   }
 
   return (
-    <div className="meso-ex-row">
+    <div
+      className={`meso-ex-row${isDragging ? " is-dragging" : ""}`}
+      ref={setNodeRef}
+      style={rowStyle}
+    >
       <div className="meso-ex-name-col">
-        <input
-          className="meso-cell meso-ex-name-input"
-          data-testid={`exercise-name-${ex.id}`}
-          data-grid-cell={gridCellDomKey(ex.id, "name")}
-          aria-label={cellAriaLabel(ex.name, "name")}
-          value={ex.name}
-          onChange={(e) => changed("name", e.target.value)}
-          onBlur={commitIfDirty}
-          {...gridCellBindings("name")}
-        />
+        <div className="meso-ex-name-row">
+          <button
+            type="button"
+            ref={setActivatorNodeRef}
+            data-testid={`exercise-drag-${ex.id}`}
+            className="meso-drag-handle"
+            aria-label={`Reorder ${ex.name || "exercise"}`}
+            {...attributes}
+            {...listeners}
+          >
+            ⠿
+          </button>
+          <input
+            className="meso-cell meso-ex-name-input"
+            data-testid={`exercise-name-${ex.id}`}
+            data-grid-cell={gridCellDomKey(ex.id, "name")}
+            aria-label={cellAriaLabel(ex.name, "name")}
+            value={ex.name}
+            onChange={(e) => changed("name", e.target.value)}
+            onBlur={commitIfDirty}
+            {...gridCellBindings("name")}
+          />
+        </div>
         <div className="meso-ex-tags">
           {ex.tag && <span className="meso-tag-chip">{ex.tag}</span>}
           {ex.last && <span className="meso-last-chip">{"last: " + ex.last}</span>}

--- a/frontend/designer/src/components/WeekGrid.test.tsx
+++ b/frontend/designer/src/components/WeekGrid.test.tsx
@@ -236,3 +236,40 @@ describe("Phase 3: aria-labels flow through to rendered cells", () => {
     expect(screen.getByTestId("exercise-sets-9")).toHaveAttribute("aria-label", "Box Squat — sets");
   });
 });
+
+describe("keyboard drag candidate filtering (day drags only target day containers)", () => {
+  // With nested sortables in one DndContext, the stock coordinate getter
+  // proposes the closest droppable of ANY type — a lifted day card keeps
+  // targeting exercise rows and can never reach the neighboring day
+  // (browser-verified). The pure filter below feeds typedKeyboardCoordinates.
+  it("keeps only same-kind droppables for the active drag", async () => {
+    const { filterContainersByActiveType } = await import("./WeekGrid");
+    const containers = [{ id: "day-1" }, { id: "ex-9" }, { id: "day-2" }] as never[];
+    expect(filterContainersByActiveType("day-1", containers).map((c: { id: string }) => c.id)).toEqual(["day-1", "day-2"]);
+    // An exercise drag keeps day containers too — the append/empty-day drop
+    // path (exercise-over-day) must stay reachable for keyboard users.
+    expect(filterContainersByActiveType("ex-9", containers).map((c: { id: string }) => c.id)).toEqual(["day-1", "ex-9", "day-2"]);
+  });
+});
+
+describe("typedCollisionDetection (day drags collide only with day containers)", () => {
+  it("returns only day collisions for a day drag", async () => {
+    const { typedCollisionDetection } = await import("./WeekGrid");
+    const rect = (top: number) => ({ top, bottom: top + 200, left: 0, right: 800, width: 800, height: 200 });
+    const containers = [
+      { id: "day-1", rect: { current: rect(0) }, data: { current: {} }, disabled: false },
+      { id: "ex-9", rect: { current: rect(40) }, data: { current: {} }, disabled: false },
+      { id: "day-2", rect: { current: rect(220) }, data: { current: {} }, disabled: false },
+    ];
+    const collisions = typedCollisionDetection({
+      active: { id: "day-2", rect: { current: { initial: rect(220), translated: rect(10) } }, data: { current: {} } },
+      collisionRect: rect(10),
+      droppableRects: new Map(containers.map((c) => [c.id, c.rect.current])),
+      droppableContainers: containers,
+      pointerCoordinates: null,
+    } as never);
+    expect(collisions.length).toBeGreaterThan(0);
+    expect(collisions.every((c: { id: unknown }) => String(c.id).startsWith("day-"))).toBe(true);
+    expect(String(collisions[0]!.id)).toBe("day-1");
+  });
+});

--- a/frontend/designer/src/components/WeekGrid.test.tsx
+++ b/frontend/designer/src/components/WeekGrid.test.tsx
@@ -273,3 +273,49 @@ describe("typedCollisionDetection (day drags collide only with day containers)",
     expect(String(collisions[0]!.id)).toBe("day-1");
   });
 });
+
+describe("typedKeyboardCoordinates delegates to the real droppable map", () => {
+  // dnd-kit's DroppableContainersMap is a real Map subclass; a spread/assign
+  // clone borrows its prototype without Map internal slots, so .get() throws
+  // "called on incompatible receiver" and keyboard reordering dies silently.
+  it("returns coordinates for a day drag without throwing on Map methods", async () => {
+    const { typedKeyboardCoordinates } = await import("./WeekGrid");
+    class FakeContainers extends Map<string, unknown> {
+      getEnabled() {
+        return [...this.values()];
+      }
+    }
+    const mk = (id: string, top: number) => {
+      const node = document.createElement("div");
+      document.body.appendChild(node);
+      return {
+        id,
+        disabled: false,
+        node: { current: node },
+        data: { current: { sortable: { containerId: "week", index: 0, items: [] } } },
+        rect: { current: { top, bottom: top + 100, left: 0, right: 800, width: 800, height: 100 } },
+      };
+    };
+    const containers = new FakeContainers();
+    for (const c of [mk("day-1", 0), mk("ex-9", 30), mk("day-2", 200)]) containers.set(c.id, c);
+    const rects = new Map([...containers.values()].map((c) => {
+      const e = c as { id: string; rect: { current: unknown } };
+      return [e.id, e.rect.current] as const;
+    }));
+    const event = new KeyboardEvent("keydown", { code: "ArrowDown", key: "ArrowDown" });
+    const coords = typedKeyboardCoordinates(event, {
+      currentCoordinates: { x: 0, y: 0 },
+      context: {
+        active: { id: "day-1" },
+        over: null,
+        collisionRect: { top: 0, bottom: 100, left: 0, right: 800, width: 800, height: 100 },
+        droppableRects: rects,
+        droppableContainers: containers,
+        scrollableAncestors: [],
+      },
+    } as never);
+    expect(coords).toBeTruthy();
+    // Proposed target must be day-2 (top 200), never ex-9 (top 30).
+    expect(coords!.y).toBeGreaterThanOrEqual(150);
+  });
+});

--- a/frontend/designer/src/components/WeekGrid.tsx
+++ b/frontend/designer/src/components/WeekGrid.tsx
@@ -110,14 +110,24 @@ export const typedCollisionDetection: CollisionDetection = (args) => {
 
 export const typedKeyboardCoordinates: KeyboardCoordinateGetter = (event, args) => {
   const containers = args.context.droppableContainers;
-  const filtered = {
-    ...args.context,
-    droppableContainers: Object.assign(Object.create(Object.getPrototypeOf(containers) ?? {}), containers, {
-      getEnabled: () =>
-        filterContainersByActiveType(args.context.active?.id ?? "", containers.getEnabled()),
-    }),
-  };
-  return sortableKeyboardCoordinates(event, { ...args, context: filtered });
+  // DroppableContainersMap is a real Map subclass — a spread/assign clone
+  // borrows its prototype WITHOUT Map internal slots, and .get() then throws
+  // "called on incompatible receiver". Delegate every member to the original
+  // map (methods bound to it), overriding only getEnabled with the filter.
+  const filtered = new Proxy(containers, {
+    get(target, prop) {
+      if (prop === "getEnabled") {
+        return () =>
+          filterContainersByActiveType(args.context.active?.id ?? "", target.getEnabled());
+      }
+      const value = Reflect.get(target, prop, target);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+  return sortableKeyboardCoordinates(event, {
+    ...args,
+    context: { ...args.context, droppableContainers: filtered },
+  });
 };
 
 export function WeekGrid(props: WeekGridProps) {

--- a/frontend/designer/src/components/WeekGrid.tsx
+++ b/frontend/designer/src/components/WeekGrid.tsx
@@ -15,6 +15,7 @@ import {
 } from "@dnd-kit/core";
 import type { DragEndEvent } from "@dnd-kit/core";
 import { SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import type { CollisionDetection, KeyboardCoordinateGetter } from "@dnd-kit/core";
 import { DayCard } from "./DayCard";
 import { WeekStrip } from "./WeekStrip";
 import type { Day, Exercise, HistoryState, Week } from "../lib/api";
@@ -73,6 +74,52 @@ export interface WeekGridProps {
   reordering?: boolean;
 }
 
+// Keyboard drags with nested sortables: the stock getter proposes the
+// closest droppable of ANY type, so a lifted day card keeps targeting
+// exercise rows and can never reach the neighboring day (browser-verified).
+// Filter the candidates to the active drag's own kind (day-* vs ex-*).
+export function filterContainersByActiveType<T extends { id: unknown }>(
+  activeId: unknown,
+  containers: T[],
+): T[] {
+  if (String(activeId).startsWith("day-")) {
+    // A dragged day only ever lands relative to another day.
+    return containers.filter((c) => String(c.id).startsWith("day-"));
+  }
+  // A dragged exercise keeps day containers too: exercise-over-day is the
+  // append/empty-day drop path, and it must stay reachable by keyboard.
+  return containers.filter(
+    (c) => String(c.id).startsWith("ex-") || String(c.id).startsWith("day-"),
+  );
+}
+
+// Same type-filtering at the collision layer: a lifted day card's center can
+// stay closest to its OWN slot (cards are tall), so `over` never reaches the
+// neighbor even when the keyboard getter proposes its coordinates. Day drags
+// collide only with day containers; exercise drags keep the full set (rows +
+// day cards, for the append-to-day path).
+export const typedCollisionDetection: CollisionDetection = (args) => {
+  if (String(args.active.id).startsWith("day-")) {
+    return closestCenter({
+      ...args,
+      droppableContainers: filterContainersByActiveType(args.active.id, args.droppableContainers),
+    });
+  }
+  return closestCenter(args);
+};
+
+export const typedKeyboardCoordinates: KeyboardCoordinateGetter = (event, args) => {
+  const containers = args.context.droppableContainers;
+  const filtered = {
+    ...args.context,
+    droppableContainers: Object.assign(Object.create(Object.getPrototypeOf(containers) ?? {}), containers, {
+      getEnabled: () =>
+        filterContainersByActiveType(args.context.active?.id ?? "", containers.getEnabled()),
+    }),
+  };
+  return sortableKeyboardCoordinates(event, { ...args, context: filtered });
+};
+
 export function WeekGrid(props: WeekGridProps) {
   const {
     program,
@@ -124,7 +171,7 @@ export function WeekGrid(props: WeekGridProps) {
   // lifts, arrows move, Space/Enter drops, Escape cancels).
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+    useSensor(KeyboardSensor, { coordinateGetter: typedKeyboardCoordinates }),
   );
 
   function handleDragEnd(event: DragEndEvent) {
@@ -185,7 +232,7 @@ export function WeekGrid(props: WeekGridProps) {
         </div>
       )}
 
-      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <DndContext sensors={sensors} collisionDetection={typedCollisionDetection} onDragEnd={handleDragEnd}>
         <SortableContext
           items={program.map((day) => `day-${day.id}`)}
           strategy={verticalListSortingStrategy}

--- a/frontend/designer/src/components/WeekGrid.tsx
+++ b/frontend/designer/src/components/WeekGrid.tsx
@@ -5,12 +5,23 @@
 // list below includes the DayCard/ExerciseRow passthrough + the coachmark
 // hook slice that CONTRACT.md's prose says are wired in but its formal prop
 // list omitted.
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import type { DragEndEvent } from "@dnd-kit/core";
+import { SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { DayCard } from "./DayCard";
 import { WeekStrip } from "./WeekStrip";
 import type { Day, Exercise, HistoryState, Week } from "../lib/api";
 import type { Id, PendingDelete } from "../hooks/usePlanData";
 import type { OneRmEditorState } from "../hooks/useOneRmEditor";
 import { useGridNav } from "../hooks/useGridNav";
+import type { ReorderDragData, ReorderDragEndEvent } from "../hooks/useReorder";
 
 export interface WeekGridProps {
   program: Day[];
@@ -53,6 +64,13 @@ export interface WeekGridProps {
   onRequestRemoveWeek(weekId: Id): void;
   onUndo?(): void;
   onRedo?(): void;
+  // Phase 4 (dnd-kit reordering): useReorder is instantiated in
+  // DesignerRoot (where usePlanData's pieces are in scope, like every other
+  // hook here) and its handler passed down — optional with a no-op fallback
+  // so WeekGrid.test.tsx's existing baseProps() (which never sets it) keeps
+  // passing untouched, same pattern as `onAddExercise` above.
+  onDragEnd?(event: ReorderDragEndEvent): void | Promise<void>;
+  reordering?: boolean;
 }
 
 export function WeekGrid(props: WeekGridProps) {
@@ -91,6 +109,8 @@ export function WeekGrid(props: WeekGridProps) {
     onRequestRemoveWeek,
     onUndo,
     onRedo,
+    onDragEnd,
+    reordering,
   } = props;
 
   // Phase 3: instantiated ONCE here (WeekGrid already receives `program`) —
@@ -98,8 +118,26 @@ export function WeekGrid(props: WeekGridProps) {
   // prop (see useGridNav.test.tsx's header).
   const gridNav = useGridNav({ program });
 
+  // Phase 4 (dnd-kit reordering): PointerSensor gets a small activation
+  // distance so a plain click into a cell input doesn't start a drag;
+  // KeyboardSensor rides the handle buttons' tab-order focus (Space/Enter
+  // lifts, arrows move, Space/Enter drops, Escape cancels).
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  function handleDragEnd(event: DragEndEvent) {
+    if (!onDragEnd) return;
+    const { active, over } = event;
+    void onDragEnd({
+      active: { id: active.id, data: { current: active.data.current as ReorderDragData } },
+      over: over ? { id: over.id, data: { current: over.data.current as ReorderDragData } } : null,
+    });
+  }
+
   return (
-    <div>
+    <div aria-busy={reordering || undefined}>
       <WeekStrip
         weeks={weeks}
         viewedWeekId={viewedWeekId}
@@ -147,33 +185,40 @@ export function WeekGrid(props: WeekGridProps) {
         </div>
       )}
 
-      {program.map((day, di) => (
-        <DayCard
-          key={day.id}
-          day={day}
-          dayIndex={di}
-          isGroup={isGroup}
-          unit={unit}
-          pendingDelete={pendingDelete}
-          deleting={deleting}
-          onRequestRemoveDay={onRequestRemoveDay}
-          onConfirmPendingDelete={onConfirmPendingDelete}
-          onCancelPendingDelete={onCancelPendingDelete}
-          onAddExercise={onAddExercise ?? (() => {})}
-          gridNav={gridNav}
-          onFieldChange={onFieldChange}
-          onCommit={onCommit}
-          onRemoveExercise={onRemoveExercise}
-          onToggleLoadType={onToggleLoadType}
-          onOpenOverride={onOpenOverride}
-          onOpenOneRm={onOpenOneRm}
-          onOneRmChange={onOneRmChange}
-          onOneRmSave={onOneRmSave}
-          onOneRmCancel={onOneRmCancel}
-          oneRmOpenForRow={oneRmOpenForRow}
-          oneRmEditorState={oneRmEditorState}
-        />
-      ))}
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext
+          items={program.map((day) => `day-${day.id}`)}
+          strategy={verticalListSortingStrategy}
+        >
+          {program.map((day, di) => (
+            <DayCard
+              key={day.id}
+              day={day}
+              dayIndex={di}
+              isGroup={isGroup}
+              unit={unit}
+              pendingDelete={pendingDelete}
+              deleting={deleting}
+              onRequestRemoveDay={onRequestRemoveDay}
+              onConfirmPendingDelete={onConfirmPendingDelete}
+              onCancelPendingDelete={onCancelPendingDelete}
+              onAddExercise={onAddExercise ?? (() => {})}
+              gridNav={gridNav}
+              onFieldChange={onFieldChange}
+              onCommit={onCommit}
+              onRemoveExercise={onRemoveExercise}
+              onToggleLoadType={onToggleLoadType}
+              onOpenOverride={onOpenOverride}
+              onOpenOneRm={onOpenOneRm}
+              onOneRmChange={onOneRmChange}
+              onOneRmSave={onOneRmSave}
+              onOneRmCancel={onOneRmCancel}
+              oneRmOpenForRow={oneRmOpenForRow}
+              oneRmEditorState={oneRmEditorState}
+            />
+          ))}
+        </SortableContext>
+      </DndContext>
 
       <button type="button" data-hover="add" className="meso-add-day-btn" data-testid="add-day-button" onClick={onAddDay}>
         + Add day

--- a/frontend/designer/src/hooks/usePlanData.ts
+++ b/frontend/designer/src/hooks/usePlanData.ts
@@ -241,6 +241,12 @@ export function usePlanData(
     pendingDelete,
     setPendingDelete,
 
+    // Phase 4 (dnd-kit reordering): a raw setState escape hatch for
+    // useReorder — see useReorder.test.tsx's header comment decision 1.
+    // None of patchExercise/updateExerciseField can reorder/splice arrays
+    // across days or reorder the day array itself.
+    setProgram,
+
     applyPlanData,
     adoptHistory,
     patchExercise,

--- a/frontend/designer/src/hooks/useReorder.test.tsx
+++ b/frontend/designer/src/hooks/useReorder.test.tsx
@@ -683,3 +683,50 @@ describe("shared in-flight guard", () => {
     expect(globalThis.fetch).toHaveBeenCalledTimes(2);
   });
 });
+
+describe("review hardening: armed delete confirms disarm before optimistic reorders", () => {
+  // pendingDelete keys a day by INDEX; a day reorder shifts indices while the
+  // POST is still in flight, so a slow reply could leave the Confirm control
+  // pointing at (and deleting) the wrong day. Every drop that mutates the
+  // program disarms the pending confirm BEFORE the fetch, mirroring
+  // applyPlanData's own disarm. Contract addition: useReorder accepts an
+  // optional setPendingDelete and calls it with null on every mutating drop.
+  function setupWithDisarm(initialProgram: Day[]) {
+    const applyPlanData = vi.fn();
+    const setPendingDelete = vi.fn();
+    const hook = renderHook(() => {
+      const [program, setProgram] = useState<Day[]>(initialProgram);
+      const reorder = useReorder({
+        planId: 7,
+        csrf: "tok",
+        viewedWeekId: 55,
+        program,
+        setProgram,
+        applyPlanData,
+        setPendingDelete,
+      });
+      return { ...reorder, program };
+    });
+    return { ...hook, applyPlanData, setPendingDelete };
+  }
+
+  it("a day reorder clears pendingDelete synchronously, before the POST", async () => {
+    const { result, setPendingDelete } = setupWithDisarm(twoDayProgram());
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({ ok: true, ...planEnvelope() }) }) as unknown as typeof fetch;
+    await act(async () => {
+      await result.current.onDragEnd(dayDragEvent(101, 102));
+    });
+    expect(setPendingDelete).toHaveBeenCalledWith(null);
+    const fetchOrder = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0]!;
+    expect(setPendingDelete.mock.invocationCallOrder[0]!).toBeLessThan(fetchOrder);
+  });
+
+  it("a within-day reorder also disarms", async () => {
+    const { result, setPendingDelete } = setupWithDisarm(twoDayProgram());
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({ ok: true, ...planEnvelope() }) }) as unknown as typeof fetch;
+    await act(async () => {
+      await result.current.onDragEnd(exerciseDragEvent(1, 101, 2, 101));
+    });
+    expect(setPendingDelete).toHaveBeenCalledWith(null);
+  });
+});

--- a/frontend/designer/src/hooks/useReorder.test.tsx
+++ b/frontend/designer/src/hooks/useReorder.test.tsx
@@ -35,10 +35,14 @@
 //    to wire (one DndContext, one callback) than coordinating two handlers.
 // 3. No-op rule: `!over || active.id === over.id` -> return before ANY
 //    optimistic state change or fetch (spec: "same position / null
-//    over-target"). A type mismatch between active/over (e.g. an exercise
-//    dropped onto a day-strip item, or vice versa) is ALSO a no-op — cross-
-//    type drops aren't a gesture the grid offers, so onDragEnd defends
-//    against a malformed event rather than guessing intent.
+//    over-target"). A same-type match (exercise-over-exercise, day-over-day)
+//    is handled directly. A CROSS-type match is RESOLVED rather than
+//    discarded — see decisions 8 and 9 below, added after live-browser
+//    testing showed dnd-kit's closestCenter routinely resolves `over` to
+//    the wrong item TYPE (a day drag's `over` lands on an exercise row far
+//    more often than on another day card, since rows' centers sit closer to
+//    the pointer) — treating that as a no-op made day reordering
+//    unreachable in practice.
 // 4. Cross-day `index` semantics: the index POSTed to prescription-move is
 //    the target day's CURRENT (pre-insertion, moved-row-excluded)
 //    `exercises.findIndex(overPrescriptionId)` — this matches the backend's
@@ -62,6 +66,32 @@
 //    synchronous no-op path, a Promise for every path that awaits a fetch —
 //    so a caller (or a test) that always `await`s the return value works
 //    either way.
+// 8. Day-over-exercise resolution: when `active.type === "day"` and
+//    `over.type === "exercise"`, resolve `over` to that exercise's OWNING
+//    day (`over.data.current.dayId`) and run the same day-reorder as a
+//    direct day-over-day drop — no-op (no optimistic update, no fetch) if
+//    the resolved day is the dragged day itself.
+// 9. Exercise-over-day resolution (append): when `active.type ===
+//    "exercise"` and `over.type === "day"`, the drop has no specific row to
+//    land on — an EMPTY day, or a drop past a day's last row where the day
+//    card's own droppable (not a row's) is `closestCenter`'s pick — treated
+//    as "append to the end of that day." Cross-day: POST prescription-move
+//    with `index` = the target day's CURRENT (pre-insertion)
+//    `exercises.length` (same insertion semantics as decision 4, just at
+//    the tail). Same-day: a session-reorder with the dragged row moved to
+//    the end of its own array; no-op if it's already last.
+// 10. Stale-week guard: a reorder POSTed while viewing week A can resolve
+//    AFTER the coach has switched to week B — applying week A's envelope
+//    (or re-fetching week A on failure) would yank the view back. Mirrors
+//    usePlanData's `viewedWeekIdRef` idiom exactly: a ref holds the CURRENT
+//    `viewedWeekId`, reassigned unconditionally every render (not just on
+//    change). `postReorder` snapshots the ref's value synchronously at drop
+//    time; on resolve (success OR failure-path re-fetch), it re-reads the
+//    ref and proceeds ONLY if unchanged — otherwise skips entirely (no
+//    `applyPlanData`, and for the failure path, no re-fetch GET at all).
+//    The in-flight `reordering` guard still clears either way (decision 6
+//    is unaffected — a stale reply still releases the lock for the next
+//    drop).
 import { act, renderHook } from "@testing-library/react";
 import { useState } from "react";
 import { useReorder } from "./useReorder";
@@ -141,20 +171,64 @@ function dayDragEvent(activeId: Id, overId: Id | null): ReorderDragEndEvent {
   };
 }
 
-function setup(initialProgram: Day[]) {
+/** Builds a dnd-kit-shaped event: a DAY active, resolved `over` an EXERCISE
+ * row — dnd-kit's closestCenter routinely does this in practice (decision
+ * 8 above). `overDayId` is the row's OWNING day, which may differ from the
+ * dragged day. */
+function dayOverExerciseDragEvent(
+  activeSessionId: Id,
+  overPrescriptionId: Id,
+  overDayId: Id,
+): ReorderDragEndEvent {
+  return {
+    active: { id: activeSessionId, data: { current: { type: "day", sessionId: activeSessionId } } },
+    over: {
+      id: overPrescriptionId,
+      data: { current: { type: "exercise", dayId: overDayId, prescriptionId: overPrescriptionId } },
+    },
+  };
+}
+
+/** Builds a dnd-kit-shaped event: an EXERCISE active, dropped `over` a DAY's
+ * own droppable — its background, not a specific row (an empty day, or past
+ * the last row; decision 9 above). */
+function exerciseOverDayDragEvent(
+  activePrescriptionId: Id,
+  activeDayId: Id,
+  overSessionId: Id,
+): ReorderDragEndEvent {
+  return {
+    active: {
+      id: activePrescriptionId,
+      data: { current: { type: "exercise", dayId: activeDayId, prescriptionId: activePrescriptionId } },
+    },
+    over: { id: `day-${overSessionId}`, data: { current: { type: "day", sessionId: overSessionId } } },
+  };
+}
+
+// Day 101: exercises 1 (Squat), 2 (Bench). Day 102: exercise 3 (Deadlift).
+// Day 103: no exercises — an empty day has no per-row droppable to hit.
+function threeDayProgramWithEmptyDay(): Day[] {
+  return [...twoDayProgram(), { id: 103, n: 3, name: "Day 3", exercises: [] }];
+}
+
+function setup(initialProgram: Day[], initialViewedWeekId: Id | null = 55) {
   const applyPlanData = vi.fn();
-  const hook = renderHook(() => {
-    const [program, setProgram] = useState<Day[]>(initialProgram);
-    const reorder = useReorder({
-      planId: 7,
-      csrf: "tok",
-      viewedWeekId: 55,
-      program,
-      setProgram,
-      applyPlanData,
-    });
-    return { ...reorder, program };
-  });
+  const hook = renderHook(
+    (props: { viewedWeekId: Id | null }) => {
+      const [program, setProgram] = useState<Day[]>(initialProgram);
+      const reorder = useReorder({
+        planId: 7,
+        csrf: "tok",
+        viewedWeekId: props.viewedWeekId,
+        program,
+        setProgram,
+        applyPlanData,
+      });
+      return { ...reorder, program };
+    },
+    { initialProps: { viewedWeekId: initialViewedWeekId } },
+  );
   return { ...hook, applyPlanData };
 }
 
@@ -293,6 +367,167 @@ describe("day reorder", () => {
   });
 });
 
+describe("day drag resolved over an exercise row (decision 8)", () => {
+  it("reorders days relative to the exercise row's owning day, POSTing the same week-reorder endpoint as a direct day-over-day drop", async () => {
+    const { result } = setup(twoDayProgram());
+    globalThis.fetch = vi.fn().mockResolvedValue(res(planEnvelope())) as unknown as typeof fetch;
+    await act(async () => {
+      // Day 101 dragged; dnd-kit's closestCenter resolves `over` to exercise
+      // 3, which lives in day 102 — same outcome as dragging day 101 onto
+      // day 102 directly.
+      await result.current.onDragEnd(dayOverExerciseDragEvent(101, 3, 102));
+    });
+    expect(result.current.program.map((d) => d.id)).toEqual([102, 101]);
+    const [url, opts] = fetchCall(0);
+    expect(url).toBe("/meso/api/plan/7/week/55/reorder/");
+    expect(opts!.method).toBe("POST");
+    expect(sentBody()).toEqual({ order: [102, 101] });
+  });
+});
+
+describe("exercise drag resolved over a day, append-to-end (decision 9)", () => {
+  it("optimistically appends across days before the POST resolves, then adopts the envelope reply", async () => {
+    const { result, applyPlanData } = setup(twoDayProgram());
+    let resolveFetch!: (v: unknown) => void;
+    globalThis.fetch = vi.fn(
+      () =>
+        new Promise((r) => {
+          resolveFetch = r;
+        }),
+    ) as unknown as typeof fetch;
+
+    let pending!: void | Promise<void>;
+    act(() => {
+      // Exercise 1 (day 101) dropped on day 102's own droppable (not a
+      // specific row) — appends after day 102's existing exercise 3.
+      pending = result.current.onDragEnd(exerciseOverDayDragEvent(1, 101, 102));
+    });
+    expect(result.current.program[0]!.exercises.map((e) => e.id)).toEqual([2]);
+    expect(result.current.program[1]!.exercises.map((e) => e.id)).toEqual([3, 1]);
+
+    const reply = planEnvelope();
+    await act(async () => {
+      resolveFetch(res(reply));
+      await pending;
+    });
+    expect(applyPlanData).toHaveBeenCalledWith(reply);
+  });
+
+  it("POSTs prescription-move with index = the target day's pre-insertion exercises.length", async () => {
+    const { result } = setup(twoDayProgram());
+    globalThis.fetch = vi.fn().mockResolvedValue(res(planEnvelope())) as unknown as typeof fetch;
+    await act(async () => {
+      await result.current.onDragEnd(exerciseOverDayDragEvent(1, 101, 102));
+    });
+    const [url, opts] = fetchCall(0);
+    expect(url).toBe("/meso/api/plan/7/prescription/1/move/");
+    expect(opts!.method).toBe("POST");
+    expect(sentBody()).toEqual({ session_id: 102, index: 1 });
+  });
+
+  it("appends into an EMPTY target day at index 0", async () => {
+    const { result } = setup(threeDayProgramWithEmptyDay());
+    globalThis.fetch = vi.fn().mockResolvedValue(res(planEnvelope())) as unknown as typeof fetch;
+    await act(async () => {
+      // Day 103 has no exercises — no per-row droppable exists to hit.
+      await result.current.onDragEnd(exerciseOverDayDragEvent(3, 102, 103));
+    });
+    expect(result.current.program[1]!.exercises).toEqual([]);
+    expect(result.current.program[2]!.exercises.map((e) => e.id)).toEqual([3]);
+    const [url, opts] = fetchCall(0);
+    expect(url).toBe("/meso/api/plan/7/prescription/3/move/");
+    expect(opts!.method).toBe("POST");
+    expect(sentBody()).toEqual({ session_id: 103, index: 0 });
+  });
+
+  it("moves a same-day exercise to the end via session-reorder when dropped on its own day", async () => {
+    const { result } = setup(twoDayProgram());
+    globalThis.fetch = vi.fn().mockResolvedValue(res(planEnvelope())) as unknown as typeof fetch;
+    await act(async () => {
+      // Exercise 1 (index 0 of day 101) dropped on day 101's own droppable.
+      await result.current.onDragEnd(exerciseOverDayDragEvent(1, 101, 101));
+    });
+    expect(result.current.program[0]!.exercises.map((e) => e.id)).toEqual([2, 1]);
+    const [url, opts] = fetchCall(0);
+    expect(url).toBe("/meso/api/plan/7/session/101/reorder/");
+    expect(opts!.method).toBe("POST");
+    expect(sentBody()).toEqual({ order: [2, 1] });
+  });
+});
+
+describe("stale-week guard (decision 10)", () => {
+  it("skips applyPlanData entirely when the coach switched weeks while a reorder POST was in flight", async () => {
+    const { result, rerender, applyPlanData } = setup(twoDayProgram());
+    let resolveFetch!: (v: unknown) => void;
+    globalThis.fetch = vi.fn(
+      () =>
+        new Promise((r) => {
+          resolveFetch = r;
+        }),
+    ) as unknown as typeof fetch;
+
+    let pending!: void | Promise<void>;
+    act(() => {
+      pending = result.current.onDragEnd(exerciseDragEvent(1, 101, 2, 101));
+    });
+    // Coach switches to a different week while the POST is still pending.
+    act(() => {
+      rerender({ viewedWeekId: 999 });
+    });
+    await act(async () => {
+      resolveFetch(res(planEnvelope()));
+      await pending;
+    });
+    expect(applyPlanData).not.toHaveBeenCalled();
+    // The in-flight guard still releases, independent of the stale check.
+    expect(result.current.reordering).toBe(false);
+  });
+
+  it("skips the failure-path re-fetch entirely (no GET, no applyPlanData) when the coach switched weeks before the POST rejects", async () => {
+    const { result, rerender, applyPlanData } = setup(twoDayProgram());
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    // Queued (not hand-controlled) so an unguarded re-fetch resolves instead
+    // of hanging the test — the behavior under test is the CALL COUNT below,
+    // not resolution timing.
+    const wouldBeRefetch = planEnvelope({ program: [{ id: 101, n: 1, name: "Day 1", exercises: [] }] });
+    globalThis.fetch = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValue(res(wouldBeRefetch)) as unknown as typeof fetch;
+
+    let pending!: void | Promise<void>;
+    act(() => {
+      pending = result.current.onDragEnd(exerciseDragEvent(1, 101, 2, 101));
+    });
+    act(() => {
+      rerender({ viewedWeekId: 999 });
+    });
+    await act(async () => {
+      await pending;
+    });
+    // Only the original (now-failed) POST — no re-fetch GET for the
+    // no-longer-viewed week.
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(applyPlanData).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(result.current.reordering).toBe(false);
+  });
+
+  it("still applies the reply when the viewed week is unchanged at resolve time (control case)", async () => {
+    const { result, rerender, applyPlanData } = setup(twoDayProgram());
+    // Rerender with the SAME viewedWeekId — not a week switch.
+    act(() => {
+      rerender({ viewedWeekId: 55 });
+    });
+    const reply = planEnvelope();
+    globalThis.fetch = vi.fn().mockResolvedValue(res(reply)) as unknown as typeof fetch;
+    await act(async () => {
+      await result.current.onDragEnd(exerciseDragEvent(1, 101, 2, 101));
+    });
+    expect(applyPlanData).toHaveBeenCalledWith(reply);
+  });
+});
+
 describe("no-op drop", () => {
   it("does nothing when an exercise is dropped on itself (same position)", async () => {
     const { result } = setup(twoDayProgram());
@@ -323,16 +558,26 @@ describe("no-op drop", () => {
     expect(result.current.program.map((d) => d.id)).toEqual([101, 102]);
   });
 
-  it("does nothing when a day is dropped over an exercise row (type mismatch)", async () => {
+  it("does nothing when a day is dropped over an exercise row belonging to that same day (resolution decision 8, same-day case)", async () => {
     const { result } = setup(twoDayProgram());
     globalThis.fetch = vi.fn() as unknown as typeof fetch;
     await act(async () => {
-      await result.current.onDragEnd({
-        active: { id: 101, data: { current: { type: "day", sessionId: 101 } } },
-        over: { id: 3, data: { current: { type: "exercise", dayId: 102, prescriptionId: 3 } } },
-      });
+      // Exercise 1 belongs to day 101 — the same day being dragged.
+      await result.current.onDragEnd(dayOverExerciseDragEvent(101, 1, 101));
     });
     expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(result.current.program.map((d) => d.id)).toEqual([101, 102]);
+  });
+
+  it("does nothing when an exercise dropped on its own day is already last (resolution decision 9, same-day case)", async () => {
+    const { result } = setup(twoDayProgram());
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+    await act(async () => {
+      // Exercise 2 is already the last row of day 101.
+      await result.current.onDragEnd(exerciseOverDayDragEvent(2, 101, 101));
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(result.current.program[0]!.exercises.map((e) => e.id)).toEqual([1, 2]);
   });
 });
 

--- a/frontend/designer/src/hooks/useReorder.test.tsx
+++ b/frontend/designer/src/hooks/useReorder.test.tsx
@@ -1,0 +1,440 @@
+// Specs for useReorder (Phase 4, docs/meso/designer-framework-plan.md +
+// scratchpad phase4-spec.md "Frontend") — the dnd-kit designer's reorder
+// hook. Does NOT exist yet; this file is RED until a later agent implements
+// ../hooks/useReorder. dnd-kit's own pointer/keyboard drag mechanics are
+// browser-verified, not jsdom-simulated (spec's explicit call-out) — these
+// specs pin the SEAMS instead: given a dnd-kit-SHAPED `DragEndEvent` (built
+// by hand below, the same way a real `onDragEnd={reorder.onDragEnd}` wired
+// into `<DndContext>` would receive one), useReorder must produce the right
+// optimistic array update, the right POST body, envelope adoption via
+// applyPlanData, failure re-fetch, and one shared in-flight guard.
+//
+// === API decisions this file pins (spec left these open) ===
+// 1. Hook signature: `useReorder({ planId, csrf, viewedWeekId, program,
+//    setProgram, applyPlanData })` -> `{ reordering, onDragEnd }`.
+//    `setProgram` is a NEW primitive `usePlanData` must export (a raw
+//    `Dispatch<SetStateAction<Day[]>>`) — investigated first: `patchExercise`
+//    only merges a partial patch onto ONE exercise matched by id, and
+//    `updateExerciseField` only writes one field at a fixed (dayIndex,
+//    exIndex); neither can reorder an array, splice an item out of one day's
+//    array and into another's, or reorder the days array itself. A raw
+//    setState escape hatch is the smallest primitive that covers all three
+//    drop shapes, so useReorder owns its own optimistic-update logic instead
+//    of usePlanData growing three bespoke reorder verbs. This file does NOT
+//    modify usePlanData.ts (RED-phase scope: failing specs only) — the green
+//    agent adds the one-line `setProgram` export to its return object.
+// 2. Drag event shape (`ReorderDragEndEvent`, modeled on dnd-kit's actual
+//    `DragEndEvent`): `{ active: { id, data: { current } }, over: { id,
+//    data: { current } } | null }`. `data.current` is a discriminated union
+//    `ReorderDragData = { type: "exercise"; dayId; prescriptionId } |
+//    { type: "day"; sessionId }` — carried by each sortable item via
+//    dnd-kit's `useSortable({ id, data })`, so onDragEnd never needs to
+//    re-derive a row's parent day by scanning `program`. ONE `onDragEnd`
+//    handles both the per-day exercise SortableContexts and the day-strip
+//    SortableContext (routed by `data.current.type`) — simpler for WeekGrid
+//    to wire (one DndContext, one callback) than coordinating two handlers.
+// 3. No-op rule: `!over || active.id === over.id` -> return before ANY
+//    optimistic state change or fetch (spec: "same position / null
+//    over-target"). A type mismatch between active/over (e.g. an exercise
+//    dropped onto a day-strip item, or vice versa) is ALSO a no-op — cross-
+//    type drops aren't a gesture the grid offers, so onDragEnd defends
+//    against a malformed event rather than guessing intent.
+// 4. Cross-day `index` semantics: the index POSTed to prescription-move is
+//    the target day's CURRENT (pre-insertion, moved-row-excluded)
+//    `exercises.findIndex(overPrescriptionId)` — this matches the backend's
+//    own insertion semantics exactly (`prescription_move` builds
+//    `target_rows` from the target session's live rows BEFORE inserting the
+//    moved row, then clamps+inserts at the posted index).
+// 5. Failure handling: console.error, then GET the viewed week
+//    (`/meso/api/plan/<id>/week/<viewedWeekId>/`, mirroring usePlanData's
+//    `switchWeek` — no request body/options) and `applyPlanData` the reply.
+//    If that re-fetch ALSO throws, it is swallowed with its own
+//    console.error (no unhandled rejection) — a double-failure leaves the
+//    optimistic state as the last-known UI, an accepted edge case this file
+//    does not test.
+// 6. In-flight guard: a single `reordering` ref+state shared across all
+//    three POST paths (mirrors useDeletes' `deletingRef`), checked
+//    SYNCHRONOUSLY at the top of `onDragEnd` — a second drop while one is
+//    pending is a full no-op (no optimistic update either, not just "no
+//    fetch"), since committing a second optimistic change before the first
+//    POST's authoritative reply lands would double-desync the array.
+// 7. `onDragEnd` returns `void | Promise<void>` — undefined for every
+//    synchronous no-op path, a Promise for every path that awaits a fetch —
+//    so a caller (or a test) that always `await`s the return value works
+//    either way.
+import { act, renderHook } from "@testing-library/react";
+import { useState } from "react";
+import { useReorder } from "./useReorder";
+import type { ReorderDragEndEvent } from "./useReorder";
+import type { Day, PlanEnvelope } from "../lib/api";
+import type { Id } from "./usePlanData";
+
+function res(body: unknown, ok = true, status = 200) {
+  return { ok, status, json: async () => body };
+}
+
+function fetchCall(n = 0) {
+  const mockFetch = globalThis.fetch as unknown as { mock: { calls: unknown[][] } };
+  return mockFetch.mock.calls[n] as [string, RequestInit | undefined];
+}
+
+function sentBody(n = 0) {
+  const [, opts] = fetchCall(n);
+  const body = opts?.body;
+  return body == null ? null : JSON.parse(body as string);
+}
+
+function planEnvelope(overrides: Partial<PlanEnvelope> = {}): PlanEnvelope {
+  return {
+    ok: true,
+    program: [],
+    weeks: [],
+    phases: [],
+    viewing: 55,
+    history: { can_undo: true, can_redo: false, undo_label: "Reordered exercises", redo_label: null },
+    ...overrides,
+  };
+}
+
+// Day 101: exercises 1 (Squat), 2 (Bench). Day 102: exercise 3 (Deadlift).
+function twoDayProgram(): Day[] {
+  return [
+    {
+      id: 101,
+      n: 1,
+      name: "Day 1",
+      exercises: [
+        { id: 1, name: "Squat", sets: "3", reps: "5", load: "100" },
+        { id: 2, name: "Bench", sets: "3", reps: "5", load: "80" },
+      ],
+    },
+    {
+      id: 102,
+      n: 2,
+      name: "Day 2",
+      exercises: [{ id: 3, name: "Deadlift", sets: "3", reps: "5", load: "120" }],
+    },
+  ];
+}
+
+/** Builds a dnd-kit-shaped exercise drag event (see decision 2 above). */
+function exerciseDragEvent(
+  activeId: Id,
+  activeDayId: Id,
+  overId: Id | null,
+  overDayId: Id = activeDayId,
+): ReorderDragEndEvent {
+  return {
+    active: { id: activeId, data: { current: { type: "exercise", dayId: activeDayId, prescriptionId: activeId } } },
+    over:
+      overId == null
+        ? null
+        : { id: overId, data: { current: { type: "exercise", dayId: overDayId, prescriptionId: overId } } },
+  };
+}
+
+/** Builds a dnd-kit-shaped day-strip drag event (see decision 2 above). */
+function dayDragEvent(activeId: Id, overId: Id | null): ReorderDragEndEvent {
+  return {
+    active: { id: activeId, data: { current: { type: "day", sessionId: activeId } } },
+    over: overId == null ? null : { id: overId, data: { current: { type: "day", sessionId: overId } } },
+  };
+}
+
+function setup(initialProgram: Day[]) {
+  const applyPlanData = vi.fn();
+  const hook = renderHook(() => {
+    const [program, setProgram] = useState<Day[]>(initialProgram);
+    const reorder = useReorder({
+      planId: 7,
+      csrf: "tok",
+      viewedWeekId: 55,
+      program,
+      setProgram,
+      applyPlanData,
+    });
+    return { ...reorder, program };
+  });
+  return { ...hook, applyPlanData };
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("within-day reorder", () => {
+  it("optimistically reorders the day's exercises before the POST resolves, then adopts the envelope reply", async () => {
+    const { result, applyPlanData } = setup(twoDayProgram());
+    let resolveFetch!: (v: unknown) => void;
+    globalThis.fetch = vi.fn(
+      () =>
+        new Promise((r) => {
+          resolveFetch = r;
+        }),
+    ) as unknown as typeof fetch;
+
+    let pending!: void | Promise<void>;
+    act(() => {
+      pending = result.current.onDragEnd(exerciseDragEvent(1, 101, 2, 101));
+    });
+    // Optimistic reorder is visible immediately, before the network resolves.
+    expect(result.current.program[0]!.exercises.map((e) => e.id)).toEqual([2, 1]);
+    expect(result.current.program[1]!.exercises.map((e) => e.id)).toEqual([3]);
+    expect(result.current.reordering).toBe(true);
+
+    const reply = planEnvelope();
+    await act(async () => {
+      resolveFetch(res(reply));
+      await pending;
+    });
+    expect(applyPlanData).toHaveBeenCalledWith(reply);
+    expect(result.current.reordering).toBe(false);
+  });
+
+  it("POSTs the session-reorder endpoint with the day's full id list in the new order", async () => {
+    const { result } = setup(twoDayProgram());
+    globalThis.fetch = vi.fn().mockResolvedValue(res(planEnvelope())) as unknown as typeof fetch;
+    await act(async () => {
+      await result.current.onDragEnd(exerciseDragEvent(1, 101, 2, 101));
+    });
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchCall(0);
+    expect(url).toBe("/meso/api/plan/7/session/101/reorder/");
+    expect(opts!.method).toBe("POST");
+    expect((opts!.headers as Record<string, string>)["X-CSRFToken"]).toBe("tok");
+    expect(sentBody()).toEqual({ order: [2, 1] });
+  });
+});
+
+describe("cross-day move", () => {
+  it("optimistically removes from the source day and inserts into the target day at the over row's index, before the POST resolves", () => {
+    const { result } = setup(twoDayProgram());
+    let resolveFetch!: (v: unknown) => void;
+    globalThis.fetch = vi.fn(
+      () =>
+        new Promise((r) => {
+          resolveFetch = r;
+        }),
+    ) as unknown as typeof fetch;
+
+    let pending!: void | Promise<void>;
+    act(() => {
+      // Drag exercise 1 (day 101) onto exercise 3, which sits at index 0 of
+      // day 102 — the moved row lands at index 0, pushing exercise 3 to 1.
+      pending = result.current.onDragEnd(exerciseDragEvent(1, 101, 3, 102));
+    });
+    expect(result.current.program[0]!.exercises.map((e) => e.id)).toEqual([2]);
+    expect(result.current.program[1]!.exercises.map((e) => e.id)).toEqual([1, 3]);
+
+    act(() => {
+      resolveFetch(res(planEnvelope()));
+    });
+    return pending;
+  });
+
+  it("POSTs prescription-move with {session_id, index} using the target day's pre-insertion index", async () => {
+    const { result } = setup(twoDayProgram());
+    globalThis.fetch = vi.fn().mockResolvedValue(res(planEnvelope())) as unknown as typeof fetch;
+    await act(async () => {
+      await result.current.onDragEnd(exerciseDragEvent(1, 101, 3, 102));
+    });
+    const [url, opts] = fetchCall(0);
+    expect(url).toBe("/meso/api/plan/7/prescription/1/move/");
+    expect(opts!.method).toBe("POST");
+    expect(sentBody()).toEqual({ session_id: 102, index: 0 });
+  });
+
+  it("dropping onto the second row of the target day lands the moved row at index 1", async () => {
+    const { result } = setup(twoDayProgram());
+    globalThis.fetch = vi.fn().mockResolvedValue(res(planEnvelope())) as unknown as typeof fetch;
+    // Move exercise 3 (day 102, alone) onto exercise 2 (day 101, index 1).
+    await act(async () => {
+      await result.current.onDragEnd(exerciseDragEvent(3, 102, 2, 101));
+    });
+    expect(sentBody()).toEqual({ session_id: 101, index: 1 });
+  });
+});
+
+describe("day reorder", () => {
+  it("optimistically reorders the day strip before the POST resolves, then adopts the envelope reply", async () => {
+    const { result, applyPlanData } = setup(twoDayProgram());
+    let resolveFetch!: (v: unknown) => void;
+    globalThis.fetch = vi.fn(
+      () =>
+        new Promise((r) => {
+          resolveFetch = r;
+        }),
+    ) as unknown as typeof fetch;
+
+    let pending!: void | Promise<void>;
+    act(() => {
+      pending = result.current.onDragEnd(dayDragEvent(101, 102));
+    });
+    expect(result.current.program.map((d) => d.id)).toEqual([102, 101]);
+
+    const reply = planEnvelope();
+    await act(async () => {
+      resolveFetch(res(reply));
+      await pending;
+    });
+    expect(applyPlanData).toHaveBeenCalledWith(reply);
+  });
+
+  it("POSTs the week-reorder endpoint with the week's full session id list in the new order", async () => {
+    const { result } = setup(twoDayProgram());
+    globalThis.fetch = vi.fn().mockResolvedValue(res(planEnvelope())) as unknown as typeof fetch;
+    await act(async () => {
+      await result.current.onDragEnd(dayDragEvent(101, 102));
+    });
+    const [url, opts] = fetchCall(0);
+    expect(url).toBe("/meso/api/plan/7/week/55/reorder/");
+    expect(opts!.method).toBe("POST");
+    expect(sentBody()).toEqual({ order: [102, 101] });
+  });
+});
+
+describe("no-op drop", () => {
+  it("does nothing when an exercise is dropped on itself (same position)", async () => {
+    const { result } = setup(twoDayProgram());
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+    await act(async () => {
+      await result.current.onDragEnd(exerciseDragEvent(1, 101, 1, 101));
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(result.current.program[0]!.exercises.map((e) => e.id)).toEqual([1, 2]);
+  });
+
+  it("does nothing when over is null (dropped outside any droppable)", async () => {
+    const { result } = setup(twoDayProgram());
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+    await act(async () => {
+      await result.current.onDragEnd(exerciseDragEvent(1, 101, null));
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when a day is dropped on itself", async () => {
+    const { result } = setup(twoDayProgram());
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+    await act(async () => {
+      await result.current.onDragEnd(dayDragEvent(101, 101));
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(result.current.program.map((d) => d.id)).toEqual([101, 102]);
+  });
+
+  it("does nothing when a day is dropped over an exercise row (type mismatch)", async () => {
+    const { result } = setup(twoDayProgram());
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+    await act(async () => {
+      await result.current.onDragEnd({
+        active: { id: 101, data: { current: { type: "day", sessionId: 101 } } },
+        over: { id: 3, data: { current: { type: "exercise", dayId: 102, prescriptionId: 3 } } },
+      });
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("failure handling", () => {
+  it("on POST failure: console.errors and re-fetches the viewed week, applying the reply", async () => {
+    const { result, applyPlanData } = setup(twoDayProgram());
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const refreshed = planEnvelope({ program: [{ id: 101, n: 1, name: "Day 1", exercises: [] }] });
+    globalThis.fetch = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(res(refreshed)) as unknown as typeof fetch;
+
+    await act(async () => {
+      await result.current.onDragEnd(exerciseDragEvent(1, 101, 2, 101));
+    });
+
+    expect(console.error).toHaveBeenCalled();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    const [refetchUrl, refetchOpts] = fetchCall(1);
+    expect(refetchUrl).toBe("/meso/api/plan/7/week/55/");
+    expect(refetchOpts).toBeUndefined();
+    expect(applyPlanData).toHaveBeenCalledWith(refreshed);
+    expect(result.current.reordering).toBe(false);
+  });
+
+  it("swallows a failed re-fetch with its own console.error (no unhandled rejection)", async () => {
+    const { result, applyPlanData } = setup(twoDayProgram());
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    globalThis.fetch = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockRejectedValueOnce(new TypeError("Failed to fetch")) as unknown as typeof fetch;
+
+    await act(async () => {
+      await result.current.onDragEnd(dayDragEvent(101, 102));
+    });
+
+    expect(console.error).toHaveBeenCalledTimes(2);
+    expect(applyPlanData).not.toHaveBeenCalled();
+    expect(result.current.reordering).toBe(false);
+  });
+});
+
+describe("shared in-flight guard", () => {
+  it("a second drop while one POST is pending fires no extra fetch", async () => {
+    const { result } = setup(twoDayProgram());
+    let resolveFetch!: (v: unknown) => void;
+    globalThis.fetch = vi.fn(
+      () =>
+        new Promise((r) => {
+          resolveFetch = r;
+        }),
+    ) as unknown as typeof fetch;
+
+    let first!: void | Promise<void>;
+    let second!: void | Promise<void>;
+    act(() => {
+      first = result.current.onDragEnd(exerciseDragEvent(1, 101, 2, 101));
+      second = result.current.onDragEnd(dayDragEvent(101, 102));
+    });
+    await act(async () => {
+      resolveFetch(res(planEnvelope()));
+      await Promise.all([first, second]);
+    });
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("the guard is a full no-op: the second drop's optimistic update never applies", async () => {
+    const { result } = setup(twoDayProgram());
+    let resolveFetch!: (v: unknown) => void;
+    globalThis.fetch = vi.fn(
+      () =>
+        new Promise((r) => {
+          resolveFetch = r;
+        }),
+    ) as unknown as typeof fetch;
+
+    let first!: void | Promise<void>;
+    let second!: void | Promise<void>;
+    act(() => {
+      first = result.current.onDragEnd(exerciseDragEvent(1, 101, 2, 101));
+      // Day drag while the exercise reorder is in flight: ignored outright.
+      second = result.current.onDragEnd(dayDragEvent(101, 102));
+    });
+    expect(result.current.program.map((d) => d.id)).toEqual([101, 102]);
+    await act(async () => {
+      resolveFetch(res(planEnvelope()));
+      await Promise.all([first, second]);
+    });
+  });
+
+  it("a retry after the in-flight POST resolves fires a fresh fetch", async () => {
+    const { result } = setup(twoDayProgram());
+    globalThis.fetch = vi.fn().mockResolvedValue(res(planEnvelope())) as unknown as typeof fetch;
+    await act(async () => {
+      await result.current.onDragEnd(exerciseDragEvent(1, 101, 2, 101));
+    });
+    expect(result.current.reordering).toBe(false);
+    await act(async () => {
+      await result.current.onDragEnd(dayDragEvent(101, 102));
+    });
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/designer/src/hooks/useReorder.ts
+++ b/frontend/designer/src/hooks/useReorder.ts
@@ -29,10 +29,14 @@ export interface UseReorderOptions {
   program: Day[];
   setProgram: Dispatch<SetStateAction<Day[]>>;
   applyPlanData: (data: PlanEnvelope) => void;
+  /** Disarm an armed day/week delete confirm before a mutating drop —
+   * pendingDelete keys days by INDEX, and a reorder shifts indices while the
+   * POST is in flight, so a stale Confirm could target the wrong day. */
+  setPendingDelete?: (value: null) => void;
 }
 
 export function useReorder(options: UseReorderOptions) {
-  const { planId, csrf, viewedWeekId, program, setProgram, applyPlanData } = options;
+  const { planId, csrf, viewedWeekId, program, setProgram, applyPlanData, setPendingDelete } = options;
 
   // One shared in-flight guard across all three drop shapes (mirrors
   // useDeletes' deletingRef) — checked SYNCHRONOUSLY at the top of
@@ -216,6 +220,11 @@ export function useReorder(options: UseReorderOptions) {
       const activeData = active.data.current;
       const overData = over.data.current;
 
+      // Any routed drop disarms an armed delete confirm first — pendingDelete
+      // keys days by index, and the optimistic reorder below shifts indices
+      // while the POST is still in flight.
+      setPendingDelete?.(null);
+
       if (activeData.type === "exercise" && overData.type === "exercise") {
         if (activeData.dayId === overData.dayId) {
           return withinDayReorder(activeData, overData);
@@ -243,7 +252,7 @@ export function useReorder(options: UseReorderOptions) {
         return appendToDay(activeData, overData);
       }
     },
-    [program, planId, viewedWeekId, setProgram, postReorder, setReorderingBoth],
+    [program, planId, viewedWeekId, setProgram, postReorder, setReorderingBoth, setPendingDelete],
   );
 
   return { reordering, onDragEnd };

--- a/frontend/designer/src/hooks/useReorder.ts
+++ b/frontend/designer/src/hooks/useReorder.ts
@@ -1,0 +1,170 @@
+// useReorder (Phase 4, dnd-kit reordering) — owns the three drag-and-drop
+// verbs (within-day exercise reorder, cross-day exercise move, day-strip
+// reorder) per useReorder.test.tsx's header comment, which is the binding
+// API contract. Mirrors useDeletes' deletingRef idiom for the shared
+// in-flight guard, and usePlanData's switchWeek for the failure re-fetch.
+import { useCallback, useRef, useState, type Dispatch, type SetStateAction } from "react";
+import { arrayMove } from "@dnd-kit/sortable";
+import { apiPost } from "../lib/api";
+import type { Day, PlanEnvelope } from "../lib/api";
+import type { Id } from "./usePlanData";
+
+/** Carried by every sortable item via dnd-kit's `useSortable({ id, data })` —
+ * see contract decision 2 (useReorder.test.tsx). */
+export type ReorderDragData =
+  | { type: "exercise"; dayId: Id; prescriptionId: Id }
+  | { type: "day"; sessionId: Id };
+
+/** Modeled on dnd-kit's real `DragEndEvent` — WeekGrid's `onDragEnd` adapts
+ * the real event into this shape before calling the hook's handler. */
+export interface ReorderDragEndEvent {
+  active: { id: Id; data: { current: ReorderDragData } };
+  over: { id: Id; data: { current: ReorderDragData } } | null;
+}
+
+export interface UseReorderOptions {
+  planId: Id;
+  csrf: string;
+  viewedWeekId: Id | null;
+  program: Day[];
+  setProgram: Dispatch<SetStateAction<Day[]>>;
+  applyPlanData: (data: PlanEnvelope) => void;
+}
+
+export function useReorder(options: UseReorderOptions) {
+  const { planId, csrf, viewedWeekId, program, setProgram, applyPlanData } = options;
+
+  // One shared in-flight guard across all three drop shapes (mirrors
+  // useDeletes' deletingRef) — checked SYNCHRONOUSLY at the top of
+  // onDragEnd so a second drop while one POST is pending is a full no-op.
+  const reorderingRef = useRef(false);
+  const [reordering, setReordering] = useState(false);
+
+  const setReorderingBoth = useCallback((value: boolean) => {
+    reorderingRef.current = value;
+    setReordering(value);
+  }, []);
+
+  // Failure path: console.error, then GET the viewed week (mirrors
+  // usePlanData's switchWeek — no request body/options) and applyPlanData
+  // the reply. A failed re-fetch is swallowed with its own console.error.
+  const refetchWeek = useCallback(
+    async (err: unknown) => {
+      console.error("Reorder failed", err);
+      try {
+        const res = await fetch(`/meso/api/plan/${planId}/week/${viewedWeekId}/`);
+        if (!res.ok) throw new Error("Request failed: " + res.status);
+        applyPlanData((await res.json()) as PlanEnvelope);
+      } catch (refetchErr) {
+        console.error("Reorder refetch failed", refetchErr);
+      }
+    },
+    [planId, viewedWeekId, applyPlanData],
+  );
+
+  const postReorder = useCallback(
+    async (url: string, body: unknown) => {
+      try {
+        const data = await apiPost<PlanEnvelope>(url, body, csrf);
+        applyPlanData(data);
+      } catch (err) {
+        await refetchWeek(err);
+      } finally {
+        setReorderingBoth(false);
+      }
+    },
+    [csrf, applyPlanData, refetchWeek, setReorderingBoth],
+  );
+
+  function withinDayReorder(
+    activeData: { type: "exercise"; dayId: Id; prescriptionId: Id },
+    overData: { type: "exercise"; dayId: Id; prescriptionId: Id },
+  ) {
+    const dayIndex = program.findIndex((d) => d.id === activeData.dayId);
+    const day = program[dayIndex];
+    if (!day) return;
+    const oldIndex = day.exercises.findIndex((e) => e.id === activeData.prescriptionId);
+    const newIndex = day.exercises.findIndex((e) => e.id === overData.prescriptionId);
+    if (oldIndex === -1 || newIndex === -1) return;
+    const reordered = arrayMove(day.exercises, oldIndex, newIndex);
+
+    setReorderingBoth(true);
+    setProgram((prev) => prev.map((d, di) => (di === dayIndex ? { ...d, exercises: reordered } : d)));
+    return postReorder(`/meso/api/plan/${planId}/session/${day.id}/reorder/`, {
+      order: reordered.map((e) => e.id),
+    });
+  }
+
+  function crossDayMove(
+    activeData: { type: "exercise"; dayId: Id; prescriptionId: Id },
+    overData: { type: "exercise"; dayId: Id; prescriptionId: Id },
+  ) {
+    const sourceIndex = program.findIndex((d) => d.id === activeData.dayId);
+    const targetIndex = program.findIndex((d) => d.id === overData.dayId);
+    const sourceDay = program[sourceIndex];
+    const targetDay = program[targetIndex];
+    if (!sourceDay || !targetDay) return;
+    const movedIndex = sourceDay.exercises.findIndex((e) => e.id === activeData.prescriptionId);
+    const moved = sourceDay.exercises[movedIndex];
+    if (!moved) return;
+    // The target's CURRENT (pre-insertion, moved-row-excluded) index of the
+    // over row — matches the backend's own insertion semantics exactly.
+    const insertIndex = targetDay.exercises.findIndex((e) => e.id === overData.prescriptionId);
+    if (insertIndex === -1) return;
+
+    const newSourceExercises = sourceDay.exercises.filter((_, i) => i !== movedIndex);
+    const newTargetExercises = [...targetDay.exercises];
+    newTargetExercises.splice(insertIndex, 0, moved);
+
+    setReorderingBoth(true);
+    setProgram((prev) =>
+      prev.map((d, di) => {
+        if (di === sourceIndex) return { ...d, exercises: newSourceExercises };
+        if (di === targetIndex) return { ...d, exercises: newTargetExercises };
+        return d;
+      }),
+    );
+    return postReorder(`/meso/api/plan/${planId}/prescription/${moved.id}/move/`, {
+      session_id: targetDay.id,
+      index: insertIndex,
+    });
+  }
+
+  function dayReorder(activeData: { type: "day"; sessionId: Id }, overData: { type: "day"; sessionId: Id }) {
+    const oldIndex = program.findIndex((d) => d.id === activeData.sessionId);
+    const newIndex = program.findIndex((d) => d.id === overData.sessionId);
+    if (oldIndex === -1 || newIndex === -1) return;
+    const reordered = arrayMove(program, oldIndex, newIndex);
+
+    setReorderingBoth(true);
+    setProgram(reordered);
+    return postReorder(`/meso/api/plan/${planId}/week/${viewedWeekId}/reorder/`, {
+      order: reordered.map((d) => d.id),
+    });
+  }
+
+  const onDragEnd = useCallback(
+    (event: ReorderDragEndEvent): void | Promise<void> => {
+      if (reorderingRef.current) return;
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const activeData = active.data.current;
+      const overData = over.data.current;
+      if (activeData.type !== overData.type) return;
+
+      if (activeData.type === "exercise" && overData.type === "exercise") {
+        if (activeData.dayId === overData.dayId) {
+          return withinDayReorder(activeData, overData);
+        }
+        return crossDayMove(activeData, overData);
+      }
+
+      if (activeData.type === "day" && overData.type === "day") {
+        return dayReorder(activeData, overData);
+      }
+    },
+    [program, planId, viewedWeekId, setProgram, postReorder, setReorderingBoth],
+  );
+
+  return { reordering, onDragEnd };
+}

--- a/frontend/designer/src/hooks/useReorder.ts
+++ b/frontend/designer/src/hooks/useReorder.ts
@@ -45,30 +45,46 @@ export function useReorder(options: UseReorderOptions) {
     setReordering(value);
   }, []);
 
-  // Failure path: console.error, then GET the viewed week (mirrors
-  // usePlanData's switchWeek — no request body/options) and applyPlanData
-  // the reply. A failed re-fetch is swallowed with its own console.error.
+  // The CURRENT viewed week, readable at async-resolve time — mirrors
+  // usePlanData's viewedWeekIdRef idiom exactly. A reorder POSTed on week A
+  // that resolves after the coach has switched to week B must not apply
+  // (or re-fetch) week A's data.
+  const viewedWeekIdRef = useRef<Id | null>(viewedWeekId);
+  viewedWeekIdRef.current = viewedWeekId;
+
+  // Failure path: console.error, then (only if the week captured at drop
+  // time is STILL the viewed week) GET it (mirrors usePlanData's
+  // switchWeek — no request body/options) and applyPlanData the reply. A
+  // failed re-fetch is swallowed with its own console.error. If the coach
+  // switched weeks before this runs, the re-fetch is skipped entirely — the
+  // now-unviewed week's data isn't worth fetching.
   const refetchWeek = useCallback(
-    async (err: unknown) => {
+    async (err: unknown, weekAtDrop: Id | null) => {
       console.error("Reorder failed", err);
+      if (viewedWeekIdRef.current !== weekAtDrop) return;
       try {
-        const res = await fetch(`/meso/api/plan/${planId}/week/${viewedWeekId}/`);
+        const res = await fetch(`/meso/api/plan/${planId}/week/${weekAtDrop}/`);
         if (!res.ok) throw new Error("Request failed: " + res.status);
         applyPlanData((await res.json()) as PlanEnvelope);
       } catch (refetchErr) {
         console.error("Reorder refetch failed", refetchErr);
       }
     },
-    [planId, viewedWeekId, applyPlanData],
+    [planId, applyPlanData],
   );
 
   const postReorder = useCallback(
     async (url: string, body: unknown) => {
+      // Snapshot synchronously at drop time — compared against the ref's
+      // (possibly-changed) value once the POST resolves.
+      const weekAtDrop = viewedWeekIdRef.current;
       try {
         const data = await apiPost<PlanEnvelope>(url, body, csrf);
-        applyPlanData(data);
+        if (viewedWeekIdRef.current === weekAtDrop) {
+          applyPlanData(data);
+        }
       } catch (err) {
-        await refetchWeek(err);
+        await refetchWeek(err, weekAtDrop);
       } finally {
         setReorderingBoth(false);
       }
@@ -143,6 +159,55 @@ export function useReorder(options: UseReorderOptions) {
     });
   }
 
+  // Dropping an exercise onto a DAY's own droppable (not a specific row) —
+  // an empty day, or past a day's last row where the day card's droppable
+  // (not a row's) is closestCenter's pick — appends it to the end of that
+  // day. Same-day: a session-reorder with the row moved to the end (no-op
+  // if it's already last). Cross-day: prescription-move with `index` = the
+  // target's pre-insertion `exercises.length` (the backend clamps, so
+  // index === length is a valid append).
+  function appendToDay(
+    activeData: { type: "exercise"; dayId: Id; prescriptionId: Id },
+    overData: { type: "day"; sessionId: Id },
+  ) {
+    const sourceIndex = program.findIndex((d) => d.id === activeData.dayId);
+    const targetIndex = program.findIndex((d) => d.id === overData.sessionId);
+    const sourceDay = program[sourceIndex];
+    const targetDay = program[targetIndex];
+    if (!sourceDay || !targetDay) return;
+    const movedIndex = sourceDay.exercises.findIndex((e) => e.id === activeData.prescriptionId);
+    const moved = sourceDay.exercises[movedIndex];
+    if (!moved) return;
+
+    if (sourceIndex === targetIndex) {
+      if (movedIndex === sourceDay.exercises.length - 1) return; // already last: no-op
+      const reordered = [...sourceDay.exercises.filter((_, i) => i !== movedIndex), moved];
+
+      setReorderingBoth(true);
+      setProgram((prev) => prev.map((d, di) => (di === sourceIndex ? { ...d, exercises: reordered } : d)));
+      return postReorder(`/meso/api/plan/${planId}/session/${sourceDay.id}/reorder/`, {
+        order: reordered.map((e) => e.id),
+      });
+    }
+
+    const insertIndex = targetDay.exercises.length; // pre-insertion length == append index
+    const newSourceExercises = sourceDay.exercises.filter((_, i) => i !== movedIndex);
+    const newTargetExercises = [...targetDay.exercises, moved];
+
+    setReorderingBoth(true);
+    setProgram((prev) =>
+      prev.map((d, di) => {
+        if (di === sourceIndex) return { ...d, exercises: newSourceExercises };
+        if (di === targetIndex) return { ...d, exercises: newTargetExercises };
+        return d;
+      }),
+    );
+    return postReorder(`/meso/api/plan/${planId}/prescription/${moved.id}/move/`, {
+      session_id: targetDay.id,
+      index: insertIndex,
+    });
+  }
+
   const onDragEnd = useCallback(
     (event: ReorderDragEndEvent): void | Promise<void> => {
       if (reorderingRef.current) return;
@@ -150,7 +215,6 @@ export function useReorder(options: UseReorderOptions) {
       if (!over || active.id === over.id) return;
       const activeData = active.data.current;
       const overData = over.data.current;
-      if (activeData.type !== overData.type) return;
 
       if (activeData.type === "exercise" && overData.type === "exercise") {
         if (activeData.dayId === overData.dayId) {
@@ -161,6 +225,22 @@ export function useReorder(options: UseReorderOptions) {
 
       if (activeData.type === "day" && overData.type === "day") {
         return dayReorder(activeData, overData);
+      }
+
+      // dnd-kit's closestCenter routinely resolves a day-strip drag onto an
+      // exercise row's droppable (rows' centers sit closer to the pointer
+      // than the day card's) — resolve to that row's owning day instead of
+      // discarding the drop.
+      if (activeData.type === "day" && overData.type === "exercise") {
+        const resolvedSessionId = overData.dayId;
+        if (resolvedSessionId === activeData.sessionId) return; // same day: no-op
+        return dayReorder(activeData, { type: "day", sessionId: resolvedSessionId });
+      }
+
+      // An exercise dropped on a day's own droppable (no specific row under
+      // the pointer) appends it to the end of that day.
+      if (activeData.type === "exercise" && overData.type === "day") {
+        return appendToDay(activeData, overData);
       }
     },
     [program, planId, viewedWeekId, setProgram, postReorder, setReorderingBoth],

--- a/frontend/designer/src/styles/designer-grid.css
+++ b/frontend/designer/src/styles/designer-grid.css
@@ -9,12 +9,53 @@
   margin-bottom: 15px;
   box-shadow: 0 1px 2px rgba(16, 18, 22, 0.03);
 }
+/* Phase 4 (dnd-kit reordering): the day card being actively dragged, via
+   dnd-kit's CSS.Transform on the sortable item's own root node. */
+.meso-day-card.is-dragging {
+  opacity: 0.85;
+  box-shadow: 0 6px 18px rgba(16, 18, 22, 0.16);
+  position: relative;
+  z-index: 1;
+}
 .meso-day-header {
   display: flex;
   align-items: center;
   gap: 11px;
   padding: 12px 15px;
   border-bottom: 1px solid var(--line-2);
+}
+/* Phase 4 (dnd-kit reordering): shared grip-handle look for both the day
+   card header and every exercise row's name cell. Deliberately minimal —
+   dim glyph, grab cursor, a focus-visible ring matching Phase 3's
+   `[data-grid-cell]:focus-visible` token. `touch-action: none` per dnd-kit's
+   own guidance for handle elements (keeps a touch-drag from also scrolling
+   the page). */
+.meso-drag-handle {
+  appearance: none;
+  cursor: grab;
+  border: 0;
+  background: transparent;
+  font: inherit;
+  font-size: 13px;
+  line-height: 1;
+  color: var(--dim);
+  padding: 2px 4px;
+  border-radius: 4px;
+  flex: 0 0 auto;
+  touch-action: none;
+}
+.meso-drag-handle:hover {
+  color: var(--ink);
+}
+.meso-drag-handle:active {
+  cursor: grabbing;
+}
+.meso-drag-handle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.meso-drag-handle--day {
+  font-size: 14px;
 }
 .meso-day-badge {
   width: 25px;
@@ -112,8 +153,23 @@
   border-bottom: 1px solid var(--line-2);
   align-items: center;
 }
+/* Phase 4 (dnd-kit reordering): the row being actively dragged, via
+   dnd-kit's CSS.Transform on the sortable item's own root node. */
+.meso-ex-row.is-dragging {
+  opacity: 0.6;
+  background: var(--soft);
+  box-shadow: 0 3px 10px rgba(16, 18, 22, 0.12);
+  position: relative;
+  z-index: 1;
+}
 .meso-ex-name-col {
   min-width: 0;
+}
+/* Phase 4: the drag handle sits before the name input, both on one line. */
+.meso-ex-name-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
 .meso-ex-name-input {
   width: 100%;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "fitness-store-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
@@ -331,6 +334,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2147,9 +2203,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "typecheck": "tsc --noEmit -p frontend/designer/tsconfig.json"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },


### PR DESCRIPTION
## Summary

Phase 4 — the **final phase** of the designer framework plan (#403): dnd-kit drag-and-drop reordering. A coach can now reorder exercises within a day, move an exercise across days (including into an empty day), and reorder day cards — by pointer or entirely by keyboard — with every operation recorded in the undo op-log. Full spec is a comment on #403 ("Phase 4 spec"); built red→green throughout (57 backend + 22 frontend failing specs first, plus red-first hardening rounds).

## Backend

Three endpoints (login + POST + billing-gated, live-row scoped, plan-locked-first, one `PlanAction` each, full `serialize_plan` envelope replies):
- `api_session_reorder` — `{"order": [...]}`, the session's exact live prescription id set, dense 0-based rewrite, idempotent.
- `api_week_reorder_sessions` — same shape over the week's sessions (`day_number`/labels untouched — order is presentation order).
- `api_prescription_move` — `{"session_id", "index"}`, same-week guard, index clamped, both sessions renumbered densely; logged history keeps pointing at the same pk.
- Plus a latent op-log fix surfaced by TDD: `restore_plan_snapshot` captured `session_id` but never wrote it back — invisible until the first FK-repointing endpoint made move-undo fail.

## Frontend

- **Drag grips** (`⠿`) on every exercise row and day header — tabbable buttons, so dnd-kit's KeyboardSensor (Space lift → arrows → Space drop, Escape cancels) rides Phase 3's tab order for fully accessible DnD. PointerSensor uses a 5px activation distance so plain cell clicks never start drags.
- **`useReorder`** hook: optimistic apply → POST → envelope re-sync (`history` stays accurate); failure → viewed-week re-fetch; one shared in-flight guard; stale replies after a week switch dropped; armed delete-confirms disarmed before any mutating drop (index-keyed confirms can't drift onto the wrong day).
- **Drop-target resolution**: nested sortables mean collisions land on "wrong-type" droppables constantly — a day dragged over an exercise row resolves to that row's day; an exercise dropped on a day card appends to it (the empty-day path).
- **Type-aware keyboard targeting**: the coordinate getter and collision detection filter candidates by drag kind (day drags see only day containers; exercise drags keep day containers for append) — delegating to the real `DroppableContainersMap` via a bound Proxy (a naïve clone throws `Map.prototype.get called on incompatible receiver` and silently kills the keyboard path).

## Review + verification

Local Codex loop, 3 iterations, **six findings fixed red-first** (stale-week apply, append/empty-day path, keyboard day-targets, confirm-disarm, the Map-receiver crash) alongside two browser-discovered defects (day reorder unreachable; empty-day drops impossible).

- [x] `uv run pytest` — 1910 passed (57 new endpoint specs incl. undo round-trips, validation matrices, LoggedSet survival)
- [x] `npx vitest run` — 415 passed (36 new hook/component specs) · typecheck clean · build green (295 kB / 89.5 kB gzip; dnd-kit adds ~16 kB gzip)
- [x] **Real-browser verification** on local dev: within-day reorder (pointer + keyboard with correct a11y announcements), cross-day move at the exact index, **keyboard day reorder end-to-end** (lift → move → drop → `week/reorder` POST → undo restores), undo/redo integration for all three operations, no drag on plain cell clicks.
- [ ] Optional human sanity pass: pointer-drag feel on a real mouse (synthetic pointer streams can't assess it).

Closes the Phases checklist of #403.