### PR TITLE
fix(meso): visible link color for on-card controls that used --accent-ink

### DIFF
--- a/app/store_project/templates/meso/_meso_base.html
+++ b/app/store_project/templates/meso/_meso_base.html
@@ -107,7 +107,7 @@
           {% if messages %}
             <div style="display:flex;flex-direction:column;gap:8px;margin:14px 0 0;">
               {% for message in messages %}
-                <div class="meso-card meso-card--pad" style="padding:11px 14px;font-size:13px;color:var(--ink);border-left:3px solid {% if message.tags == 'error' %}var(--warn){% else %}var(--accent-ink){% endif %};">{{ message }}</div>
+                <div class="meso-card meso-card--pad" style="padding:11px 14px;font-size:13px;color:var(--ink);border-left:3px solid {% if message.tags == 'error' %}var(--warn){% else %}var(--accent){% endif %};">{{ message }}</div>
               {% endfor %}
             </div>
           {% endif %}

--- a/app/store_project/templates/meso/athlete_home.html
+++ b/app/store_project/templates/meso/athlete_home.html
@@ -42,7 +42,7 @@
          reveals it only when the app is installable and not already installed or
          dismissed, and swaps in the native button vs the manual iOS steps. -->
     <div id="meso-install-card" class="meso-card meso-card--pad"
-         style="display:none;align-items:flex-start;gap:12px;margin-bottom:14px;border:1px solid var(--line);border-left:3px solid var(--accent-ink);">
+         style="display:none;align-items:flex-start;gap:12px;margin-bottom:14px;border:1px solid var(--line);border-left:3px solid var(--accent);">
       <span style="font-size:18px;line-height:1.3;">📲</span>
       <span style="flex:1;min-width:0;">
         <span style="display:block;font-size:14px;font-weight:700;letter-spacing:-0.01em;">Install Meso on your phone</span>
@@ -98,7 +98,7 @@
       {% endfor %}
 
       <details {% if not pending.invites and not pending.requests %}open{% endif %} style="margin-top:6px;">
-        <summary style="list-style:none;cursor:pointer;font-size:12.5px;font-weight:650;color:var(--accent-ink);">+ Request a coach</summary>
+        <summary style="list-style:none;cursor:pointer;font-size:12.5px;font-weight:650;color:var(--accent);">+ Request a coach</summary>
         <form method="post" action="{% url 'meso:athlete_request_coach' %}" style="display:flex;gap:9px;margin-top:10px;">
           {% csrf_token %}
           <input name="email" type="email" required maxlength="254" placeholder="coach@email.com" style="flex:1;appearance:none;border:1px solid var(--line);border-radius:8px;background:var(--rail);font:inherit;font-size:13px;color:var(--ink);padding:8px 10px;outline:none;" />
@@ -113,7 +113,7 @@
            until the athlete's first log lands), so it's one-time + cross-device;
            meso_onboarding.js persists a manual dismiss across reloads. -->
       <div class="meso-card meso-card--pad" data-coachmark-key="firstlog-home"
-           style="display:flex;align-items:flex-start;gap:12px;margin-bottom:14px;border:1px solid var(--line);border-left:3px solid var(--accent-ink);">
+           style="display:flex;align-items:flex-start;gap:12px;margin-bottom:14px;border:1px solid var(--line);border-left:3px solid var(--accent);">
         <span style="font-size:18px;line-height:1.3;">👇</span>
         <span style="flex:1;min-width:0;">
           <span style="display:block;font-size:14px;font-weight:700;letter-spacing:-0.01em;">New here? Log your first workout</span>

--- a/app/store_project/templates/meso/athlete_session.html
+++ b/app/store_project/templates/meso/athlete_session.html
@@ -49,7 +49,7 @@
       <!-- First-log coachmark (first-time UX Phase 4): server-driven, shown only
            to a first-ever logger; meso_onboarding.js persists a manual dismiss. -->
       <div class="meso-card meso-card--pad" data-coachmark-key="firstlog-session"
-           style="display:flex;align-items:flex-start;gap:12px;margin-bottom:14px;border:1px solid var(--line);border-left:3px solid var(--accent-ink);">
+           style="display:flex;align-items:flex-start;gap:12px;margin-bottom:14px;border:1px solid var(--line);border-left:3px solid var(--accent);">
         <span style="font-size:18px;line-height:1.3;">💡</span>
         <span style="flex:1;min-width:0;">
           <span style="display:block;font-size:14px;font-weight:700;letter-spacing:-0.01em;">How to log a set</span>

--- a/app/store_project/templates/meso/coach_billing.html
+++ b/app/store_project/templates/meso/coach_billing.html
@@ -109,7 +109,7 @@
           {% empty %}
             <div class="meso-row" style="color:var(--dim);padding:16px;">
               No agent runs yet this month. Open a program in the
-              <a href="{% url 'meso:designer' %}" style="color:var(--accent-ink);">Designer</a> and ask the agent for help.
+              <a href="{% url 'meso:designer' %}" style="color:var(--accent);">Designer</a> and ask the agent for help.
             </div>
           {% endfor %}
         </div>

--- a/app/store_project/templates/meso/roster.html
+++ b/app/store_project/templates/meso/roster.html
@@ -67,7 +67,7 @@
             <p class="meso-eyebrow" style="margin:0;">Individuals</p>
             <div class="meso-spacer"></div>
             <span class="meso-row-meta">{{ athletes|length }} athlete{{ athletes|length|pluralize }}</span>
-            <a href="{% url 'meso:relationship_history' %}" class="meso-row-meta" style="text-decoration:none;color:var(--accent-ink);white-space:nowrap;">· Past athletes →</a>
+            <a href="{% url 'meso:relationship_history' %}" class="meso-row-meta" style="text-decoration:none;color:var(--accent);white-space:nowrap;">· Past athletes →</a>
           </div>
           {% for a in athletes %}
             <a class="meso-row" href="{% url 'meso:athlete' a.id %}">
@@ -157,11 +157,11 @@
                address should ever be entered into a throwaway sandbox account. -->
           {% if is_sandbox %}
             <div style="border-top:1px solid var(--line-2);padding:11px 16px;">
-              <span class="meso-row-meta">Inviting real athletes is off in the demo — <a href="{% url 'meso:sandbox_signup' %}" style="color:var(--accent-ink);">create a free account</a>.</span>
+              <span class="meso-row-meta">Inviting real athletes is off in the demo — <a href="{% url 'meso:sandbox_signup' %}" style="color:var(--accent);">create a free account</a>.</span>
             </div>
           {% else %}
             <details style="border-top:1px solid var(--line-2);">
-              <summary style="list-style:none;cursor:pointer;padding:11px 16px;font-size:12.5px;font-weight:650;color:var(--accent-ink);">+ Invite an athlete</summary>
+              <summary style="list-style:none;cursor:pointer;padding:11px 16px;font-size:12.5px;font-weight:650;color:var(--accent);">+ Invite an athlete</summary>
               <form method="post" action="{% url 'meso:coach_invite' %}" style="display:flex;gap:9px;padding:4px 16px 16px;">
                 {% csrf_token %}
                 <input name="email" type="email" required maxlength="254" placeholder="athlete@email.com" style="flex:1;appearance:none;border:1px solid var(--line);border-radius:8px;background:var(--rail);font:inherit;font-size:13px;color:var(--ink);padding:8px 10px;outline:none;" />
@@ -174,7 +174,7 @@
                A program is rooted at one athlete, so this picks the athlete then
                creates (or reopens) their plan and lands in the designer. -->
           <details style="border-top:1px solid var(--line-2);">
-            <summary style="list-style:none;cursor:pointer;padding:11px 16px;font-size:12.5px;font-weight:650;color:var(--accent-ink);">+ New program</summary>
+            <summary style="list-style:none;cursor:pointer;padding:11px 16px;font-size:12.5px;font-weight:650;color:var(--accent);">+ New program</summary>
             <div style="display:flex;flex-direction:column;gap:8px;padding:4px 16px 16px;">
               {% if athletes %}
                 <p class="meso-sub" style="margin:0 0 2px;">Pick an athlete to start a program for.</p>
@@ -232,7 +232,7 @@
 
           <!-- Create a brand-new group (Phase 2b): name + focus + pick members. -->
           <details style="border-top:1px solid var(--line-2);">
-            <summary style="list-style:none;cursor:pointer;padding:11px 16px;font-size:12.5px;font-weight:650;color:var(--accent-ink);">+ New group</summary>
+            <summary style="list-style:none;cursor:pointer;padding:11px 16px;font-size:12.5px;font-weight:650;color:var(--accent);">+ New group</summary>
             <form method="post" action="{% url 'meso:group_create' %}" style="display:flex;flex-direction:column;gap:11px;padding:4px 16px 16px;">
               {% csrf_token %}
               <input name="name" required maxlength="255" placeholder="Group name" style="appearance:none;border:1px solid var(--line);border-radius:8px;background:var(--rail);font:inherit;font-size:13px;color:var(--ink);padding:8px 10px;outline:none;" />


### PR DESCRIPTION
Closes #422

`--accent-ink` is white — it's the "ink ON accent" token (`.meso-btn--primary` text, brand-mark glyph). Several templates used it as a *text/border color on white cards*, rendering invisible-but-clickable UI. Verified live before the fix: the demo roster's "create a free account" signup link and the coach roster's "+ Invite an athlete" / "+ New program" / "+ New group" controls were white-on-white.

## What changed (templates only; the token itself is untouched — its value is correct for its purpose)

`color/border var(--accent-ink)` → `var(--accent)` (steel-blue, the `.meso-crumbs a` pattern) at **11 sites** — the issue's six plus five more of the same bug class found by a full `accent-ink` audit:

- `roster.html` ×5 — "· Past athletes →", sandbox signup link, and the three `<summary>` controls
- `coach_billing.html` ×1 — "Designer" link
- `athlete_home.html` ×3 — "+ Request a coach" summary, install-prompt + first-log coachmark border stripes
- `athlete_session.html` ×1 — first-log coachmark border stripe
- `_meso_base.html` ×1 — non-error flash-message accent stripe (the sandbox banner right above it already used `var(--accent)` correctly)

The coachmark-stripe fixes match the designer island's own `.meso-coachmark` CSS, which uses `border-left: 3px solid var(--accent)` for the identical pattern.

**Audited and correctly kept** (genuinely on accent-filled backgrounds): `.meso-btn--primary`/`hover`, `.meso-brand-mark i`, the set-done checkmark glyph, the deliver week-chip `is_target` branch, and the designer island's scoped variable re-declaration. The React designer island's own CSS is a separate build pipeline and out of scope.

## Validation

- `just lint` clean; meso suite 1667 passed (template-only change).
- Visual: seeded server + Playwright screenshot of the coach roster — all four roster controls now clearly visible steel-blue.
- Codex review loop: CLEAN (0 blocking, 0 nits).
