### PR TITLE
docs(meso): archive the completed demo onboarding tour plan

### DIFF
--- a/docs/archive/meso/demo-onboarding-tour-plan.md
+++ b/docs/archive/meso/demo-onboarding-tour-plan.md
@@ -2,10 +2,10 @@
 
 Status: **COMPLETE** — all 5 phases shipped 2026-07-07 (PRs [#432](https://github.com/lancegoyke/fitness-store/pull/432), [#433](https://github.com/lancegoyke/fitness-store/pull/433), [#434](https://github.com/lancegoyke/fitness-store/pull/434), [#435](https://github.com/lancegoyke/fitness-store/pull/435), [#436](https://github.com/lancegoyke/fitness-store/pull/436)). Tracking issue: [#430](https://github.com/lancegoyke/fitness-store/issues/430).
 
-Sibling of the [public sandbox demo](./public-sandbox-demo-plan.md) (which this
-reshapes) and the [walkthrough video](./demo-walkthrough-video-plan.md). The
+Sibling of the [public sandbox demo](../../meso/public-sandbox-demo-plan.md) (which this
+reshapes) and the [walkthrough video](../../meso/demo-walkthrough-video-plan.md). The
 real-coach half extends the one-click demo from the
-[first-time-UX plan](../archive/meso/first-time-ux-plan.md).
+[first-time-UX plan](./first-time-ux-plan.md).
 
 ## Why
 


### PR DESCRIPTION
All 5 phases of the guided demo onboarding tour shipped today (#432, #433, #434, #435, #436 — issue #430). Moves the plan to `docs/archive/meso/` per the archive convention, with its relative links repointed for the new location. No inbound links elsewhere in docs/ needed updating. Docs-only — CI/deploy will skip via paths-ignore.