### PR TITLE
docs(meso): designer framework plan complete — archive

### DIFF
--- a/app/store_project/meso/history.py
+++ b/app/store_project/meso/history.py
@@ -1,6 +1,6 @@
 """Plan-wide snapshot serializer/restorer for the undo/redo op-log (Phase 1).
 
-The designer needs plan-wide undo/redo (``docs/meso/designer-framework-plan.md``
+The designer needs plan-wide undo/redo (``docs/archive/meso/designer-framework-plan.md``
 Decision 2 + Phase 1), built on Phase 0's soft delete
 (``Week``/``Session``/``ExercisePrescription.deleted_at``). Every mutating
 designer endpoint records ONE ``PlanAction`` (see ``models.py``) on the undo

--- a/app/store_project/meso/models.py
+++ b/app/store_project/meso/models.py
@@ -1377,7 +1377,7 @@ class Week(models.Model):
     # None. The delete endpoint stamps only this row — children are hidden by
     # serializers/lookups filtering live rows at each level of the walk, not by
     # a cascading write, so an independently-deleted child stays deleted if a
-    # later undo restores this week. See docs/meso/designer-framework-plan.md.
+    # later undo restores this week. See docs/archive/meso/designer-framework-plan.md.
     deleted_at = models.DateTimeField(
         _("Deleted at"), null=True, blank=True, default=None
     )
@@ -2500,7 +2500,7 @@ class AthleteOneRm(models.Model):
 # pops the max-seq undo row, restores its snapshot, and pushes the mirror-image
 # redo row (same seq+label, snapshot = the state just left); redo is the exact
 # mirror. See ``history.py`` (the snapshot serializer/restorer + the
-# ``record_plan_action`` recorder) and ``docs/meso/designer-framework-plan.md``.
+# ``record_plan_action`` recorder) and ``docs/archive/meso/designer-framework-plan.md``.
 # ---------------------------------------------------------------------------
 
 

--- a/app/store_project/meso/tests/test_designer_delete.py
+++ b/app/store_project/meso/tests/test_designer_delete.py
@@ -12,7 +12,7 @@ deleted row are hidden implicitly because every read (serializers + view
 lookups) filters live rows at each level of the walk, not because the delete
 cascaded a write onto them.
 
-Covers, per ``docs/meso/designer-framework-plan.md`` Phase 0:
+Covers, per ``docs/archive/meso/designer-framework-plan.md`` Phase 0:
 
 - the three new endpoints (``api_prescription_delete``/``api_session_delete``/
   ``api_week_delete``): happy path (200, envelope shape, DB row survives with

--- a/app/store_project/meso/tests/test_designer_island.py
+++ b/app/store_project/meso/tests/test_designer_island.py
@@ -1,6 +1,6 @@
 """Phase 2 PR B — designer.html swaps from Alpine to the React island.
 
-See ``docs/meso/designer-framework-plan.md`` and
+See ``docs/archive/meso/designer-framework-plan.md`` and
 ``frontend/designer/CONTRACT.md``. The template stops rendering the whole UI
 server-side: it now emits only the
 mount point (``#meso-designer-root``) plus the same hydration payloads the

--- a/app/store_project/meso/tests/test_designer_reorder.py
+++ b/app/store_project/meso/tests/test_designer_reorder.py
@@ -1,7 +1,7 @@
 """Phase 4 — dnd-kit reorder endpoints (RED, designer framework Phase 4, #403).
 
 The designer's drag-and-drop needs three write endpoints, built on Phase 0's
-soft delete + Phase 1's undo op-log (``docs/meso/designer-framework-plan.md``
+soft delete + Phase 1's undo op-log (``docs/archive/meso/designer-framework-plan.md``
 Phase 4):
 
 - ``api_session_reorder`` — reorder the exercise rows within one session

--- a/app/store_project/meso/tests/test_designer_undo.py
+++ b/app/store_project/meso/tests/test_designer_undo.py
@@ -1,6 +1,6 @@
 """Phase 1 — undo/redo backend (the ``PlanAction`` op-log).
 
-The designer needs plan-wide undo/redo (``docs/meso/designer-framework-plan.md``
+The designer needs plan-wide undo/redo (``docs/archive/meso/designer-framework-plan.md``
 Decision 2 + Phase 1), built on Phase 0's soft-delete: every mutating designer
 endpoint records ONE ``PlanAction`` (stack ``undo``, monotonically increasing
 ``seq``, a short human ``label``, and a plan-wide ``snapshot`` of the editable

--- a/docs/archive/meso/designer-framework-plan.md
+++ b/docs/archive/meso/designer-framework-plan.md
@@ -1,5 +1,10 @@
 # Meso — designer React island + undo/redo, keyboard nav, drag-and-drop
 
+> **Status: COMPLETE (2026-07-02).** All phases shipped — #404/#405 (Phase 0),
+> #407 (Phase 1), #408/#409 (Phase 2), #411 (Phase 3), #412 (Phase 4). The
+> tracking issue #403 is closed; per-phase outcomes are annotated below and
+> in #403's body. Deferred items remain listed at the bottom.
+
 ## Why
 
 The designer (`templates/meso/designer.html` + `static/js/meso.js`) has outgrown
@@ -205,7 +210,7 @@ undo actions), the 1RM editor keeps Enter/Escape, add-exercise/add-day replies
 that resolve after a mid-flight week switch are dropped, and the phone-preview
 coachmark is ported. The full checklist above was verified in a real browser.
 
-### Phase 3 — keyboard navigation — 🚧 next
+### Phase 3 — keyboard navigation — ✅ shipped (#411)
 
 - Roving tabindex across grid cells; arrow keys move focus, Enter commits /
   Escape reverts a cell, Tab follows the natural order; focus survives
@@ -214,7 +219,7 @@ coachmark is ported. The full checklist above was verified in a real browser.
 - Fixes the a11y gaps the #401 review deferred (unlabeled inputs, focus rings
   killed by `outline:none`).
 
-### Phase 4 — drag-and-drop
+### Phase 4 — drag-and-drop — ✅ shipped (#412)
 
 - dnd-kit: reorder exercises within a day, move exercises across days, reorder
   days within a week (weeks-reorder deferred). Keyboard sensor gives


### PR DESCRIPTION
Closes out #403's paper trail: completion banner + Phase 3/4 outcome annotations on the plan doc, moved to docs/archive/meso/ per the archive convention, with the six code-comment references repointed. No behavior changes.