### PR TITLE
feat(meso): host the walkthrough video on S3 and embed it on the landing page

### DIFF
--- a/app/config/settings/base.py
+++ b/app/config/settings/base.py
@@ -344,6 +344,23 @@ MESO_SANDBOX_TTL_HOURS = int(os.environ.get("MESO_SANDBOX_TTL_HOURS", "48"))
 MESO_SANDBOX_PER_IP_PER_HOUR = int(os.environ.get("MESO_SANDBOX_PER_IP_PER_HOUR", "5"))
 MESO_SANDBOX_MAX_CONCURRENT = int(os.environ.get("MESO_SANDBOX_MAX_CONCURRENT", "100"))
 
+# Public walkthrough video (issue #415 follow-up to #388). `just record-demo`
+# regenerates docs/demo/out/meso-walkthrough.mp4 (git-ignored); `just
+# publish-demo-video` (scripts/publish_demo_video.py) uploads it — plus a
+# poster frame — to the `masterfit` S3 bucket at a fixed public key, so these
+# defaults work with zero config in every environment (the bucket serves
+# public-read objects unsigned; see AWS_S3_OBJECT_PARAMETERS above). Override
+# to "" to hide the landing page's video section entirely (e.g. mid-refresh,
+# before a first upload).
+MESO_DEMO_VIDEO_URL = os.environ.get(
+    "MESO_DEMO_VIDEO_URL",
+    "https://masterfit.s3.amazonaws.com/meso/demo/meso-walkthrough.mp4",
+)
+MESO_DEMO_VIDEO_POSTER_URL = os.environ.get(
+    "MESO_DEMO_VIDEO_POSTER_URL",
+    "https://masterfit.s3.amazonaws.com/meso/demo/meso-walkthrough-poster.webp",
+)
+
 # Cache
 
 DEFAULT_CACHE_TIMEOUT = 604800  # one week

--- a/app/store_project/meso/tests/test_landing.py
+++ b/app/store_project/meso/tests/test_landing.py
@@ -25,6 +25,8 @@ These tests cover:
 import re
 
 import pytest
+from django.conf import settings
+from django.test import override_settings
 from django.urls import reverse
 
 from store_project.meso import presenters
@@ -154,6 +156,47 @@ class TestLandingContent:
         """A pricing signal renders from the shared constant, not a hardcoded string."""
         resp = client.get(reverse("meso:roster"))
         assert presenters.PRICE_SUMMARY in resp.content.decode()
+
+
+# ---------------------------------------------------------------------------
+# Hosted walkthrough video (issue #415 follow-up to #388)
+# ---------------------------------------------------------------------------
+
+
+class TestLandingDemoVideo:
+    def test_video_section_renders_with_settings_url(self, client):
+        """The <video> section renders from settings, not a hardcoded URL."""
+        resp = client.get(reverse("meso:roster"))
+        body = resp.content.decode()
+        assert "<video" in body
+        assert f'<source src="{settings.MESO_DEMO_VIDEO_URL}"' in body
+        assert 'type="video/mp4"' in body
+
+    def test_poster_renders_from_settings(self, client):
+        resp = client.get(reverse("meso:roster"))
+        body = resp.content.decode()
+        assert f'poster="{settings.MESO_DEMO_VIDEO_POSTER_URL}"' in body
+
+    def test_preload_none_guards_page_weight(self, client):
+        """The page-weight guarantee.
+
+        An anonymous visit must not fetch the video unless the visitor
+        presses play — the only thing that should load unconditionally is
+        the poster.
+        """
+        resp = client.get(reverse("meso:roster"))
+        assert 'preload="none"' in resp.content.decode()
+
+    @override_settings(MESO_DEMO_VIDEO_URL="")
+    def test_hidden_when_url_is_blank(self, client):
+        """An empty override hides the section, not a broken/empty player.
+
+        E.g. mid-refresh, before a first upload.
+        """
+        resp = client.get(reverse("meso:roster"))
+        body = resp.content.decode()
+        assert "<video" not in body
+        assert "See it in action" not in body
 
 
 # ---------------------------------------------------------------------------

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -321,6 +321,13 @@ class RosterView(TemplateView):
                     # same constant the roster/billing/designer surfaces render,
                     # so the price can't drift out of sync with the landing page.
                     "price_summary": presenters.PRICE_SUMMARY,
+                    # The hosted walkthrough video (issue #415 follow-up to
+                    # #388) — settings-driven so `just record-demo && just
+                    # publish-demo-video` is the entire refresh story; an empty
+                    # override hides the section (template checks
+                    # `{% if demo_video_url %}`).
+                    "demo_video_url": settings.MESO_DEMO_VIDEO_URL,
+                    "demo_video_poster_url": settings.MESO_DEMO_VIDEO_POSTER_URL,
                 },
             )
         if not _is_coach(request.user):

--- a/app/store_project/templates/meso/landing.html
+++ b/app/store_project/templates/meso/landing.html
@@ -98,6 +98,41 @@ visitor — demo/trial lead, athlete login is a compact strip, not a card.
       <span class="meso-row-meta">Training with a coach? <a href="{% url 'account_login' %}?next={{ athlete_next|urlencode }}" style="color:var(--accent);font-weight:600;">Log in to your training</a> — or tap the link in your email invite.</span>
     </div>
 
+    {% comment %}
+      Hosted walkthrough video (issue #415 follow-up to #388) — the real coach
+      flow (roster -> athlete -> designer -> agent proposal -> review ->
+      deliver), captured by `just record-demo` and hosted on S3 by
+      `just publish-demo-video` (scripts/publish_demo_video.py). Both write to
+      fixed keys, so refreshing after a UI change is just re-running those two
+      commands — nothing here or in settings needs to change.
+
+      `preload="none"` + this `{% if %}` guard are the page-weight guarantee:
+      an anonymous visit that never presses play costs nothing beyond the
+      ~50KB poster image, and the whole section (including that image) simply
+      isn't in the page when the setting is blanked (e.g. mid-refresh, before
+      a first upload). Framed with `.meso-hero-shot` (meso.css) — the same
+      card chrome as the hero screenshot above, so the two product visuals on
+      this page read as one system.
+    {% endcomment %}
+    {% if demo_video_url %}
+      <div class="meso-card meso-card--pad" style="text-align:center;margin-bottom:18px;">
+        <p class="meso-eyebrow">See it in action</p>
+        <p style="font-size:18px;font-weight:800;letter-spacing:-0.02em;margin:6px 0 16px;">The coach flow, start to finish — about a minute</p>
+        <video
+          class="meso-hero-shot"
+          controls
+          preload="none"
+          {% if demo_video_poster_url %}poster="{{ demo_video_poster_url }}"{% endif %}
+          width="1280"
+          height="720"
+          aria-label="Walkthrough of the Meso coach flow: roster, athlete profile, designer, AI agent proposal, review, and delivery."
+        >
+          <source src="{{ demo_video_url }}" type="video/mp4" />
+          <p class="meso-row-meta">Your browser doesn't support embedded video. <a href="{{ demo_video_url }}" style="color:var(--accent);font-weight:600;">Download the video</a> instead.</p>
+        </video>
+      </div>
+    {% endif %}
+
     <!-- How it works, one line each. -->
     <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:14px;">
       <div class="meso-card meso-card--pad">

--- a/justfile
+++ b/justfile
@@ -126,3 +126,13 @@ capture-landing-still:
     docker compose up -d --wait
     just frontend-build
     uv run python scripts/capture_landing_still.py
+
+# Publish the walkthrough video (docs/demo/out/meso-walkthrough.mp4) + a poster
+# frame to S3 (issue #415 follow-up) so the Meso landing page has something to
+# embed. Needs a video to already exist — this doesn't record one. No docker
+# services required (it's just an upload). The full refresh loop, after any UI
+# change, is:
+#
+#     just record-demo && just publish-demo-video
+publish-demo-video:
+    uv run python scripts/publish_demo_video.py

--- a/scripts/publish_demo_video.py
+++ b/scripts/publish_demo_video.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Publish the Meso walkthrough demo video (issue #388) for public hosting.
+
+`just record-demo` (``scripts/record_demo.py``) writes a fresh
+``docs/demo/out/meso-walkthrough.mp4`` — a git-ignored local artifact. This
+script is the other half: it uploads that file to the ``masterfit`` S3 bucket
+(where all other site media already lives) at a fixed, public key, plus a
+poster frame for the landing page's ``<video poster=...>``, so the Meso
+landing page (issue #415 follow-up) has something stable to embed.
+
+The whole refresh loop, end to end, is two commands:
+
+    just record-demo && just publish-demo-video
+
+Both objects are uploaded to the *same* key every time (no versioning by
+timestamp/hash) — the landing page's URL never changes, so re-running this
+after a UI change is the entire "update the video" story; nothing in
+settings or the template needs touching.
+
+Uploaded objects (``ACL: public-read``, matching every other object this app
+puts in the bucket — see ``AWS_S3_OBJECT_PARAMETERS`` in
+``config/settings/production.py``):
+
+    s3://masterfit/meso/demo/meso-walkthrough.mp4
+    s3://masterfit/meso/demo/meso-walkthrough-poster.webp
+
+Run via ``just publish-demo-video`` (``uv run python
+scripts/publish_demo_video.py``). Needs ``AWS_ACCESS_KEY_ID`` /
+``AWS_SECRET_ACCESS_KEY`` for an IAM identity with ``s3:PutObject`` on the
+bucket (see ``resolve_aws_credentials`` below for where those are read from)
+and, for the poster, ``ffmpeg`` on ``PATH`` (or Playwright's bundled copy —
+reuses ``record_demo.find_ffmpeg``).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from io import BytesIO
+from pathlib import Path
+
+import boto3
+from boto3.exceptions import S3UploadFailedError
+from botocore.exceptions import ClientError
+from dotenv import dotenv_values
+from PIL import Image
+from record_demo import REPO_ROOT
+from record_demo import find_ffmpeg
+from record_demo import log
+
+VIDEO_PATH = REPO_ROOT / "docs" / "demo" / "out" / "meso-walkthrough.mp4"
+
+BUCKET = "masterfit"
+VIDEO_KEY = "meso/demo/meso-walkthrough.mp4"
+POSTER_KEY = "meso/demo/meso-walkthrough-poster.webp"
+
+# masterfit's actual bucket region (``aws s3api get-bucket-location --bucket
+# masterfit`` -> us-west-1) — passed explicitly so boto3 talks to the right
+# regional endpoint on the first request instead of round-tripping through
+# botocore's cross-region redirect handling. Overridable for parity with how
+# every other AWS_* setting in this app is env-overridable.
+DEFAULT_AWS_REGION = "us-west-1"
+
+# A real ~20s 1280x720 recording (docs/demo/README.md's storyboard) lands
+# around 500-700 KB once ffmpeg's re-encoded it to h264/mp4. 50 KB is well
+# below any legitimate recording and well above a truncated/zero-byte write —
+# generous on purpose, this is a truncation/corruption guard, not a quality gate.
+MIN_VIDEO_BYTES = 50 * 1024
+
+# The poster is grabbed mid-video, not frame 0 (a blank/loading first paint).
+# Timestamp picked by eyeballing a `ffmpeg -vf fps=1/2` contact sheet of the
+# current recording: 8s lands on STEP 4's resolved agent proposal — the diff
+# list ("Bulgarian Split Squat -> Hip Thrust", etc.) and "Review N changes" CTA
+# next to the populated week grid, the single frame that best shows the
+# propose -> review -> approve pitch. Re-eyeball this constant if a storyboard
+# edit (record_demo.py) reshuffles step order/timing enough to land it
+# somewhere less representative (e.g. a loading state or blank composer).
+POSTER_TIMESTAMP_SECONDS = 8.0
+POSTER_SIZE = (1280, 720)  # matches record_demo.VIEWPORT — no letterboxing
+WEBP_QUALITY = 82
+POSTER_MAX_BYTES = 60 * 1024  # comfortably under the "well under 100KB" bar
+
+
+def check_video():
+    if not VIDEO_PATH.exists():
+        sys.exit(
+            f"FAILED: {VIDEO_PATH.relative_to(REPO_ROOT)} doesn't exist — run "
+            "`just record-demo` first."
+        )
+    size = VIDEO_PATH.stat().st_size
+    if size < MIN_VIDEO_BYTES:
+        sys.exit(
+            f"FAILED: {VIDEO_PATH.relative_to(REPO_ROOT)} is only {size} bytes "
+            f"(< {MIN_VIDEO_BYTES} byte floor) — looks empty/truncated, not a "
+            "real recording. Re-run `just record-demo` and check its output."
+        )
+    return size
+
+
+def extract_poster(video_path: Path) -> bytes:
+    """Grab one frame at POSTER_TIMESTAMP_SECONDS and encode it as WebP.
+
+    Mirrors ``capture_landing_still.optimize()``'s quality-stepping loop —
+    same target (a small, well-compressed still), same tool (Pillow).
+    """
+    ffmpeg_path = find_ffmpeg()
+    if not ffmpeg_path:
+        sys.exit(
+            "FAILED: no ffmpeg found (system PATH or Playwright's bundled "
+            "copy) — can't extract a poster frame. Install ffmpeg and re-run."
+        )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        raw_png = Path(tmpdir) / "poster-raw.png"
+        cmd = [
+            ffmpeg_path,
+            "-y",
+            "-ss",
+            str(POSTER_TIMESTAMP_SECONDS),
+            "-i",
+            str(video_path),
+            "-frames:v",
+            "1",
+            str(raw_png),
+        ]
+        log(f"$ {' '.join(cmd)}")
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0 or not raw_png.exists():
+            sys.stderr.write(result.stderr)
+            sys.exit("FAILED: ffmpeg couldn't extract the poster frame.")
+
+        with Image.open(raw_png) as im:
+            im = im.convert("RGB")
+            if im.size != POSTER_SIZE:
+                im = im.resize(POSTER_SIZE, Image.LANCZOS)
+            quality = WEBP_QUALITY
+            while True:
+                buf = BytesIO()
+                im.save(buf, "WEBP", quality=quality, method=6)
+                data = buf.getvalue()
+                if len(data) <= POSTER_MAX_BYTES or quality <= 40:
+                    break
+                quality -= 10
+    return data
+
+
+def resolve_aws_credentials():
+    """Resolve the AWS creds this upload should authenticate with.
+
+    Already-exported process env wins (CI/the Hetzner box, where a real
+    deploy session may already have them), else ``.env`` — the same source
+    ``AWS_ACCESS_KEY_ID``/``AWS_SECRET_ACCESS_KEY`` come from everywhere else
+    in this app (``get_env_var()`` in ``config/settings/base.py``).
+    Deliberately doesn't fall through to boto3's own default chain (an IAM
+    role, ``~/.aws/credentials``, ...) — that would let a missing/typo'd
+    ``.env`` entry silently pick up some unrelated ambient credential instead
+    of failing loudly.
+    """
+    from_env = {
+        "aws_access_key_id": os.environ.get("AWS_ACCESS_KEY_ID"),
+        "aws_secret_access_key": os.environ.get("AWS_SECRET_ACCESS_KEY"),
+    }
+    if from_env["aws_access_key_id"] and from_env["aws_secret_access_key"]:
+        return from_env
+
+    dotenv = dotenv_values(REPO_ROOT / ".env")
+    from_dotenv = {
+        "aws_access_key_id": dotenv.get("AWS_ACCESS_KEY_ID"),
+        "aws_secret_access_key": dotenv.get("AWS_SECRET_ACCESS_KEY"),
+    }
+    if from_dotenv["aws_access_key_id"] and from_dotenv["aws_secret_access_key"]:
+        return from_dotenv
+
+    sys.exit(
+        "FAILED: no AWS credentials found (checked the process env, then "
+        ".env) — set AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY."
+    )
+
+
+def s3_client():
+    creds = resolve_aws_credentials()
+    region = os.environ.get("AWS_S3_REGION_NAME") or DEFAULT_AWS_REGION
+    return boto3.client(
+        "s3",
+        region_name=region,
+        aws_access_key_id=creds["aws_access_key_id"],
+        aws_secret_access_key=creds["aws_secret_access_key"],
+    )
+
+
+def upload(s3, path_or_bytes, key, content_type, *, is_path):
+    extra_args = {
+        "ACL": "public-read",
+        "ContentType": content_type,
+        "CacheControl": "max-age=86400",
+    }
+    try:
+        if is_path:
+            # upload_file's transfer manager wraps any ClientError (e.g. a bad
+            # key) in its own S3UploadFailedError rather than raising it
+            # directly — catch both.
+            s3.upload_file(
+                Filename=str(path_or_bytes),
+                Bucket=BUCKET,
+                Key=key,
+                ExtraArgs=extra_args,
+            )
+        else:
+            s3.put_object(
+                Bucket=BUCKET,
+                Key=key,
+                Body=path_or_bytes,
+                **extra_args,
+            )
+    except (ClientError, S3UploadFailedError) as exc:
+        sys.exit(
+            f"FAILED: S3 upload of {key} failed ({exc}). If this is "
+            "InvalidAccessKeyId/InvalidClientTokenId/SignatureDoesNotMatch, "
+            "check AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY in .env — that "
+            "key may be stale/rotated."
+        )
+
+
+def public_url(key):
+    return f"https://{BUCKET}.s3.amazonaws.com/{key}"
+
+
+def main():
+    video_size = check_video()
+    log(f"video: {VIDEO_PATH.relative_to(REPO_ROOT)} ({video_size / 1024:.0f} KB)")
+
+    poster_bytes = extract_poster(VIDEO_PATH)
+    log(f"poster: extracted ({len(poster_bytes) / 1024:.1f} KB)")
+
+    s3 = s3_client()
+
+    log(f"uploading video -> s3://{BUCKET}/{VIDEO_KEY}")
+    upload(s3, VIDEO_PATH, VIDEO_KEY, "video/mp4", is_path=True)
+
+    log(f"uploading poster -> s3://{BUCKET}/{POSTER_KEY}")
+    upload(s3, poster_bytes, POSTER_KEY, "image/webp", is_path=False)
+
+    log(
+        "\ndone:\n"
+        f"  {public_url(VIDEO_KEY)} ({video_size / 1024:.0f} KB)\n"
+        f"  {public_url(POSTER_KEY)} ({len(poster_bytes) / 1024:.1f} KB)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/publish_demo_video.py
+++ b/scripts/publish_demo_video.py
@@ -160,6 +160,9 @@ def resolve_aws_credentials():
     from_env = {
         "aws_access_key_id": os.environ.get("AWS_ACCESS_KEY_ID"),
         "aws_secret_access_key": os.environ.get("AWS_SECRET_ACCESS_KEY"),
+        # Temporary STS/SSO credentials are only valid with their session
+        # token; long-lived IAM user keys have none, so this stays optional.
+        "aws_session_token": os.environ.get("AWS_SESSION_TOKEN"),
     }
     if from_env["aws_access_key_id"] and from_env["aws_secret_access_key"]:
         return from_env
@@ -168,6 +171,7 @@ def resolve_aws_credentials():
     from_dotenv = {
         "aws_access_key_id": dotenv.get("AWS_ACCESS_KEY_ID"),
         "aws_secret_access_key": dotenv.get("AWS_SECRET_ACCESS_KEY"),
+        "aws_session_token": dotenv.get("AWS_SESSION_TOKEN"),
     }
     if from_dotenv["aws_access_key_id"] and from_dotenv["aws_secret_access_key"]:
         return from_dotenv
@@ -186,6 +190,7 @@ def s3_client():
         region_name=region,
         aws_access_key_id=creds["aws_access_key_id"],
         aws_secret_access_key=creds["aws_secret_access_key"],
+        aws_session_token=creds["aws_session_token"],
     )
 
 
@@ -193,7 +198,10 @@ def upload(s3, path_or_bytes, key, content_type, *, is_path):
     extra_args = {
         "ACL": "public-read",
         "ContentType": content_type,
-        "CacheControl": "max-age=86400",
+        # These keys are fixed and overwritten on every publish — "no-cache"
+        # makes browsers revalidate (ETag 304 when unchanged) instead of
+        # serving a stale walkthrough for up to a day after a refresh.
+        "CacheControl": "no-cache",
     }
     try:
         if is_path:

--- a/scripts/publish_demo_video.py
+++ b/scripts/publish_demo_video.py
@@ -89,6 +89,17 @@ def check_video():
             f"FAILED: {VIDEO_PATH.relative_to(REPO_ROOT)} doesn't exist — run "
             "`just record-demo` first."
         )
+    # A successful record-demo run deletes its intermediate .webm after mp4
+    # conversion — one left behind means the LATEST run fell back to WebM
+    # (e.g. ffmpeg without libx264) and this .mp4 is a stale earlier take.
+    fallback_webm = VIDEO_PATH.with_suffix(".webm")
+    if fallback_webm.exists():
+        sys.exit(
+            f"FAILED: {fallback_webm.relative_to(REPO_ROOT)} exists, so the "
+            "last `just record-demo` run fell back to WebM and the .mp4 here "
+            "is from an older take. Fix the mp4 conversion (ffmpeg with "
+            "libx264), re-run `just record-demo`, then publish."
+        )
     size = VIDEO_PATH.stat().st_size
     if size < MIN_VIDEO_BYTES:
         sys.exit(


### PR DESCRIPTION
First #415 follow-up (refs #415, #388): the walkthrough video is now hosted and embedded — a visitor can watch the coach flow (~22s) without entering the demo.

## What changed

- **Hosting**: `scripts/publish_demo_video.py` + `just publish-demo-video` upload the #388 artifact and an ffmpeg-extracted poster frame to the `masterfit` media bucket at fixed public-read keys. Both are live and verified:
  - `https://masterfit.s3.amazonaws.com/meso/demo/meso-walkthrough.mp4` (573 KB, h264 1280×720)
  - `https://masterfit.s3.amazonaws.com/meso/demo/meso-walkthrough-poster.webp` (53.8 KB — t=8.0s, the resolved agent-proposal frame)
  - Refresh loop: `just record-demo && just publish-demo-video`. Objects serve `Cache-Control: no-cache` so a republish is visible immediately (ETag 304s keep revalidation cheap).
- **Settings**: `MESO_DEMO_VIDEO_URL` / `MESO_DEMO_VIDEO_POSTER_URL` in base.py, env-overridable, defaulting to the S3 URLs; empty override hides the section.
- **Landing embed**: "See it in action" section between the athlete strip and the Design/Deliver/Adapt row — `<video controls preload="none">` framed with the hero's `.meso-hero-shot` chrome. Only the poster loads until someone presses play.
- **Guardrails in the publish script**: refuses a missing/truncated mp4, refuses a stale mp4 when the last recording fell back to WebM (a lingering `.webm` proves the mp4 is an older take), honors `AWS_SESSION_TOKEN` for temporary credentials, and pins the bucket's real region (us-west-1).

## Validation

- `just lint` clean; meso suite 1671 passed (new `TestLandingDemoVideo`: renders with settings URL, poster present, `preload="none"` asserted, hidden when URL blank).
- Codex review loop: 3 iterations — 2 nits fixed (session token, cache staleness; live objects republished with `no-cache`), then 1 nit fixed (stale-mp4 guard), then CLEAN.

## Heads-up (not in this PR)

The `AWS_ACCESS_KEY_ID` in the local `.env` is dead (`InvalidAccessKeyId` on every call) — it never surfaces because local dev overrides `STORAGES` to the filesystem. The publish above used the machine's own AWS profile. Worth rotating/replacing the `.env` entry.
