### PR TITLE
fix(meso): split cutover reset into its own migration (Postgres pending-trigger-events)

### DIFF
--- a/app/store_project/meso/migrations/0036_reset_program_data.py
+++ b/app/store_project/meso/migrations/0036_reset_program_data.py
@@ -1,0 +1,48 @@
+from django.db import migrations
+
+
+def reset_program_data(apps, schema_editor):
+    """Pre-launch reshape (no data to preserve): delete every ``Plan`` so the
+    fixed-lineup schema ops (the NEXT migration) apply to empty program tables AND
+    the demo rebuilds cleanly post-deploy.
+
+    Deleting the plans cascades the WHOLE program hierarchy — mesocycles → weeks →
+    sessions → prescriptions/logs/deliveries, agent batches → proposed changes, and
+    the designer undo/redo ``PlanAction`` stacks — while leaving the coach/athlete/
+    group/subscription scaffolding intact (``Plan`` FKs *to* those; they are not
+    cascaded). This matters because:
+
+    - the new NOT NULL ``Session.session_slot`` FK and the repointed ``prescription``
+      FKs would otherwise violate their constraints against pre-existing rows;
+    - ``seed_meso_demo`` early-returns when ``plan.mesocycles.exists()`` and the group
+      path only builds when the shared plan is missing, so leaving empty
+      ``Mesocycle``/``Week`` shells behind would leave delivered-but-empty programs the
+      reseeder never rebuilds — deleting the plans resets to the fresh-DB state the
+      reseeder is built to populate (idempotent), which recreates the new-shape tree;
+    - stale ``PlanAction`` snapshots reference the retired per-week rows, so an undo
+      after the cutover would restore an old-shape snapshot with no slots/cells — the
+      cascade drops those stacks with their plans.
+
+    This reset lives in its OWN migration (separate from the schema cutover in
+    ``0037``) on purpose: on Postgres a cascade DELETE queues deferred RI trigger
+    events, and ``ALTER TABLE`` refuses to run against a table with pending trigger
+    events *in the same transaction* ("cannot ALTER TABLE ... because it has pending
+    trigger events"). Committing this migration first flushes those events, so the
+    ALTERs in ``0037`` land on clean, empty tables. (SQLite has no such rule, which
+    is why the combined form passed CI but failed the prod migrate.)
+
+    On a fresh DB there are no plans, so this is a no-op. Reseed with
+    ``manage.py seed_meso_demo`` after the deploy. Irreversible (reverse = no-op).
+    """
+    apps.get_model("meso", "Plan").objects.all().delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('meso', '0035_tourevent'),
+    ]
+
+    operations = [
+        migrations.RunPython(reset_program_data, migrations.RunPython.noop),
+    ]

--- a/app/store_project/meso/migrations/0037_fixed_lineup_schema_cutover.py
+++ b/app/store_project/meso/migrations/0037_fixed_lineup_schema_cutover.py
@@ -4,43 +4,19 @@ import django.db.models.deletion
 from django.db import migrations, models
 
 
-def reset_program_data(apps, schema_editor):
-    """Pre-launch reshape (no data to preserve): delete every ``Plan`` so the
-    fixed-lineup schema ops below apply to empty program tables AND the demo
-    rebuilds cleanly post-deploy.
-
-    Deleting the plans cascades the WHOLE program hierarchy — mesocycles → weeks →
-    sessions → prescriptions/logs/deliveries, agent batches → proposed changes, and
-    the designer undo/redo ``PlanAction`` stacks — while leaving the coach/athlete/
-    group/subscription scaffolding intact (``Plan`` FKs *to* those; they are not
-    cascaded). This matters because:
-
-    - the new NOT NULL ``Session.session_slot`` FK and the repointed ``prescription``
-      FKs would otherwise violate their constraints against pre-existing rows;
-    - ``seed_meso_demo`` early-returns when ``plan.mesocycles.exists()`` and the group
-      path only builds when the shared plan is missing, so leaving empty
-      ``Mesocycle``/``Week`` shells behind would leave delivered-but-empty programs the
-      reseeder never rebuilds — deleting the plans resets to the fresh-DB state the
-      reseeder is built to populate (idempotent), which recreates the new-shape tree;
-    - stale ``PlanAction`` snapshots reference the retired per-week rows, so an undo
-      after the cutover would restore an old-shape snapshot with no slots/cells — the
-      cascade drops those stacks with their plans.
-
-    On a fresh test DB there are no plans, so this is a no-op there. Reseed with
-    ``manage.py seed_meso_demo`` after the deploy. Irreversible (reverse = no-op).
-    """
-    apps.get_model("meso", "Plan").objects.all().delete()
-
-
 class Migration(migrations.Migration):
 
+    # The fixed-lineup schema cutover. The destructive program-data reset it needs
+    # (empty tables so the new NOT NULL FKs + repoints apply) runs in the PREVIOUS
+    # migration (0036) so its cascade DELETE commits — flushing Postgres deferred
+    # trigger events — before these ALTERs run. See 0036 for the "pending trigger
+    # events" rationale.
     dependencies = [
         ('exercises', '0002_auto_20201204_2000'),
-        ('meso', '0035_tourevent'),
+        ('meso', '0036_reset_program_data'),
     ]
 
     operations = [
-        migrations.RunPython(reset_program_data, migrations.RunPython.noop),
         migrations.RemoveField(
             model_name='exerciseprescription',
             name='exercise',


### PR DESCRIPTION
## Hotfix — the P0 (#438) deploy migrate failed on prod

```
django.db.utils.OperationalError: cannot ALTER TABLE "meso_exerciseprescription" because it has pending trigger events
```

**Cause:** `0036_fixed_lineup_schema_cutover` did `Plan.objects.all().delete()` (cascade) and then `ALTER TABLE meso_exerciseprescription` (RemoveField) **in one transaction**. Postgres refuses to ALTER a table that has pending cascade-delete trigger events. SQLite (CI's test DB) has no such rule → CI passed; and a *fresh* DB wouldn't hit it (nothing to cascade-delete) — only a **populated** DB (prod's demo data) does. The failed migrate rolled back atomically, so prod stayed on the pre-P0 schema/image (site never went down, HTTP 200 throughout).

**Fix:** split the destructive reset into its own migration so the DELETE **commits** (flushing the deferred trigger events) before the schema ALTERs run:
- `0036_reset_program_data` — the `RunPython` `Plan` delete (atomic).
- `0037_fixed_lineup_schema_cutover` — the pure DDL, now against empty tables.

**Verified on real Postgres:** migrated a throwaway DB to 0035, seeded an old-shape `Plan → Mesocycle → Week → Session → ExercisePrescription` chain (the exact prod condition), then `migrate` → both `0036` and `0037` apply **OK**, ending with the new slots+cells schema and 0 plans. SQLite suite still **2111 passed**; `makemigrations --check` clean.

Same deploy note as #438: the reset wipes program data (pre-launch, all demo) and the on-demand sandbox self-heals via `load_demo`; run `seed_meso_demo` post-deploy to rebuild any persistent demo.