### PR TITLE
refactor(meso): segment the demo loaders behind load_demo (#430 Phase 1)

### DIFF
--- a/app/store_project/meso/demo.py
+++ b/app/store_project/meso/demo.py
@@ -71,33 +71,186 @@ def _demo_athletes(coach):
 
 def has_demo(coach):
     """Whether this coach currently has demo data loaded."""
-    return CoachAthlete.objects.for_coach(coach).filter(is_demo=True).exists()
+    return has_athletes(coach)
+
+
+def _lock(coach):
+    """Serialize concurrent loads for this coach (double-submit protection).
+
+    A per-coach row lock — real only inside a transaction, on a backend that
+    supports it (Postgres); a no-op on the SQLite test DB, where requests
+    don't race anyway. Called at the top of **every** segment loader, not just
+    the aggregate: once the guided tour (Phase 2) wires each segment to its own
+    POST endpoint, a segment can be loaded on its own — with no ``load_demo``
+    call wrapping it — so it needs the same double-submit protection ``load_demo``
+    always had. Re-acquiring the same row lock from nested segment calls within
+    one transaction (e.g. ``load_log`` → ``load_delivery`` → ``load_program`` →
+    ``load_athletes``) is harmless — it's the same connection re-affirming a
+    lock it already holds, not a new wait.
+    """
+    User.objects.select_for_update().get(pk=coach.pk)
+
+
+def _demo_athlete_and_link(coach, slug):
+    """The demo athlete + link for ``slug``, assuming ``load_athletes`` already ran."""
+    athlete = User.objects.get(email=demo_email(coach, slug))
+    link = CoachAthlete.objects.get(coach=coach, athlete=athlete)
+    return athlete, link
+
+
+# -- segment loaders ----------------------------------------------------------
+#
+# Per-feature slices of ``load_demo`` (guided-tour Phase 1, decision O3): each
+# is idempotent and ensures its own prerequisites, so the tour (Phase 2) can
+# fire any one of them, in any order, from its own step/endpoint. ``load_demo``
+# below is the thin aggregate that runs all five — the O6 "skip · load
+# everything" path and the pre-tour ``demo_load`` view behavior.
+
+
+@transaction.atomic
+def load_athletes(coach):
+    """Segment: the 5 demo athlete users + active demo links. No prerequisites."""
+    _lock(coach)
+    today = date.today()
+    for spec in ATHLETES:
+        athlete = _ensure_demo_athlete(coach, spec, today)
+        _ensure_demo_link(coach, athlete)
+
+
+@transaction.atomic
+def load_program(coach):
+    """Segment: Maya's "Hypertrophy Block" plan tree. Depends on ``athletes``."""
+    _lock(coach)
+    load_athletes(coach)
+    _, maya_link = _demo_athlete_and_link(coach, "maya")
+    _ensure_demo_plan(maya_link)
+
+
+@transaction.atomic
+def load_delivery(coach):
+    """Segment: deliver Maya's current week. Depends on ``program``."""
+    _lock(coach)
+    load_program(coach)
+    _, maya_link = _demo_athlete_and_link(coach, "maya")
+    plan = _ensure_demo_plan(maya_link)
+    _ensure_demo_delivery(plan)
+
+
+@transaction.atomic
+def load_log(coach):
+    """Segment: log Maya's Lower session + refresh her 1RM.
+
+    Depends on ``delivery`` (in the real workflow an athlete can't log a
+    session that was never delivered to them), which in turn pulls in
+    ``program``/``athletes``.
+    """
+    _lock(coach)
+    load_delivery(coach)
+    maya, maya_link = _demo_athlete_and_link(coach, "maya")
+    plan = _ensure_demo_plan(maya_link)
+    _ensure_demo_log(maya, plan, date.today())
+
+
+@transaction.atomic
+def load_group(coach):
+    """Segment: Strength Squad + shared plan + per-athlete overrides.
+
+    Depends on ``athletes`` only — the group has its own shared plan, separate
+    from Maya's individual one, so it never needs ``program``/``delivery``/``log``.
+    """
+    _lock(coach)
+    load_athletes(coach)
+    athletes = {
+        slug: _demo_athlete_and_link(coach, slug) for slug in GROUP["member_slugs"]
+    }
+    _ensure_demo_group(coach, athletes)
+
+
+#: Segment name → loader, for views to dispatch a per-segment load by POST field.
+SEGMENTS = {
+    "athletes": load_athletes,
+    "program": load_program,
+    "delivery": load_delivery,
+    "log": load_log,
+    "group": load_group,
+}
 
 
 @transaction.atomic
 def load_demo(coach):
-    """Stand up (or top up) this coach's demo workspace. Idempotent.
+    """Stand up (or top up) this coach's whole demo workspace. Idempotent.
 
-    Re-running never duplicates: every row is upserted by its natural key, the
-    plan tree is only built when absent, and the demo week is delivered only once.
+    A thin aggregate over the segment loaders above — the O6 "skip · load
+    everything" path and the pre-tour behavior of the ``demo_load`` view keep
+    working exactly as before the split. Re-running never duplicates: every
+    row is upserted by its natural key, the plan tree is only built when
+    absent, and the demo week is delivered only once.
 
-    Concurrency: a per-coach row lock serializes two concurrent loads (a
-    double-submit / retry) so the second waits and then reuses what the first
-    created, rather than both seeing "no plan" and each building one. (The
-    decorator's ``atomic`` makes the lock real on Postgres; it's a no-op on the
-    SQLite test DB, where requests don't race anyway.)
+    Concurrency: see ``_lock`` — every segment loader locks the coach row
+    itself, so this aggregate doesn't need to *also* hold its own lock for
+    correctness. It still takes one anyway: a single lock acquisition up front
+    means a concurrent ``load_demo`` retry blocks for the whole aggregate
+    rather than interleaving segment-by-segment with another in-flight call.
     """
-    User.objects.select_for_update().get(pk=coach.pk)
-    today = date.today()
-    athletes = {}
-    for spec in ATHLETES:
-        athlete = _ensure_demo_athlete(coach, spec, today)
-        link = _ensure_demo_link(coach, athlete)
-        athletes[spec["slug"]] = (athlete, link)
-    maya, maya_link = athletes["maya"]
-    plan = _ensure_demo_plan(maya_link)
-    _ensure_demo_log(maya, plan, today)
-    _ensure_demo_group(coach, athletes)
+    _lock(coach)
+    load_athletes(coach)
+    load_program(coach)
+    load_delivery(coach)
+    load_log(coach)
+    load_group(coach)
+
+
+# -- per-segment "is it loaded?" predicates ------------------------------------
+#
+# Mirrors ``has_demo``: loaded-ness is derived from data, never stored (O7), so
+# the tour can ask "has this step's data already been added?" without its own
+# state. Kept cheap (``exists()``), ``is_demo``-scoped.
+
+
+def has_athletes(coach):
+    """Whether this coach's demo athlete links are loaded."""
+    return CoachAthlete.objects.for_coach(coach).filter(is_demo=True).exists()
+
+
+def has_program(coach):
+    """Whether Maya's demo plan tree has been built.
+
+    Scoped to the *individual* tree (``source_group`` excluded, mirroring
+    ``CoachAthlete.working_plan``): the ``group`` segment's delivery
+    materializes its own per-member ``Mesocycle``/``Week`` rows onto group
+    members' individual relationships (``sync_delivered_plan``) — those must
+    not be mistaken for the ``program`` segment.
+    """
+    return Mesocycle.objects.filter(
+        plan__relationship__coach=coach,
+        plan__relationship__is_demo=True,
+        plan__source_group__isnull=True,
+    ).exists()
+
+
+def has_delivery(coach):
+    """Whether Maya's demo current week has been delivered.
+
+    Same ``source_group`` exclusion as ``has_program`` — a materialized
+    group-member week being delivered (part of the ``group`` segment) must not
+    read as the ``delivery`` segment.
+    """
+    return Week.objects.filter(
+        mesocycle__plan__relationship__coach=coach,
+        mesocycle__plan__relationship__is_demo=True,
+        mesocycle__plan__source_group__isnull=True,
+        delivered_at__isnull=False,
+    ).exists()
+
+
+def has_log(coach):
+    """Whether Maya's demo session has been logged."""
+    return SessionLog.objects.filter(athlete__in=_demo_athletes(coach)).exists()
+
+
+def has_group(coach):
+    """Whether the demo group has been created."""
+    return MesoGroup.objects.filter(coach=coach, is_demo=True).exists()
 
 
 @transaction.atomic
@@ -230,13 +383,16 @@ def _build_plan_tree(plan, spec):
                     )
 
 
-def _ensure_demo_log(athlete, plan, today):
-    """Deliver + log Maya's current-week session at the model layer (no notify).
+def _demo_log_session(plan):
+    """The ``Session`` ``SAMPLE_LOG`` describes (Maya's current-week "Lower" day).
 
-    Idempotent: the week is delivered once and the log rows are created only when
-    absent. Refreshes the athlete's derived 1RM so the demo's %1RM lift shows one.
+    Shared by ``_ensure_demo_delivery`` and ``_ensure_demo_log`` — split out of
+    the old combined ``_ensure_demo_log`` (guided-tour Phase 1) so "deliver the
+    week" and "log the session" can be separate segment loaders. ``None`` only
+    if the plan tree hasn't been built yet (the ``program`` segment never
+    skipped in practice — every caller here ensures it first).
     """
-    session = (
+    return (
         Session.objects.filter(
             week__mesocycle__plan=plan,
             week__mesocycle__name=SAMPLE_LOG["mesocycle"],
@@ -246,13 +402,36 @@ def _ensure_demo_log(athlete, plan, today):
         .select_related("week")
         .first()
     )
+
+
+def _ensure_demo_delivery(plan):
+    """Deliver Maya's current-week session at the model layer (no notify).
+
+    Idempotent: the week is delivered once. Stamps only ``Week.delivered_at``
+    (no ``WeekDelivery`` snapshot) — matching the pre-split behavior; a full
+    snapshot is the deliver *view*'s job, not the demo's.
+    """
+    session = _demo_log_session(plan)
     if session is None:
         return None
-
     week = session.week
     if week.delivered_at is None:
         week.delivered_at = timezone.now()
         week.save(update_fields=["delivered_at"])
+    return week
+
+
+def _ensure_demo_log(athlete, plan, today):
+    """Log Maya's current-week session + refresh her derived 1RM (no notify).
+
+    Idempotent: the log rows are created only when absent. Assumes the week is
+    already delivered — the ``log`` segment loader ensures that itself via
+    ``load_delivery`` before calling this; logging against an undelivered week
+    doesn't error, it just wouldn't reflect the demo's real step order.
+    """
+    session = _demo_log_session(plan)
+    if session is None:
+        return None
 
     log, created = SessionLog.objects.get_or_create(
         session=session,

--- a/app/store_project/meso/tests/test_demo_segments.py
+++ b/app/store_project/meso/tests/test_demo_segments.py
@@ -1,0 +1,377 @@
+"""Guided demo onboarding tour — Phase 1: segmenting the demo loaders.
+
+``load_demo`` (``meso/demo.py``) used to be one monolithic load. This phase
+splits it into five idempotent, per-coach **segment** loaders — ``athletes`` /
+``program`` / ``delivery`` / ``log`` / ``group`` — that each ensure their own
+prerequisites, so a later guided tour (Phase 2) can offer them one at a time,
+in any order, from their own step. This is a **behavior-preserving refactor**
+(``docs/meso/demo-onboarding-tour-plan.md``, Phase 1): ``load_demo`` stays the
+aggregate and ``create_sandbox`` still eager-loads it, so nothing changes for
+users yet — these tests pin that the split reproduces today's exact workspace.
+
+Covers:
+
+- each segment loader, run alone on an empty workspace, creates *exactly* its
+  slice plus its prerequisites — no more, no less (the ``has_*`` predicates
+  make this checkable);
+- each loader is idempotent;
+- loaders compose safely out of dependency order;
+- all five segments together reproduce ``load_demo``'s workspace exactly;
+- the ``has_*`` predicates flip precisely when their segment loads;
+- ``clear_demo`` still removes everything after a piecemeal load;
+- the ``demo_load`` endpoint's new optional ``segment`` POST field;
+- no outbound email from any segment load (mirrors ``test_demo.py``'s
+  no-notifications guarantee).
+"""
+
+import pytest
+from django.urls import reverse
+
+from store_project.meso import demo
+from store_project.meso.models import CoachAthlete
+from store_project.meso.models import CoachProfile
+from store_project.meso.models import LoggedSet
+from store_project.meso.models import Mesocycle
+from store_project.meso.models import MesoGroup
+from store_project.meso.models import Plan
+from store_project.meso.models import SessionLog
+from store_project.meso.models import Week
+from store_project.users.factories import UserFactory
+from store_project.users.models import User
+
+pytestmark = pytest.mark.django_db
+
+
+def _coach():
+    coach = UserFactory()
+    CoachProfile.objects.create(user=coach)
+    return coach
+
+
+def _maya_plan(coach):
+    """Maya's individual plan (excludes any group-materialized plan)."""
+    return Plan.objects.get(
+        relationship__coach=coach,
+        relationship__is_demo=True,
+        source_group__isnull=True,
+    )
+
+
+def _maya_week(coach):
+    """The ``Week`` ``SAMPLE_LOG`` describes, on Maya's individual plan."""
+    return Week.objects.get(
+        mesocycle__plan__relationship__coach=coach,
+        mesocycle__plan__relationship__is_demo=True,
+        mesocycle__plan__source_group__isnull=True,
+        mesocycle__name=demo.SAMPLE_LOG["mesocycle"],
+        index=demo.SAMPLE_LOG["week_index"],
+    )
+
+
+def _row_counts():
+    """A cheap fingerprint of every model the demo loaders touch."""
+    return (
+        User.objects.count(),
+        CoachAthlete.objects.count(),
+        Plan.objects.count(),
+        Mesocycle.objects.count(),
+        Week.objects.count(),
+        MesoGroup.objects.count(),
+        SessionLog.objects.count(),
+        LoggedSet.objects.count(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Each segment, alone on an empty workspace, creates exactly its slice
+# ---------------------------------------------------------------------------
+
+
+class TestSegmentSlices:
+    def test_load_athletes_creates_only_athletes(self):
+        coach = _coach()
+        demo.load_athletes(coach)
+        assert demo.has_athletes(coach) is True
+        assert demo.has_program(coach) is False
+        assert demo.has_delivery(coach) is False
+        assert demo.has_log(coach) is False
+        assert demo.has_group(coach) is False
+        assert CoachAthlete.objects.for_coach(coach).filter(is_demo=True).count() == 5
+
+    def test_load_program_creates_athletes_and_plan_tree_only(self):
+        coach = _coach()
+        demo.load_program(coach)
+        assert demo.has_athletes(coach) is True
+        assert demo.has_program(coach) is True
+        assert demo.has_delivery(coach) is False
+        assert demo.has_log(coach) is False
+        assert demo.has_group(coach) is False
+        plan = _maya_plan(coach)
+        assert plan.title == demo.SAMPLE_PLAN["title"]
+        assert plan.mesocycles.exists()
+
+    def test_load_delivery_creates_program_and_delivered_week_only(self):
+        coach = _coach()
+        demo.load_delivery(coach)
+        assert demo.has_program(coach) is True
+        assert demo.has_delivery(coach) is True
+        assert demo.has_log(coach) is False
+        assert demo.has_group(coach) is False
+        week = _maya_week(coach)
+        assert week.delivered_at is not None
+        assert not SessionLog.objects.filter(
+            athlete__in=demo._demo_athletes(coach)
+        ).exists()
+
+    def test_load_log_creates_delivery_and_log_only(self):
+        coach = _coach()
+        demo.load_log(coach)
+        assert demo.has_delivery(coach) is True
+        assert demo.has_log(coach) is True
+        assert demo.has_group(coach) is False
+        log = SessionLog.objects.get(athlete__in=demo._demo_athletes(coach))
+        assert log.sets.exists()
+
+    def test_load_group_creates_athletes_and_group_only(self):
+        coach = _coach()
+        demo.load_group(coach)
+        assert demo.has_athletes(coach) is True
+        assert demo.has_group(coach) is True
+        # The group's own shared plan must not read as Maya's ``program`` segment.
+        assert demo.has_program(coach) is False
+        assert demo.has_delivery(coach) is False
+        assert demo.has_log(coach) is False
+        group = MesoGroup.objects.get(coach=coach, is_demo=True)
+        assert len(group.active_member_users()) == 3
+        assert group.shared_plan() is not None
+
+
+# ---------------------------------------------------------------------------
+# Idempotency — running a segment twice never duplicates
+# ---------------------------------------------------------------------------
+
+
+class TestSegmentIdempotency:
+    @pytest.mark.parametrize("segment", list(demo.SEGMENTS))
+    def test_segment_loader_is_idempotent(self, segment):
+        coach = _coach()
+        loader = demo.SEGMENTS[segment]
+        loader(coach)
+        first = _row_counts()
+        loader(coach)
+        assert _row_counts() == first
+
+
+# ---------------------------------------------------------------------------
+# Out-of-order composition — steps can be taken in any order
+# ---------------------------------------------------------------------------
+
+
+class TestOutOfOrderComposition:
+    def test_group_then_program_then_delivery_is_safe(self):
+        coach = _coach()
+        demo.load_group(coach)
+        demo.load_program(coach)
+        demo.load_delivery(coach)
+        assert demo.has_athletes(coach) is True
+        assert demo.has_program(coach) is True
+        assert demo.has_delivery(coach) is True
+        assert demo.has_group(coach) is True
+        assert demo.has_log(coach) is False
+        # No duplicate rows from the repeated prerequisite chains.
+        assert CoachAthlete.objects.for_coach(coach).filter(is_demo=True).count() == 5
+        assert (
+            Plan.objects.filter(
+                relationship__coach=coach,
+                relationship__is_demo=True,
+                source_group__isnull=True,
+            ).count()
+            == 1
+        )
+        assert MesoGroup.objects.filter(coach=coach, is_demo=True).count() == 1
+
+    def test_all_segments_in_reverse_dependency_order(self):
+        """Loading every segment back-to-front still lands on the full workspace."""
+        coach = _coach()
+        for name in reversed(list(demo.SEGMENTS)):
+            demo.SEGMENTS[name](coach)
+        assert demo.has_athletes(coach) is True
+        assert demo.has_program(coach) is True
+        assert demo.has_delivery(coach) is True
+        assert demo.has_log(coach) is True
+        assert demo.has_group(coach) is True
+
+
+# ---------------------------------------------------------------------------
+# Equivalence — all segments together reproduce load_demo exactly
+# ---------------------------------------------------------------------------
+
+
+class TestSegmentsEquivalentToLoadDemo:
+    def test_all_segments_match_load_demo(self):
+        coach_a = _coach()
+        for loader in demo.SEGMENTS.values():
+            loader(coach_a)
+        coach_b = _coach()
+        demo.load_demo(coach_b)
+
+        def slugs(coach):
+            return {u.email.split("@")[0] for u in demo._demo_athletes(coach)}
+
+        expected_slugs = {spec["slug"] for spec in demo.ATHLETES}
+        assert slugs(coach_a) == slugs(coach_b) == expected_slugs
+
+        plan_a, plan_b = _maya_plan(coach_a), _maya_plan(coach_b)
+        assert plan_a.title == plan_b.title == demo.SAMPLE_PLAN["title"]
+        assert plan_a.mesocycles.count() == plan_b.mesocycles.count()
+
+        week_a, week_b = _maya_week(coach_a), _maya_week(coach_b)
+        assert week_a.delivered_at is not None
+        assert week_b.delivered_at is not None
+
+        def logged_sets(coach):
+            return LoggedSet.objects.filter(
+                session_log__athlete__in=demo._demo_athletes(coach)
+            ).count()
+
+        assert (
+            SessionLog.objects.filter(athlete__in=demo._demo_athletes(coach_a)).count()
+            == 1
+        )
+        assert (
+            SessionLog.objects.filter(athlete__in=demo._demo_athletes(coach_b)).count()
+            == 1
+        )
+        assert logged_sets(coach_a) == logged_sets(coach_b) > 0
+
+        group_a = MesoGroup.objects.get(coach=coach_a, is_demo=True)
+        group_b = MesoGroup.objects.get(coach=coach_b, is_demo=True)
+        assert group_a.name == group_b.name == demo.GROUP["name"]
+        assert len(group_a.active_member_users()) == len(group_b.active_member_users())
+
+
+# ---------------------------------------------------------------------------
+# has_* predicates — derived from data, flip exactly when their segment loads
+# ---------------------------------------------------------------------------
+
+
+class TestHasPredicates:
+    def test_predicates_flip_one_at_a_time_as_segments_load(self):
+        coach = _coach()
+        assert demo.has_athletes(coach) is False
+        assert demo.has_program(coach) is False
+        assert demo.has_delivery(coach) is False
+        assert demo.has_log(coach) is False
+        assert demo.has_group(coach) is False
+
+        demo.load_athletes(coach)
+        assert demo.has_athletes(coach) is True
+        assert demo.has_program(coach) is False
+
+        demo.load_program(coach)
+        assert demo.has_program(coach) is True
+        assert demo.has_delivery(coach) is False
+
+        demo.load_delivery(coach)
+        assert demo.has_delivery(coach) is True
+        assert demo.has_log(coach) is False
+
+        demo.load_log(coach)
+        assert demo.has_log(coach) is True
+        assert demo.has_group(coach) is False
+
+        demo.load_group(coach)
+        assert demo.has_group(coach) is True
+
+    def test_has_demo_mirrors_has_athletes(self):
+        coach = _coach()
+        assert demo.has_demo(coach) is False
+        demo.load_athletes(coach)
+        assert demo.has_demo(coach) is True
+
+
+# ---------------------------------------------------------------------------
+# clear_demo still removes everything after a piecemeal load
+# ---------------------------------------------------------------------------
+
+
+class TestClearAfterPiecemealLoad:
+    def test_clear_demo_removes_all_segments(self):
+        coach = _coach()
+        demo.load_group(coach)
+        demo.load_log(coach)
+        demo.clear_demo(coach)
+        assert demo.has_athletes(coach) is False
+        assert demo.has_program(coach) is False
+        assert demo.has_delivery(coach) is False
+        assert demo.has_log(coach) is False
+        assert demo.has_group(coach) is False
+        assert CoachAthlete.objects.for_coach(coach).filter(is_demo=True).count() == 0
+        assert MesoGroup.objects.filter(coach=coach, is_demo=True).count() == 0
+        assert list(demo._demo_athletes(coach)) == []
+
+
+# ---------------------------------------------------------------------------
+# No outbound email from any segment load
+# ---------------------------------------------------------------------------
+
+
+class TestNoNotifications:
+    @pytest.mark.parametrize("segment", list(demo.SEGMENTS))
+    def test_segment_load_sends_no_email(self, segment, mailoutbox):
+        coach = _coach()
+        demo.SEGMENTS[segment](coach)
+        assert mailoutbox == []
+
+
+# ---------------------------------------------------------------------------
+# The demo_load endpoint's optional ``segment`` field
+# ---------------------------------------------------------------------------
+
+
+class TestDemoLoadEndpointSegments:
+    def test_no_segment_behaves_as_today(self, client):
+        coach = _coach()
+        client.force_login(coach)
+        resp = client.post(reverse("meso:demo_load"))
+        assert resp.status_code == 302
+        assert resp.url == reverse("meso:roster")
+        assert demo.has_demo(coach) is True
+        assert demo.has_program(coach) is True
+        assert demo.has_group(coach) is True
+
+    def test_valid_segment_loads_only_that_segment(self, client):
+        coach = _coach()
+        client.force_login(coach)
+        resp = client.post(reverse("meso:demo_load"), {"segment": "athletes"})
+        assert resp.status_code == 302
+        assert resp.url == reverse("meso:roster")
+        assert demo.has_athletes(coach) is True
+        assert demo.has_program(coach) is False
+        assert demo.has_group(coach) is False
+
+    def test_invalid_segment_400s_and_creates_nothing(self, client):
+        coach = _coach()
+        client.force_login(coach)
+        resp = client.post(reverse("meso:demo_load"), {"segment": "bogus"})
+        assert resp.status_code == 400
+        assert demo.has_demo(coach) is False
+        assert not CoachAthlete.objects.filter(is_demo=True).exists()
+
+    def test_segment_load_ensures_a_coach_profile(self, client):
+        user = UserFactory()  # no CoachProfile yet
+        client.force_login(user)
+        client.post(reverse("meso:demo_load"), {"segment": "athletes"})
+        assert CoachProfile.objects.filter(user=user).exists()
+
+    def test_anonymous_is_redirected_to_login(self, client):
+        resp = client.post(reverse("meso:demo_load"), {"segment": "athletes"})
+        assert resp.status_code == 302
+        assert reverse("account_login") in resp.url
+        assert not CoachAthlete.objects.filter(is_demo=True).exists()
+
+    def test_segment_load_sends_no_email(self, client, mailoutbox):
+        coach = _coach()
+        client.force_login(coach)
+        client.post(reverse("meso:demo_load"), {"segment": "group"})
+        assert mailoutbox == []

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -827,6 +827,16 @@ def sandbox_enter(request):
     return _noindex(redirect("meso:roster"))
 
 
+#: Per-segment success flash, keyed the same as ``meso_demo.SEGMENTS``.
+_SEGMENT_MESSAGES = {
+    "athletes": "Sample athletes added — meet your new roster.",
+    "program": "Sample program built — a full mesocycle, ready to explore.",
+    "delivery": "This week delivered to Maya's phone.",
+    "log": "Session logged — Maya's results are in.",
+    "group": "Sample group added — shared programming + per-athlete overrides.",
+}
+
+
 @login_required
 @require_POST
 def demo_load(request):
@@ -836,16 +846,32 @@ def demo_load(request):
     built/delivered/logged program, and a group — scoped to this coach, idempotent,
     billing-neutral, and silent (no demo-athlete email/push). Lands on the roster
     where the data now shows, with a "Remove demo data" affordance.
+
+    An optional ``segment`` POST field narrows the load to one slice of the demo
+    (``meso_demo.SEGMENTS`` — ``athletes``/``program``/``delivery``/``log``/``group``)
+    instead of the full aggregate; an unrecognized name loads nothing and 400s.
+    No URL changes: this stays the one ``meso:demo_load`` endpoint for both the
+    full load and (guided-tour Phase 2) each step's per-segment "add sample data"
+    action — the tour will start passing ``segment`` here.
     """
     # Loading a demo is an implicit "I'm coaching now": ensure the CoachProfile
     # exists (mirrors start_coaching's free path) so demo links never make a user a
-    # coach via a side door without one — keeping coach state consistent.
+    # coach via a side door without one — keeping coach state consistent, for both
+    # the aggregate and per-segment paths.
     CoachProfile.objects.get_or_create(user=request.user)
-    meso_demo.load_demo(request.user)
-    messages.success(
-        request,
-        "Demo data loaded — explore a populated workspace. Remove it any time.",
-    )
+    segment = request.POST.get("segment")
+    if segment:
+        loader = meso_demo.SEGMENTS.get(segment)
+        if loader is None:
+            return HttpResponseBadRequest("Unknown demo segment.")
+        loader(request.user)
+        messages.success(request, _SEGMENT_MESSAGES[segment])
+    else:
+        meso_demo.load_demo(request.user)
+        messages.success(
+            request,
+            "Demo data loaded — explore a populated workspace. Remove it any time.",
+        )
     return redirect("meso:roster")
 
 

--- a/docs/meso/demo-onboarding-tour-plan.md
+++ b/docs/meso/demo-onboarding-tour-plan.md
@@ -101,16 +101,18 @@ from data (O7).
 
 ## Phases (PR-sized)
 
-0. **Self-athlete + non-billable seat** *(standalone, shippable alone)* —
+0. **Self-athlete + non-billable seat** *(standalone, shippable alone)* — ✅
+   shipped, PR [#432](https://github.com/lancegoyke/fitness-store/pull/432) —
    `is_self` on `CoachAthlete` + migration; `billable()` exclusion; allow/validate
    `coach == athlete` (single self-link); minimal "Add yourself as an athlete"
    affordance on the roster; audit roster/profile/deliver rendering. Tests:
    self-link doesn't move `active_seat_count`; over-limit freeze ignores it.
-1. **Segment the demo loaders** *(behavior-preserving refactor)* — split
-   `load_demo` into `athletes`/`program`/`delivery`/`log`/`group` loaders +
-   `has_*` predicates; add per-segment load endpoints (or `demo/load/?segment=`).
-   `load_demo` stays the aggregate; `create_sandbox` **still eager-loads** so
-   nothing changes for users yet. Pure plumbing + tests.
+1. **Segment the demo loaders** *(behavior-preserving refactor)* — PR [#433](https://github.com/lancegoyke/fitness-store/pull/433) —
+   split `load_demo` into `athletes`/`program`/`delivery`/`log`/`group` loaders +
+   `has_*` predicates; the existing `demo_load` view now accepts an optional
+   `segment` POST field (no URL change). `load_demo` stays the aggregate;
+   `create_sandbox` **still eager-loads** so nothing changes for users yet.
+   Pure plumbing + tests.
 2. **Sandbox tour** *(the visible change)* — tour engine (coach-mark driver +
    server-persisted step state); flip `create_sandbox` to **empty-start**;
    auto-start the tour; wire each step's action to its segment endpoint; add the


### PR DESCRIPTION
## Summary

Phase 1 of the [guided demo onboarding tour plan](docs/meso/demo-onboarding-tour-plan.md) (part of #430) — a **behavior-preserving refactor**: `load_demo` splits into five idempotent, per-coach, `is_demo`-scoped segment loaders (`athletes` / `program` / `delivery` / `log` / `group`) so the Phase 2 tour can populate the workspace one feature at a time. Nothing changes for users — `create_sandbox` still eager-loads, and `load_demo` (now a thin aggregate) builds the identical workspace.

- Each loader ensures its own prerequisites idempotently (program → athletes; delivery → program; log → delivery; group → athletes), so segments are safe to fire in any order.
- The old `_ensure_demo_log` is split into `_ensure_demo_delivery` (stamps `Week.delivered_at`, exactly the pre-split behavior) and a log-only `_ensure_demo_log`, sharing a `_demo_log_session` lookup.
- The per-coach `select_for_update` double-submit lock moved into a `_lock` helper acquired by **every** segment loader — a lone segment POST (Phase 2) gets the same protection `load_demo` always had.
- `has_athletes`/`has_program`/`has_delivery`/`has_log`/`has_group` predicates, derived from data (decision O7). `has_program`/`has_delivery` exclude `source_group`-materialized rows — the group segment's per-member delivery snapshots must not read as the program/delivery segments (mirrors `working_plan()`'s exclusion).
- `demo_load` accepts an optional `segment` POST field on the same URL: absent → aggregate exactly as today; unknown name → 400, nothing loaded.

## Test plan

- 28 new tests in `test_demo_segments.py`: per-segment slices + prerequisites, idempotency, out-of-order composition, piecemeal ≡ `load_demo` equivalence against a second coach, `has_*` flips, `clear_demo` after piecemeal loads, endpoint segment/aggregate/400/auth paths, no outbound email.
- Full suite: 1971 passed; lint + format clean.
- Driven in the dev app: fresh `/meso/demo/` sandbox still lands on the identical fully-populated workspace (5 athletes, Maya's delivered week + logged Lower session, Strength Squad group).

Part of #430 (does not close it — Phases 2–4 remain).