### PR TITLE
feat(deploy): make web rolling-deploy ready (graceful drain + dynamic upstreams)

### DIFF
--- a/caddy/fitness-store.caddy
+++ b/caddy/fitness-store.caddy
@@ -16,7 +16,22 @@ yourdomain.com {
         Referrer-Policy strict-origin-when-cross-origin
     }
 
-    reverse_proxy fitness-store-web:8000 {
+    reverse_proxy {
+        # Dynamic upstreams: re-resolve the proxy-network alias every few seconds
+        # instead of pinning one IP at config load. During a rolling deploy both
+        # the old and new container share the `fitness-store-web` alias, so Caddy
+        # load-balances across both; when the old one is removed it drops out of
+        # the pool on the next refresh. Paired with lb_retries + fail_duration
+        # this makes the container swap seamless (no 502 on teardown).
+        dynamic a {
+            name fitness-store-web
+            port 8000
+            refresh 3s
+        }
+        lb_policy round_robin
+        lb_retries 2
+        fail_duration 10s
+
         header_up X-Real-IP {remote_host}
         header_up X-Forwarded-Proto {scheme}
         header_up X-Forwarded-Host {host}

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -45,6 +45,10 @@ services:
       context: .
     image: fitness-store-app # shared by the qcluster worker (same code, diff command)
     restart: unless-stopped
+    # During a rolling deploy the old container is `docker stop`ped once the new
+    # one is healthy; this gives gunicorn up to 30s (its default graceful-timeout)
+    # to finish in-flight requests on SIGTERM before SIGKILL, so no request is cut.
+    stop_grace_period: 30s
     env_file:
       - .env
     environment:


### PR DESCRIPTION
## Why
Prep so mastering.fitness deploys become zero-downtime. Pairs with **lancegoyke/deploy#44**, which adds the opt-in `ROLLING_SERVICE` rolling-replace mechanism to `project-deploy.sh`. This PR makes the `web` service's container swap seamless.

## What
- **`docker-compose.production.yml`** — add `stop_grace_period: 30s` to `web` so gunicorn gets its full default graceful-timeout to drain in-flight requests on SIGTERM before SIGKILL when the old container is stopped during a roll.
- **`caddy/fitness-store.caddy`** — switch `reverse_proxy` from a single static upstream to **dynamic A-record upstreams** on the `fitness-store-web` alias (`refresh 3s`) with `lb_retries 2` + `fail_duration 10s`. During a roll both the old and new container share the alias, so Caddy load-balances across both and drops the old one the instant it disappears — no 502 on teardown. With a single container it behaves exactly as today.

## Testing
- `caddy validate` passes against **caddy:2.10.2** (the box's exact version) — `dynamic a` module present, config valid.
- `docker compose config` passes; `stop_grace_period: 30s` resolves under `web`.

Both changes are safe to deploy **before** rolling is enabled (harmless with one container). This deploy is the last one with a brief 502 window; enabling `ROLLING_SERVICE=web` afterward closes it.