### PR TITLE
fix(meso): drop the duplicate 'live demo' welcome flash (#425)

### DIFF
--- a/app/store_project/meso/tests/test_sandbox.py
+++ b/app/store_project/meso/tests/test_sandbox.py
@@ -209,15 +209,19 @@ class TestSandboxEnterView:
         assert resp.status_code == 200
         assert b"Roster" in resp.content
 
-    def test_welcome_flash_does_not_promise_kept_work(self, client):
-        """No "keep your work" over-promise in the welcome flash.
+    def test_entry_shows_a_single_live_demo_message(self, client):
+        """Landing on the roster shows the "live demo" message exactly once.
+
+        The persistent sandbox banner (_meso_base.html) already carries it on
+        every screen; a welcome flash on entry duplicated it on the roster
+        (issue #425). The banner is the single source of that copy now.
 
         Carry-over is deferred (S6): signup starts a FRESH workspace, so no
         copy may promise the visitor keeps their sandbox work.
         """
         resp = client.get(reverse("meso:sandbox_enter"), follow=True)
         body = resp.content.decode()
-        assert "You&#x27;re in a live demo" in body  # the flash rendered
+        assert body.lower().count("live demo") == 1  # the banner, not also a flash
         assert "keep your work" not in body
 
     def test_expiry_is_about_48_hours_out(self, client):

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -815,14 +815,11 @@ def sandbox_enter(request):
     # Two auth backends are configured (ModelBackend + allauth) — login() can't
     # infer which one, so it must be named explicitly.
     login(request, user, backend="django.contrib.auth.backends.ModelBackend")
-    # No "keep your work" promise: carry-over at signup is deferred (S6) — a
-    # new account starts a fresh workspace.
-    messages.success(
-        request,
-        "You're in a live demo — explore freely. Create a free account any "
-        f"time to start a {CoachSubscription.TRIAL_DAYS}-day free trial and "
-        "run the AI agent.",
-    )
+    # No welcome flash: the persistent sandbox banner (_meso_base.html) already
+    # says "You're in a live demo" on every screen, so a flash on entry only
+    # duplicated it on the roster (issue #425). Carry-over at signup is deferred
+    # (S6) — a new account starts a fresh workspace, and neither surface promises
+    # kept work.
     return _noindex(redirect("meso:roster"))
 
 


### PR DESCRIPTION
## Problem

On the `/meso/` roster, sandbox visitors saw the "You're in a live demo…" message **twice**.

Entering the sandbox (`demo_enter`) set a `messages.success` welcome flash saying *"You're in a live demo — explore freely…"* and then redirected to the roster. The roster — like every sandbox screen — also renders the **persistent sandbox banner** (`_meso_base.html`) with the same *"You're in a live demo…"* copy. So the roster stacked the two on top of each other.

Fixes #425.

## Fix

The persistent banner is the intended, always-on source of that messaging (issue #389, Phase 1) — it stays visible on every sandbox page, unlike a one-shot flash. So the entry flash was pure duplication. Removed it.

- `demo_enter` no longer emits a welcome flash; the login + redirect are unchanged, and the banner still greets the visitor on the roster.
- No over-promise regression: the "no keep your work" constraint (S6) already lives in the banner copy and its test.

## Test

Refocused the old `test_welcome_flash_does_not_promise_kept_work` into `test_entry_shows_a_single_live_demo_message`, which now asserts the roster body contains "live demo" **exactly once** — a direct regression guard for this bug (it was 2 before, 1 after).

`uv run pytest app/store_project/meso/tests/test_sandbox.py` → 75 passed. `ruff check` clean.