### PR TITLE
feat(meso): real-coach tour — the self-coaching variant (#430 Phase 3)

### DIFF
--- a/app/store_project/meso/context_processors.py
+++ b/app/store_project/meso/context_processors.py
@@ -18,23 +18,41 @@ def sandbox_status(request):
     Lazy: pages that never reference ``is_sandbox`` in their template pay no
     extra query.
 
-    ``show_meso_tour`` (guided-tour Phase 2, issue #430) is the same kind of
-    cheap gate for ``_tour.html``: *whether* to render the tour at all, not
-    the tour's own content (that's a plain dict built by the
-    ``meso_tour_config`` template tag, called only inside the ``{% if
-    show_meso_tour %}`` guard — a lazy proxy can't be fed straight into
-    ``json_script``, since the C-accelerated JSON encoder only recognizes a
-    real ``dict``, not a ``SimpleLazyObject`` wrapping one). Phase 2 is
-    sandbox-only, so this short-circuits on ``is_sandbox`` before ever
-    touching ``tour_state`` — a real coach's page still does zero extra
-    queries.
+    ``show_meso_tour`` (guided-tour Phase 2 sandbox + Phase 3 real coach,
+    issue #430) is the same kind of cheap gate for ``_tour.html``: *whether*
+    to render the tour at all, not the tour's own content (that's a plain
+    dict built by the ``meso_tour_config`` template tag, called only inside
+    the ``{% if show_meso_tour %}`` guard — a lazy proxy can't be fed straight
+    into ``json_script``, since the C-accelerated JSON encoder only
+    recognizes a real ``dict``, not a ``SimpleLazyObject`` wrapping one).
+
+    Two independent ways in (decision 4):
+
+    - **Sandbox**: exactly the Phase 2 rule — ``is_sandbox`` and the tour not
+      dismissed/completed (``tour.is_active``, which also treats a
+      never-started state as active — fine here, since ``create_sandbox``
+      always arms the tour at step 0 immediately).
+    - **Real coach**: the tour must be *explicitly* active
+      (``tour.is_touring`` — a literal ``status == "active"``, not just "not
+      hidden"). A real coach's never-started ``{}`` reads as *not* touring,
+      so the tour never self-mounts on them; they opt in via the roster's
+      "Start the guided tour" entry card, whose POST writes that explicit
+      status.
+
+    Short-circuits on ``is_sandbox`` before ever touching ``tour_state``, and
+    the real-coach branch short-circuits on ``is_authenticated`` before
+    querying — an anonymous visitor's page still does zero extra queries.
     """
     user = getattr(request, "user", None)
     is_sandbox_lazy = SimpleLazyObject(lambda: sandbox.is_sandbox(user))
+
+    def _show_tour():
+        if is_sandbox_lazy:
+            return tour.is_active(user)
+        return bool(getattr(user, "is_authenticated", False)) and tour.is_touring(user)
+
     return {
         "is_sandbox": is_sandbox_lazy,
         "trial_days": CoachSubscription.TRIAL_DAYS,
-        "show_meso_tour": SimpleLazyObject(
-            lambda: bool(is_sandbox_lazy) and tour.is_active(user)
-        ),
+        "show_meso_tour": SimpleLazyObject(_show_tour),
     }

--- a/app/store_project/meso/templatetags/meso_extras.py
+++ b/app/store_project/meso/templatetags/meso_extras.py
@@ -36,5 +36,10 @@ def meso_tour_config(context):
     call eagerly here because ``_tour.html`` only calls this tag inside its
     ``{% if show_meso_tour %}`` guard — never on a page where the tour is
     hidden.
+
+    The variant (sandbox vs. self-coaching, Phase 3) is derived here via
+    ``variant_for`` rather than stored — the same user always resolves the
+    same way at any given moment (O7).
     """
-    return meso_tour.build_config(context["request"].user)
+    user = context["request"].user
+    return meso_tour.build_config(user, meso_tour.variant_for(user))

--- a/app/store_project/meso/tests/test_tour.py
+++ b/app/store_project/meso/tests/test_tour.py
@@ -1,19 +1,31 @@
-"""Guided demo onboarding tour — Phase 2 (issue #430).
+"""Guided demo onboarding tour — Phase 2 sandbox + Phase 3 real coach (#430).
 
 Phase 1 (``test_demo_segments.py``) split ``load_demo`` into idempotent
-per-feature segment loaders. This phase drives them from an in-app guided
-tour and flips ``create_sandbox`` to an **empty start** (the tour populates
-the workspace step by step instead). Covers:
+per-feature segment loaders. Phase 2 drove them from an in-app guided tour
+and flipped ``create_sandbox`` to an **empty start** (the tour populates the
+workspace step by step instead). Phase 3 extends the same eight steps to a
+real, authenticated coach: instead of loading fake demo data, the actions
+guide them to add *themselves* as an athlete and program for themselves
+(O5) — a distinct "self" variant of the config, derived per-request
+(``tour.variant_for``) rather than stored. Covers:
 
 - ``tour.STEPS`` data sanity (every ``url_name`` reverses, every named
-  segment exists in ``meso_demo.SEGMENTS``);
+  sandbox segment exists in ``meso_demo.SEGMENTS``, every step carries both
+  variants);
 - the ``tour.py`` helpers directly (``tour_status``/``is_active``/
-  ``start_tour``/``set_step``/``dismiss``/``complete``/``build_config``);
+  ``is_touring``/``variant_for``/``start_tour``/``set_step``/``dismiss``/
+  ``complete``/``build_config``);
 - ``create_sandbox``'s empty-start flip: a fresh sandbox has no demo data and
   an active tour parked at step 0;
 - the roster's tour mount + embedded config JSON — present for an active
-  sandbox coach, absent for a real coach, absent once dismissed/completed,
-  and the static "Get started" card is suppressed while touring;
+  sandbox coach or an explicitly-touring real coach, absent for a real coach
+  who never started (Phase 3's stricter gate) or dismissed/completed either
+  variant, and the static "Get started" card is suppressed while touring;
+- the self variant's build_config resolution: ``welcome``/``designer``/
+  ``agent`` steps' typed ``action``/``loaded`` gating off the coach's
+  self-link, working plan, and agent allowance;
+- the roster's empty-workspace tour-entry card (Phase 3) and its
+  ``tour_state`` "restart" hop into a mounted tour;
 - ``meso:tour_state`` (advance/back/goto clamp + persist, dismiss/complete
   persist, restart resets, anonymous -> login, AJAX vs. plain-POST shape);
 - ``meso:tour_skip`` (the O6 "skip · load everything" shortcut): loads the
@@ -28,7 +40,12 @@ from django.urls import reverse
 from store_project.meso import demo
 from store_project.meso import sandbox
 from store_project.meso import tour
+from store_project.meso.factories import AgentProposalBatchFactory
+from store_project.meso.factories import CoachAthleteFactory
+from store_project.meso.factories import PlanFactory
+from store_project.meso.models import CoachAthlete
 from store_project.meso.models import CoachProfile
+from store_project.meso.models import CoachSubscription
 from store_project.users.factories import UserFactory
 
 pytestmark = pytest.mark.django_db
@@ -50,10 +67,11 @@ class TestStepsSanity:
         for step in tour.STEPS:
             reverse(step["url_name"])  # raises NoReverseMatch on a typo
 
-    def test_every_named_segment_exists_in_demo_segments(self):
+    def test_every_named_sandbox_segment_exists_in_demo_segments(self):
         for step in tour.STEPS:
-            if step["segment"] is not None:
-                assert step["segment"] in demo.SEGMENTS
+            segment = step["sandbox"].get("segment")
+            if segment is not None:
+                assert segment in demo.SEGMENTS
 
     def test_eight_steps(self):
         assert len(tour.STEPS) == 8
@@ -61,6 +79,16 @@ class TestStepsSanity:
     def test_step_keys_are_unique(self):
         keys = [step["key"] for step in tour.STEPS]
         assert len(keys) == len(set(keys))
+
+    def test_every_step_carries_both_variants(self):
+        # Phase 3: shared key/url_name/anchor, variant-specific title/body/action.
+        for step in tour.STEPS:
+            assert "sandbox" in step
+            assert "self" in step
+            assert step["sandbox"]["title"]
+            assert step["sandbox"]["body"]
+            assert step["self"]["title"]
+            assert step["self"]["body"]
 
 
 # ---------------------------------------------------------------------------
@@ -100,6 +128,33 @@ class TestIsActive:
         coach.coach_profile.tour_state = {"step": 1, "status": status}
         coach.coach_profile.save(update_fields=["tour_state"])
         assert tour.is_active(coach) is False
+
+
+class TestIsTouring:
+    """The Phase 3 real-coach mount gate — stricter than ``is_active``."""
+
+    def test_never_started_is_not_touring(self):
+        # The one case that differs from is_active: a never-started `{}` is
+        # "active" (not hidden) but not explicitly touring.
+        coach = _coach()
+        assert tour.is_touring(coach) is False
+
+    def test_explicitly_started_is_touring(self):
+        coach = _coach()
+        tour.start_tour(coach.coach_profile)
+        assert tour.is_touring(coach) is True
+
+    def test_in_progress_is_touring(self):
+        coach = _coach()
+        tour.set_step(coach.coach_profile, 2)
+        assert tour.is_touring(coach) is True
+
+    @pytest.mark.parametrize("status", ["dismissed", "completed"])
+    def test_hidden_statuses_are_not_touring(self, status):
+        coach = _coach()
+        coach.coach_profile.tour_state = {"step": 1, "status": status}
+        coach.coach_profile.save(update_fields=["tour_state"])
+        assert tour.is_touring(coach) is False
 
 
 class TestStartSetDismissComplete:
@@ -154,13 +209,21 @@ class TestStartSetDismissComplete:
 
 
 class TestBuildConfig:
+    """Exercises the sandbox variant explicitly — the Phase 2 contract, untouched.
+
+    ``build_config`` now takes a required ``variant`` (Phase 3) instead of
+    inferring it, so these calls pass ``"sandbox"`` explicitly; the coach
+    fixture (``_coach()``, no ``SandboxSession``) predates the variant split
+    and was always exercising the segment-based behavior these tests assert.
+    """
+
     def test_none_without_a_coach_profile(self):
         user = UserFactory()
-        assert tour.build_config(user) is None
+        assert tour.build_config(user, "sandbox") is None
 
     def test_carries_all_steps_with_resolved_urls(self):
         coach = _coach()
-        config = tour.build_config(coach)
+        config = tour.build_config(coach, "sandbox")
         assert len(config["steps"]) == len(tour.STEPS)
         for step, spec in zip(config["steps"], tour.STEPS):
             assert step["key"] == spec["key"]
@@ -168,19 +231,19 @@ class TestBuildConfig:
 
     def test_loaded_flags_start_false_and_flip_with_the_segment(self):
         coach = _coach()
-        config = tour.build_config(coach)
+        config = tour.build_config(coach, "sandbox")
         welcome = next(s for s in config["steps"] if s["key"] == "welcome")
         assert welcome["loaded"] is False
 
         demo.load_athletes(coach)
 
-        config = tour.build_config(coach)
+        config = tour.build_config(coach, "sandbox")
         welcome = next(s for s in config["steps"] if s["key"] == "welcome")
         assert welcome["loaded"] is True
 
     def test_steps_with_no_segment_have_no_loaded_flag(self):
         coach = _coach()
-        config = tour.build_config(coach)
+        config = tour.build_config(coach, "sandbox")
         profile_step = next(s for s in config["steps"] if s["key"] == "profile")
         assert profile_step["loaded"] is None
 
@@ -188,7 +251,7 @@ class TestBuildConfig:
         coach = _coach()
         tour.set_step(coach.coach_profile, 2)
 
-        config = tour.build_config(coach)
+        config = tour.build_config(coach, "sandbox")
 
         assert config["step"] == 2
         assert config["status"] == "active"
@@ -196,6 +259,167 @@ class TestBuildConfig:
         assert config["skip_url"] == reverse("meso:tour_skip")
         assert config["demo_load_url"] == reverse("meso:demo_load")
         assert config["signup_url"] == reverse("meso:sandbox_signup")
+
+    def test_sandbox_steps_never_carry_a_generic_action(self):
+        # The additive Phase 3 `action` field must stay null for every sandbox
+        # step — the driver's segment/signup_gate branches are untouched.
+        coach = _coach()
+        config = tour.build_config(coach, "sandbox")
+        for step in config["steps"]:
+            assert step["action"] is None
+
+
+class TestVariantFor:
+    def test_sandbox_coach_is_sandbox(self):
+        user = sandbox.create_sandbox()
+        assert tour.variant_for(user) == "sandbox"
+
+    def test_real_coach_is_self(self):
+        coach = _coach()
+        assert tour.variant_for(coach) == "self"
+
+    def test_anonymous_is_self(self):
+        # Never actually rendered (no CoachProfile, no page reaches this), but
+        # variant_for shouldn't itself blow up on a non-sandbox user.
+        user = UserFactory()
+        assert tour.variant_for(user) == "self"
+
+
+class TestBuildConfigSelfVariant:
+    """The self-coaching variant's data-dependent resolution (Phase 3, O5)."""
+
+    def test_welcome_offers_roster_add_self_and_is_unloaded_at_first(self):
+        coach = _coach()
+        config = tour.build_config(coach, "self")
+        welcome = next(s for s in config["steps"] if s["key"] == "welcome")
+        assert welcome["segment"] is None
+        assert welcome["loaded"] is False
+        assert welcome["action"] == {
+            "url": reverse("meso:roster_add_self"),
+            "label": "Add yourself as your first athlete",
+            "fields": {},
+        }
+
+    def test_welcome_loaded_flips_once_the_self_link_exists(self):
+        coach = _coach()
+        CoachAthlete.add_self(coach)
+
+        config = tour.build_config(coach, "self")
+
+        welcome = next(s for s in config["steps"] if s["key"] == "welcome")
+        assert welcome["loaded"] is True
+        # Still offered (disabled "Done" state is the driver's job, not ours).
+        assert welcome["action"] is not None
+
+    def test_designer_has_no_action_without_a_self_link(self):
+        coach = _coach()
+        config = tour.build_config(coach, "self")
+        designer = next(s for s in config["steps"] if s["key"] == "designer")
+        assert designer["action"] is None
+        assert designer["loaded"] is False
+        assert "welcome step" in designer["body"]
+
+    def test_designer_offers_plan_create_once_the_self_link_exists(self):
+        coach = _coach()
+        CoachAthlete.add_self(coach)
+
+        config = tour.build_config(coach, "self")
+
+        designer = next(s for s in config["steps"] if s["key"] == "designer")
+        assert designer["loaded"] is False
+        assert designer["action"] == {
+            "url": reverse("meso:plan_create", args=[coach.pk]),
+            "label": "Start a program for yourself",
+            "fields": {},
+        }
+
+    def test_designer_loaded_once_the_self_link_has_a_working_plan(self):
+        coach = _coach()
+        link = CoachAthlete.add_self(coach)
+        link.create_plan()
+
+        config = tour.build_config(coach, "self")
+
+        designer = next(s for s in config["steps"] if s["key"] == "designer")
+        assert designer["loaded"] is True
+        assert designer["action"] is not None
+
+    def test_agent_has_no_action_without_a_self_link(self):
+        coach = _coach()
+        config = tour.build_config(coach, "self")
+        agent = next(s for s in config["steps"] if s["key"] == "agent")
+        assert agent["action"] is None
+        assert agent["signup_gate"] is False
+
+    def test_agent_offers_the_draft_action_for_a_fresh_coach_with_a_self_link(self):
+        # A fresh coach has no CoachSubscription row → billing_status FREE,
+        # and FREE_AGENT_ALLOWANCE (5) > 0 runs used → can_use_agent is True.
+        coach = _coach()
+        CoachAthlete.add_self(coach)
+
+        config = tour.build_config(coach, "self")
+
+        agent = next(s for s in config["steps"] if s["key"] == "agent")
+        assert agent["action"] == {
+            "url": reverse("meso:plan_create", args=[coach.pk]),
+            "label": "Draft next block with AI",
+            "fields": {"draft": "agent"},
+        }
+
+    def test_agent_has_no_action_once_the_free_allowance_is_exhausted(self):
+        coach = _coach()
+        CoachAthlete.add_self(coach)
+        # An unrelated plan/relationship just to attribute the batches to this
+        # coach — the self-link's own plan stays empty throughout.
+        other_plan = PlanFactory(relationship=CoachAthleteFactory(coach=coach))
+        for _ in range(CoachSubscription.FREE_AGENT_ALLOWANCE):
+            AgentProposalBatchFactory(plan=other_plan, coach=coach)
+
+        config = tour.build_config(coach, "self")
+
+        agent = next(s for s in config["steps"] if s["key"] == "agent")
+        assert agent["action"] is None
+
+    def test_agent_has_no_action_once_a_working_plan_already_exists(self):
+        coach = _coach()
+        link = CoachAthlete.add_self(coach)
+        link.create_plan()
+
+        config = tour.build_config(coach, "self")
+
+        agent = next(s for s in config["steps"] if s["key"] == "agent")
+        assert agent["action"] is None
+
+    def test_finish_has_no_signup_gate_and_anchors_the_invite_control(self):
+        coach = _coach()
+        config = tour.build_config(coach, "self")
+        finish = next(s for s in config["steps"] if s["key"] == "finish")
+        assert finish["signup_gate"] is False
+        assert finish["anchor"] == "roster-invite"
+        assert "Invite your first real athlete" in finish["body"]
+
+    @pytest.mark.parametrize("key", ["profile", "deliver", "results", "groups"])
+    def test_static_steps_have_no_action_or_loaded_flag(self, key):
+        coach = _coach()
+        config = tour.build_config(coach, "self")
+        step = next(s for s in config["steps"] if s["key"] == key)
+        assert step["action"] is None
+        assert step["loaded"] is None
+        assert step["segment"] is None
+
+    def test_posting_roster_add_self_flips_welcome_and_unlocks_designer(self, client):
+        # An end-to-end version of the two tests above, through the real view.
+        coach = _coach()
+        client.force_login(coach)
+
+        client.post(reverse("meso:roster_add_self"))
+
+        config = tour.build_config(coach, "self")
+        welcome = next(s for s in config["steps"] if s["key"] == "welcome")
+        designer = next(s for s in config["steps"] if s["key"] == "designer")
+        assert welcome["loaded"] is True
+        assert designer["action"] is not None
+        assert designer["action"]["url"] == reverse("meso:plan_create", args=[coach.pk])
 
 
 # ---------------------------------------------------------------------------
@@ -232,6 +456,9 @@ class TestRosterTourMount:
         assert 'id="meso-tour-config"' in body
 
     def test_real_coach_never_sees_the_tour(self, client):
+        # A real coach who has never touched the tour: `{}` — not the literal
+        # `"active"` `is_touring` requires — so the tour never self-mounts
+        # (Phase 3's stricter real-coach gate; they opt in via the entry card).
         coach = _coach()
         client.force_login(coach)
 
@@ -239,6 +466,42 @@ class TestRosterTourMount:
 
         assert 'id="meso-tour"' not in body
         assert 'id="meso-tour-config"' not in body
+
+    def test_real_coach_with_an_explicitly_active_tour_sees_the_mount(self, client):
+        # Phase 3: a real coach who opted in (the entry card's "restart" POST,
+        # or here directly via start_tour) does get the mount.
+        coach = _coach()
+        tour.start_tour(coach.coach_profile)
+        client.force_login(coach)
+
+        body = client.get(reverse("meso:roster")).content.decode()
+
+        assert 'id="meso-tour"' in body
+        assert 'id="meso-tour-config"' in body
+
+    def test_real_coachs_dismissed_tour_does_not_mount(self, client):
+        coach = _coach()
+        tour.start_tour(coach.coach_profile)
+        tour.dismiss(coach.coach_profile)
+        client.force_login(coach)
+
+        body = client.get(reverse("meso:roster")).content.decode()
+
+        assert 'id="meso-tour"' not in body
+
+    def test_real_coachs_completed_tour_does_not_mount_and_original_card_returns(
+        self, client
+    ):
+        coach = _coach()
+        tour.start_tour(coach.coach_profile)
+        tour.complete(coach.coach_profile)
+        client.force_login(coach)
+
+        body = client.get(reverse("meso:roster")).content.decode()
+
+        assert 'id="meso-tour"' not in body
+        assert "Welcome to your coaching workspace" in body
+        assert "Start the guided tour" not in body
 
     def test_dismissed_sandbox_coach_does_not_see_the_tour(self, client):
         user = sandbox.create_sandbox()
@@ -289,6 +552,88 @@ class TestRosterTourMount:
         assert config["step"] == 0
         assert config["status"] == "active"
         assert len(config["steps"]) == 8
+
+    def test_a_touring_real_coachs_config_uses_the_self_variant(self, client):
+        coach = _coach()
+        tour.start_tour(coach.coach_profile)
+        client.force_login(coach)
+
+        body = client.get(reverse("meso:roster")).content.decode()
+        start = body.index('id="meso-tour-config"')
+        script_start = body.index(">", start) + 1
+        script_end = body.index("</script>", script_start)
+        config = json.loads(body[script_start:script_end])
+
+        welcome = next(s for s in config["steps"] if s["key"] == "welcome")
+        assert welcome["segment"] is None
+        assert welcome["action"]["url"] == reverse("meso:roster_add_self")
+
+
+# ---------------------------------------------------------------------------
+# Roster: the empty-workspace tour-entry card (Phase 3) — replaces the static
+# Get-started card's CTA for a real coach who hasn't dismissed/completed the
+# tour, while leaving a dismissed/completed tour's card exactly as before.
+# ---------------------------------------------------------------------------
+
+
+class TestTourEntryCard:
+    def test_fresh_real_coach_sees_the_tour_entry_card(self, client):
+        coach = _coach()
+        client.force_login(coach)
+
+        body = client.get(reverse("meso:roster")).content.decode()
+
+        assert "Welcome to your coaching workspace" in body
+        assert "Start the guided tour" in body
+
+    def test_dismissed_tour_shows_the_original_card_without_the_entry(self, client):
+        coach = _coach()
+        tour.start_tour(coach.coach_profile)
+        tour.dismiss(coach.coach_profile)
+        client.force_login(coach)
+
+        body = client.get(reverse("meso:roster")).content.decode()
+
+        assert "Welcome to your coaching workspace" in body
+        assert "Start the guided tour" not in body
+
+    def test_completed_tour_shows_the_original_card_without_the_entry(self, client):
+        coach = _coach()
+        tour.start_tour(coach.coach_profile)
+        tour.complete(coach.coach_profile)
+        client.force_login(coach)
+
+        body = client.get(reverse("meso:roster")).content.decode()
+
+        assert "Welcome to your coaching workspace" in body
+        assert "Start the guided tour" not in body
+
+    def test_a_non_empty_workspace_never_shows_the_get_started_card(self, client):
+        coach = _coach()
+        CoachAthleteFactory(coach=coach)
+        client.force_login(coach)
+
+        body = client.get(reverse("meso:roster")).content.decode()
+
+        assert "Welcome to your coaching workspace" not in body
+        assert "Start the guided tour" not in body
+
+    def test_posting_restart_from_the_entry_card_mounts_the_tour(self, client):
+        coach = _coach()
+        client.force_login(coach)
+
+        resp = client.post(
+            reverse("meso:tour_state"), {"action": "restart"}, follow=True
+        )
+
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert 'id="meso-tour"' in body
+        assert 'id="meso-tour-config"' in body
+        assert CoachProfile.objects.get(user=coach).tour_state == {
+            "step": 0,
+            "status": "active",
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/app/store_project/meso/tour.py
+++ b/app/store_project/meso/tour.py
@@ -1,123 +1,202 @@
-"""Guided demo onboarding tour — Phase 2 (issue #430).
+"""Guided demo onboarding tour — Phase 2 (sandbox) + Phase 3 (real coach), issue #430.
 
 Phase 1 (``docs/meso/demo-onboarding-tour-plan.md``) split ``demo.load_demo``
-into idempotent, per-feature segment loaders. This phase drives them one at a
-time from an in-app guided tour: eight steps, each introducing a feature and
-(where relevant) offering an "add sample data" action tied to one segment.
+into idempotent, per-feature segment loaders. Phase 2 drove them one at a time
+from an in-app guided tour for the anonymous sandbox. Phase 3 extends the same
+eight steps to a real, authenticated coach with an empty workspace: instead of
+loading fake demo athletes, they're guided to add *themselves* as an athlete
+and program for themselves (O5) — the self-coaching variant.
 
-``STEPS`` is the single source of truth — the front-end config
-(``build_config``), the tour-state endpoint, and the tests all read from it.
-Progress persists server-side on ``CoachProfile.tour_state`` (O2): only the
-step index + dismissed/complete flag are stored — whether a step's *data* is
-loaded is always derived (``has_athletes``/``has_program``/... via
-``_segment_loaded``), never stored (O7), mirroring ``demo.has_demo``.
+``STEPS`` is still the single source of truth, but each step now carries two
+sub-dicts, ``"sandbox"`` and ``"self"``, for the copy/action that vary by
+audience; ``key``/``url_name``/``anchor`` stay shared/top-level (a step's
+*page* is the same regardless of who's touring it — anchor overrides only
+where the spotlighted control itself differs, e.g. ``finish``'s
+"roster-invite"). ``build_config(user, variant)`` resolves whichever variant
+into the exact flat step shape the JS driver already consumed in Phase 2, plus
+one additive field (``action``) the self variant uses for its typed
+actions — sandbox steps still produce ``segment``/``action_label``/
+``signup_gate`` exactly as before, so the sandbox contract (front-end and
+tests) is untouched.
 
-Phase 2 is sandbox-only (``is_active``/``build_config`` don't gate on
-audience themselves — the caller, ``context_processors.sandbox_status``,
-combines this module's state check with ``sandbox.is_sandbox`` so a real
-coach's page never even calls into here). This module intentionally has no
-import of ``sandbox`` — ``sandbox.create_sandbox`` imports *this* module to
-seed the initial tour state, and keeping the dependency one-directional avoids
-a circular import.
+The **variant is derived, never stored** (O7 spirit, decision 2): a throwaway
+sandbox coach always gets ``"sandbox"``; every other authenticated coach gets
+``"self"``. ``tour_state`` keeps only the step index + dismissed/complete
+flag, exactly as in Phase 2 — nothing here persists *which* variant a coach
+is on.
+
+This module still has no *top-level* import of ``sandbox`` — ``sandbox.
+create_sandbox`` imports *this* module at the top level to seed the initial
+tour state, and a top-level import back would form a real cycle. ``variant_
+for`` breaks that with a deferred (function-body) import instead, which is
+safe because by the time any request calls it, both modules are fully loaded.
 """
 
 from django.urls import reverse
 
 from . import demo as meso_demo
+from .billing import access as billing_access
+from .models import CoachAthlete
 from .models import CoachProfile
 
-#: The 8-step sandbox tour (O2/O3). ``segment`` names a ``meso_demo.SEGMENTS``
-#: loader (or ``None`` when the step has no data action); ``anchor`` is the
-#: ``data-tour`` value spotlighted on the step's page (``None`` → centered
-#: card, no spotlight). ``url_name`` is reversed server-side into each step's
-#: "Take me there" link — every one of these is a bare, no-argument URL that
-#: already redirects to "the coach's current thing" (working plan / latest
-#: session / roster), so the tour never needs to know *which* athlete/plan.
+#: The 8-step tour (O2/O3), shared across audiences. ``url_name``/``anchor``
+#: are the step's "Take me there" target + spotlighted control — the same
+#: physical page/control regardless of variant (``finish`` is the one
+#: exception: the self variant overrides ``anchor`` in its own sub-dict,
+#: since a real coach spotlights the roster's invite control there instead of
+#: nothing). ``"sandbox"``/``"self"`` carry the varying title/body/action.
 STEPS = [
     {
         "key": "welcome",
-        "title": "Where your clients live",
-        "body": "This is your roster — every athlete you coach, at a glance. "
-        "Add 5 sample athletes to see it in action.",
         "url_name": "meso:roster",
         "anchor": "roster-individuals",
-        "segment": "athletes",
-        "action_label": "Add 5 sample athletes",
+        "sandbox": {
+            "title": "Where your clients live",
+            "body": "This is your roster — every athlete you coach, at a glance. "
+            "Add 5 sample athletes to see it in action.",
+            "segment": "athletes",
+            "action_label": "Add 5 sample athletes",
+        },
+        "self": {
+            "title": "Where your clients live",
+            "body": "This is your roster — every athlete you coach, at a glance. "
+            "Add yourself as your first athlete to see it in action.",
+            "action_label": "Add yourself as your first athlete",
+        },
     },
     {
         "key": "profile",
-        "title": "One athlete, one record",
-        "body": "Click into Maya to see her contraindications, training "
-        "history, and program — everything you need before you build for her.",
         "url_name": "meso:roster",
         "anchor": "roster-athlete-rows",
-        "segment": None,
-        "action_label": None,
+        "sandbox": {
+            "title": "One athlete, one record",
+            "body": "Click into Maya to see her contraindications, training "
+            "history, and program — everything you need before you build for her.",
+        },
+        "self": {
+            "title": "One athlete, one record",
+            "body": "Click into your own profile to see the same contraindications, "
+            "training history, and program view every athlete gets.",
+        },
     },
     {
         "key": "designer",
-        "title": "Program Designer",
-        "body": "The flagship: lay out a mesocycle week by week. Load a "
-        "sample program to see a full block.",
         "url_name": "meso:designer",
         "anchor": "designer-root",
-        "segment": "program",
-        "action_label": "Load a sample mesocycle",
+        "sandbox": {
+            "title": "Program Designer",
+            "body": "The flagship: lay out a mesocycle week by week. Load a "
+            "sample program to see a full block.",
+            "segment": "program",
+            "action_label": "Load a sample mesocycle",
+        },
+        "self": {
+            "title": "Program Designer",
+            "body": "The flagship: lay out a mesocycle week by week. Start a "
+            "program for yourself to see a full block take shape.",
+            "action_label": "Start a program for yourself",
+            # Shown instead of ``body`` when there's no self-link yet (the
+            # action itself is omitted too — step 1 has to come first).
+            "locked_body": "Add yourself as an athlete first (the welcome "
+            "step) — then come back here to build your own program.",
+        },
     },
     {
         "key": "deliver",
-        "title": "Deliver to their phone",
-        "body": "Push the current week straight to the athlete's phone — "
-        "she sees it the moment you send it.",
         "url_name": "meso:deliver",
         "anchor": "deliver-send",
-        "segment": "delivery",
-        "action_label": "Deliver the sample week",
+        "sandbox": {
+            "title": "Deliver to their phone",
+            "body": "Push the current week straight to the athlete's phone — "
+            "she sees it the moment you send it.",
+            "segment": "delivery",
+            "action_label": "Deliver the sample week",
+        },
+        "self": {
+            "title": "Deliver to your phone",
+            "body": "Push the current week straight to your own phone — "
+            "you'll see it the moment you send it, exactly like any athlete would.",
+        },
     },
     {
         "key": "results",
-        "title": "What actually happened",
-        "body": "Logged sets, adherence, and estimated 1RM flow back here "
-        "the moment she logs a session.",
         "url_name": "meso:results",
         "anchor": "results-main",
-        "segment": "log",
-        "action_label": "Log a sample session",
+        "sandbox": {
+            "title": "What actually happened",
+            "body": "Logged sets, adherence, and estimated 1RM flow back here "
+            "the moment she logs a session.",
+            "segment": "log",
+            "action_label": "Log a sample session",
+        },
+        "self": {
+            "title": "What actually happened",
+            "body": "Log your own sets from your phone at /meso/me/ — logged "
+            "sets, adherence, and estimated 1RM flow back here the moment you do.",
+        },
     },
     {
         "key": "groups",
-        "title": "Program a whole group at once",
-        "body": "Groups share one program with per-athlete auto-adjusts — "
-        "build it once, tune it per person.",
         "url_name": "meso:roster",
         "anchor": "roster-groups",
-        "segment": "group",
-        "action_label": "Add a sample group",
+        "sandbox": {
+            "title": "Program a whole group at once",
+            "body": "Groups share one program with per-athlete auto-adjusts — "
+            "build it once, tune it per person.",
+            "segment": "group",
+            "action_label": "Add a sample group",
+        },
+        "self": {
+            "title": "Program a whole group at once",
+            "body": "Groups share one program with per-athlete auto-adjusts — "
+            "built for when you're coaching several athletes together. Coaching "
+            "just yourself for now? Skip this one.",
+        },
     },
     {
         "key": "agent",
-        "title": "Adapt · the AI agent",
-        "body": "The agent reads an athlete's fatigue and adherence and "
-        "proposes next week's adjustments. Create a free account to run it "
-        "for real.",
         "url_name": "meso:designer",
         "anchor": "designer-root",
-        "segment": None,
-        "action_label": None,
-        # Sandbox-only step: no data action, just an explanation + the signup
-        # gate the agent endpoint already enforces (guards in test_sandbox.py).
-        "signup_gate": True,
+        "sandbox": {
+            "title": "Adapt · the AI agent",
+            "body": "The agent reads an athlete's fatigue and adherence and "
+            "proposes next week's adjustments. Create a free account to run it "
+            "for real.",
+            # Sandbox-only: no data action, just an explanation + the signup
+            # gate the agent endpoint already enforces (test_sandbox.py).
+            "signup_gate": True,
+        },
+        "self": {
+            "title": "Adapt · the AI agent",
+            "body": "The agent reads your fatigue and adherence and drafts "
+            "next week's adjustments. Draft your next block with it now.",
+            "action_label": "Draft next block with AI",
+            # Shown when the action isn't offered (no self-link yet, no agent
+            # allowance left, or a working plan already exists) — one generic
+            # explanation rather than three separate reasons (keep it simple).
+            "locked_body": "The agent drafts your next training block once "
+            "you're on your own roster with an active program — start a free "
+            "trial if you're not seeing this yet.",
+        },
     },
     {
         "key": "finish",
-        "title": "You're ready",
-        "body": "Create a free account to keep coaching for real — or "
-        "remove this demo data and start over.",
         "url_name": "meso:roster",
         "anchor": None,
-        "segment": None,
-        "action_label": None,
-        "signup_gate": True,
+        "sandbox": {
+            "title": "You're ready",
+            "body": "Create a free account to keep coaching for real — or "
+            "remove this demo data and start over.",
+            "signup_gate": True,
+        },
+        "self": {
+            "title": "You're ready",
+            "body": "Invite your first real athlete — your roster is yours from here.",
+            # Spotlights the roster's real "+ Invite an athlete" control
+            # (``data-tour="roster-invite"``) instead of the centered,
+            # anchor-less card the sandbox's signup-gated finish step uses.
+            "anchor": "roster-invite",
+        },
     },
 ]
 
@@ -125,7 +204,7 @@ STEPS = [
 _HIDDEN_STATUSES = {"dismissed", "completed"}
 
 #: segment name → the ``demo.has_*`` predicate that derives its loaded-ness
-#: (O7 — never stored, always read off the data).
+#: (O7 — never stored, always read off the data). Sandbox variant only.
 _HAS_PREDICATES = {
     "athletes": meso_demo.has_athletes,
     "program": meso_demo.has_program,
@@ -155,11 +234,48 @@ def tour_status(user):
 def is_active(user):
     """Whether the tour should still render for ``user`` (not dismissed/completed).
 
-    Doesn't check audience (sandbox vs. real coach) itself — Phase 2 callers
-    (``context_processors.sandbox_status``) combine this with
-    ``sandbox.is_sandbox`` before ever rendering anything.
+    Doesn't check audience (sandbox vs. real coach) itself, and doesn't
+    distinguish "never started" from "in progress" — both read as active
+    here. That's exactly right for the sandbox (whose tour is armed at step 0
+    the instant ``create_sandbox`` runs, so "never started" can't happen) and
+    for the roster's tour-entry-card decision (a real coach who never started
+    OR is mid-tour should never see the *original* Get-started card). It is
+    **not** the real-coach *mount* gate, though — a real coach's never-started
+    ``{}`` must not auto-mount the tour (O2); see ``is_touring`` for that
+    stricter check.
     """
     return tour_status(user).get("status") not in _HIDDEN_STATUSES
+
+
+def is_touring(user):
+    """Whether a real coach's tour is *explicitly* active right now (Phase 3 gate).
+
+    Unlike ``is_active`` (which also treats a never-started ``{}`` state as
+    active — fine for the sandbox, which is always armed from creation), a
+    real coach only sees the tour mounted once they've explicitly opted in —
+    the roster's "Start the guided tour" button, which fires ``tour_state``'s
+    ``restart`` action and always writes a literal ``status: "active"``. A
+    coach who has never touched the tour reads ``{}`` here (status ``None``,
+    not the string ``"active"``), so this is False and the tour never
+    self-mounts on them.
+    """
+    return tour_status(user).get("status") == "active"
+
+
+def variant_for(user):
+    """Which step variant applies to ``user`` — sandbox coach vs. real coach (O5).
+
+    Derived, never stored (decision 2): a throwaway sandbox coach gets the
+    fake-data ``"sandbox"`` steps; every other authenticated coach gets the
+    self-coaching ``"self"`` steps. The ``sandbox`` import is deferred to the
+    function body — ``sandbox.create_sandbox`` imports this module at the top
+    level, so importing it back at *this* module's top level would form a
+    real cycle; by the time any caller actually invokes this function both
+    modules are fully loaded, so the deferred import always succeeds.
+    """
+    from . import sandbox as meso_sandbox
+
+    return "sandbox" if meso_sandbox.is_sandbox(user) else "self"
 
 
 def start_tour(profile):
@@ -197,33 +313,151 @@ def _segment_loaded(user, segment):
     return bool(predicate(user)) if predicate else None
 
 
-def build_config(user):
-    """The front-end tour config.
+def _sandbox_step_fields(step, user):
+    """Resolve one step's sandbox-variant fields — byte-identical to Phase 2.
 
-    Every step (with a resolved URL + loaded state) plus the coach's current
-    progress and the endpoints the driver posts to. Returns ``None`` if
-    ``user`` has no ``CoachProfile`` to read progress from (defensive —
-    callers gate on ``is_active``/``is_sandbox`` first, and every sandbox
-    coach has one).
+    Produces the same ``segment``/``action_label``/``signup_gate``/``loaded``
+    keys the JS driver has always read; ``action`` (the Phase 3 generic form
+    action) is always ``None`` here, so ``resolveActionState`` never takes
+    that branch for a sandbox step.
+    """
+    spec = step["sandbox"]
+    segment = spec.get("segment")
+    return {
+        "title": spec["title"],
+        "body": spec["body"],
+        "anchor": step["anchor"],
+        "segment": segment,
+        "action_label": spec.get("action_label"),
+        "signup_gate": spec.get("signup_gate", False),
+        "action": None,
+        "loaded": _segment_loaded(user, segment),
+    }
+
+
+def _self_context(user):
+    """One-shot facts every dynamic self-variant step needs (computed once per call).
+
+    The welcome/designer/agent steps all key off the same self-link / working
+    -plan / agent-allowance state, so this is read once per ``build_config``
+    call rather than re-queried per step.
+    """
+    self_link = (
+        CoachAthlete.objects.for_coach(user).active().filter(is_self=True).first()
+    )
+    return {
+        "has_self_link": self_link is not None,
+        "has_plan": bool(self_link and self_link.working_plan()),
+        "can_use_agent": billing_access.can_use_agent(user),
+        # Cheap to resolve unconditionally (no query) — used only once a
+        # self-link exists, but harmless to compute either way.
+        "plan_create_url": reverse("meso:plan_create", args=[user.pk]),
+    }
+
+
+def _self_step_fields(step, ctx):
+    """Resolve one step's self-variant title/body/action/loaded/anchor (O5).
+
+    Only the three steps with a real data action branch on ``ctx``:
+
+    - ``welcome``: action always offered (``roster_add_self``); ``loaded`` —
+      and the driver's disabled "Done ✓" state — flips once the self-link
+      exists.
+    - ``designer``: action offered only once the self-link exists (posting
+      ``plan_create`` for the coach's own athlete id); ``loaded`` mirrors
+      whether that link already has a working plan. No self-link yet → no
+      action, and the body swaps to ``locked_body`` ("do step 1 first").
+    - ``agent``: action offered only when the self-link exists **and** the
+      coach still has agent allowance **and** there's no working plan yet
+      (mirrors the roster's "Draft with AI" gate); any other combination
+      falls back to the generic ``locked_body``, no ``loaded`` concept.
+
+    Every other step (profile/deliver/results/groups/finish) is static copy
+    with no action at all — the driver already renders an action-less step
+    fine (Next/Back + "Take me there" still work).
+    """
+    spec = step["self"]
+    key = step["key"]
+    title = spec["title"]
+    body = spec["body"]
+    anchor = spec.get("anchor", step["anchor"])
+    action = None
+    loaded = None
+
+    if key == "welcome":
+        loaded = ctx["has_self_link"]
+        action = {
+            "url": reverse("meso:roster_add_self"),
+            "label": spec["action_label"],
+            "fields": {},
+        }
+    elif key == "designer":
+        loaded = ctx["has_plan"]
+        if ctx["has_self_link"]:
+            action = {
+                "url": ctx["plan_create_url"],
+                "label": spec["action_label"],
+                "fields": {},
+            }
+        else:
+            body = spec["locked_body"]
+    elif key == "agent":
+        if ctx["has_self_link"] and ctx["can_use_agent"] and not ctx["has_plan"]:
+            action = {
+                "url": ctx["plan_create_url"],
+                "label": spec["action_label"],
+                "fields": {"draft": "agent"},
+            }
+        else:
+            body = spec["locked_body"]
+
+    return {
+        "title": title,
+        "body": body,
+        "anchor": anchor,
+        "action": action,
+        "loaded": loaded,
+    }
+
+
+def build_config(user, variant):
+    """The front-end tour config for ``user`` under ``variant``.
+
+    ``variant`` — ``"sandbox"`` or ``"self"`` — is resolved by the caller
+    (``variant_for``; O7: derived, never stored), so this stays a pure read
+    given the already-known audience. Every step gets its variant's resolved
+    title/body/action (``_sandbox_step_fields``/``_self_step_fields``) plus
+    the coach's current progress and the endpoints the driver posts to.
+    Returns ``None`` if ``user`` has no ``CoachProfile`` to read progress from
+    (defensive — callers gate on ``is_active``/``is_touring``/``is_sandbox``
+    first, and every sandbox coach has one).
     """
     profile = CoachProfile.objects.filter(user=user).first()
     if profile is None:
         return None
     state = profile.tour_state or {}
-    steps = [
-        {
-            "key": step["key"],
-            "title": step["title"],
-            "body": step["body"],
-            "url": reverse(step["url_name"]),
-            "anchor": step["anchor"],
-            "segment": step["segment"],
-            "action_label": step["action_label"],
-            "signup_gate": step.get("signup_gate", False),
-            "loaded": _segment_loaded(user, step["segment"]),
-        }
-        for step in STEPS
-    ]
+    self_ctx = _self_context(user) if variant == "self" else None
+    steps = []
+    for step in STEPS:
+        fields = (
+            _self_step_fields(step, self_ctx)
+            if variant == "self"
+            else _sandbox_step_fields(step, user)
+        )
+        steps.append(
+            {
+                "key": step["key"],
+                "title": fields["title"],
+                "body": fields["body"],
+                "url": reverse(step["url_name"]),
+                "anchor": fields["anchor"],
+                "segment": fields.get("segment"),
+                "action_label": fields.get("action_label"),
+                "signup_gate": fields.get("signup_gate", False),
+                "action": fields.get("action"),
+                "loaded": fields.get("loaded"),
+            }
+        )
     return {
         "steps": steps,
         "step": _clamp(state.get("step", 0)),

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -415,6 +415,14 @@ class RosterView(TemplateView):
         # Self-coaching (guided-tour Phase 0): the roster offers "Add yourself as
         # an athlete" until the coach's one self-link is active.
         ctx["has_self_link"] = any(link.is_self for link in links)
+        # Guided-tour Phase 3: an empty workspace's Get-started card becomes the
+        # tour entry point for anyone whose tour hasn't been dismissed/completed
+        # (covers "never started" — the common real-coach case — and, harmlessly,
+        # an in-progress tour, though that branch never renders since the tour
+        # itself is mounted instead whenever ``show_meso_tour`` is true). Once
+        # dismissed/completed, this reads False and the original card returns —
+        # nothing is ever a dead end.
+        ctx["tour_entry_available"] = meso_tour.is_active(self.request.user)
         return ctx
 
 

--- a/app/store_project/static/js/meso_tour.js
+++ b/app/store_project/static/js/meso_tour.js
@@ -1,13 +1,16 @@
-/* Meso — guided demo onboarding tour driver (issue #430, Phase 2).
+/* Meso — guided demo onboarding tour driver (issue #430, Phase 2 sandbox +
+ * Phase 3 real-coach self-coaching variant).
  *
  * Hand-rolled vanilla JS (no Alpine, no CDN — mirrors meso_onboarding.js's
  * style): reads its config from a `json_script` element `_tour.html` embeds
  * (`#meso-tour-config`), then renders a spotlight + card overlay into the
  * server-rendered mount (`#meso-tour`) and drives it — Next/Back/dismiss
- * persist server-side via `fetch` to `state_url`; the per-step "add sample
- * data" action and the "skip · load everything" shortcut are real HTML
- * `<form method="post">`s (a full page reload, so Django's flash message +
- * the segment's freshly-true `loaded` flag show up the normal way).
+ * persist server-side via `fetch` to `state_url`; the per-step data action
+ * (sandbox: "add sample data" against a `segment`; self-coaching: a typed
+ * `action` — `roster_add_self`/`plan_create` — Phase 3) and the "skip · load
+ * everything" shortcut are real HTML `<form method="post">`s (a full page
+ * reload, so Django's flash message + the freshly-true `loaded` flag show up
+ * the normal way).
  *
  * The pure decision logic (step clamping/advance, anchor-retry cutoff, config
  * parsing, per-step action state, current-page detection) is unit-tested
@@ -66,9 +69,12 @@
   }
 
   // What the step's action control should look like, given its `segment`
-  // (data-loading action) / `signup_gate` (sandbox agent+finish steps) /
-  // `loaded` (O7 — derived, never stored) fields. Returns null for a step
-  // with no action at all (e.g. the "profile" step).
+  // (sandbox data-loading action) / `action` (Phase 3 self-variant typed
+  // form action — `{url, label, fields}`) / `signup_gate` (sandbox
+  // agent+finish steps) / `loaded` (O7 — derived, never stored) fields.
+  // Returns null for a step with no action at all (e.g. the "profile" step).
+  // `segment` and `action` are mutually exclusive in practice (sandbox steps
+  // carry the former, self-variant steps the latter), checked in that order.
   function resolveActionState(step) {
     if (!step) return null;
     if (step.segment) {
@@ -77,6 +83,15 @@
         : {
             kind: "segment",
             label: step.action_label || "Add sample data",
+            disabled: false,
+          };
+    }
+    if (step.action) {
+      return step.loaded
+        ? { kind: "form", label: "Done ✓", disabled: true }
+        : {
+            kind: "form",
+            label: step.action.label || "Continue",
             disabled: false,
           };
     }
@@ -212,6 +227,38 @@
         '<input type="hidden" name="next" value="' +
         escapeHtml(root.location.pathname + root.location.search) +
         '">' +
+        '<button type="submit" class="meso-btn meso-btn--primary"' +
+        (action.disabled ? " disabled" : "") +
+        ">" +
+        escapeHtml(action.label) +
+        "</button></form>";
+    } else if (action && action.kind === "form") {
+      // Self-variant typed action (Phase 3): a real form POST straight to the
+      // resolved endpoint (`roster_add_self` / `plan_create`) with whatever
+      // hidden fields the step specifies (e.g. `draft=agent`). No `next` field
+      // — unlike the sandbox's segment action, these endpoints already
+      // redirect to the right place (roster / the designer), which the plan
+      // deliberately leans on rather than fighting.
+      var fields = (step.action && step.action.fields) || {};
+      var fieldsHtml = Object.keys(fields)
+        .map(function (name) {
+          return (
+            '<input type="hidden" name="' +
+            escapeHtml(name) +
+            '" value="' +
+            escapeHtml(fields[name]) +
+            '">'
+          );
+        })
+        .join("");
+      actionHtml =
+        '<form method="post" action="' +
+        escapeHtml(step.action.url) +
+        '" class="meso-tour-action-form">' +
+        '<input type="hidden" name="csrfmiddlewaretoken" value="' +
+        csrf +
+        '">' +
+        fieldsHtml +
         '<button type="submit" class="meso-btn meso-btn--primary"' +
         (action.disabled ? " disabled" : "") +
         ">" +

--- a/app/store_project/templates/meso/roster.html
+++ b/app/store_project/templates/meso/roster.html
@@ -32,9 +32,11 @@
         {% elif is_empty and not show_meso_tour %}
           <!-- First-run onboarding (first-time-UX Phase 2): teach Invite → Build →
                Deliver and offer the one-click demo. Suppressed while the guided
-               demo tour (issue #430) is active — its own welcome step replaces
-               this card for a sandbox coach; a real coach (show_meso_tour is
-               always False in Phase 2) sees this exactly as before. -->
+               demo tour (issue #430) is actually mounted — its own welcome step
+               replaces this card while touring (sandbox or self). Once the tour
+               is dismissed/completed, ``tour_entry_available`` is False and the
+               CTA block below falls back to the original demo-only card, so
+               nothing is ever a dead end (guided-tour Phase 3). -->
           <div class="meso-card meso-card--pad" style="display:flex;flex-direction:column;gap:15px;">
             <div>
               <p class="meso-eyebrow" style="margin:0 0 4px;">Get started</p>
@@ -55,13 +57,30 @@
                 <div style="min-width:0;"><div class="meso-row-name">Deliver the week</div><div class="meso-row-meta">Push it to their phone; their logged results flow back to you.</div></div>
               </li>
             </ol>
-            <div style="display:flex;gap:10px;flex-wrap:wrap;align-items:center;">
-              <form method="post" action="{% url 'meso:demo_load' %}" style="margin:0;">
-                {% csrf_token %}
-                <button type="submit" class="meso-btn meso-btn--primary">Load a demo athlete &amp; program</button>
-              </form>
-              <span class="meso-sub" style="margin:0;">Not sure yet? Explore a populated workspace first — or invite your first athlete below.</span>
-            </div>
+            {% if tour_entry_available %}
+              <!-- Tour entry (guided-tour Phase 3): the roster's empty-state card
+                   is the on-ramp into the self-coaching tour for a real coach who
+                   hasn't started (or has dismissed/completed) it. -->
+              <div style="display:flex;gap:10px;flex-wrap:wrap;align-items:center;">
+                <form method="post" action="{% url 'meso:tour_state' %}" style="margin:0;">
+                  {% csrf_token %}
+                  <input type="hidden" name="action" value="restart" />
+                  <button type="submit" class="meso-btn meso-btn--primary">Start the guided tour</button>
+                </form>
+                <form method="post" action="{% url 'meso:demo_load' %}" style="margin:0;">
+                  {% csrf_token %}
+                  <button type="submit" class="meso-btn meso-btn--ghost">Load a demo athlete &amp; program</button>
+                </form>
+              </div>
+            {% else %}
+              <div style="display:flex;gap:10px;flex-wrap:wrap;align-items:center;">
+                <form method="post" action="{% url 'meso:demo_load' %}" style="margin:0;">
+                  {% csrf_token %}
+                  <button type="submit" class="meso-btn meso-btn--primary">Load a demo athlete &amp; program</button>
+                </form>
+                <span class="meso-sub" style="margin:0;">Not sure yet? Explore a populated workspace first — or invite your first athlete below.</span>
+              </div>
+            {% endif %}
           </div>
         {% endif %}
 
@@ -168,7 +187,7 @@
               <span class="meso-row-meta">Inviting real athletes is off in the demo — <a href="{% url 'meso:sandbox_signup' %}" style="color:var(--accent);">create a free account</a>.</span>
             </div>
           {% else %}
-            <details style="border-top:1px solid var(--line-2);">
+            <details data-tour="roster-invite" style="border-top:1px solid var(--line-2);">
               <summary style="list-style:none;cursor:pointer;padding:11px 16px;font-size:12.5px;font-weight:650;color:var(--accent);">+ Invite an athlete</summary>
               <form method="post" action="{% url 'meso:coach_invite' %}" style="display:flex;gap:9px;padding:4px 16px 16px;">
                 {% csrf_token %}

--- a/docs/meso/demo-onboarding-tour-plan.md
+++ b/docs/meso/demo-onboarding-tour-plan.md
@@ -119,9 +119,12 @@ from data (O7).
    the tour auto-starts; each step's action posts its segment to `demo_load`
    (returning to the page it came from via a safe `next`); **skip ·
    load-everything** (`tour_skip`) and **dismiss** controls.
-3. **Real-coach tour** — the self-coaching variant of the steps; replace the
-   empty-state "Get started" card (`roster.html:32-63`) with the tour entry; the
-   agent step actually drafts for a trial coach. *(Depends on Phase 0 + 2.)*
+3. **Real-coach tour** — PR [#435](https://github.com/lancegoyke/fitness-store/pull/435) — the self-coaching variant of the steps
+   (variant derived from `is_sandbox`, never stored; typed per-step actions:
+   `roster_add_self`, `plan_create` for yourself, agent draft when
+   `can_use_agent`); the empty-state "Get started" card becomes the tour
+   entry ("Start the guided tour", demo load kept as the secondary; original
+   card returns once dismissed/completed). *(Depended on Phase 0 + 2.)*
 4. **Analytics + polish** — funnel events (start → per-step → finish, per-segment
    opt-in) via the `analytics` app; mobile bottom-sheet steps; keyboard/ARIA a11y;
    `prefers-reduced-motion`.

--- a/frontend/meso_tour.test.js
+++ b/frontend/meso_tour.test.js
@@ -185,6 +185,66 @@ describe("resolveActionState", () => {
       }).kind,
     ).toBe("segment");
   });
+
+  // Phase 3 — self-coaching variant's generic form action (roster_add_self /
+  // plan_create), distinct from the sandbox's segment action.
+  it("offers the self-variant form action when not yet loaded", () => {
+    expect(
+      resolveActionState({
+        segment: null,
+        action: { url: "/meso/athlete/self/add/", label: "Add yourself as your first athlete", fields: {} },
+        loaded: false,
+      }),
+    ).toEqual({
+      kind: "form",
+      label: "Add yourself as your first athlete",
+      disabled: false,
+    });
+  });
+
+  it("shows a disabled done-state once the self-variant action's step is loaded", () => {
+    expect(
+      resolveActionState({
+        segment: null,
+        action: { url: "/meso/athlete/self/add/", label: "Add yourself as your first athlete", fields: {} },
+        loaded: true,
+      }),
+    ).toEqual({ kind: "form", label: "Done ✓", disabled: true });
+  });
+
+  it("falls back to a generic label when the form action has none", () => {
+    expect(
+      resolveActionState({
+        segment: null,
+        action: { url: "/meso/athlete/1/plan/new/", fields: {} },
+        loaded: false,
+      }),
+    ).toEqual({ kind: "form", label: "Continue", disabled: false });
+  });
+
+  it("prefers the segment action over a form action when both are set", () => {
+    // Not a real server-produced shape (sandbox and self-variant steps are
+    // mutually exclusive), but pins the precedence order defensively.
+    expect(
+      resolveActionState({
+        segment: "athletes",
+        action_label: "Add 5 sample athletes",
+        action: { url: "/meso/athlete/self/add/", label: "Add yourself" },
+        loaded: false,
+      }).kind,
+    ).toBe("segment");
+  });
+
+  it("prefers a form action over signup_gate when both are set", () => {
+    expect(
+      resolveActionState({
+        segment: null,
+        action: { url: "/meso/athlete/1/plan/new/", label: "Start a program for yourself" },
+        signup_gate: true,
+        loaded: false,
+      }).kind,
+    ).toBe("form");
+  });
 });
 
 describe("isCurrentPage", () => {


### PR DESCRIPTION
## Summary

Phase 3 of the [guided demo onboarding tour plan](docs/meso/demo-onboarding-tour-plan.md) (part of #430): a real coach with an empty workspace gets the **same 8-step tour** as the sandbox, but the data steps guide them to **coach themselves** — no fake demo athletes (decision O5), building on Phase 0's non-billable self-athlete links.

- **Two variants, one STEPS list**: shared `key`/`url_name`/`anchor` top-level, per-variant `sandbox`/`self` sub-dicts; `build_config(user, variant)` resolves to the flat shape the driver already consumes. The variant is derived from `is_sandbox` — never stored (O7). Sandbox output is **byte-identical to Phase 2**, pinned by a dedicated test.
- **Typed self actions** (`{url, label, fields}` form posts): step 1 → `roster_add_self` (Phase 0, never a paid seat); step 3 → `plan_create` for the coach's own record, offered once the self-link exists, landing in the designer; step 7 → `plan_create` + `draft=agent` when the agent gate allows; step 8 anchors the invite control ("Invite your first real athlete") — no signup gate.
- **Opt-in visibility**: `show_meso_tour` = the unchanged sandbox rule OR a real coach with `tour_state` **explicitly** active (new `tour.is_touring` — a never-started `{}` must not self-mount on a real coach).
- **The empty-state "Get started" card becomes the tour entry**: "Start the guided tour" primary + the demo load as secondary; once dismissed/completed the original card returns exactly — nothing is a dead end.

## Test plan

- Tour suite extended: variant derivation, `is_touring` vs `is_active`, per-step self-action gating (no self-link → no action; self-link → `plan_create`; working plan → loaded), entry-card rendering/round-trip, real-coach mount gates, sandbox contract pinned untouched. Vitest: new form-action driver cases.
- Full suite: **2063 passed**; vitest 455; ruff/format clean; `makemigrations --check` clean (no new migrations).
- **Driven in the browser as a real coach**: entry card → Start → "Add yourself as your first athlete" (You badge, seat count stayed 0 of 1) → "Start a program for yourself" → landed in the designer with the tour following ("Done ✓", no redundant "Take me there").

Part of #430 (does not close it — Phase 4 analytics/polish remains).