### PR TITLE
feat(meso): landing meta/OG tags, price line, dedup demo-card copy

### DIFF
--- a/app/store_project/meso/templatetags/meso_extras.py
+++ b/app/store_project/meso/templatetags/meso_extras.py
@@ -9,3 +9,16 @@ register = template.Library()
 def initials(name):
     """Two-letter monogram for an avatar ("Maya Okonkwo" → "MO")."""
     return _initials(str(name))
+
+
+@register.filter
+def absolute_uri(path, request):
+    """``path`` (typically a ``{% static %}`` URL) made absolute (issue #418).
+
+    Social-share crawlers (OG image, etc.) require an absolute URL — a relative
+    ``/static/...`` path renders as a broken preview image in Slack/iMessage/
+    Discord. Template variable lookups can't call a method with an argument
+    (``request.build_absolute_uri`` alone calls it with none, resolving to the
+    *current page's* URL), so this filter does the two-argument call instead.
+    """
+    return request.build_absolute_uri(path)

--- a/app/store_project/meso/tests/test_landing.py
+++ b/app/store_project/meso/tests/test_landing.py
@@ -22,9 +22,12 @@ These tests cover:
   front door is reachable without already knowing the URL.
 """
 
+import re
+
 import pytest
 from django.urls import reverse
 
+from store_project.meso import presenters
 from store_project.meso.models import CoachAthlete
 from store_project.meso.models import CoachProfile
 from store_project.meso.models import CoachSubscription
@@ -141,6 +144,59 @@ class TestLandingContent:
         demo_entry = body.index("Try the coach demo")
         athlete_entry = body.index("Training with a coach?")
         assert demo_entry < athlete_entry
+
+    def test_landing_demo_card_no_signup_is_not_repeated(self, client):
+        """The badge says "No signup"; the body used to repeat it (issue #418)."""
+        resp = client.get(reverse("meso:roster"))
+        assert resp.content.decode().count("No signup") == 1
+
+    def test_landing_shows_the_flat_price(self, client):
+        """A pricing signal renders from the shared constant, not a hardcoded string."""
+        resp = client.get(reverse("meso:roster"))
+        assert presenters.PRICE_SUMMARY in resp.content.decode()
+
+
+# ---------------------------------------------------------------------------
+# Meta description + Open Graph tags (issue #418)
+# ---------------------------------------------------------------------------
+
+
+class TestLandingMeta:
+    def test_meta_description_renders(self, client):
+        resp = client.get(reverse("meso:roster"))
+        body = resp.content.decode()
+        assert '<meta name="description" content="' in body
+        assert "coaches" in body.lower()
+
+    def test_og_description_matches_meta_description_block(self, client):
+        """og:description shares its block with the plain description tag."""
+        resp = client.get(reverse("meso:roster"))
+        body = resp.content.decode()
+        assert 'property="og:description"' in body
+
+    def test_og_image_is_absolute_and_points_at_the_hero_shot(self, client):
+        resp = client.get(reverse("meso:roster"))
+        body = resp.content.decode()
+        match = re.search(r'property="og:image" content="([^"]+)"', body)
+        assert match is not None
+        url = match.group(1)
+        assert url.startswith("http://") or url.startswith("https://")
+        assert url.endswith("meso-landing-designer.webp")
+
+    def test_og_image_dimensions_and_twitter_card(self, client):
+        resp = client.get(reverse("meso:roster"))
+        body = resp.content.decode()
+        assert '<meta property="og:image:width" content="1280" />' in body
+        assert '<meta property="og:image:height" content="800" />' in body
+        assert '<meta name="twitter:card" content="summary_large_image" />' in body
+
+    def test_og_type_and_url(self, client):
+        resp = client.get(reverse("meso:roster"))
+        body = resp.content.decode()
+        assert '<meta property="og:type" content="website" />' in body
+        match = re.search(r'property="og:url" content="([^"]+)"', body)
+        assert match is not None
+        assert match.group(1).startswith("http")
 
 
 # ---------------------------------------------------------------------------

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -317,6 +317,10 @@ class RosterView(TemplateView):
                     # — same value ``become_coach`` exposes, so a future
                     # ``TRIAL_DAYS`` change can't leave the landing copy stale.
                     "trial_days": CoachSubscription.TRIAL_DAYS,
+                    # The flat-price line on the coach card (issue #418) — the
+                    # same constant the roster/billing/designer surfaces render,
+                    # so the price can't drift out of sync with the landing page.
+                    "price_summary": presenters.PRICE_SUMMARY,
                 },
             )
         if not _is_coach(request.user):

--- a/app/store_project/templates/meso/_meso_base.html
+++ b/app/store_project/templates/meso/_meso_base.html
@@ -10,6 +10,34 @@
     {% endcomment %}
     {% block head_top %}{% endblock %}
     <title>{% block title %}Meso{% endblock %} · Mastering Fitness</title>
+    {% comment %}
+      Search + social metadata (issue #418). ``meta_description`` carries both
+      the plain description and og:description together — one block, so the two
+      can never drift apart — with a sensible sitewide default; ``landing.html``
+      overrides it with marketing copy. ``og:title`` can't literally reuse the
+      ``title`` block above (Django forbids the same block name twice in one
+      template), so pages that customize ``title`` should mirror it here too.
+      ``og:url``/``og:image`` need ``request`` (absent only outside the normal
+      request/response cycle — every Meso page, including the
+      service-worker-precached ``offline.html``, renders through a real Django
+      view, so this is defensive, not load-bearing today).
+    {% endcomment %}
+    {% block meta_description %}
+      <meta name="description" content="Meso is coaching software for building periodized training programs and delivering them to athletes' phones." />
+      <meta property="og:description" content="Meso is coaching software for building periodized training programs and delivering them to athletes' phones." />
+    {% endblock %}
+    <meta property="og:title" content="{% block og_title %}Meso · Mastering Fitness{% endblock %}" />
+    <meta property="og:type" content="website" />
+    {% if request %}<meta property="og:url" content="{{ request.build_absolute_uri }}" />{% endif %}
+    {% block og_image %}
+      {% if request %}
+        {% static 'webp/meso-landing-designer.webp' as og_image_static %}
+        <meta property="og:image" content="{{ og_image_static|absolute_uri:request }}" />
+        <meta property="og:image:width" content="1280" />
+        <meta property="og:image:height" content="800" />
+      {% endif %}
+    {% endblock %}
+    <meta name="twitter:card" content="summary_large_image" />
     <link rel="shortcut icon" href="{% static 'png/favicon-black.png' %}" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/app/store_project/templates/meso/landing.html
+++ b/app/store_project/templates/meso/landing.html
@@ -4,6 +4,18 @@
 {% block title %}Meso — coaching, periodized{% endblock %}
 
 {% comment %}
+  Marketing copy for search + social shares (issue #418) — mirrors the <title>
+  block above (Django can't reuse a block by name twice in one template, see
+  _meso_base.html). og:description shares this block with the plain
+  description tag so they can't drift.
+{% endcomment %}
+{% block meta_description %}
+  <meta name="description" content="Meso is where coaches build periodized training programs, deliver them to athletes' phones, and let an AI agent draft the week-to-week adjustments." />
+  <meta property="og:description" content="Meso is where coaches build periodized training programs, deliver them to athletes' phones, and let an AI agent draft the week-to-week adjustments." />
+{% endblock %}
+{% block og_title %}Meso — coaching, periodized · Mastering Fitness{% endblock %}
+
+{% comment %}
 First-time-UX Phase 3: the public front door. ``/meso/`` renders this for an
 anonymous visitor (RosterView splits on auth) instead of bouncing to login.
 Login-free and coach-nav-free — it explains Meso in one screen and offers
@@ -58,7 +70,7 @@ visitor — demo/trial lead, athlete login is a compact strip, not a card.
       <div class="meso-card meso-card--pad">
         <span class="meso-badge meso-badge--muted"><i></i>No signup</span>
         <p style="font-size:16px;font-weight:800;letter-spacing:-0.02em;margin:10px 0 4px;">Try the coach demo</p>
-        <p class="meso-row-meta" style="margin-bottom:14px;">No signup. Land in a populated workspace and build a real program.</p>
+        <p class="meso-row-meta" style="margin-bottom:14px;">Land in a populated workspace and build a real program.</p>
         <div style="display:flex;gap:10px;flex-wrap:wrap;">
           <a class="meso-btn meso-btn--primary" href="{% url 'meso:sandbox_enter' %}">Launch the demo</a>
         </div>
@@ -73,13 +85,15 @@ visitor — demo/trial lead, athlete login is a compact strip, not a card.
           <a class="meso-btn meso-btn--primary" href="{% url 'meso:become_coach' %}">Get started as a coach</a>
         </div>
         <p class="meso-row-meta" style="margin-top:12px;">See what Meso does for coaches and pick a plan.</p>
+        <p class="meso-row-meta" style="margin-top:4px;">One flat price when you're ready — {{ price_summary }}.</p>
       </div>
     </div>
 
     <!-- Athletes already have a coach — the nav's Log in link covers them
          twice over (store nav + Meso topnav), so this is a strip, not a
-         card (issue #417). No signup link: cold athletes without an invite
-         aren't a real entry path, since coaches invite them. -->
+         card (issue #417). Deliberately carries no open-signup link: cold
+         athletes without an invite aren't a real entry path, since coaches
+         invite them. -->
     <div class="meso-card meso-card--pad" style="text-align:center;margin-bottom:18px;">
       <span class="meso-row-meta">Training with a coach? <a href="{% url 'account_login' %}?next={{ athlete_next|urlencode }}" style="color:var(--accent);font-weight:600;">Log in to your training</a> — or tap the link in your email invite.</span>
     </div>


### PR DESCRIPTION
Closes #418

Batched landing-page polish: shareable head metadata, one less repeated phrase, and a pricing signal before the first click.

## What changed

- **Meta description + OG tags** (`_meso_base.html`): description/og:description share ONE overridable block (they can never drift), plus og:title, og:type, og:url, og:image → the #419 hero screenshot (`webp/meso-landing-designer.webp`, 1280×800) made absolute via a new `absolute_uri` template filter, and `twitter:card summary_large_image`. `landing.html` overrides with 147-char marketing copy. `/meso/` now unfurls with a product image instead of a bare link.
  - `og:title` is a sibling block pages mirror when overriding `title` — Django forbids two same-name blocks in one template (documented inline).
  - `offline.html`/SW precache verified: the service worker's `cache.addAll()` is a real HTTP GET through the normal request cycle, so the head renders fine; `{% if request %}` guards are defensive only.
- **Demo card dedup** (`landing.html`): badge keeps "No signup"; body now "Land in a populated workspace and build a real program."
- **Price line** (`landing.html` + `views.py`): "One flat price when you're ready — $19/mo — unlimited athletes." rendered from `presenters.PRICE_SUMMARY` via the anonymous roster-view context (same pattern as `trial_days` from #420) — not hardcoded.

## Validation

- `just lint` clean; meso suite 1667 passed (test_landing.py grown 14 → 20: meta description present, og:image absolute + right filename, price line asserted against the constant, `count("No signup") == 1`).
- Rendered anon `/meso/`, `/meso/offline/`, and an authenticated coach page — head tags correct in all three.
- Codex review loop: CLEAN (0 blocking, 0 nits).
