### PR TITLE
feat(meso): name the free trial everywhere the funnel needs it

### DIFF
--- a/app/store_project/meso/context_processors.py
+++ b/app/store_project/meso/context_processors.py
@@ -1,10 +1,18 @@
 from django.utils.functional import SimpleLazyObject
 
 from . import sandbox
+from .models import CoachSubscription
 
 
 def sandbox_status(request):
     """Whether the current visitor is a throwaway sandbox coach (issue #389).
+
+    Also carries ``trial_days`` (issue #416): the persistent sandbox banner in
+    ``_meso_base.html`` renders on every sandbox page, not just one view, so
+    the value needs to reach the template the same way ``is_sandbox`` does
+    rather than being threaded through every view's ``get_context_data``.
+    Cheap either way — no query, just the model constant — so it isn't lazy
+    like ``is_sandbox``.
 
     Lazy: pages that never reference ``is_sandbox`` in their template pay no
     extra query.
@@ -12,5 +20,6 @@ def sandbox_status(request):
     return {
         "is_sandbox": SimpleLazyObject(
             lambda: sandbox.is_sandbox(getattr(request, "user", None))
-        )
+        ),
+        "trial_days": CoachSubscription.TRIAL_DAYS,
     }

--- a/app/store_project/meso/tests/test_landing.py
+++ b/app/store_project/meso/tests/test_landing.py
@@ -27,6 +27,7 @@ from django.urls import reverse
 
 from store_project.meso.models import CoachAthlete
 from store_project.meso.models import CoachProfile
+from store_project.meso.models import CoachSubscription
 from store_project.users.factories import UserFactory
 
 pytestmark = pytest.mark.django_db
@@ -104,6 +105,19 @@ class TestLandingContent:
         # The Designer is a coach-only surface; the anonymous landing's topnav
         # must not link to it.
         assert reverse("meso:designer") not in body
+
+    def test_landing_names_the_free_trial(self, client):
+        """The funnel sells the trial, not just the free tier (issue #416).
+
+        Renders from ``CoachSubscription.TRIAL_DAYS`` so a future constant
+        change can't leave the landing copy stale.
+        """
+        resp = client.get(reverse("meso:roster"))
+        body = resp.content.decode()
+        assert "free trial" in body.lower()
+        assert f"{CoachSubscription.TRIAL_DAYS} days" in body
+        # The demo card's gate line points the limitation at the trial too.
+        assert "held back" in body.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/app/store_project/meso/tests/test_sandbox.py
+++ b/app/store_project/meso/tests/test_sandbox.py
@@ -50,6 +50,7 @@ from store_project.meso import sandbox
 from store_project.meso import tasks
 from store_project.meso.models import AgentProposalBatch
 from store_project.meso.models import CoachProfile
+from store_project.meso.models import CoachSubscription
 from store_project.meso.models import MesoGroup
 from store_project.meso.models import Plan
 from store_project.meso.models import SandboxSession
@@ -656,6 +657,20 @@ class TestSandboxBanner:
         # Carry-over is deferred (S6): signup starts a FRESH workspace — the
         # banner must not promise the visitor keeps their sandbox work.
         assert "keep your work" not in body
+
+    def test_banner_points_at_the_free_trial_not_the_free_tier(self, client):
+        """The banner sells the trial, not the weaker free tier (issue #416).
+
+        Full access lives behind the trial (the free tier caps at 5 agent
+        runs/mo); renders from ``CoachSubscription.TRIAL_DAYS`` so a future
+        constant change can't leave the banner stale.
+        """
+        coach = _sandbox_coach()
+        client.force_login(coach)
+
+        body = client.get(reverse("meso:roster")).content.decode()
+        assert "free trial" in body.lower()
+        assert f"{CoachSubscription.TRIAL_DAYS}-day free trial" in body
 
     def test_roster_shows_no_banner_for_a_real_coach(self, client):
         coach = UserFactory()

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -311,7 +311,13 @@ class RosterView(TemplateView):
             return render(
                 request,
                 "meso/landing.html",
-                {"athlete_next": reverse("meso:athlete_home")},
+                {
+                    "athlete_next": reverse("meso:athlete_home"),
+                    # Names the trial on the coach card + demo card (issue #416)
+                    # — same value ``become_coach`` exposes, so a future
+                    # ``TRIAL_DAYS`` change can't leave the landing copy stale.
+                    "trial_days": CoachSubscription.TRIAL_DAYS,
+                },
             )
         if not _is_coach(request.user):
             return redirect("meso:athlete_home")

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -809,7 +809,8 @@ def sandbox_enter(request):
     messages.success(
         request,
         "You're in a live demo — explore freely. Create a free account any "
-        "time to run the AI agent.",
+        f"time to start a {CoachSubscription.TRIAL_DAYS}-day free trial and "
+        "run the AI agent.",
     )
     return _noindex(redirect("meso:roster"))
 
@@ -3089,7 +3090,11 @@ def agent_propose(request, plan_id):
         return JsonResponse(
             {
                 "ok": False,
-                "error": "Create a free account to run the AI agent.",
+                "error": (
+                    "Create a free account and start a "
+                    f"{CoachSubscription.TRIAL_DAYS}-day free trial to run "
+                    "the AI agent."
+                ),
                 "signup_required": True,
                 "signup_url": reverse("meso:sandbox_signup"),
             },

--- a/app/store_project/templates/meso/_meso_base.html
+++ b/app/store_project/templates/meso/_meso_base.html
@@ -71,7 +71,7 @@
             {% endcomment %}
             <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;padding:10px 14px;margin:14px 0 0;background:var(--soft);border:1px solid var(--soft-line);border-left:3px solid var(--accent);border-radius:9px;font-size:13px;color:var(--accent-deep);">
               {# No "keep your work" promise — carry-over at signup is deferred (S6). #}
-              <span style="flex:1;min-width:0;">You're in a live demo — your work here is temporary. <strong>Create a free account</strong> to run the AI agent.</span>
+              <span style="flex:1;min-width:0;">You're in a live demo — your work here is temporary. <strong>Create a free account</strong> and start a {{ trial_days }}-day free trial to run the AI agent.</span>
               <a class="meso-btn meso-btn--primary" href="{% url 'meso:sandbox_signup' %}">Create a free account</a>
             </div>
           {% endif %}

--- a/app/store_project/templates/meso/landing.html
+++ b/app/store_project/templates/meso/landing.html
@@ -59,7 +59,7 @@ honest entry actions: log in as an athlete, or become a coach.
       <div class="meso-card meso-card--pad">
         <span class="meso-badge"><i></i>Coaches</span>
         <p style="font-size:16px;font-weight:800;letter-spacing:-0.02em;margin:10px 0 4px;">Coach with Meso</p>
-        <p class="meso-row-meta" style="margin-bottom:14px;">Design programs, run groups, and let the AI agent draft adjustments you approve. Start free — no card required.</p>
+        <p class="meso-row-meta" style="margin-bottom:14px;">Design programs, run groups, and let the AI agent draft adjustments you approve. Everything free for {{ trial_days }} days, including the AI agent — no card.</p>
         <div style="display:flex;gap:10px;flex-wrap:wrap;">
           <a class="meso-btn meso-btn--primary" href="{% url 'meso:become_coach' %}">Get started as a coach</a>
         </div>
@@ -73,7 +73,7 @@ honest entry actions: log in as an athlete, or become a coach.
         <div style="display:flex;gap:10px;flex-wrap:wrap;">
           <a class="meso-btn meso-btn--primary" href="{% url 'meso:sandbox_enter' %}">Try the demo</a>
         </div>
-        <p class="meso-row-meta" style="margin-top:12px;">Fully interactive — the AI agent is the only thing it holds back.</p>
+        <p class="meso-row-meta" style="margin-top:12px;">Fully interactive — only the AI agent is held back. That's yours on a free trial.</p>
       </div>
     </div>
 


### PR DESCRIPTION
Closes #416

The funnel ends in "start a free trial," but no public surface said those words — the landing coach card and the sandbox sold the free tier (1 athlete, 5 agent runs/mo) instead of the 14-day full-access trial. Every prospect-facing surface now points at the trial, with the day count sourced from `CoachSubscription.TRIAL_DAYS` (never hardcoded).

## Surfaces updated

1. **Coach card** (`landing.html`): "…Everything free for 14 days, including the AI agent — no card."
2. **Sandbox banner** (`_meso_base.html`): "…Create a free account and start a 14-day free trial to run the AI agent." `trial_days` flows through the existing `sandbox_status` context processor (same channel as `is_sandbox`), so it reaches every sandbox page without per-view threading.
3. **Demo card gate line** (`landing.html`): "Fully interactive — only the AI agent is held back. That's yours on a free trial."
4. **Sandbox-enter flash + agent-gate 403** (`views.py`, follow-on commit): the flash on entering the demo and — the moment that matters most — the 403 shown when a sandbox user actually tries to run the agent both sold the free tier; both now name the trial.

Honesty check: `meso:sandbox_signup` → `account_signup?next=/meso/become-coach/` → BecomeCoachView's real "Start 14-day free trial" button, so the copy matches the actual post-signup path.

## Validation

- `just lint` clean; meso suite 1658 passed.
- New tests pin the copy to the constant: `test_landing_names_the_free_trial`, `test_banner_points_at_the_free_trial_not_the_free_tier` — both assert against `CoachSubscription.TRIAL_DAYS` so a future constant change can't drift the copy.
- Codex review loop: CLEAN (0 blocking, 0 nits).
