### PR TITLE
feat(meso): P1 multi-week table UI — serialize_mesocycle_grid + MesoTable (#440)

### DIFF
--- a/app/store_project/meso/serializers.py
+++ b/app/store_project/meso/serializers.py
@@ -989,11 +989,13 @@ def serialize_mesocycle_grid(mesocycle):
 
     # One query for every live cell in the block, grouped by (slot, week) so
     # each row's dense ``cells`` map is built without a per-row lookup.
+    # ``select_related("swap_exercise")`` lets swap_display resolve a
+    # catalog-only swap's name below without a per-cell query.
     cells_by_key = {
         (cell.exercise_slot_id, cell.week_id): cell
         for cell in models.Prescription.objects.filter(
             exercise_slot_id__in=exercise_slot_ids, week_id__in=week_ids
-        )
+        ).select_related("swap_exercise")
     }
 
     days = []
@@ -1005,6 +1007,16 @@ def serialize_mesocycle_grid(mesocycle):
                 cell = cells_by_key.get((exercise_slot.pk, week.pk))
                 if cell is None:
                     continue
+                # The resolved one-week swap display name: free-text
+                # swap_name if set, else the swapped catalog exercise's name,
+                # else "" (no swap) — the table needs this to show a badge
+                # for catalog-only swaps too (swap_name blank).
+                if cell.swap_name:
+                    swap_display = cell.swap_name
+                elif cell.swap_exercise_id:
+                    swap_display = cell.swap_exercise.name
+                else:
+                    swap_display = ""
                 cells[str(week.pk)] = {
                     "prescription_id": cell.pk,
                     "sets": cell.sets,
@@ -1017,6 +1029,7 @@ def serialize_mesocycle_grid(mesocycle):
                     "skipped": cell.skipped,
                     "swap_name": cell.swap_name,
                     "swap_exercise_id": cell.swap_exercise_id,
+                    "swap_display": swap_display,
                 }
             rows.append(
                 {

--- a/app/store_project/meso/serializers.py
+++ b/app/store_project/meso/serializers.py
@@ -172,6 +172,11 @@ def serialize_session(session):
     }
 
 
+def _week_label(week):
+    """The week strip / grid's short label, e.g. "Wk 3"."""
+    return f"Wk {week.index}"
+
+
 def serialize_week(week):
     """One column in the designer's week strip.
 
@@ -181,7 +186,7 @@ def serialize_week(week):
     return {
         "id": week.pk,
         "index": week.index,
-        "label": f"Wk {week.index}",
+        "label": _week_label(week),
         "phase": week.phase,
         "vol": week.volume,
         "inten": week.intensity,
@@ -915,5 +920,147 @@ def serialize_plan(plan, week=None):
         "phases": phases,
         # Undo/redo button state (designer framework Phase 1) — rides every
         # serialize_plan response so the designer's buttons stay accurate.
+        "history": serialize_plan_history(plan),
+    }
+
+
+def _pick_session_id(slot_id, sessions_by_slot, current_week_id, weeks):
+    """The live ``Session`` pk the P1 grid uses for one day column.
+
+    Prefers the current (deliver-target) week's session for this slot, since
+    that's the row the write endpoints (add-exercise, remove-day) already key
+    off of; falls back to the earliest live week that has one (``weeks`` is
+    already ordered by ``index``) when the current week is missing a session
+    for this slot (e.g. it was independently soft-deleted). ``None`` only when
+    no live week has a session for this slot at all.
+    """
+    by_week = sessions_by_slot.get(slot_id)
+    if not by_week:
+        return None
+    if current_week_id is not None and current_week_id in by_week:
+        return by_week[current_week_id]
+    for week in weeks:
+        if week.pk in by_week:
+            return by_week[week.pk]
+    return None
+
+
+def serialize_mesocycle_grid(mesocycle):
+    """The P1 multi-week table: every live day × row × week cell, densely.
+
+    Unlike ``serialize_plan``'s single-week ``program`` (one week's sessions),
+    this renders the whole block at once — one row per live ``ExerciseSlot``,
+    one column per live ``Week``, keyed by ``str(week_id)`` so the grid can
+    look a cell up directly. A cell is live iff both its ``ExerciseSlot`` and
+    its ``Week`` are live (``Prescription`` carries no ``deleted_at`` of its
+    own); every live (slot × week) pair should have exactly one, built from a
+    single query grouped in Python to avoid N+1 over the block.
+    """
+    plan = mesocycle.plan
+    weeks = list(mesocycle.weeks.filter(deleted_at__isnull=True).order_by("index"))
+    week_ids = [w.pk for w in weeks]
+    current_week_id = next((w.pk for w in weeks if w.is_current), None)
+
+    session_slots = list(
+        mesocycle.session_slots.filter(deleted_at__isnull=True).order_by(
+            "order", "day_number"
+        )
+    )
+    slot_ids = [s.pk for s in session_slots]
+
+    # session_id resolution: one query over every live session for this
+    # block's live slots/weeks, grouped ``slot_id -> {week_id: session_id}``
+    # so ``_pick_session_id`` can prefer the current week per slot.
+    sessions_by_slot = defaultdict(dict)
+    for sess in models.Session.objects.filter(
+        week_id__in=week_ids, session_slot_id__in=slot_ids, deleted_at__isnull=True
+    ):
+        sessions_by_slot[sess.session_slot_id][sess.week_id] = sess.pk
+
+    exercise_slots = list(
+        models.ExerciseSlot.objects.filter(
+            session_slot_id__in=slot_ids, deleted_at__isnull=True
+        ).order_by("order")
+    )
+    exercise_slot_ids = [e.pk for e in exercise_slots]
+    rows_by_slot = defaultdict(list)
+    for exercise_slot in exercise_slots:
+        rows_by_slot[exercise_slot.session_slot_id].append(exercise_slot)
+
+    # One query for every live cell in the block, grouped by (slot, week) so
+    # each row's dense ``cells`` map is built without a per-row lookup.
+    cells_by_key = {
+        (cell.exercise_slot_id, cell.week_id): cell
+        for cell in models.Prescription.objects.filter(
+            exercise_slot_id__in=exercise_slot_ids, week_id__in=week_ids
+        )
+    }
+
+    days = []
+    for slot in session_slots:
+        rows = []
+        for exercise_slot in rows_by_slot.get(slot.pk, []):
+            cells = {}
+            for week in weeks:
+                cell = cells_by_key.get((exercise_slot.pk, week.pk))
+                if cell is None:
+                    continue
+                cells[str(week.pk)] = {
+                    "prescription_id": cell.pk,
+                    "sets": cell.sets,
+                    "reps": cell.reps,
+                    "load": cell.load,
+                    "load_type": cell.load_type,
+                    "rpe": cell.rpe,
+                    "rest": cell.rest,
+                    "note": cell.note,
+                    "skipped": cell.skipped,
+                    "swap_name": cell.swap_name,
+                    "swap_exercise_id": cell.swap_exercise_id,
+                }
+            rows.append(
+                {
+                    "exercise_slot_id": exercise_slot.pk,
+                    "name": exercise_slot.name,
+                    "exercise_id": exercise_slot.exercise_id,
+                    "order": exercise_slot.order,
+                    "tags": list(exercise_slot.tags or []),
+                    "cells": cells,
+                }
+            )
+        days.append(
+            {
+                "session_slot_id": slot.pk,
+                "session_id": _pick_session_id(
+                    slot.pk, sessions_by_slot, current_week_id, weeks
+                ),
+                "day_number": slot.day_number,
+                "name": slot.name,
+                "bias": slot.bias,
+                "order": slot.order,
+                "rows": rows,
+            }
+        )
+
+    return {
+        "mesocycle": {
+            "id": mesocycle.pk,
+            "plan_id": plan.pk,
+            "name": mesocycle.name,
+            "week_count": mesocycle.week_count,
+        },
+        "weeks": [
+            {
+                "id": w.pk,
+                "index": w.index,
+                "label": _week_label(w),
+                "phase": w.phase,
+                "deload": w.is_deload,
+                "current": w.is_current,
+                "delivered_at": w.delivered_at.isoformat() if w.delivered_at else None,
+            }
+            for w in weeks
+        ],
+        "days": days,
         "history": serialize_plan_history(plan),
     }

--- a/app/store_project/meso/tests/test_mesocycle_grid_endpoint.py
+++ b/app/store_project/meso/tests/test_mesocycle_grid_endpoint.py
@@ -1,0 +1,187 @@
+"""GET /meso/api/plan/<id>/grid/ — the P1 multi-week table's data (backend).
+
+``serialize_mesocycle_grid`` (``test_serializers.py``) builds the dense
+day × row × week shape; this endpoint exposes it read-only, scoped by
+ownership only (mirrors ``week_view`` — not billing-gated, since viewing never
+mutates anything). It defaults to the plan's current mesocycle (the block its
+current week belongs to) and accepts ``?mesocycle=<id>`` to view another block
+in the same plan. The designer view also hydrates the same payload into the
+page (``grid_data``) for the initial page load.
+"""
+
+import pytest
+from django.urls import reverse
+
+from store_project.meso.factories import CoachAthleteFactory
+from store_project.meso.factories import MesocycleFactory
+from store_project.meso.factories import PlanFactory
+from store_project.meso.factories import WeekFactory
+from store_project.meso.models import CoachAthlete
+from store_project.users.factories import UserFactory
+
+from ._helpers import day
+from ._helpers import presc
+
+pytestmark = pytest.mark.django_db
+
+
+def _aged_link(coach, days_ago, **kwargs):
+    from datetime import timedelta
+
+    from django.utils import timezone
+
+    link = CoachAthleteFactory(coach=coach, status=CoachAthlete.Status.ACTIVE, **kwargs)
+    CoachAthlete.objects.filter(pk=link.pk).update(
+        created_at=timezone.now() - timedelta(days=days_ago)
+    )
+    link.refresh_from_db()
+    return link
+
+
+def _seeded_plan():
+    """An owned plan with a two-day, two-week current block."""
+    link = CoachAthleteFactory()
+    plan = link.create_plan()  # scaffold: 1 block, 1 week, 2 days, 1 row each
+    meso = plan.mesocycles.get()
+    meso.append_week()  # a second week, same block-shared days/rows
+    return link, plan, meso
+
+
+class TestMesocycleGridEndpoint:
+    def _url(self, plan):
+        return reverse("meso:api_mesocycle_grid", kwargs={"plan_id": plan.pk})
+
+    def test_returns_ok_and_the_grid_shape_for_the_owner(self, client):
+        link, plan, meso = _seeded_plan()
+        client.force_login(link.coach)
+        resp = client.get(self._url(plan))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["mesocycle"]["id"] == meso.pk
+        assert body["mesocycle"]["plan_id"] == plan.pk
+        assert len(body["weeks"]) == 2
+        assert len(body["days"]) == 2
+        assert "history" in body
+
+    def test_grid_is_dense_across_both_weeks(self, client):
+        link, plan, meso = _seeded_plan()
+        client.force_login(link.coach)
+        resp = client.get(self._url(plan))
+        body = resp.json()
+        week_ids = {str(w["id"]) for w in body["weeks"]}
+        for day_data in body["days"]:
+            for row in day_data["rows"]:
+                assert set(row["cells"].keys()) == week_ids
+
+    def test_requires_login(self, client):
+        link, plan, meso = _seeded_plan()
+        resp = client.get(self._url(plan))
+        assert resp.status_code in (302, 403)
+
+    def test_foreign_coach_forbidden(self, client):
+        link, plan, meso = _seeded_plan()
+        client.force_login(UserFactory())  # not this plan's coach
+        assert client.get(self._url(plan)).status_code in (403, 404)
+
+    def test_404_for_unknown_plan(self, client):
+        link = CoachAthleteFactory()
+        client.force_login(link.coach)
+        resp = client.get(
+            reverse("meso:api_mesocycle_grid", kwargs={"plan_id": 999999})
+        )
+        assert resp.status_code == 404
+
+    def test_over_limit_coach_can_still_view(self, client):
+        # Read access is not billing-gated: a suspended coach keeps read access
+        # (mirrors week_view's ``test_over_limit_coach_can_still_view``).
+        coach = UserFactory()
+        _aged_link(coach, days_ago=30)  # kept (oldest)
+        suspended = _aged_link(coach, days_ago=1)
+        plan = suspended.create_plan()
+        client.force_login(coach)
+        assert client.get(self._url(plan)).status_code == 200
+
+    def test_rejects_post(self, client):
+        link, plan, meso = _seeded_plan()
+        client.force_login(link.coach)
+        assert client.post(self._url(plan)).status_code == 405
+
+    def test_mesocycle_query_param_selects_that_block(self, client):
+        link = CoachAthleteFactory()
+        plan = link.create_plan()
+        first_meso = plan.mesocycles.get()
+        second_meso = MesocycleFactory(plan=plan, name="Block 2", order=1)
+        week = WeekFactory(mesocycle=second_meso, index=1, is_current=False)
+        session = day(week, day_number=1, name="Only day")
+        presc(session, name="Only row")
+        client.force_login(link.coach)
+        resp = client.get(self._url(plan) + f"?mesocycle={second_meso.pk}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["mesocycle"]["id"] == second_meso.pk
+        assert body["mesocycle"]["id"] != first_meso.pk
+
+    def test_mesocycle_query_param_rejects_a_foreign_mesocycle(self, client):
+        link, plan, meso = _seeded_plan()
+        other_meso = MesocycleFactory()  # belongs to a different plan
+        client.force_login(link.coach)
+        resp = client.get(self._url(plan) + f"?mesocycle={other_meso.pk}")
+        assert resp.status_code == 404
+
+    def test_mesocycle_query_param_rejects_a_nonexistent_id(self, client):
+        link, plan, meso = _seeded_plan()
+        client.force_login(link.coach)
+        resp = client.get(self._url(plan) + "?mesocycle=999999")
+        assert resp.status_code == 404
+
+    def test_mesocycle_query_param_rejects_a_non_integer(self, client):
+        link, plan, meso = _seeded_plan()
+        client.force_login(link.coach)
+        resp = client.get(self._url(plan) + "?mesocycle=not-an-int")
+        assert resp.status_code == 400
+
+    def test_defaults_to_the_current_weeks_mesocycle(self, client):
+        link = CoachAthleteFactory()
+        plan = link.create_plan()
+        first_meso = plan.mesocycles.get()
+        second_meso = MesocycleFactory(plan=plan, name="Block 2", order=1)
+        week2 = WeekFactory(mesocycle=second_meso, index=1, is_current=True)
+        # Only one week can be current plan-wide.
+        first_meso.weeks.update(is_current=False)
+        week2.is_current = True
+        week2.save(update_fields=["is_current"])
+        client.force_login(link.coach)
+        resp = client.get(self._url(plan))
+        assert resp.json()["mesocycle"]["id"] == second_meso.pk
+
+    def test_no_mesocycle_at_all_is_404(self, client):
+        rel = CoachAthleteFactory()
+        plan = PlanFactory(relationship=rel)  # bare — no scaffold, no mesocycle
+        client.force_login(rel.coach)
+        resp = client.get(self._url(plan))
+        assert resp.status_code == 404
+
+    def test_mesocycle_with_no_weeks_returns_an_empty_ish_grid(self, client):
+        rel = CoachAthleteFactory()
+        plan = PlanFactory(relationship=rel)
+        MesocycleFactory(plan=plan, name="Empty block", order=0)
+        client.force_login(rel.coach)
+        resp = client.get(self._url(plan))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["weeks"] == []
+        assert body["days"] == []
+
+
+class TestDesignerViewGridContext:
+    def test_designer_context_includes_grid_data(self, client):
+        link, plan, meso = _seeded_plan()
+        client.force_login(link.coach)
+        resp = client.get(reverse("meso:designer_plan", kwargs={"plan_id": plan.pk}))
+        assert resp.status_code == 200
+        grid_data = resp.context["grid_data"]
+        assert grid_data["mesocycle"]["id"] == meso.pk
+        assert len(grid_data["weeks"]) == 2
+        body = resp.content.decode()
+        assert 'id="meso-grid-data"' in body

--- a/app/store_project/meso/tests/test_serializers.py
+++ b/app/store_project/meso/tests/test_serializers.py
@@ -653,6 +653,7 @@ class TestSerializeMesocycleGrid:
             "skipped": False,
             "swap_name": "",
             "swap_exercise_id": None,
+            "swap_display": "",
         }
 
     def test_deleted_week_is_excluded(self):
@@ -700,9 +701,41 @@ class TestSerializeMesocycleGrid:
         swapped_cell = squat["cells"][str(f.week2.pk)]
         assert swapped_cell["swap_name"] == "Front Squat"
         assert swapped_cell["swap_exercise_id"] == substitute.pk
+        # Free-text swap_name wins over the catalog swap_exercise for display.
+        assert swapped_cell["swap_display"] == "Front Squat"
         # The untouched week still reads no swap.
         assert squat["cells"][str(f.week1.pk)]["swap_name"] == ""
         assert squat["cells"][str(f.week1.pk)]["swap_exercise_id"] is None
+        assert squat["cells"][str(f.week1.pk)]["swap_display"] == ""
+
+    def test_swap_display_is_free_text_swap_name_when_set(self):
+        f = _build_grid_meso()
+        f.squat_cell2.swap_name = "Front Squat"
+        f.squat_cell2.save(update_fields=["swap_name"])
+        result = serialize_mesocycle_grid(f.meso)
+        squat = result["days"][0]["rows"][0]
+        cell = squat["cells"][str(f.week2.pk)]
+        assert cell["swap_display"] == "Front Squat"
+
+    def test_swap_display_falls_back_to_swap_exercise_name_for_a_catalog_only_swap(
+        self,
+    ):
+        f = _build_grid_meso()
+        substitute = ExerciseFactory(name="Hack Squat")
+        f.squat_cell2.swap_exercise = substitute
+        f.squat_cell2.swap_name = ""
+        f.squat_cell2.save(update_fields=["swap_exercise", "swap_name"])
+        result = serialize_mesocycle_grid(f.meso)
+        squat = result["days"][0]["rows"][0]
+        cell = squat["cells"][str(f.week2.pk)]
+        # A catalog-only swap (no free-text swap_name) must still surface a
+        # display name — this is the P1 table's "no visible badge" gap: the
+        # coach couldn't tell a catalog swap was active.
+        assert cell["swap_display"] == "Hack Squat"
+        assert cell["swap_exercise_id"] == substitute.pk
+        assert cell["swap_name"] == ""
+        # The ROW identity is still block-wide, unaffected by the swap.
+        assert squat["name"] == "Back Squat"
 
     def test_history_reuses_serialize_plan_history(self):
         f = _build_grid_meso()

--- a/app/store_project/meso/tests/test_serializers.py
+++ b/app/store_project/meso/tests/test_serializers.py
@@ -17,7 +17,9 @@ from datetime import date
 from types import SimpleNamespace
 
 import pytest
+from django.utils import timezone
 
+from store_project.exercises.factories import ExerciseFactory
 from store_project.meso.factories import CoachAthleteFactory
 from store_project.meso.factories import LoggedSetFactory
 from store_project.meso.factories import MesocycleFactory
@@ -25,10 +27,13 @@ from store_project.meso.factories import PlanFactory
 from store_project.meso.factories import SessionLogFactory
 from store_project.meso.factories import WeekFactory
 from store_project.meso.models import Plan
+from store_project.meso.models import Session
 from store_project.meso.models import SessionLog
 from store_project.meso.models import Unit
 from store_project.meso.models import Week
+from store_project.meso.serializers import serialize_mesocycle_grid
 from store_project.meso.serializers import serialize_plan
+from store_project.meso.serializers import serialize_plan_history
 
 from ._helpers import day
 from ._helpers import presc
@@ -473,3 +478,242 @@ class TestLastLoggedColumn:
             sets=[("6", "200", "9")],
         )
         assert "last" not in self._box_squat(s.plan)
+
+
+# ---------------------------------------------------------------------------
+# serialize_mesocycle_grid — the P1 multi-week table (backend, dense grid)
+# ---------------------------------------------------------------------------
+
+
+def _build_grid_meso():
+    """A 2-day, 3-row, 2-week block, fully wired for the P1 grid serializer.
+
+    Day 1 (order 0): Back Squat (order 0, catalog-linked, tagged) + Leg Press
+    (order 1). Day 2 (order 1): Bench Press (order 0). Every row carries a
+    real cell in both weeks so density can be asserted directly.
+    """
+    rel = CoachAthleteFactory()
+    plan = PlanFactory(relationship=rel, status=Plan.Status.ACTIVE)
+    meso = MesocycleFactory(plan=plan, name="Hypertrophy", order=0, week_count=4)
+    week1 = WeekFactory(mesocycle=meso, index=1, phase="Accum", is_current=True)
+    week2 = WeekFactory(
+        mesocycle=meso,
+        index=2,
+        phase="Accum",
+        is_current=False,
+        delivered_at=timezone.now(),
+    )
+
+    day1 = day(week1, day_number=1, name="Lower", bias="Quad bias", order=0)
+    day2 = day(week1, day_number=2, name="Upper", bias="Push/pull", order=1)
+    # Block-shared identity (P0): week 2's days reuse the SAME SessionSlot.
+    day1_wk2 = day(week2, session_slot=day1.session_slot)
+    day2_wk2 = day(week2, session_slot=day2.session_slot)
+
+    catalog = ExerciseFactory()
+    squat_cell1 = presc(
+        day1,
+        name="Back Squat",
+        order=0,
+        exercise=catalog,
+        tags=["main"],
+        sets="4",
+        reps="6",
+        load="100",
+        rpe="7",
+        rest="120",
+        note="tempo",
+    )
+    squat_row = squat_cell1.exercise_slot
+    squat_cell2 = presc(
+        exercise_slot=squat_row, week=week2, sets="4", reps="5", load="105", rpe="8"
+    )
+
+    press_cell1 = presc(day1, name="Leg Press", order=1, sets="3", reps="12", load="80")
+    press_row = press_cell1.exercise_slot
+    press_cell2 = presc(
+        exercise_slot=press_row, week=week2, sets="3", reps="10", load="85"
+    )
+
+    bench_cell1 = presc(
+        day2, name="Bench Press", order=0, sets="4", reps="8", load="60"
+    )
+    bench_row = bench_cell1.exercise_slot
+    bench_cell2 = presc(
+        exercise_slot=bench_row, week=week2, sets="4", reps="8", load="65"
+    )
+
+    return SimpleNamespace(
+        plan=plan,
+        meso=meso,
+        week1=week1,
+        week2=week2,
+        day1=day1,
+        day2=day2,
+        day1_wk2=day1_wk2,
+        day2_wk2=day2_wk2,
+        squat_row=squat_row,
+        press_row=press_row,
+        bench_row=bench_row,
+        squat_cell1=squat_cell1,
+        squat_cell2=squat_cell2,
+        press_cell1=press_cell1,
+        press_cell2=press_cell2,
+        bench_cell1=bench_cell1,
+        bench_cell2=bench_cell2,
+        catalog=catalog,
+    )
+
+
+class TestSerializeMesocycleGrid:
+    def test_top_level_keys(self):
+        f = _build_grid_meso()
+        result = serialize_mesocycle_grid(f.meso)
+        assert set(result.keys()) == {"mesocycle", "weeks", "days", "history"}
+
+    def test_mesocycle_envelope(self):
+        f = _build_grid_meso()
+        result = serialize_mesocycle_grid(f.meso)
+        assert result["mesocycle"] == {
+            "id": f.meso.pk,
+            "plan_id": f.plan.pk,
+            "name": "Hypertrophy",
+            "week_count": 4,
+        }
+
+    def test_weeks_ordered_by_index_with_full_meta(self):
+        f = _build_grid_meso()
+        result = serialize_mesocycle_grid(f.meso)
+        assert [w["id"] for w in result["weeks"]] == [f.week1.pk, f.week2.pk]
+        assert result["weeks"][0] == {
+            "id": f.week1.pk,
+            "index": 1,
+            "label": "Wk 1",
+            "phase": "Accum",
+            "deload": False,
+            "current": True,
+            "delivered_at": None,
+        }
+        wk2 = result["weeks"][1]
+        assert wk2["id"] == f.week2.pk
+        assert wk2["index"] == 2
+        assert wk2["label"] == "Wk 2"
+        assert wk2["current"] is False
+        assert wk2["delivered_at"] == f.week2.delivered_at.isoformat()
+
+    def test_days_ordered_with_session_id_and_identity(self):
+        f = _build_grid_meso()
+        result = serialize_mesocycle_grid(f.meso)
+        assert [d["session_slot_id"] for d in result["days"]] == [
+            f.day1.session_slot_id,
+            f.day2.session_slot_id,
+        ]
+        day1_data = result["days"][0]
+        assert day1_data["day_number"] == 1
+        assert day1_data["name"] == "Lower"
+        assert day1_data["bias"] == "Quad bias"
+        assert day1_data["order"] == 0
+        # Current week (week1) wins the session_id.
+        assert day1_data["session_id"] == f.day1.pk
+
+    def test_rows_ordered_by_order_with_block_identity(self):
+        f = _build_grid_meso()
+        result = serialize_mesocycle_grid(f.meso)
+        day1_rows = result["days"][0]["rows"]
+        assert [r["exercise_slot_id"] for r in day1_rows] == [
+            f.squat_row.pk,
+            f.press_row.pk,
+        ]
+        squat = day1_rows[0]
+        assert squat["name"] == "Back Squat"
+        assert squat["exercise_id"] == f.catalog.pk
+        assert squat["order"] == 0
+        assert squat["tags"] == ["main"]
+
+    def test_cells_are_dense_one_per_live_week(self):
+        f = _build_grid_meso()
+        result = serialize_mesocycle_grid(f.meso)
+        squat = result["days"][0]["rows"][0]
+        assert set(squat["cells"].keys()) == {str(f.week1.pk), str(f.week2.pk)}
+
+    def test_cell_carries_all_numeric_fields(self):
+        f = _build_grid_meso()
+        result = serialize_mesocycle_grid(f.meso)
+        squat = result["days"][0]["rows"][0]
+        cell = squat["cells"][str(f.week1.pk)]
+        assert cell == {
+            "prescription_id": f.squat_cell1.pk,
+            "sets": "4",
+            "reps": "6",
+            "load": "100",
+            "load_type": f.squat_cell1.load_type,
+            "rpe": "7",
+            "rest": "120",
+            "note": "tempo",
+            "skipped": False,
+            "swap_name": "",
+            "swap_exercise_id": None,
+        }
+
+    def test_deleted_week_is_excluded(self):
+        f = _build_grid_meso()
+        f.week2.soft_delete()
+        result = serialize_mesocycle_grid(f.meso)
+        assert [w["id"] for w in result["weeks"]] == [f.week1.pk]
+        squat = result["days"][0]["rows"][0]
+        assert set(squat["cells"].keys()) == {str(f.week1.pk)}
+
+    def test_deleted_session_slot_is_excluded(self):
+        f = _build_grid_meso()
+        f.day2.session_slot.soft_delete()
+        result = serialize_mesocycle_grid(f.meso)
+        assert [d["session_slot_id"] for d in result["days"]] == [
+            f.day1.session_slot_id
+        ]
+
+    def test_deleted_exercise_slot_is_excluded(self):
+        f = _build_grid_meso()
+        f.press_row.soft_delete()
+        result = serialize_mesocycle_grid(f.meso)
+        day1_rows = result["days"][0]["rows"]
+        assert [r["exercise_slot_id"] for r in day1_rows] == [f.squat_row.pk]
+
+    def test_skipped_cell_still_appears_flagged(self):
+        f = _build_grid_meso()
+        f.squat_cell2.skipped = True
+        f.squat_cell2.save(update_fields=["skipped"])
+        result = serialize_mesocycle_grid(f.meso)
+        squat = result["days"][0]["rows"][0]
+        cell = squat["cells"][str(f.week2.pk)]
+        assert cell["skipped"] is True
+
+    def test_swap_surfaces_on_the_cell_but_row_name_stays_block_identity(self):
+        f = _build_grid_meso()
+        substitute = ExerciseFactory()
+        f.squat_cell2.swap_exercise = substitute
+        f.squat_cell2.swap_name = "Front Squat"
+        f.squat_cell2.save(update_fields=["swap_exercise", "swap_name"])
+        result = serialize_mesocycle_grid(f.meso)
+        squat = result["days"][0]["rows"][0]
+        # The ROW identity is unchanged — a swap is a one-week cell exception.
+        assert squat["name"] == "Back Squat"
+        swapped_cell = squat["cells"][str(f.week2.pk)]
+        assert swapped_cell["swap_name"] == "Front Squat"
+        assert swapped_cell["swap_exercise_id"] == substitute.pk
+        # The untouched week still reads no swap.
+        assert squat["cells"][str(f.week1.pk)]["swap_name"] == ""
+        assert squat["cells"][str(f.week1.pk)]["swap_exercise_id"] is None
+
+    def test_history_reuses_serialize_plan_history(self):
+        f = _build_grid_meso()
+        result = serialize_mesocycle_grid(f.meso)
+        assert result["history"] == serialize_plan_history(f.plan)
+
+    def test_session_id_falls_back_to_first_live_week_when_current_lacks_one(self):
+        f = _build_grid_meso()
+        # Simulate the current week's session for day1 having been individually
+        # removed while the day (SessionSlot) itself stays live.
+        Session.objects.filter(pk=f.day1.pk).update(deleted_at=timezone.now())
+        result = serialize_mesocycle_grid(f.meso)
+        day1_data = result["days"][0]
+        assert day1_data["session_id"] == f.day1_wk2.pk

--- a/app/store_project/meso/urls.py
+++ b/app/store_project/meso/urls.py
@@ -189,6 +189,13 @@ urlpatterns = [
         views.week_view,
         name="api_week_view",
     ),
+    # P1 multi-week table (backend): the current (or ``?mesocycle=``) block's
+    # dense day × row × week grid — read-only, mirrors ``week_view``.
+    path(
+        "api/plan/<int:plan_id>/grid/",
+        views.api_mesocycle_grid,
+        name="api_mesocycle_grid",
+    ),
     path(
         "api/plan/<int:plan_id>/week/<int:week_id>/current/",
         views.week_set_current,

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -89,6 +89,7 @@ from .models import WeekDelivery
 from .serializers import current_week
 from .serializers import group_adjustments
 from .serializers import serialize_chat_thread
+from .serializers import serialize_mesocycle_grid
 from .serializers import serialize_plan
 from .serializers import serialize_plan_history
 from .serializers import serialize_prescription
@@ -255,6 +256,15 @@ class MesoDesignerView(LoginRequiredMixin, TemplateView):
         if plan is None:
             raise Http404("Unknown plan")
         ctx["plan_data"] = serialize_plan(plan)
+        # P1 multi-week table (backend): the current block's dense day × row ×
+        # week grid, hydrated alongside ``plan_data`` so the table can render
+        # without a round-trip on first paint. Uses the same block resolution
+        # as ``serialize_plan`` (the current week's mesocycle); left unset for
+        # a plan with no block at all (shouldn't happen post-scaffold, but a
+        # corrupt/legacy row shouldn't 500 the whole designer).
+        mesocycle = _default_grid_mesocycle(plan)
+        if mesocycle is not None:
+            ctx["grid_data"] = serialize_mesocycle_grid(mesocycle)
         # The persisted agent conversation, rebuilt from this plan's proposal
         # batches so the chat survives a reload (the JS hydrates ``messages``
         # from it, falling back to the greeting when empty).
@@ -2594,6 +2604,49 @@ def week_view(request, plan_id, week_id):
         Week, pk=week_id, mesocycle__plan=plan, deleted_at__isnull=True
     )
     return JsonResponse({"ok": True, **serialize_plan(plan, week=week)})
+
+
+def _default_grid_mesocycle(plan):
+    """The block the P1 grid opens onto when no ``?mesocycle=`` is given.
+
+    Mirrors ``serialize_plan``'s block resolution: the current (live) week's
+    block, falling back to the plan's first block for the rare case where the
+    plan has a block but no materialized weeks yet (a fresh, not-yet-designed
+    block). ``None`` only when the plan has no block at all.
+    """
+    open_week = current_week(plan)
+    if open_week is not None:
+        return open_week.mesocycle
+    return plan.mesocycles.order_by("order").first()
+
+
+@login_required
+@require_GET
+def api_mesocycle_grid(request, plan_id):
+    """The P1 multi-week table's data: every live day × row × week cell.
+
+    A pure read (mirrors ``week_view``) — scoped by ownership only (404/403),
+    **not** billing-gated: an over-limit coach keeps read access. Defaults to
+    the plan's current mesocycle; ``?mesocycle=<id>`` views another block of
+    the same plan (404 for one that doesn't belong to it, 400 for a
+    non-integer). A plan with no block at all is a 404; a block with no
+    materialized weeks yet returns a valid, empty-ish grid.
+    """
+    plan, forbidden = _coach_plan_or_forbidden(request, plan_id)
+    if forbidden is not None:
+        return forbidden
+    raw_mesocycle_id = request.GET.get("mesocycle")
+    if raw_mesocycle_id is not None:
+        try:
+            mesocycle_id = int(raw_mesocycle_id)
+        except (TypeError, ValueError):
+            return HttpResponseBadRequest("mesocycle must be an integer.")
+        mesocycle = get_object_or_404(Mesocycle, pk=mesocycle_id, plan=plan)
+    else:
+        mesocycle = _default_grid_mesocycle(plan)
+        if mesocycle is None:
+            raise Http404("This plan has no block yet.")
+    return JsonResponse({"ok": True, **serialize_mesocycle_grid(mesocycle)})
 
 
 @login_required

--- a/app/store_project/templates/meso/designer.html
+++ b/app/store_project/templates/meso/designer.html
@@ -20,6 +20,7 @@
   <body class="meso">
     {% if plan_data %}
       {{ plan_data|json_script:"meso-plan-data" }}
+      {% if grid_data %}{{ grid_data|json_script:"meso-grid-data" }}{% endif %}
       {{ chat_thread|json_script:"meso-chat-thread" }}
       {{ designer_flags|json_script:"meso-designer-flags" }}
       <span id="meso-csrf" data-token="{{ csrf_token }}" hidden></span>

--- a/frontend/designer/src/DesignerRoot.test.tsx
+++ b/frontend/designer/src/DesignerRoot.test.tsx
@@ -214,6 +214,70 @@ describe("hydration: #meso-grid-data / P1 table view default", () => {
     expect(screen.getByTestId("meso-table-view")).toBeInTheDocument();
   });
 
+  it("switching the main view refetches the newly-activated view's data source, so neither view shows stale state", async () => {
+    // The table (gridState) and "This week" (planData) are two sibling data
+    // owners — an edit made in one must not leave the other showing stale
+    // server state after the coach switches back to it.
+    const user = userEvent.setup();
+    jsonScript("meso-plan-data", planPayload());
+    jsonScript("meso-chat-thread", []);
+    csrfSpan();
+    jsonScript("meso-designer-flags", flagsPayload());
+    jsonScript("meso-grid-data", gridPayload());
+
+    const weekReply = {
+      ok: true,
+      program: [
+        {
+          id: 1,
+          n: 1,
+          name: "Lower",
+          exercises: [{ id: 9, name: "Squat", sets: "3", reps: "5", load: "100", load_type: "abs" }],
+        },
+      ],
+      weeks: [{ id: 1, index: 1, label: "Wk 1", current: true }],
+      phases: [{ name: "Hypertrophy", weeks: "4 wk", state: "current" }],
+      viewing: 1,
+    };
+    const gridReply = { ok: true, ...gridPayload() };
+    const fetchMock = vi.fn((url: string) => {
+      const body = url.includes("/grid/") ? gridReply : weekReply;
+      return Promise.resolve({ ok: true, status: 200, json: async () => body });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<DesignerRoot />);
+    expect(screen.getByTestId("meso-table-view")).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled(); // no refetch on initial mount
+
+    await user.click(screen.getByText("This week"));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/meso/api/plan/7/week/1/"));
+
+    await user.click(screen.getByText("Table"));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/meso/api/plan/7/grid/"));
+  });
+
+  it("targets the deliver link at the grid's CURRENT week while the table view is active, not planData's viewedWeekId", () => {
+    jsonScript("meso-plan-data", planPayload()); // viewing: 1 (planData's viewed week)
+    jsonScript("meso-chat-thread", []);
+    csrfSpan();
+    jsonScript("meso-designer-flags", flagsPayload());
+    jsonScript(
+      "meso-grid-data",
+      gridPayload({
+        weeks: [
+          { id: 1, index: 0, label: "Wk 1", phase: "Accum", deload: false, current: false, delivered_at: null },
+          { id: 2, index: 1, label: "Wk 2", phase: "Accum", deload: false, current: true, delivered_at: null },
+        ],
+      }),
+    );
+
+    render(<DesignerRoot />);
+
+    expect(screen.getByTestId("meso-table-view")).toBeInTheDocument();
+    expect(screen.getByTestId("deliver-link")).toHaveAttribute("href", "/meso/deliver/7/?week=2");
+  });
+
   it("console.errors and does not crash on malformed grid JSON, still rendering the week view", () => {
     jsonScript("meso-plan-data", planPayload());
     jsonScript("meso-chat-thread", []);

--- a/frontend/designer/src/DesignerRoot.test.tsx
+++ b/frontend/designer/src/DesignerRoot.test.tsx
@@ -158,6 +158,7 @@ function gridPayload(overrides: Record<string, unknown> = {}) {
                 skipped: false,
                 swap_name: "",
                 swap_exercise_id: null,
+                swap_display: "",
               },
             },
           },
@@ -217,13 +218,25 @@ describe("hydration: #meso-grid-data / P1 table view default", () => {
   it("switching the main view refetches the newly-activated view's data source, so neither view shows stale state", async () => {
     // The table (gridState) and "This week" (planData) are two sibling data
     // owners — an edit made in one must not leave the other showing stale
-    // server state after the coach switches back to it.
+    // server state after the coach switches back to it. The grid's CURRENT
+    // week (id 2) is deliberately different from planData's own viewedWeekId
+    // (id 1, from planPayload's `viewing: 1`) — reactivating "This week" must
+    // target the GRID's current week (the table may have removed the week
+    // planData last viewed), not planData's possibly-stale/deleted one.
     const user = userEvent.setup();
     jsonScript("meso-plan-data", planPayload());
     jsonScript("meso-chat-thread", []);
     csrfSpan();
     jsonScript("meso-designer-flags", flagsPayload());
-    jsonScript("meso-grid-data", gridPayload());
+    jsonScript(
+      "meso-grid-data",
+      gridPayload({
+        weeks: [
+          { id: 1, index: 0, label: "Wk 1", phase: "Accum", deload: false, current: false, delivered_at: null },
+          { id: 2, index: 1, label: "Wk 2", phase: "Accum", deload: false, current: true, delivered_at: null },
+        ],
+      }),
+    );
 
     const weekReply = {
       ok: true,
@@ -235,11 +248,19 @@ describe("hydration: #meso-grid-data / P1 table view default", () => {
           exercises: [{ id: 9, name: "Squat", sets: "3", reps: "5", load: "100", load_type: "abs" }],
         },
       ],
-      weeks: [{ id: 1, index: 1, label: "Wk 1", current: true }],
+      weeks: [{ id: 2, index: 2, label: "Wk 2", current: true }],
       phases: [{ name: "Hypertrophy", weeks: "4 wk", state: "current" }],
-      viewing: 1,
+      viewing: 2,
     };
-    const gridReply = { ok: true, ...gridPayload() };
+    const gridReply = {
+      ok: true,
+      ...gridPayload({
+        weeks: [
+          { id: 1, index: 0, label: "Wk 1", phase: "Accum", deload: false, current: false, delivered_at: null },
+          { id: 2, index: 1, label: "Wk 2", phase: "Accum", deload: false, current: true, delivered_at: null },
+        ],
+      }),
+    };
     const fetchMock = vi.fn((url: string) => {
       const body = url.includes("/grid/") ? gridReply : weekReply;
       return Promise.resolve({ ok: true, status: 200, json: async () => body });
@@ -251,7 +272,8 @@ describe("hydration: #meso-grid-data / P1 table view default", () => {
     expect(fetchMock).not.toHaveBeenCalled(); // no refetch on initial mount
 
     await user.click(screen.getByText("This week"));
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/meso/api/plan/7/week/1/"));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/meso/api/plan/7/week/2/"));
+    expect(fetchMock).not.toHaveBeenCalledWith("/meso/api/plan/7/week/1/");
 
     await user.click(screen.getByText("Table"));
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/meso/api/plan/7/grid/"));

--- a/frontend/designer/src/DesignerRoot.test.tsx
+++ b/frontend/designer/src/DesignerRoot.test.tsx
@@ -120,6 +120,119 @@ describe("hydration: full payload", () => {
   });
 });
 
+// === P1 (multi-week table): #meso-grid-data hydration + the new default
+// view. `view` gains a "table" member (frontend/designer/CONTRACT.md predates
+// this — see the P1 spec instead); the default `view` becomes "table" when
+// grid data is hydrated, falling back to today's "week" default otherwise —
+// every OTHER describe block in this file never hydrates #meso-grid-data, so
+// none of them needed touching.
+function gridPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    mesocycle: { id: 1, plan_id: 7, name: "Block 1", week_count: 1 },
+    weeks: [{ id: 1, index: 0, label: "Wk 1", phase: "Accum", deload: false, current: true, delivered_at: null }],
+    days: [
+      {
+        session_slot_id: 1,
+        session_id: 11,
+        day_number: 1,
+        name: "Lower",
+        bias: "Quad bias",
+        order: 0,
+        rows: [
+          {
+            exercise_slot_id: 9,
+            name: "Squat",
+            exercise_id: 55,
+            order: 0,
+            tags: [],
+            cells: {
+              "1": {
+                prescription_id: 100,
+                sets: "3",
+                reps: "5",
+                load: "100",
+                load_type: "abs",
+                rpe: "8",
+                rest: "90",
+                note: "",
+                skipped: false,
+                swap_name: "",
+                swap_exercise_id: null,
+              },
+            },
+          },
+        ],
+      },
+    ],
+    history: { can_undo: false, can_redo: false, undo_label: "", redo_label: "" },
+    ...overrides,
+  };
+}
+
+describe("hydration: #meso-grid-data / P1 table view default", () => {
+  it("defaults to the table view when #meso-grid-data is present", () => {
+    jsonScript("meso-plan-data", planPayload());
+    jsonScript("meso-chat-thread", []);
+    csrfSpan();
+    jsonScript("meso-designer-flags", flagsPayload());
+    jsonScript("meso-grid-data", gridPayload());
+
+    render(<DesignerRoot />);
+
+    expect(screen.getByTestId("meso-table-view")).toBeInTheDocument();
+    expect(screen.getByTestId("meso-day-table-1")).toBeInTheDocument();
+  });
+
+  it("falls back to the week view when #meso-grid-data is absent", () => {
+    jsonScript("meso-plan-data", planPayload());
+    jsonScript("meso-chat-thread", []);
+    csrfSpan();
+    jsonScript("meso-designer-flags", flagsPayload());
+
+    render(<DesignerRoot />);
+
+    expect(screen.queryByTestId("meso-table-view")).not.toBeInTheDocument();
+    expect(screen.getByTestId("exercise-name-9")).toBeInTheDocument();
+  });
+
+  it("can switch from the table view to the week view and back via the segmented control", async () => {
+    const user = userEvent.setup();
+    jsonScript("meso-plan-data", planPayload());
+    jsonScript("meso-chat-thread", []);
+    csrfSpan();
+    jsonScript("meso-designer-flags", flagsPayload());
+    jsonScript("meso-grid-data", gridPayload());
+
+    render(<DesignerRoot />);
+    expect(screen.getByTestId("meso-table-view")).toBeInTheDocument();
+
+    await user.click(screen.getByText("This week"));
+    expect(screen.queryByTestId("meso-table-view")).not.toBeInTheDocument();
+    expect(screen.getByTestId("exercise-name-9")).toBeInTheDocument();
+
+    await user.click(screen.getByText("Table"));
+    expect(screen.getByTestId("meso-table-view")).toBeInTheDocument();
+  });
+
+  it("console.errors and does not crash on malformed grid JSON, still rendering the week view", () => {
+    jsonScript("meso-plan-data", planPayload());
+    jsonScript("meso-chat-thread", []);
+    csrfSpan();
+    jsonScript("meso-designer-flags", flagsPayload());
+    const el = document.createElement("script");
+    el.type = "application/json";
+    el.id = "meso-grid-data";
+    el.textContent = "{not valid json";
+    document.body.appendChild(el);
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(<DesignerRoot />);
+
+    expect(spy).toHaveBeenCalled();
+    expect(screen.getByTestId("exercise-name-9")).toBeInTheDocument();
+  });
+});
+
 describe("hydration: missing or malformed payload", () => {
   it("renders nothing when #meso-plan-data is absent", () => {
     const { container } = render(<DesignerRoot />);

--- a/frontend/designer/src/DesignerRoot.test.tsx
+++ b/frontend/designer/src/DesignerRoot.test.tsx
@@ -300,6 +300,49 @@ describe("hydration: #meso-grid-data / P1 table view default", () => {
     expect(screen.getByTestId("deliver-link")).toHaveAttribute("href", "/meso/deliver/7/?week=2");
   });
 
+  // Code-review nit: the global Ctrl/Cmd+Z window listener lives inside
+  // useUndoRedo and always called ITS OWN planData undo/redo — even while
+  // the table (gridState) is the active view, leaving the visible table
+  // stale after an undo. DesignerRoot now overrides useUndoRedo's keyboard
+  // handlers to the grid's own undo/redo while view === "table". Both
+  // planData.undo and gridState.undo POST to the same `/undo/` endpoint, so
+  // the distinguishing signal that the GRID path ran is the follow-up GET
+  // to `/grid/` (gridState.undo refetches the grid; planData's undo does
+  // not).
+  it("routes a Ctrl/Cmd+Z keyboard shortcut to the grid's own undo while the table view is active", async () => {
+    jsonScript("meso-plan-data", planPayload());
+    jsonScript("meso-chat-thread", []);
+    csrfSpan();
+    jsonScript("meso-designer-flags", flagsPayload());
+    jsonScript(
+      "meso-grid-data",
+      gridPayload({
+        history: { can_undo: true, can_redo: false, undo_label: "Edited Squat", redo_label: null },
+      }),
+    );
+
+    const gridReply = {
+      ok: true,
+      ...gridPayload({
+        history: { can_undo: false, can_redo: true, undo_label: null, redo_label: "Edited Squat" },
+      }),
+    };
+    const fetchMock = vi.fn(() => {
+      return Promise.resolve({ ok: true, status: 200, json: async () => gridReply });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<DesignerRoot />);
+    expect(screen.getByTestId("meso-table-view")).toBeInTheDocument();
+
+    fireEvent.keyDown(document.body, { key: "z", ctrlKey: true });
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith("/meso/api/plan/7/undo/", expect.anything()),
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/meso/api/plan/7/grid/"));
+  });
+
   it("console.errors and does not crash on malformed grid JSON, still rendering the week view", () => {
     jsonScript("meso-plan-data", planPayload());
     jsonScript("meso-chat-thread", []);

--- a/frontend/designer/src/DesignerRoot.tsx
+++ b/frontend/designer/src/DesignerRoot.tsx
@@ -2,7 +2,7 @@
 // Hydrates once from the #meso-plan-data / #meso-chat-thread / #meso-csrf /
 // #meso-designer-flags json_script elements the same way designer.html's
 // init()/hydrateThread() did, composes every hook, and renders the tree.
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import "./designer.css";
 
 import { TopBar } from "./components/TopBar";
@@ -40,6 +40,7 @@ import type {
   PlanSummary,
   Week,
 } from "./lib/api";
+import { deliverHref as buildDeliverHref } from "./lib/deliver";
 
 // P1 (multi-week table) adds "table" as the DEFAULT view when a mesocycle
 // grid is hydrated — see readHydration()'s gridData/initialView below. The
@@ -272,9 +273,38 @@ export function DesignerRoot() {
   // usePlanData's program/weeks/phases.
   const gridState = useGrid({ planId, csrf, initialGrid: hydrated?.gridData ?? null });
 
+  // P1: the table and the one-week view are two sibling data owners
+  // (gridState vs planData) — switching the primary canvas view between them
+  // must refetch whichever one is being activated, so neither view can show
+  // state left stale by an edit made in the OTHER view. Never fires on
+  // initial mount (only from user action, below).
+  const selectView = useCallback(
+    (v: ViewMode) => {
+      if (v === view) return;
+      if (v === "table") {
+        void gridState.refetchGrid();
+      } else {
+        void planData.reloadWeek();
+      }
+      setView(v);
+    },
+    [view, gridState, planData],
+  );
+
   if (!hydrated) return null;
 
   const flags = hydrated.flags;
+
+  // P1: the table view can move the "current" week without planData ever
+  // hearing about it ("Make current" in MesoTable calls gridState.
+  // setCurrentWeek, not planData.setCurrentWeek) — so while the table is the
+  // active view, Deliver must target the GRID's current week, not planData's
+  // (possibly stale) viewedWeekId.
+  const gridCurrentWeekId = gridState.grid
+    ? gridState.grid.weeks.find((w) => w.current)?.id ?? gridState.grid.weeks[0]?.id ?? null
+    : null;
+  const effectiveDeliverHref =
+    view === "table" && gridState.grid ? buildDeliverHref(planId, gridCurrentWeekId) : planData.deliverHref;
 
   return (
     <div className="meso-designer-root">
@@ -286,8 +316,8 @@ export function DesignerRoot() {
         athlete={planData.athlete}
         group={planData.group}
         cycleLabel={planData.cycleLabel}
-        onPreviewAsAthlete={() => setView("athlete")}
-        deliverHref={planData.deliverHref}
+        onPreviewAsAthlete={() => selectView("athlete")}
+        deliverHref={effectiveDeliverHref}
       />
 
       <div className="meso-designer-body">
@@ -297,7 +327,7 @@ export function DesignerRoot() {
           athlete={planData.athlete}
           group={planData.group}
           phases={planData.phases}
-          onOpenBlockView={() => setView("block")}
+          onOpenBlockView={() => selectView("block")}
         />
 
         <ChatPanel
@@ -316,19 +346,19 @@ export function DesignerRoot() {
         <div className="meso-canvas">
           <div className="meso-canvas-header">
             <div className="meso-seg">
-              <button type="button" className={`meso-seg-btn meso-seg-btn--v${view === "table" ? " is-on" : ""}`} onClick={() => setView("table")}>
+              <button type="button" className={`meso-seg-btn meso-seg-btn--v${view === "table" ? " is-on" : ""}`} onClick={() => selectView("table")}>
                 Table
               </button>
-              <button type="button" className={`meso-seg-btn meso-seg-btn--v${view === "week" ? " is-on" : ""}`} onClick={() => setView("week")}>
+              <button type="button" className={`meso-seg-btn meso-seg-btn--v${view === "week" ? " is-on" : ""}`} onClick={() => selectView("week")}>
                 This week
               </button>
-              <button type="button" className={`meso-seg-btn meso-seg-btn--v${view === "block" ? " is-on" : ""}`} onClick={() => setView("block")}>
+              <button type="button" className={`meso-seg-btn meso-seg-btn--v${view === "block" ? " is-on" : ""}`} onClick={() => selectView("block")}>
                 Periodization
               </button>
               <button
                 type="button"
                 className={`meso-seg-btn meso-seg-btn--v${view === "athlete" ? " is-on" : ""}`}
-                onClick={() => setView("athlete")}
+                onClick={() => selectView("athlete")}
               >
                 Athlete view
               </button>

--- a/frontend/designer/src/DesignerRoot.tsx
+++ b/frontend/designer/src/DesignerRoot.tsx
@@ -230,12 +230,25 @@ export function DesignerRoot() {
     setPendingDelete: planData.setPendingDelete,
     applyPlanData: planData.applyPlanData,
   });
+  // P1 (multi-week table): a self-contained sibling data owner — the grid is
+  // its own server contract (serialize_mesocycle_grid), not a slice of
+  // usePlanData's program/weeks/phases. Defined here (before useUndoRedo) so
+  // its undo/redo are in scope to override the keyboard shortcut below.
+  const gridState = useGrid({ planId, csrf, initialGrid: hydrated?.gridData ?? null });
+
   const undoRedo = useUndoRedo({
     planId,
     csrf,
     viewedWeekId: planData.viewedWeekId,
     history: planData.history,
     applyPlanData: planData.applyPlanData,
+    // P1: the table is a sibling data owner (gridState), not a slice of
+    // planData — the global Ctrl/Cmd+Z shortcut must follow whichever view
+    // is actually on screen, so route it to the grid's own undo/redo while
+    // the table view is active. Falls back to planData's undo/redo
+    // otherwise (unchanged behavior).
+    keyboardUndo: view === "table" ? gridState.undo : undefined,
+    keyboardRedo: view === "table" ? gridState.redo : undefined,
   });
   const overrideEditor = useOverrideEditor({
     planId,
@@ -267,11 +280,6 @@ export function DesignerRoot() {
     initialResumeUrl: hydrated?.initialResumeUrl ?? null,
   });
   const coachmarks = useCoachmarks();
-
-  // P1 (multi-week table): a self-contained sibling data owner — the grid is
-  // its own server contract (serialize_mesocycle_grid), not a slice of
-  // usePlanData's program/weeks/phases.
-  const gridState = useGrid({ planId, csrf, initialGrid: hydrated?.gridData ?? null });
 
   // P1: the table and the one-week view are two sibling data owners
   // (gridState vs planData) — switching the primary canvas view between them

--- a/frontend/designer/src/DesignerRoot.tsx
+++ b/frontend/designer/src/DesignerRoot.tsx
@@ -11,6 +11,7 @@ import { LeftRail } from "./components/LeftRail";
 import { ChatPanel } from "./components/ChatPanel";
 import type { DesignerFlags } from "./components/ChatPanel";
 import { WeekGrid } from "./components/WeekGrid";
+import { MesoTable } from "./components/MesoTable";
 import { BlockView } from "./components/BlockView";
 import type { PeriodStyle } from "./components/BlockView";
 import { AthletePreview } from "./components/AthletePreview";
@@ -24,13 +25,27 @@ import { useUndoRedo } from "./hooks/useUndoRedo";
 import { useOverrideEditor } from "./hooks/useOverrideEditor";
 import { useOneRmEditor } from "./hooks/useOneRmEditor";
 import { useReorder } from "./hooks/useReorder";
+import { useGrid } from "./hooks/useGrid";
 import { useAgentChat } from "./hooks/useAgentChat";
 import type { ChatMessage } from "./hooks/useAgentChat";
 import { useCoachmarks } from "./hooks/useCoachmarks";
 
-import type { AthleteIdentity, Day, GroupIdentity, HistoryState, Phase, PlanSummary, Week } from "./lib/api";
+import type {
+  AthleteIdentity,
+  Day,
+  GroupIdentity,
+  HistoryState,
+  MesoGrid,
+  Phase,
+  PlanSummary,
+  Week,
+} from "./lib/api";
 
-type ViewMode = "week" | "block" | "athlete";
+// P1 (multi-week table) adds "table" as the DEFAULT view when a mesocycle
+// grid is hydrated — see readHydration()'s gridData/initialView below. The
+// pre-existing "week"/"block"/"athlete" branches are untouched (transitional
+// fallback — see MesoTable.tsx's header).
+type ViewMode = "week" | "block" | "athlete" | "table";
 
 interface HydratedPlanPayload {
   plan: PlanSummary;
@@ -58,6 +73,7 @@ interface Hydrated {
   initialMessages: ChatMessage[];
   initialResumeUrl: string | null;
   flags: DesignerFlags;
+  gridData: MesoGrid | null;
 }
 
 // The thread starts with a single orienting greeting — a group-aware opening
@@ -136,6 +152,19 @@ function readHydration(): Hydrated | null {
     }
   }
 
+  // P1 (multi-week table): optional — absent on plans without a mesocycle
+  // grid yet, same tolerate-absence/parse-error handling as every other
+  // hydration element above.
+  let gridData: MesoGrid | null = null;
+  const gridEl = document.getElementById("meso-grid-data");
+  if (gridEl) {
+    try {
+      gridData = JSON.parse(gridEl.textContent || "") as MesoGrid;
+    } catch (err) {
+      console.error("Could not parse grid data", err);
+    }
+  }
+
   return {
     planId: data.plan.id,
     unit: data.plan.unit || "kg",
@@ -151,13 +180,17 @@ function readHydration(): Hydrated | null {
     initialMessages,
     initialResumeUrl,
     flags,
+    gridData,
   };
 }
 
 export function DesignerRoot() {
   const [hydrated] = useState<Hydrated | null>(() => readHydration());
   const [mode, setMode] = useState<DesignerMode>(hydrated?.initialMode ?? "individual");
-  const [view, setView] = useState<ViewMode>("week");
+  // P1: default to the table view once a mesocycle grid is hydrated (it
+  // becomes the coach's primary editing surface); falls back to today's
+  // "week" default on plans with no grid yet.
+  const [view, setView] = useState<ViewMode>(hydrated?.gridData ? "table" : "week");
   const [periodStyle, setPeriodStyle] = useState<PeriodStyle>("timeline");
   const [checks, setChecks] = useState<Record<string, boolean>>({});
 
@@ -234,6 +267,11 @@ export function DesignerRoot() {
   });
   const coachmarks = useCoachmarks();
 
+  // P1 (multi-week table): a self-contained sibling data owner — the grid is
+  // its own server contract (serialize_mesocycle_grid), not a slice of
+  // usePlanData's program/weeks/phases.
+  const gridState = useGrid({ planId, csrf, initialGrid: hydrated?.gridData ?? null });
+
   if (!hydrated) return null;
 
   const flags = hydrated.flags;
@@ -278,6 +316,9 @@ export function DesignerRoot() {
         <div className="meso-canvas">
           <div className="meso-canvas-header">
             <div className="meso-seg">
+              <button type="button" className={`meso-seg-btn meso-seg-btn--v${view === "table" ? " is-on" : ""}`} onClick={() => setView("table")}>
+                Table
+              </button>
               <button type="button" className={`meso-seg-btn meso-seg-btn--v${view === "week" ? " is-on" : ""}`} onClick={() => setView("week")}>
                 This week
               </button>
@@ -302,6 +343,26 @@ export function DesignerRoot() {
           </div>
 
           <div className="meso-canvas-body">
+            {view === "table" && (
+              <MesoTable
+                grid={gridState.grid}
+                history={gridState.history}
+                busy={gridState.busy}
+                unit={unit}
+                onPatchCell={gridState.patchCell}
+                onRenameExercise={gridState.renameExercise}
+                onAddExercise={gridState.addExercise}
+                onRemoveExercise={gridState.removeExercise}
+                onAddDay={gridState.addDay}
+                onRemoveDay={gridState.removeDay}
+                onAddWeek={gridState.addWeek}
+                onRemoveWeek={gridState.removeWeek}
+                onSetCurrentWeek={gridState.setCurrentWeek}
+                onUndo={gridState.undo}
+                onRedo={gridState.redo}
+              />
+            )}
+
             {view === "week" && (
               <div className="meso-week-view">
                 <div className="meso-week-view-head">

--- a/frontend/designer/src/DesignerRoot.tsx
+++ b/frontend/designer/src/DesignerRoot.tsx
@@ -284,7 +284,14 @@ export function DesignerRoot() {
       if (v === "table") {
         void gridState.refetchGrid();
       } else {
-        void planData.reloadWeek();
+        // Reactivate on the grid's current week — the week planData last
+        // viewed may have been removed in the table (reloadWeek(viewedWeekId)
+        // would 404 and strand a deleted week). Falls back to planData's own
+        // viewed week when there's no grid.
+        const target = gridState.grid
+          ? gridState.grid.weeks.find((w) => w.current)?.id ?? gridState.grid.weeks[0]?.id ?? null
+          : null;
+        void planData.reloadWeek(target ?? undefined);
       }
       setView(v);
     },

--- a/frontend/designer/src/components/MesoTable.test.tsx
+++ b/frontend/designer/src/components/MesoTable.test.tsx
@@ -1,0 +1,352 @@
+// Specs for MesoTable (P1 multi-week table) — one <table> per training day,
+// exercise rows down the side, WEEK COLUMNS across the top. Per-cell editing
+// (sets/reps/load+load_type/rpe/rest/note) commits on blur/Enter, carrying
+// forward ExerciseRow's dirtySinceFocus semantics (only actually-typed
+// fields persist). Deload marker/skipped em-dash/swap badge are display-only
+// in P1 — no write UX for swap/skip.
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MesoTable } from "./MesoTable";
+import type { GridCell, GridDay, GridRow, GridWeek, MesoGrid } from "../lib/api";
+
+function week(overrides: Partial<GridWeek> = {}): GridWeek {
+  return {
+    id: 1,
+    index: 0,
+    label: "Wk 1",
+    phase: "Accum",
+    deload: false,
+    current: true,
+    delivered_at: null,
+    ...overrides,
+  };
+}
+
+function cell(overrides: Partial<GridCell> = {}): GridCell {
+  return {
+    prescription_id: 100,
+    sets: "3",
+    reps: "5",
+    load: "100",
+    load_type: "abs",
+    rpe: "8",
+    rest: "90",
+    note: "",
+    skipped: false,
+    swap_name: "",
+    swap_exercise_id: null,
+    ...overrides,
+  };
+}
+
+function row(overrides: Partial<GridRow> = {}): GridRow {
+  return {
+    exercise_slot_id: 9,
+    name: "Squat",
+    exercise_id: 55,
+    order: 0,
+    tags: [],
+    cells: { "1": cell() },
+    ...overrides,
+  };
+}
+
+function day(overrides: Partial<GridDay> = {}): GridDay {
+  return {
+    session_slot_id: 1,
+    session_id: 11,
+    day_number: 1,
+    name: "Lower",
+    bias: "Quad bias",
+    order: 0,
+    rows: [row()],
+    ...overrides,
+  };
+}
+
+function grid(overrides: Partial<MesoGrid> = {}): MesoGrid {
+  return {
+    mesocycle: { id: 1, plan_id: 7, name: "Block 1", week_count: 1 },
+    weeks: [week()],
+    days: [day()],
+    history: { can_undo: false, can_redo: false, undo_label: "", redo_label: "" },
+    ...overrides,
+  };
+}
+
+const HISTORY_NONE = { can_undo: false, can_redo: false, undo_label: "", redo_label: "" };
+
+function baseProps(overrides: Partial<Parameters<typeof MesoTable>[0]> = {}) {
+  return {
+    grid: grid(),
+    history: HISTORY_NONE,
+    busy: false,
+    unit: "kg",
+    onPatchCell: vi.fn(),
+    onRenameExercise: vi.fn(),
+    onAddExercise: vi.fn(),
+    onRemoveExercise: vi.fn(),
+    onAddDay: vi.fn(),
+    onRemoveDay: vi.fn(),
+    onAddWeek: vi.fn(),
+    onRemoveWeek: vi.fn(),
+    onSetCurrentWeek: vi.fn(),
+    onUndo: vi.fn(),
+    onRedo: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("layout", () => {
+  it("renders one table per day", () => {
+    render(
+      <MesoTable
+        {...baseProps({
+          grid: grid({ days: [day({ session_slot_id: 1, name: "Lower" }), day({ session_slot_id: 2, name: "Upper" })] }),
+        })}
+      />,
+    );
+    expect(screen.getByTestId("meso-day-table-1")).toBeInTheDocument();
+    expect(screen.getByTestId("meso-day-table-2")).toBeInTheDocument();
+  });
+
+  it("renders nothing when grid is null", () => {
+    const { container } = render(<MesoTable {...baseProps({ grid: null })} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe("week columns", () => {
+  it("renders label, a deload marker, and marks the current week", () => {
+    render(
+      <MesoTable
+        {...baseProps({
+          grid: grid({
+            weeks: [
+              week({ id: 1, label: "Wk 1", current: true }),
+              week({ id: 2, label: "Wk 2", deload: true, current: false }),
+            ],
+          }),
+        })}
+      />,
+    );
+    const col1 = screen.getByTestId("week-col-1");
+    expect(col1).toHaveTextContent("Wk 1");
+    expect(col1).toHaveAttribute("aria-current", "true");
+
+    const col2 = screen.getByTestId("week-col-2");
+    expect(col2).toHaveTextContent("Wk 2");
+    expect(col2).toHaveTextContent("▽");
+    expect(col2).not.toHaveAttribute("aria-current");
+  });
+});
+
+describe("cells", () => {
+  it("renders every editable field's value, including rest", () => {
+    render(<MesoTable {...baseProps()} />);
+    expect(screen.getByTestId("cell-sets-100")).toHaveValue("3");
+    expect(screen.getByTestId("cell-reps-100")).toHaveValue("5");
+    expect(screen.getByTestId("cell-load-100")).toHaveValue("100");
+    expect(screen.getByTestId("cell-rpe-100")).toHaveValue("8");
+    expect(screen.getByTestId("cell-rest-100")).toHaveValue("90");
+    expect(screen.getByTestId("cell-note-100")).toHaveValue("");
+  });
+
+  it("commits only the dirtied field on blur", async () => {
+    const user = userEvent.setup();
+    const onPatchCell = vi.fn();
+    render(<MesoTable {...baseProps({ onPatchCell })} />);
+    const setsInput = screen.getByTestId("cell-sets-100");
+    await user.clear(setsInput);
+    await user.type(setsInput, "4");
+    await user.tab();
+    expect(onPatchCell).toHaveBeenCalledWith(100, { sets: "4" });
+  });
+
+  it("commits on Enter the same as blur", async () => {
+    const user = userEvent.setup();
+    const onPatchCell = vi.fn();
+    render(<MesoTable {...baseProps({ onPatchCell })} />);
+    const noteInput = screen.getByTestId("cell-note-100");
+    await user.type(noteInput, "left knee sore");
+    await user.keyboard("{Enter}");
+    expect(onPatchCell).toHaveBeenCalledWith(100, { note: "left knee sore" });
+  });
+
+  it("does not call onPatchCell on a no-op focus+blur (dirtySinceFocus gate)", async () => {
+    const user = userEvent.setup();
+    const onPatchCell = vi.fn();
+    render(<MesoTable {...baseProps({ onPatchCell })} />);
+    await user.click(screen.getByTestId("cell-sets-100"));
+    await user.tab();
+    expect(onPatchCell).not.toHaveBeenCalled();
+  });
+
+  it("toggles load_type immediately on click (not gated by blur)", async () => {
+    const user = userEvent.setup();
+    const onPatchCell = vi.fn();
+    render(<MesoTable {...baseProps({ onPatchCell })} />);
+    expect(screen.getByTestId("cell-loadtype-100")).toHaveTextContent("kg");
+    await user.click(screen.getByTestId("cell-loadtype-100"));
+    expect(onPatchCell).toHaveBeenCalledWith(100, { load_type: "pct" });
+  });
+
+  it("renders a skipped cell as a read-only em-dash with no inputs", () => {
+    render(
+      <MesoTable
+        {...baseProps({
+          grid: grid({ days: [day({ rows: [row({ cells: { "1": cell({ skipped: true }) } })] })] }),
+        })}
+      />,
+    );
+    expect(screen.getByTestId("cell-skipped-100")).toHaveTextContent("—");
+    expect(screen.queryByTestId("cell-sets-100")).not.toBeInTheDocument();
+  });
+
+  it("renders a swap badge alongside editable numbers for a swapped cell", () => {
+    render(
+      <MesoTable
+        {...baseProps({
+          grid: grid({
+            days: [day({ rows: [row({ cells: { "1": cell({ swap_name: "Leg Press", swap_exercise_id: 77 }) } })] })],
+          }),
+        })}
+      />,
+    );
+    expect(screen.getByTestId("cell-swap-100")).toHaveTextContent("Leg Press");
+    expect(screen.getByTestId("cell-sets-100")).toBeInTheDocument();
+  });
+});
+
+describe("row rename", () => {
+  it("calls onRenameExercise with the exercise_slot_id and new name on blur", async () => {
+    const user = userEvent.setup();
+    const onRenameExercise = vi.fn();
+    render(<MesoTable {...baseProps({ onRenameExercise })} />);
+    const nameInput = screen.getByTestId("row-name-9");
+    await user.type(nameInput, "!");
+    await user.tab();
+    expect(onRenameExercise).toHaveBeenCalledWith(9, "Squat!");
+  });
+});
+
+describe("remove exercise (arm -> confirm)", () => {
+  it("arms then confirms, calling onRemoveExercise", async () => {
+    const user = userEvent.setup();
+    const onRemoveExercise = vi.fn();
+    render(<MesoTable {...baseProps({ onRemoveExercise })} />);
+    await user.click(screen.getByTestId("remove-exercise-9"));
+    await user.click(screen.getByTestId("confirm-remove-exercise-9"));
+    expect(onRemoveExercise).toHaveBeenCalledWith(9);
+  });
+
+  it("cancel disarms without calling onRemoveExercise", async () => {
+    const user = userEvent.setup();
+    const onRemoveExercise = vi.fn();
+    render(<MesoTable {...baseProps({ onRemoveExercise })} />);
+    await user.click(screen.getByTestId("remove-exercise-9"));
+    await user.click(screen.getByTestId("cancel-remove-exercise-9"));
+    expect(onRemoveExercise).not.toHaveBeenCalled();
+    expect(screen.getByTestId("remove-exercise-9")).toBeInTheDocument();
+  });
+});
+
+describe("remove day (arm -> confirm)", () => {
+  it("arms then confirms, calling onRemoveDay with the day", async () => {
+    const user = userEvent.setup();
+    const onRemoveDay = vi.fn();
+    render(<MesoTable {...baseProps({ onRemoveDay })} />);
+    await user.click(screen.getByTestId("remove-day-1"));
+    await user.click(screen.getByTestId("confirm-remove-day-1"));
+    expect(onRemoveDay).toHaveBeenCalledWith(expect.objectContaining({ session_slot_id: 1 }));
+  });
+});
+
+describe("weeks: make-current / remove (arm -> confirm)", () => {
+  it("make-current calls onSetCurrentWeek", async () => {
+    const user = userEvent.setup();
+    const onSetCurrentWeek = vi.fn();
+    render(
+      <MesoTable
+        {...baseProps({
+          grid: grid({ weeks: [week({ id: 1, current: true }), week({ id: 2, label: "Wk 2", current: false })] }),
+          onSetCurrentWeek,
+        })}
+      />,
+    );
+    await user.click(screen.getByTestId("make-current-2"));
+    expect(onSetCurrentWeek).toHaveBeenCalledWith(2);
+  });
+
+  it("remove-week arms then confirms, calling onRemoveWeek", async () => {
+    const user = userEvent.setup();
+    const onRemoveWeek = vi.fn();
+    render(
+      <MesoTable
+        {...baseProps({
+          grid: grid({ weeks: [week({ id: 1, current: true }), week({ id: 2, label: "Wk 2", current: false })] }),
+          onRemoveWeek,
+        })}
+      />,
+    );
+    await user.click(screen.getByTestId("remove-week-2"));
+    await user.click(screen.getByTestId("confirm-remove-week-2"));
+    expect(onRemoveWeek).toHaveBeenCalledWith(2);
+  });
+
+  it("does not offer make-current/remove-week for the current week", () => {
+    render(<MesoTable {...baseProps({ grid: grid({ weeks: [week({ id: 1, current: true })] }) })} />);
+    expect(screen.queryByTestId("make-current-1")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("remove-week-1")).not.toBeInTheDocument();
+  });
+});
+
+describe("add affordances", () => {
+  it("calls onAddExercise with the day, onAddDay, and onAddWeek", async () => {
+    const user = userEvent.setup();
+    const onAddExercise = vi.fn();
+    const onAddDay = vi.fn();
+    const onAddWeek = vi.fn();
+    render(<MesoTable {...baseProps({ onAddExercise, onAddDay, onAddWeek })} />);
+    await user.click(screen.getByTestId("add-exercise-1"));
+    expect(onAddExercise).toHaveBeenCalledWith(expect.objectContaining({ session_slot_id: 1 }));
+    await user.click(screen.getByTestId("add-day"));
+    expect(onAddDay).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByTestId("add-week"));
+    expect(onAddWeek).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("undo/redo toolbar", () => {
+  it("reflects history.can_undo/can_redo and calls onUndo/onRedo", async () => {
+    const user = userEvent.setup();
+    const onUndo = vi.fn();
+    const onRedo = vi.fn();
+    render(
+      <MesoTable
+        {...baseProps({
+          history: { can_undo: true, can_redo: false, undo_label: "Edited Squat", redo_label: "" },
+          onUndo,
+          onRedo,
+        })}
+      />,
+    );
+    expect(screen.getByTestId("grid-undo")).not.toBeDisabled();
+    expect(screen.getByTestId("grid-redo")).toBeDisabled();
+    await user.click(screen.getByTestId("grid-undo"));
+    expect(onUndo).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables both buttons while busy", () => {
+    render(
+      <MesoTable
+        {...baseProps({
+          history: { can_undo: true, can_redo: true, undo_label: "x", redo_label: "y" },
+          busy: true,
+        })}
+      />,
+    );
+    expect(screen.getByTestId("grid-undo")).toBeDisabled();
+    expect(screen.getByTestId("grid-redo")).toBeDisabled();
+  });
+});

--- a/frontend/designer/src/components/MesoTable.test.tsx
+++ b/frontend/designer/src/components/MesoTable.test.tsx
@@ -35,6 +35,7 @@ function cell(overrides: Partial<GridCell> = {}): GridCell {
     skipped: false,
     swap_name: "",
     swap_exercise_id: null,
+    swap_display: "",
     ...overrides,
   };
 }
@@ -208,13 +209,55 @@ describe("cells", () => {
       <MesoTable
         {...baseProps({
           grid: grid({
-            days: [day({ rows: [row({ cells: { "1": cell({ swap_name: "Leg Press", swap_exercise_id: 77 }) } })] })],
+            days: [
+              day({
+                rows: [
+                  row({
+                    cells: {
+                      "1": cell({ swap_name: "Leg Press", swap_exercise_id: 77, swap_display: "Leg Press" }),
+                    },
+                  }),
+                ],
+              }),
+            ],
           }),
         })}
       />,
     );
     expect(screen.getByTestId("cell-swap-100")).toHaveTextContent("Leg Press");
     expect(screen.getByTestId("cell-sets-100")).toBeInTheDocument();
+  });
+
+  it("renders the swap badge for a catalog-only swap (swap_name blank, swap_display resolved)", () => {
+    // A catalog swap (swap_exercise_id set) with no free-text swap_name is a
+    // real gap otherwise: the old `cell.swap_name` gate would render NO badge
+    // even though the backend's delivery/logging use the substitute exercise.
+    render(
+      <MesoTable
+        {...baseProps({
+          grid: grid({
+            days: [
+              day({
+                rows: [
+                  row({
+                    cells: {
+                      "1": cell({ swap_name: "", swap_exercise_id: 77, swap_display: "Hack Squat" }),
+                    },
+                  }),
+                ],
+              }),
+            ],
+          }),
+        })}
+      />,
+    );
+    expect(screen.getByTestId("cell-swap-100")).toHaveTextContent("Hack Squat");
+    expect(screen.getByTestId("cell-sets-100")).toBeInTheDocument();
+  });
+
+  it("renders no swap badge for a plain cell (no swap_display)", () => {
+    render(<MesoTable {...baseProps()} />);
+    expect(screen.queryByTestId("cell-swap-100")).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/designer/src/components/MesoTable.tsx
+++ b/frontend/designer/src/components/MesoTable.tsx
@@ -415,13 +415,13 @@ export function MesoTable(props: MesoTableProps) {
                               ) : (
                                 <>
                                   <GridCellEditor cell={cell} unit={unit} onPatchCell={onPatchCell} />
-                                  {cell.swap_name && (
+                                  {cell.swap_display && (
                                     <span
                                       className="meso-table-swap-badge"
                                       data-testid={`cell-swap-${cell.prescription_id}`}
-                                      title={"Swapped for " + cell.swap_name + " this week"}
+                                      title={"Swapped for " + cell.swap_display + " this week"}
                                     >
-                                      {cell.swap_name}
+                                      {cell.swap_display}
                                     </span>
                                   )}
                                 </>

--- a/frontend/designer/src/components/MesoTable.tsx
+++ b/frontend/designer/src/components/MesoTable.tsx
@@ -1,0 +1,548 @@
+// MesoTable (P1 multi-week table) — one <table> per training day, exercise
+// rows down the side, WEEK COLUMNS across the top. Becomes the coach's
+// default editing surface; WeekStrip/WeekGrid/DayCard/ExerciseRow (the
+// one-week-at-a-time view) stay reachable as a transitional fallback (they
+// are NOT deleted in this PR).
+//
+// Per-cell fields commit on blur/Enter, carrying forward ExerciseRow's
+// dirtySinceFocus pattern (CONTRACT.md "ExerciseRow") — but scoped PER CELL,
+// tracking which of a cell's several fields were actually typed into, since
+// useGrid.patchCell's endpoint takes a partial patch (only the dirtied
+// fields), not a whole-row POST like useAutosave.persistRow. The load_type
+// toggle is the one exception: like ExerciseRow's toggleLoadType, it commits
+// immediately on click (an atomic flip, not a per-keystroke draft).
+//
+// P1: deferred (see docs/meso/fixed-selection-plan.md) — dnd-kit drag
+// reordering, keyboard grid-nav (useGridNav), in-cell group override editor /
+// one-rm editor, agent-chat wiring, coachmarks. Swap/skip/add-this-week
+// WRITE UX is P2 — this file only ever DISPLAYS swap_name/skipped.
+import { useEffect, useRef, useState } from "react";
+import type { GridCell, GridDay, GridHistory, GridRow, GridWeek, MesoGrid } from "../lib/api";
+import type { GridCellPatch, Id } from "../hooks/useGrid";
+
+export interface MesoTableProps {
+  grid: MesoGrid | null;
+  history: GridHistory;
+  busy: boolean;
+  unit: string;
+  onPatchCell(cellId: Id, patch: GridCellPatch): void;
+  onRenameExercise(exerciseSlotId: Id, name: string): void;
+  onAddExercise(day: GridDay): void;
+  onRemoveExercise(exerciseSlotId: Id): void;
+  onAddDay(): void;
+  onRemoveDay(day: GridDay): void;
+  onAddWeek(): void;
+  onRemoveWeek(weekId: Id): void;
+  onSetCurrentWeek(weekId: Id): void;
+  onUndo(): void;
+  onRedo(): void;
+}
+
+/** The single arm/confirm slot — mirrors usePlanData's PendingDelete
+ * (one thing armed at a time), but kept local to MesoTable since useGrid's
+ * remove verbs fire the mutation directly with no confirm step of their own. */
+type ArmedKind = "exercise" | "day" | "week";
+type Armed = { type: ArmedKind; id: Id } | null;
+
+const EDITABLE_FIELDS = ["sets", "reps", "load", "rpe", "rest", "note"] as const;
+type EditableField = (typeof EDITABLE_FIELDS)[number];
+
+function draftFrom(cell: GridCell): Record<EditableField, string> {
+  return { sets: cell.sets, reps: cell.reps, load: cell.load, rpe: cell.rpe, rest: cell.rest, note: cell.note };
+}
+
+interface GridCellEditorProps {
+  cell: GridCell;
+  unit: string;
+  onPatchCell(cellId: Id, patch: GridCellPatch): void;
+}
+
+function GridCellEditor({ cell, unit, onPatchCell }: GridCellEditorProps) {
+  const [draft, setDraft] = useState<Record<EditableField, string>>(() => draftFrom(cell));
+  // Per-cell (not per-field) dirty set: on commit, only the fields the coach
+  // actually typed into are sent — an unconditional blur commit would
+  // autosave (and record a no-op undo action for) every field merely tabbed
+  // through.
+  const dirtyRef = useRef<Set<EditableField>>(new Set());
+
+  // Resync the draft whenever the source of truth changes — our own commit's
+  // optimistic update, or an external refetch (undo/redo, another coach
+  // action) — never while the coach is mid-edit, since this only runs when
+  // these values actually change.
+  useEffect(() => {
+    setDraft(draftFrom(cell));
+    dirtyRef.current = new Set();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cell.sets, cell.reps, cell.load, cell.rpe, cell.rest, cell.note]);
+
+  function changed(field: EditableField, value: string) {
+    dirtyRef.current.add(field);
+    setDraft((prev) => ({ ...prev, [field]: value }));
+  }
+
+  function commitIfDirty() {
+    if (dirtyRef.current.size === 0) return;
+    const patch: GridCellPatch = {};
+    for (const field of dirtyRef.current) {
+      patch[field] = draft[field];
+    }
+    dirtyRef.current = new Set();
+    onPatchCell(cell.prescription_id, patch);
+  }
+
+  function onKeyDownField(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      commitIfDirty();
+    }
+  }
+
+  function toggleLoadType() {
+    onPatchCell(cell.prescription_id, { load_type: cell.load_type === "pct" ? "abs" : "pct" });
+  }
+
+  const cellId = cell.prescription_id;
+
+  return (
+    <div className="meso-table-cell-editor">
+      <div className="meso-table-cell-setsreps">
+        <input
+          className="meso-cell meso-num-input"
+          data-testid={`cell-sets-${cellId}`}
+          aria-label="sets"
+          value={draft.sets}
+          onChange={(e) => changed("sets", e.target.value)}
+          onBlur={commitIfDirty}
+          onKeyDown={onKeyDownField}
+        />
+        <span className="meso-x-sep">×</span>
+        <input
+          className="meso-cell meso-num-input"
+          data-testid={`cell-reps-${cellId}`}
+          aria-label="reps"
+          value={draft.reps}
+          onChange={(e) => changed("reps", e.target.value)}
+          onBlur={commitIfDirty}
+          onKeyDown={onKeyDownField}
+        />
+      </div>
+      <div className="meso-table-cell-load">
+        <input
+          className="meso-cell meso-num-input"
+          data-testid={`cell-load-${cellId}`}
+          aria-label="load"
+          value={draft.load}
+          onChange={(e) => changed("load", e.target.value)}
+          onBlur={commitIfDirty}
+          onKeyDown={onKeyDownField}
+        />
+        <button
+          type="button"
+          data-testid={`cell-loadtype-${cellId}`}
+          className="meso-load-toggle"
+          title={cell.load_type === "pct" ? "Load is % of 1RM — tap for absolute" : "Load is absolute — tap for % of 1RM"}
+          aria-label={cell.load_type === "pct" ? "Load type: percent of 1RM" : "Load type: absolute"}
+          onClick={toggleLoadType}
+        >
+          {cell.load_type === "pct" ? "%" : unit}
+        </button>
+      </div>
+      <input
+        className="meso-cell meso-num-input"
+        data-testid={`cell-rpe-${cellId}`}
+        aria-label="RPE"
+        value={draft.rpe}
+        onChange={(e) => changed("rpe", e.target.value)}
+        onBlur={commitIfDirty}
+        onKeyDown={onKeyDownField}
+      />
+      <input
+        className="meso-cell meso-num-input"
+        data-testid={`cell-rest-${cellId}`}
+        aria-label="rest"
+        value={draft.rest}
+        onChange={(e) => changed("rest", e.target.value)}
+        onBlur={commitIfDirty}
+        onKeyDown={onKeyDownField}
+      />
+      <input
+        className="meso-note"
+        data-testid={`cell-note-${cellId}`}
+        aria-label="note"
+        placeholder="—"
+        value={draft.note}
+        onChange={(e) => changed("note", e.target.value)}
+        onBlur={commitIfDirty}
+        onKeyDown={onKeyDownField}
+      />
+    </div>
+  );
+}
+
+interface RowNameEditorProps {
+  row: GridRow;
+  onRename(exerciseSlotId: Id, name: string): void;
+}
+
+function RowNameEditor({ row, onRename }: RowNameEditorProps) {
+  const [value, setValue] = useState(row.name);
+  const dirtyRef = useRef(false);
+
+  useEffect(() => {
+    setValue(row.name);
+    dirtyRef.current = false;
+  }, [row.name]);
+
+  function commitIfDirty() {
+    if (!dirtyRef.current) return;
+    dirtyRef.current = false;
+    onRename(row.exercise_slot_id, value);
+  }
+
+  return (
+    <input
+      className="meso-cell meso-ex-name-input"
+      data-testid={`row-name-${row.exercise_slot_id}`}
+      aria-label="exercise name"
+      value={value}
+      onChange={(e) => {
+        dirtyRef.current = true;
+        setValue(e.target.value);
+      }}
+      onBlur={commitIfDirty}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          commitIfDirty();
+        }
+      }}
+    />
+  );
+}
+
+export function MesoTable(props: MesoTableProps) {
+  const {
+    grid,
+    history,
+    busy,
+    unit,
+    onPatchCell,
+    onRenameExercise,
+    onAddExercise,
+    onRemoveExercise,
+    onAddDay,
+    onRemoveDay,
+    onAddWeek,
+    onRemoveWeek,
+    onSetCurrentWeek,
+    onUndo,
+    onRedo,
+  } = props;
+
+  const [armed, setArmed] = useState<Armed>(null);
+  const isArmed = (type: ArmedKind, id: Id) => !!armed && armed.type === type && armed.id === id;
+  const disarm = () => setArmed(null);
+
+  if (!grid) return null;
+
+  return (
+    <div className="meso-table-view" data-testid="meso-table-view">
+      <div className="meso-table-toolbar">
+        <button
+          type="button"
+          data-testid="grid-undo"
+          data-hover="rail"
+          className="meso-week-strip-btn"
+          disabled={busy || !history.can_undo}
+          aria-label="Undo"
+          title={history.undo_label ? "Undo: " + history.undo_label : "Undo"}
+          onClick={onUndo}
+        >
+          ↺ Undo
+        </button>
+        <button
+          type="button"
+          data-testid="grid-redo"
+          data-hover="rail"
+          className="meso-week-strip-btn"
+          disabled={busy || !history.can_redo}
+          aria-label="Redo"
+          title={history.redo_label ? "Redo: " + history.redo_label : "Redo"}
+          onClick={onRedo}
+        >
+          Redo ↻
+        </button>
+        <div className="meso-flex-spacer" />
+        <button
+          type="button"
+          data-testid="add-week"
+          data-hover="add"
+          className="meso-week-strip-btn meso-week-strip-btn--dashed"
+          disabled={busy}
+          onClick={onAddWeek}
+        >
+          + Add week
+        </button>
+      </div>
+
+      {grid.days.map((day) => {
+        const dayArmed = isArmed("day", day.session_slot_id);
+        return (
+          <div className="meso-table-day" key={day.session_slot_id}>
+            <div className="meso-table-day-header">
+              <div className="meso-day-name">{day.name}</div>
+              {day.bias && <div className="meso-day-bias">{day.bias}</div>}
+              <div className="meso-flex-spacer" />
+              {!dayArmed && (
+                <button
+                  type="button"
+                  data-testid={`remove-day-${day.session_slot_id}`}
+                  className="meso-remove-x"
+                  disabled={busy}
+                  aria-label="Remove this day"
+                  title="Remove this day"
+                  onClick={() => setArmed({ type: "day", id: day.session_slot_id })}
+                >
+                  ×
+                </button>
+              )}
+              {dayArmed && (
+                <span className="meso-confirm-pair">
+                  <button
+                    type="button"
+                    data-testid={`confirm-remove-day-${day.session_slot_id}`}
+                    className="meso-confirm-btn"
+                    disabled={busy}
+                    aria-label="Confirm remove day"
+                    onClick={() => {
+                      onRemoveDay(day);
+                      disarm();
+                    }}
+                  >
+                    Confirm?
+                  </button>
+                  <button
+                    type="button"
+                    data-testid={`cancel-remove-day-${day.session_slot_id}`}
+                    className="meso-cancel-btn"
+                    disabled={busy}
+                    aria-label="Cancel remove day"
+                    onClick={disarm}
+                  >
+                    Cancel
+                  </button>
+                </span>
+              )}
+            </div>
+
+            <div className="meso-table-scroll">
+              <table className="meso-table" data-testid={`meso-day-table-${day.session_slot_id}`}>
+                <thead>
+                  <tr>
+                    <th className="meso-table-exercise-col">Exercise</th>
+                    {grid.weeks.map((week) => (
+                      <WeekColumnHeader
+                        key={week.id}
+                        week={week}
+                        armed={isArmed("week", week.id)}
+                        busy={busy}
+                        onArm={() => setArmed({ type: "week", id: week.id })}
+                        onDisarm={disarm}
+                        onSetCurrentWeek={onSetCurrentWeek}
+                        onRemoveWeek={onRemoveWeek}
+                      />
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {day.rows.map((row) => {
+                    const rowArmed = isArmed("exercise", row.exercise_slot_id);
+                    return (
+                      <tr key={row.exercise_slot_id} data-testid={`meso-row-${row.exercise_slot_id}`}>
+                        <td className="meso-table-row-name-col">
+                          <RowNameEditor row={row} onRename={onRenameExercise} />
+                          {!rowArmed && (
+                            <button
+                              type="button"
+                              data-testid={`remove-exercise-${row.exercise_slot_id}`}
+                              className="meso-remove-x meso-remove-x--sm"
+                              disabled={busy}
+                              aria-label="Remove exercise"
+                              title="Remove exercise"
+                              onClick={() => setArmed({ type: "exercise", id: row.exercise_slot_id })}
+                            >
+                              ×
+                            </button>
+                          )}
+                          {rowArmed && (
+                            <span className="meso-confirm-pair">
+                              <button
+                                type="button"
+                                data-testid={`confirm-remove-exercise-${row.exercise_slot_id}`}
+                                className="meso-confirm-btn"
+                                disabled={busy}
+                                aria-label="Confirm remove exercise"
+                                onClick={() => {
+                                  onRemoveExercise(row.exercise_slot_id);
+                                  disarm();
+                                }}
+                              >
+                                Confirm?
+                              </button>
+                              <button
+                                type="button"
+                                data-testid={`cancel-remove-exercise-${row.exercise_slot_id}`}
+                                className="meso-cancel-btn"
+                                disabled={busy}
+                                aria-label="Cancel remove exercise"
+                                onClick={disarm}
+                              >
+                                Cancel
+                              </button>
+                            </span>
+                          )}
+                        </td>
+                        {grid.weeks.map((week) => {
+                          const cell = row.cells[String(week.id)];
+                          const testId = `cell-${row.exercise_slot_id}-${week.id}`;
+                          if (!cell) return <td key={week.id} data-testid={testId} />;
+                          return (
+                            <td key={week.id} data-testid={testId} className="meso-table-cell">
+                              {cell.skipped ? (
+                                <span className="meso-table-skipped" data-testid={`cell-skipped-${cell.prescription_id}`}>
+                                  —
+                                </span>
+                              ) : (
+                                <>
+                                  <GridCellEditor cell={cell} unit={unit} onPatchCell={onPatchCell} />
+                                  {cell.swap_name && (
+                                    <span
+                                      className="meso-table-swap-badge"
+                                      data-testid={`cell-swap-${cell.prescription_id}`}
+                                      title={"Swapped for " + cell.swap_name + " this week"}
+                                    >
+                                      {cell.swap_name}
+                                    </span>
+                                  )}
+                                </>
+                              )}
+                            </td>
+                          );
+                        })}
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+
+            <button
+              type="button"
+              data-hover="add"
+              className="meso-add-row"
+              data-testid={`add-exercise-${day.session_slot_id}`}
+              disabled={busy}
+              onClick={() => onAddExercise(day)}
+            >
+              + Add exercise
+            </button>
+          </div>
+        );
+      })}
+
+      <button
+        type="button"
+        data-hover="add"
+        className="meso-add-day-btn"
+        data-testid="add-day"
+        disabled={busy}
+        onClick={onAddDay}
+      >
+        + Add day
+      </button>
+    </div>
+  );
+}
+
+interface WeekColumnHeaderProps {
+  week: GridWeek;
+  armed: boolean;
+  busy: boolean;
+  onArm(): void;
+  onDisarm(): void;
+  onSetCurrentWeek(weekId: Id): void;
+  onRemoveWeek(weekId: Id): void;
+}
+
+function WeekColumnHeader({ week, armed, busy, onArm, onDisarm, onSetCurrentWeek, onRemoveWeek }: WeekColumnHeaderProps) {
+  return (
+    <th
+      data-testid={`week-col-${week.id}`}
+      aria-current={week.current ? "true" : undefined}
+      className={`meso-table-week-col${week.current ? " meso-table-week-col--current" : ""}`}
+    >
+      <div className="meso-table-week-label">
+        <span>{week.label}</span>
+        {week.deload && (
+          <span aria-label="Deload week" title="Deload week" className="meso-table-deload-marker">
+            ▽
+          </span>
+        )}
+      </div>
+      {!week.current && (
+        <div className="meso-table-week-controls">
+          <button
+            type="button"
+            data-testid={`make-current-${week.id}`}
+            className="meso-week-strip-btn meso-week-strip-btn--accent"
+            disabled={busy}
+            title="Make this the live week — delivery will send it"
+            onClick={() => onSetCurrentWeek(week.id)}
+          >
+            Make current
+          </button>
+          {!armed && (
+            <button
+              type="button"
+              data-testid={`remove-week-${week.id}`}
+              className="meso-week-strip-btn"
+              disabled={busy}
+              aria-label="Remove this week"
+              title="Remove this week"
+              onClick={onArm}
+            >
+              Remove
+            </button>
+          )}
+          {armed && (
+            <span className="meso-week-strip-confirm">
+              <button
+                type="button"
+                data-testid={`confirm-remove-week-${week.id}`}
+                className="meso-week-strip-btn meso-week-strip-btn--confirm"
+                disabled={busy}
+                aria-label="Confirm remove week"
+                onClick={() => {
+                  onRemoveWeek(week.id);
+                  onDisarm();
+                }}
+              >
+                Confirm?
+              </button>
+              <button
+                type="button"
+                data-testid={`cancel-remove-week-${week.id}`}
+                className="meso-week-strip-btn"
+                disabled={busy}
+                aria-label="Cancel remove week"
+                onClick={onDisarm}
+              >
+                Cancel
+              </button>
+            </span>
+          )}
+        </div>
+      )}
+    </th>
+  );
+}

--- a/frontend/designer/src/designer.css
+++ b/frontend/designer/src/designer.css
@@ -10,6 +10,7 @@
 @import "./styles/designer-rail.css";
 @import "./styles/designer-chat.css";
 @import "./styles/designer-grid.css";
+@import "./styles/designer-mesotable.css";
 @import "./styles/designer-block.css";
 @import "./styles/designer-athlete.css";
 @import "./styles/designer-modal.css";

--- a/frontend/designer/src/hooks/useGrid.test.ts
+++ b/frontend/designer/src/hooks/useGrid.test.ts
@@ -1,0 +1,477 @@
+// Specs for useGrid (P1 multi-week table) — a self-contained state-owning
+// hook for MesoTable. Cell edits (patchCell/renameExercise) are optimistic +
+// fire-and-forget, mirroring useAutosave's semantics (CONTRACT.md
+// "useAutosave") — no rollback on failure. Structural verbs (add/remove
+// day|week|exercise, undo/redo) POST then refetch the whole grid (GET
+// grid/), mirroring usePlanData/useReorder's ref-guard idiom so concurrent
+// structural ops can't race.
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useGrid } from "./useGrid";
+import type { GridCell, GridDay, GridRow, GridWeek, MesoGrid } from "../lib/api";
+
+function week(overrides: Partial<GridWeek> = {}): GridWeek {
+  return {
+    id: 1,
+    index: 0,
+    label: "Wk 1",
+    phase: "Accum",
+    deload: false,
+    current: true,
+    delivered_at: null,
+    ...overrides,
+  };
+}
+
+function cell(overrides: Partial<GridCell> = {}): GridCell {
+  return {
+    prescription_id: 100,
+    sets: "3",
+    reps: "5",
+    load: "100",
+    load_type: "abs",
+    rpe: "8",
+    rest: "90",
+    note: "",
+    skipped: false,
+    swap_name: "",
+    swap_exercise_id: null,
+    ...overrides,
+  };
+}
+
+function row(overrides: Partial<GridRow> = {}): GridRow {
+  return {
+    exercise_slot_id: 9,
+    name: "Squat",
+    exercise_id: 55,
+    order: 0,
+    tags: [],
+    cells: { "1": cell() },
+    ...overrides,
+  };
+}
+
+function day(overrides: Partial<GridDay> = {}): GridDay {
+  return {
+    session_slot_id: 1,
+    session_id: 11,
+    day_number: 1,
+    name: "Lower",
+    bias: "",
+    order: 0,
+    rows: [row()],
+    ...overrides,
+  };
+}
+
+function grid(overrides: Partial<MesoGrid> = {}): MesoGrid {
+  return {
+    mesocycle: { id: 1, plan_id: 7, name: "Block 1", week_count: 1 },
+    weeks: [week()],
+    days: [day()],
+    history: { can_undo: false, can_redo: false, undo_label: "", redo_label: "" },
+    ...overrides,
+  };
+}
+
+function res(body: unknown, ok = true, status = 200) {
+  return { ok, status, json: async () => body };
+}
+
+function sentBody(n = 0) {
+  const mockFetch = globalThis.fetch as unknown as { mock: { calls: unknown[][] } };
+  const call = mockFetch.mock.calls[n] as [string, RequestInit];
+  return call[1].body == null ? null : JSON.parse(call[1].body as string);
+}
+
+function setup(initialGrid: MesoGrid | null = grid()) {
+  return renderHook(() => useGrid({ planId: 7, csrf: "tok", initialGrid }));
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("initial hydration", () => {
+  it("seeds grid/history from initialGrid", () => {
+    const { result } = setup();
+    expect(result.current.grid?.days).toHaveLength(1);
+    expect(result.current.history).toEqual({ can_undo: false, can_redo: false, undo_label: "", redo_label: "" });
+  });
+
+  it("tolerates a null initialGrid", () => {
+    const { result } = setup(null);
+    expect(result.current.grid).toBe(null);
+  });
+});
+
+describe("patchCell", () => {
+  it("optimistically updates the cell and POSTs only the given patch, adopting history", async () => {
+    const { result } = setup();
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      res({
+        ok: true,
+        prescription: {},
+        history: { can_undo: true, can_redo: false, undo_label: "Edited Squat", redo_label: "" },
+      }),
+    ) as unknown as typeof fetch;
+
+    act(() => {
+      result.current.patchCell(100, { sets: "4" });
+    });
+
+    // Optimistic: reflected immediately, before the fetch resolves.
+    expect(result.current.grid?.days[0]?.rows[0]?.cells["1"]?.sets).toBe("4");
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(url).toBe("/meso/api/plan/7/prescription/100/");
+    expect(opts.method).toBe("POST");
+    expect(sentBody()).toEqual({ sets: "4" });
+
+    await waitFor(() => expect(result.current.history.can_undo).toBe(true));
+    expect(result.current.history.undo_label).toBe("Edited Squat");
+  });
+
+  it("leaves other cells/fields untouched", () => {
+    const { result } = setup(
+      grid({
+        days: [
+          day({
+            rows: [
+              row({ exercise_slot_id: 9, cells: { "1": cell({ prescription_id: 100, reps: "5" }) } }),
+              row({ exercise_slot_id: 10, cells: { "1": cell({ prescription_id: 200, sets: "5" }) } }),
+            ],
+          }),
+        ],
+      }),
+    );
+    globalThis.fetch = vi.fn().mockResolvedValue(res({ ok: true })) as unknown as typeof fetch;
+    act(() => {
+      result.current.patchCell(100, { sets: "4" });
+    });
+    expect(result.current.grid?.days[0]?.rows[0]?.cells["1"]).toMatchObject({ sets: "4", reps: "5" });
+    expect(result.current.grid?.days[0]?.rows[1]?.cells["1"]).toMatchObject({ sets: "5" });
+  });
+
+  it("console.errors on failure without rolling back the optimistic update", async () => {
+    const { result } = setup();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("boom")) as unknown as typeof fetch;
+
+    act(() => {
+      result.current.patchCell(100, { note: "left knee sore" });
+    });
+
+    await waitFor(() => expect(console.error).toHaveBeenCalled());
+    expect(result.current.grid?.days[0]?.rows[0]?.cells["1"]?.note).toBe("left knee sore");
+  });
+});
+
+describe("renameExercise", () => {
+  it("POSTs {name} to the row's FIRST live week's (non-swapped) cell, optimistically updating row.name", async () => {
+    const { result } = setup(
+      grid({
+        weeks: [week({ id: 1 }), week({ id: 2, label: "Wk 2", current: false })],
+        days: [
+          day({
+            rows: [
+              row({
+                exercise_slot_id: 9,
+                name: "Squat",
+                cells: {
+                  "1": cell({ prescription_id: 100 }),
+                  "2": cell({ prescription_id: 101, swap_name: "Leg Press", swap_exercise_id: 77 }),
+                },
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      res({ ok: true, history: { can_undo: true, can_redo: false, undo_label: "Renamed Squat", redo_label: "" } }),
+    ) as unknown as typeof fetch;
+
+    act(() => {
+      result.current.renameExercise(9, "Front Squat");
+    });
+
+    expect(result.current.grid?.days[0]?.rows[0]?.name).toBe("Front Squat");
+    const [url, opts] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(url).toBe("/meso/api/plan/7/prescription/100/"); // week[0]'s cell, not the swapped week[1] one
+    expect(JSON.parse(opts.body as string)).toEqual({ name: "Front Squat" });
+    await waitFor(() => expect(result.current.history.undo_label).toBe("Renamed Squat"));
+  });
+});
+
+describe("addExercise", () => {
+  it("POSTs session/{sessionId}/exercise/ with a null body, then refetches the grid", async () => {
+    const initial = grid();
+    const { result } = setup(initial);
+    const refreshed = grid({
+      days: [day({ rows: [row(), row({ exercise_slot_id: 20, name: "New exercise" })] })],
+    });
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(res({ ok: true }))
+      .mockResolvedValueOnce(res({ ok: true, ...refreshed })) as unknown as typeof fetch;
+
+    await act(async () => {
+      await result.current.addExercise(initial.days[0]!);
+    });
+
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0]![0]).toBe("/meso/api/plan/7/session/11/exercise/");
+    expect(calls[0]![1].method).toBe("POST");
+    expect(calls[0]![1].body).toBe(null);
+    expect(calls[1]![0]).toBe("/meso/api/plan/7/grid/");
+    expect(result.current.grid?.days[0]?.rows).toHaveLength(2);
+  });
+});
+
+describe("removeExercise", () => {
+  it("POSTs prescription/{cellId}/delete/ for the row's first-week cell, then refetches", async () => {
+    const initial = grid();
+    const { result } = setup(initial);
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(res({ ok: true }))
+      .mockResolvedValueOnce(res({ ok: true, ...grid({ days: [day({ rows: [] })] }) })) as unknown as typeof fetch;
+
+    await act(async () => {
+      await result.current.removeExercise(9);
+    });
+
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0]![0]).toBe("/meso/api/plan/7/prescription/100/delete/");
+    expect(calls[1]![0]).toBe("/meso/api/plan/7/grid/");
+    expect(result.current.grid?.days[0]?.rows).toHaveLength(0);
+  });
+});
+
+describe("addDay", () => {
+  it("POSTs session/ with {week_id: current week id}, then refetches", async () => {
+    const initial = grid({ weeks: [week({ id: 1, current: true }), week({ id: 2, current: false })] });
+    const { result } = setup(initial);
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(res({ ok: true }))
+      .mockResolvedValueOnce(res({ ok: true, ...grid({ days: [day(), day({ session_slot_id: 2, name: "Upper" })] }) })) as unknown as typeof fetch;
+
+    await act(async () => {
+      await result.current.addDay();
+    });
+
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0]![0]).toBe("/meso/api/plan/7/session/");
+    expect(JSON.parse(calls[0]![1].body as string)).toEqual({ week_id: 1 });
+    expect(calls[1]![0]).toBe("/meso/api/plan/7/grid/");
+    expect(result.current.grid?.days).toHaveLength(2);
+  });
+});
+
+describe("removeDay", () => {
+  it("POSTs session/{sessionId}/delete/, then refetches", async () => {
+    const initial = grid();
+    const { result } = setup(initial);
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(res({ ok: true }))
+      .mockResolvedValueOnce(res({ ok: true, ...grid({ days: [] }) })) as unknown as typeof fetch;
+
+    await act(async () => {
+      await result.current.removeDay(initial.days[0]!);
+    });
+
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0]![0]).toBe("/meso/api/plan/7/session/11/delete/");
+    expect(calls[1]![0]).toBe("/meso/api/plan/7/grid/");
+    expect(result.current.grid?.days).toHaveLength(0);
+  });
+});
+
+describe("addWeek", () => {
+  it("POSTs week/ with a null body, then refetches", async () => {
+    const { result } = setup();
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(res({ ok: true }))
+      .mockResolvedValueOnce(
+        res({ ok: true, ...grid({ weeks: [week({ id: 1 }), week({ id: 2, label: "Wk 2", current: false })] }) }),
+      ) as unknown as typeof fetch;
+
+    await act(async () => {
+      await result.current.addWeek();
+    });
+
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0]![0]).toBe("/meso/api/plan/7/week/");
+    expect(calls[0]![1].body).toBe(null);
+    expect(calls[1]![0]).toBe("/meso/api/plan/7/grid/");
+    expect(result.current.grid?.weeks).toHaveLength(2);
+  });
+});
+
+describe("removeWeek", () => {
+  it("POSTs week/{weekId}/delete/, then refetches", async () => {
+    const { result } = setup();
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(res({ ok: true }))
+      .mockResolvedValueOnce(res({ ok: true, ...grid() })) as unknown as typeof fetch;
+
+    await act(async () => {
+      await result.current.removeWeek(1);
+    });
+
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0]![0]).toBe("/meso/api/plan/7/week/1/delete/");
+    expect(calls[1]![0]).toBe("/meso/api/plan/7/grid/");
+  });
+});
+
+describe("setCurrentWeek", () => {
+  it("POSTs week/{weekId}/current/ with a null body, then refetches", async () => {
+    const initial = grid({ weeks: [week({ id: 1, current: true }), week({ id: 2, current: false })] });
+    const { result } = setup(initial);
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(res({ ok: true }))
+      .mockResolvedValueOnce(
+        res({ ok: true, ...grid({ weeks: [week({ id: 1, current: false }), week({ id: 2, current: true })] }) }),
+      ) as unknown as typeof fetch;
+
+    await act(async () => {
+      await result.current.setCurrentWeek(2);
+    });
+
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0]![0]).toBe("/meso/api/plan/7/week/2/current/");
+    expect(calls[0]![1].body).toBe(null);
+    expect(calls[1]![0]).toBe("/meso/api/plan/7/grid/");
+    expect(result.current.grid?.weeks[1]?.current).toBe(true);
+  });
+});
+
+describe("undo/redo", () => {
+  it("undo POSTs {week_id: current week id} to undo/, then refetches the grid (ignoring its own envelope)", async () => {
+    const initial = grid({
+      history: { can_undo: true, can_redo: false, undo_label: "Edited Squat", redo_label: "" },
+    });
+    const { result } = setup(initial);
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(res({ ok: true, program: [], weeks: [], phases: [], viewing: null })) // undo's own single-week envelope, ignored
+      .mockResolvedValueOnce(
+        res({
+          ok: true,
+          ...grid({ history: { can_undo: false, can_redo: true, undo_label: "", redo_label: "Edited Squat" } }),
+        }),
+      ) as unknown as typeof fetch;
+
+    await act(async () => {
+      await result.current.undo();
+    });
+
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0]![0]).toBe("/meso/api/plan/7/undo/");
+    expect(JSON.parse(calls[0]![1].body as string)).toEqual({ week_id: 1 });
+    expect(calls[1]![0]).toBe("/meso/api/plan/7/grid/");
+    expect(result.current.history.can_undo).toBe(false);
+    expect(result.current.history.can_redo).toBe(true);
+  });
+
+  it("redo POSTs {week_id} to redo/, then refetches", async () => {
+    const initial = grid({
+      history: { can_undo: false, can_redo: true, undo_label: "", redo_label: "Edited Squat" },
+    });
+    const { result } = setup(initial);
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(res({ ok: true }))
+      .mockResolvedValueOnce(res({ ok: true, ...grid() })) as unknown as typeof fetch;
+
+    await act(async () => {
+      await result.current.redo();
+    });
+
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0]![0]).toBe("/meso/api/plan/7/redo/");
+    expect(calls[1]![0]).toBe("/meso/api/plan/7/grid/");
+  });
+
+  it("undo is a no-op when history.can_undo is false", async () => {
+    const { result } = setup(grid({ history: { can_undo: false, can_redo: false, undo_label: "", redo_label: "" } }));
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+    await act(async () => {
+      await result.current.undo();
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("concurrency guard on structural ops", () => {
+  it("a second structural call while one is in flight is a no-op; busy reflects it", async () => {
+    const { result } = setup();
+    let resolvePost!: (v: unknown) => void;
+    const fetchMock = vi.fn();
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolvePost = resolve;
+        }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    let first!: Promise<void>;
+    let second!: Promise<void>;
+    act(() => {
+      first = result.current.addWeek();
+      second = result.current.addWeek();
+    });
+
+    expect(result.current.busy).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // the second call bailed before POSTing
+
+    fetchMock.mockResolvedValueOnce(res({ ok: true, ...grid() })); // the refetch GET
+
+    await act(async () => {
+      resolvePost(res({ ok: true }));
+      await first;
+      await second;
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2); // POST + GET only — no third/fourth call
+    expect(result.current.busy).toBe(false);
+  });
+});
+
+describe("refetchGrid", () => {
+  it("GETs the grid endpoint (no options) and adopts the reply", async () => {
+    const { result } = setup();
+    const data = grid({ mesocycle: { id: 1, plan_id: 7, name: "Renamed block", week_count: 1 } });
+    globalThis.fetch = vi.fn().mockResolvedValue(res({ ok: true, ...data })) as unknown as typeof fetch;
+
+    await act(async () => {
+      await result.current.refetchGrid();
+    });
+
+    const [url, opts] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(url).toBe("/meso/api/plan/7/grid/");
+    expect(opts).toBeUndefined();
+    expect(result.current.grid?.mesocycle.name).toBe("Renamed block");
+  });
+
+  it("console.errors and leaves state unchanged on a failed refetch", async () => {
+    const { result } = setup();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    globalThis.fetch = vi.fn().mockResolvedValue(res({}, false, 500)) as unknown as typeof fetch;
+
+    await act(async () => {
+      await result.current.refetchGrid();
+    });
+
+    expect(console.error).toHaveBeenCalled();
+    expect(result.current.grid?.mesocycle.name).toBe("Block 1");
+  });
+});

--- a/frontend/designer/src/hooks/useGrid.test.ts
+++ b/frontend/designer/src/hooks/useGrid.test.ts
@@ -202,6 +202,44 @@ describe("renameExercise", () => {
     expect(JSON.parse(opts.body as string)).toEqual({ name: "Front Squat" });
     await waitFor(() => expect(result.current.history.undo_label).toBe("Renamed Squat"));
   });
+
+  it("retargets to the first NON-swapped cell when week[0]'s cell is itself the swap", async () => {
+    // prescription_patch treats a `name` edit on a swapped cell as editing
+    // the one-week swap, not the block ExerciseSlot.name — so renaming must
+    // never target week[0]'s cell when THAT week is the swapped one.
+    const { result } = setup(
+      grid({
+        weeks: [week({ id: 1 }), week({ id: 2, label: "Wk 2", current: false })],
+        days: [
+          day({
+            rows: [
+              row({
+                exercise_slot_id: 9,
+                name: "Squat",
+                cells: {
+                  "1": cell({ prescription_id: 100, swap_name: "Leg Press", swap_exercise_id: 77 }),
+                  "2": cell({ prescription_id: 101 }),
+                },
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      res({ ok: true, history: { can_undo: true, can_redo: false, undo_label: "Renamed Squat", redo_label: "" } }),
+    ) as unknown as typeof fetch;
+
+    act(() => {
+      result.current.renameExercise(9, "Front Squat");
+    });
+
+    expect(result.current.grid?.days[0]?.rows[0]?.name).toBe("Front Squat");
+    const [url, opts] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(url).toBe("/meso/api/plan/7/prescription/101/"); // week[1]'s (unswapped) cell, not the swapped week[0] one
+    expect(JSON.parse(opts.body as string)).toEqual({ name: "Front Squat" });
+    await waitFor(() => expect(result.current.history.undo_label).toBe("Renamed Squat"));
+  });
 });
 
 describe("addExercise", () => {

--- a/frontend/designer/src/hooks/useGrid.test.ts
+++ b/frontend/designer/src/hooks/useGrid.test.ts
@@ -35,6 +35,7 @@ function cell(overrides: Partial<GridCell> = {}): GridCell {
     skipped: false,
     swap_name: "",
     swap_exercise_id: null,
+    swap_display: "",
     ...overrides,
   };
 }

--- a/frontend/designer/src/hooks/useGrid.ts
+++ b/frontend/designer/src/hooks/useGrid.ts
@@ -59,6 +59,20 @@ function firstWeekCellId(grid: MesoGrid | null, row: GridRow | undefined): Id | 
   return row.cells[String(firstWeek.id)]?.prescription_id;
 }
 
+/** The row's rename target: the first live week's cell that is NOT a one-week
+ * swap (prescription_patch only rewrites the block ExerciseSlot.name for an
+ * unswapped cell). Falls back to the first week's cell if every week is
+ * swapped (rare) — best-effort. */
+function renameTargetCellId(grid: MesoGrid | null, row: GridRow | undefined): Id | undefined {
+  if (!grid || !row) return undefined;
+  for (const week of grid.weeks) {
+    const c = row.cells[String(week.id)];
+    if (c && c.swap_name === "" && c.swap_exercise_id == null) return c.prescription_id;
+  }
+  const first = grid.weeks[0];
+  return first ? row.cells[String(first.id)]?.prescription_id : undefined;
+}
+
 function currentWeekId(grid: MesoGrid | null): Id | undefined {
   if (!grid) return undefined;
   return (grid.weeks.find((w) => w.current) ?? grid.weeks[0])?.id;
@@ -151,7 +165,7 @@ export function useGrid(options: UseGridOptions) {
   const renameExercise = useCallback(
     (exerciseSlotId: Id, name: string) => {
       const row = findRow(grid, exerciseSlotId);
-      const cellId = firstWeekCellId(grid, row);
+      const cellId = renameTargetCellId(grid, row);
       if (cellId == null) return;
       setGrid((prev) => (prev ? updateRowNameInGrid(prev, exerciseSlotId, name) : prev));
       apiPost(`/meso/api/plan/${planId}/prescription/${cellId}/`, { name }, csrf)

--- a/frontend/designer/src/hooks/useGrid.ts
+++ b/frontend/designer/src/hooks/useGrid.ts
@@ -1,0 +1,315 @@
+// useGrid — self-contained state-owning hook for the P1 multi-week table
+// (MesoTable). Owns `grid`/`history` and every verb that mutates it.
+//
+// Cell edits (patchCell/renameExercise) are optimistic + fire-and-forget,
+// mirroring useAutosave's semantics (CONTRACT.md "useAutosave") — updated in
+// local state immediately, POSTed without being awaited by the caller, and
+// NOT rolled back on failure (only console.error'd), same as persistRow.
+//
+// Structural verbs (add/remove day|week|exercise, set-current, undo/redo)
+// await their POST, then call refetchGrid() (a plain GET, mirroring
+// usePlanData's switchWeek) to re-sync the whole grid — mirroring
+// usePlanData/useReorder's ref-guard idiom, one shared in-flight guard across
+// every structural verb so a double-click can't race two refetches.
+import { useCallback, useRef, useState } from "react";
+import { apiPost } from "../lib/api";
+import type { GridCell, GridDay, GridHistory, GridRow, MesoGrid } from "../lib/api";
+
+export type Id = number | string;
+
+/** The cell fields the coach can type into (rest is new in P1). Everything
+ * else on GridCell — prescription_id/skipped/swap_* — is server-derived,
+ * display-only in P1 (never sent back in a patch). */
+export type GridCellPatch = Partial<
+  Pick<GridCell, "sets" | "reps" | "load" | "load_type" | "rpe" | "rest" | "note">
+>;
+
+interface GridHistoryCarrier {
+  history?: GridHistory;
+}
+
+const EMPTY_GRID_HISTORY: GridHistory = {
+  can_undo: false,
+  can_redo: false,
+  undo_label: "",
+  redo_label: "",
+};
+
+export interface UseGridOptions {
+  planId: Id;
+  csrf: string;
+  initialGrid: MesoGrid | null;
+}
+
+function findRow(grid: MesoGrid | null, exerciseSlotId: Id): GridRow | undefined {
+  if (!grid) return undefined;
+  for (const day of grid.days) {
+    const row = day.rows.find((r) => r.exercise_slot_id === exerciseSlotId);
+    if (row) return row;
+  }
+  return undefined;
+}
+
+/** The row's FIRST live week's cell — always non-swapped in normal data (see
+ * CONTRACT: renameExercise must retarget a swapped cell otherwise). */
+function firstWeekCellId(grid: MesoGrid | null, row: GridRow | undefined): Id | undefined {
+  if (!grid || !row) return undefined;
+  const firstWeek = grid.weeks[0];
+  if (!firstWeek) return undefined;
+  return row.cells[String(firstWeek.id)]?.prescription_id;
+}
+
+function currentWeekId(grid: MesoGrid | null): Id | undefined {
+  if (!grid) return undefined;
+  return (grid.weeks.find((w) => w.current) ?? grid.weeks[0])?.id;
+}
+
+/** Immutably patch every cell (across every day/row/week) whose
+ * prescription_id matches — in practice exactly one, since prescription_id
+ * is unique per (row, week). */
+function updateCellInGrid(grid: MesoGrid, cellId: Id, patch: GridCellPatch): MesoGrid {
+  return {
+    ...grid,
+    days: grid.days.map((day) => ({
+      ...day,
+      rows: day.rows.map((row) => {
+        let changed = false;
+        const cells: Record<string, GridCell> = {};
+        for (const [weekId, c] of Object.entries(row.cells)) {
+          if (c.prescription_id === cellId) {
+            changed = true;
+            cells[weekId] = { ...c, ...patch };
+          } else {
+            cells[weekId] = c;
+          }
+        }
+        return changed ? { ...row, cells } : row;
+      }),
+    })),
+  };
+}
+
+function updateRowNameInGrid(grid: MesoGrid, exerciseSlotId: Id, name: string): MesoGrid {
+  return {
+    ...grid,
+    days: grid.days.map((day) => ({
+      ...day,
+      rows: day.rows.map((row) => (row.exercise_slot_id === exerciseSlotId ? { ...row, name } : row)),
+    })),
+  };
+}
+
+export function useGrid(options: UseGridOptions) {
+  const { planId, csrf, initialGrid } = options;
+  const [grid, setGrid] = useState<MesoGrid | null>(initialGrid);
+  const [history, setHistory] = useState<GridHistory>(initialGrid?.history ?? EMPTY_GRID_HISTORY);
+
+  // One shared in-flight guard across every structural (refetch-driven) verb
+  // — mirrors useDeletes' deletingRef / useReorder's reorderingRef, checked
+  // synchronously so a double-click can't race two refetches.
+  const busyRef = useRef(false);
+  const [busy, setBusy] = useState(false);
+
+  const adoptGridHistory = useCallback((data: GridHistoryCarrier) => {
+    if (data && data.history) setHistory(data.history);
+  }, []);
+
+  const refetchGrid = useCallback(async () => {
+    try {
+      const res = await fetch(`/meso/api/plan/${planId}/grid/`);
+      if (!res.ok) throw new Error("Request failed: " + res.status);
+      const data = (await res.json()) as MesoGrid & { ok?: boolean };
+      setGrid({ mesocycle: data.mesocycle, weeks: data.weeks, days: data.days, history: data.history });
+      setHistory(data.history);
+    } catch (err) {
+      console.error("Refetch grid failed", err);
+    }
+  }, [planId]);
+
+  const runStructural = useCallback(async (fn: () => Promise<void>) => {
+    if (busyRef.current) return;
+    busyRef.current = true;
+    setBusy(true);
+    try {
+      await fn();
+    } finally {
+      busyRef.current = false;
+      setBusy(false);
+    }
+  }, []);
+
+  const patchCell = useCallback(
+    (cellId: Id, patch: GridCellPatch) => {
+      setGrid((prev) => (prev ? updateCellInGrid(prev, cellId, patch) : prev));
+      apiPost(`/meso/api/plan/${planId}/prescription/${cellId}/`, patch, csrf)
+        .then((data) => adoptGridHistory(data as GridHistoryCarrier))
+        .catch((err) => console.error("Cell autosave failed", err));
+    },
+    [planId, csrf, adoptGridHistory],
+  );
+
+  const renameExercise = useCallback(
+    (exerciseSlotId: Id, name: string) => {
+      const row = findRow(grid, exerciseSlotId);
+      const cellId = firstWeekCellId(grid, row);
+      if (cellId == null) return;
+      setGrid((prev) => (prev ? updateRowNameInGrid(prev, exerciseSlotId, name) : prev));
+      apiPost(`/meso/api/plan/${planId}/prescription/${cellId}/`, { name }, csrf)
+        .then((data) => adoptGridHistory(data as GridHistoryCarrier))
+        .catch((err) => console.error("Rename exercise failed", err));
+    },
+    [grid, planId, csrf, adoptGridHistory],
+  );
+
+  const addExercise = useCallback(
+    (day: GridDay) =>
+      runStructural(async () => {
+        try {
+          await apiPost(`/meso/api/plan/${planId}/session/${day.session_id}/exercise/`, null, csrf);
+        } catch (err) {
+          console.error("Add exercise failed", err);
+          return;
+        }
+        await refetchGrid();
+      }),
+    [planId, csrf, runStructural, refetchGrid],
+  );
+
+  const removeExercise = useCallback(
+    (exerciseSlotId: Id) =>
+      runStructural(async () => {
+        const row = findRow(grid, exerciseSlotId);
+        const cellId = firstWeekCellId(grid, row);
+        if (cellId == null) return;
+        try {
+          await apiPost(`/meso/api/plan/${planId}/prescription/${cellId}/delete/`, null, csrf);
+        } catch (err) {
+          console.error("Remove exercise failed", err);
+          return;
+        }
+        await refetchGrid();
+      }),
+    [grid, planId, csrf, runStructural, refetchGrid],
+  );
+
+  const addDay = useCallback(
+    () =>
+      runStructural(async () => {
+        const weekId = currentWeekId(grid);
+        try {
+          await apiPost(`/meso/api/plan/${planId}/session/`, { week_id: weekId }, csrf);
+        } catch (err) {
+          console.error("Add day failed", err);
+          return;
+        }
+        await refetchGrid();
+      }),
+    [grid, planId, csrf, runStructural, refetchGrid],
+  );
+
+  const removeDay = useCallback(
+    (day: GridDay) =>
+      runStructural(async () => {
+        try {
+          await apiPost(`/meso/api/plan/${planId}/session/${day.session_id}/delete/`, null, csrf);
+        } catch (err) {
+          console.error("Remove day failed", err);
+          return;
+        }
+        await refetchGrid();
+      }),
+    [planId, csrf, runStructural, refetchGrid],
+  );
+
+  const addWeek = useCallback(
+    () =>
+      runStructural(async () => {
+        try {
+          await apiPost(`/meso/api/plan/${planId}/week/`, null, csrf);
+        } catch (err) {
+          console.error("Add week failed", err);
+          return;
+        }
+        await refetchGrid();
+      }),
+    [planId, csrf, runStructural, refetchGrid],
+  );
+
+  const removeWeek = useCallback(
+    (weekId: Id) =>
+      runStructural(async () => {
+        try {
+          await apiPost(`/meso/api/plan/${planId}/week/${weekId}/delete/`, null, csrf);
+        } catch (err) {
+          console.error("Remove week failed", err);
+          return;
+        }
+        await refetchGrid();
+      }),
+    [planId, csrf, runStructural, refetchGrid],
+  );
+
+  const setCurrentWeek = useCallback(
+    (weekId: Id) =>
+      runStructural(async () => {
+        try {
+          await apiPost(`/meso/api/plan/${planId}/week/${weekId}/current/`, null, csrf);
+        } catch (err) {
+          console.error("Set current week failed", err);
+          return;
+        }
+        await refetchGrid();
+      }),
+    [planId, csrf, runStructural, refetchGrid],
+  );
+
+  const undo = useCallback(
+    () =>
+      runStructural(async () => {
+        if (!history.can_undo) return;
+        const weekId = currentWeekId(grid);
+        try {
+          await apiPost(`/meso/api/plan/${planId}/undo/`, { week_id: weekId }, csrf);
+        } catch (err) {
+          console.error("Undo failed", err);
+          return;
+        }
+        await refetchGrid();
+      }),
+    [grid, history.can_undo, planId, csrf, runStructural, refetchGrid],
+  );
+
+  const redo = useCallback(
+    () =>
+      runStructural(async () => {
+        if (!history.can_redo) return;
+        const weekId = currentWeekId(grid);
+        try {
+          await apiPost(`/meso/api/plan/${planId}/redo/`, { week_id: weekId }, csrf);
+        } catch (err) {
+          console.error("Redo failed", err);
+          return;
+        }
+        await refetchGrid();
+      }),
+    [grid, history.can_redo, planId, csrf, runStructural, refetchGrid],
+  );
+
+  return {
+    grid,
+    history,
+    busy,
+    patchCell,
+    renameExercise,
+    addExercise,
+    removeExercise,
+    addDay,
+    removeDay,
+    addWeek,
+    removeWeek,
+    setCurrentWeek,
+    undo,
+    redo,
+    refetchGrid,
+  };
+}

--- a/frontend/designer/src/hooks/usePlanData.test.ts
+++ b/frontend/designer/src/hooks/usePlanData.test.ts
@@ -308,6 +308,38 @@ describe("reloadWeek", () => {
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
+  it("GETs an explicit target week instead of the currently-viewed week when given one", async () => {
+    // Guards against reactivating on a week that's been deleted elsewhere
+    // (e.g. the table removed the week planData last viewed) — the caller
+    // can hand reloadWeek a different, still-live target instead.
+    const { result } = setup({ viewing: 3 });
+    const data = {
+      ok: true,
+      program: [day({ id: 20, name: "Upper" })],
+      weeks: [week({ id: 5, label: "Wk 5", current: true })],
+      phases: [phase()],
+      viewing: 5,
+    };
+    globalThis.fetch = vi.fn().mockResolvedValue(res(data)) as unknown as typeof fetch;
+    await act(async () => {
+      await result.current.reloadWeek(5);
+    });
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(url).toBe("/meso/api/plan/7/week/5/");
+    expect(opts).toBeUndefined();
+    expect(result.current.program[0]?.id).toBe(20);
+  });
+
+  it("is a no-op when explicitly given a null/undefined target and there is no viewed week", async () => {
+    const { result } = setup({ viewing: null });
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+    await act(async () => {
+      await result.current.reloadWeek(undefined);
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
   it("leaves state unchanged and console.errors on a failed fetch", async () => {
     const { result } = setup({ viewing: 1, program: [day({ id: 99 })] });
     vi.spyOn(console, "error").mockImplementation(() => {});

--- a/frontend/designer/src/hooks/usePlanData.test.ts
+++ b/frontend/designer/src/hooks/usePlanData.test.ts
@@ -278,6 +278,48 @@ describe("switchWeek", () => {
   });
 });
 
+describe("reloadWeek", () => {
+  it("GETs the currently-viewed week endpoint (even though it's already viewed) and applies the reply", async () => {
+    const { result } = setup({ viewing: 3 });
+    const data = {
+      ok: true,
+      program: [day({ id: 10, name: "Lower" })],
+      weeks: [week({ id: 3, label: "Wk 3", current: true })],
+      phases: [phase()],
+      viewing: 3,
+    };
+    globalThis.fetch = vi.fn().mockResolvedValue(res(data)) as unknown as typeof fetch;
+    await act(async () => {
+      await result.current.reloadWeek();
+    });
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(url).toBe("/meso/api/plan/7/week/3/");
+    expect(opts).toBeUndefined();
+    expect(result.current.program[0]?.id).toBe(10);
+  });
+
+  it("is a no-op when there is no viewed week", async () => {
+    const { result } = setup({ viewing: null });
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+    await act(async () => {
+      await result.current.reloadWeek();
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("leaves state unchanged and console.errors on a failed fetch", async () => {
+    const { result } = setup({ viewing: 1, program: [day({ id: 99 })] });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    globalThis.fetch = vi.fn().mockResolvedValue(res({}, false, 500)) as unknown as typeof fetch;
+    await act(async () => {
+      await result.current.reloadWeek();
+    });
+    expect(result.current.program[0]!.id).toBe(99);
+    expect(console.error).toHaveBeenCalled();
+  });
+});
+
 describe("addWeek", () => {
   it("POSTs the week endpoint and applies the reply", async () => {
     const { result } = setup({ viewing: 1 });

--- a/frontend/designer/src/hooks/usePlanData.ts
+++ b/frontend/designer/src/hooks/usePlanData.ts
@@ -163,21 +163,29 @@ export function usePlanData(
     [planId, viewedWeekId, applyPlanData],
   );
 
-  // Unlike switchWeek, reloadWeek ALWAYS refetches the currently-viewed week
-  // — used when re-activating the "week" view after another view (the P1
-  // table) may have mutated the same week server-side, so switchWeek's
-  // same-id-is-a-no-op guard would otherwise leave it stale.
-  const reloadWeek = useCallback(async () => {
-    const target = viewedWeekIdRef.current;
-    if (target == null) return;
-    try {
-      const res = await fetch(`/meso/api/plan/${planId}/week/${target}/`);
-      if (!res.ok) throw new Error("Request failed: " + res.status);
-      applyPlanData((await res.json()) as PlanEnvelope);
-    } catch (err) {
-      console.error("Reload week failed", err);
-    }
-  }, [planId, applyPlanData]);
+  // Unlike switchWeek, reloadWeek ALWAYS refetches (never no-ops on a
+  // same-id target) — used when re-activating the "week" view after another
+  // view (the P1 table) may have mutated the same week server-side, so
+  // switchWeek's same-id-is-a-no-op guard would otherwise leave it stale.
+  // Defaults to the currently-viewed week, but accepts an explicit
+  // `targetWeekId` override: the caller (DesignerRoot.selectView) may need to
+  // reactivate on the GRID's current week instead, since planData's own
+  // viewedWeekId can point at a week the table has since deleted (a GET to a
+  // deleted week 404s and would otherwise strand a stale render).
+  const reloadWeek = useCallback(
+    async (targetWeekId?: Id) => {
+      const target = targetWeekId ?? viewedWeekIdRef.current;
+      if (target == null) return;
+      try {
+        const res = await fetch(`/meso/api/plan/${planId}/week/${target}/`);
+        if (!res.ok) throw new Error("Request failed: " + res.status);
+        applyPlanData((await res.json()) as PlanEnvelope);
+      } catch (err) {
+        console.error("Reload week failed", err);
+      }
+    },
+    [planId, applyPlanData],
+  );
 
   const addWeek = useCallback(async () => {
     try {

--- a/frontend/designer/src/hooks/usePlanData.ts
+++ b/frontend/designer/src/hooks/usePlanData.ts
@@ -163,6 +163,22 @@ export function usePlanData(
     [planId, viewedWeekId, applyPlanData],
   );
 
+  // Unlike switchWeek, reloadWeek ALWAYS refetches the currently-viewed week
+  // — used when re-activating the "week" view after another view (the P1
+  // table) may have mutated the same week server-side, so switchWeek's
+  // same-id-is-a-no-op guard would otherwise leave it stale.
+  const reloadWeek = useCallback(async () => {
+    const target = viewedWeekIdRef.current;
+    if (target == null) return;
+    try {
+      const res = await fetch(`/meso/api/plan/${planId}/week/${target}/`);
+      if (!res.ok) throw new Error("Request failed: " + res.status);
+      applyPlanData((await res.json()) as PlanEnvelope);
+    } catch (err) {
+      console.error("Reload week failed", err);
+    }
+  }, [planId, applyPlanData]);
+
   const addWeek = useCallback(async () => {
     try {
       const data = await apiPost<PlanEnvelope>(`/meso/api/plan/${planId}/week/`, null, csrf);
@@ -254,6 +270,7 @@ export function usePlanData(
     addExercise,
     addDay,
     switchWeek,
+    reloadWeek,
     addWeek,
     setCurrentWeek,
 

--- a/frontend/designer/src/hooks/useUndoRedo.test.ts
+++ b/frontend/designer/src/hooks/useUndoRedo.test.ts
@@ -205,4 +205,67 @@ describe("keyboard wiring (window keydown, registered for the hook's lifetime)",
     });
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
+
+  // P1 (multi-week table): the table view's undo/redo lives in a sibling
+  // hook (useGrid), but the window keydown listener lives here — so
+  // DesignerRoot overrides what the shortcut invokes via keyboardUndo/
+  // keyboardRedo, letting the shortcut follow whichever view is active
+  // instead of always hitting this hook's own planData undo/redo.
+  it("routes Ctrl/Cmd+Z to keyboardUndo when provided, and does not hit the internal planData undo", async () => {
+    const applyPlanData = vi.fn();
+    const keyboardUndo = vi.fn();
+    const keyboardRedo = vi.fn();
+    renderHook(() =>
+      useUndoRedo({
+        planId: 7,
+        csrf: "tok",
+        viewedWeekId: 5,
+        history: HISTORY_BOTH,
+        applyPlanData,
+        keyboardUndo,
+        keyboardRedo,
+      }),
+    );
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+    await act(async () => {
+      dispatch({ ctrlKey: true });
+      await Promise.resolve();
+    });
+    expect(keyboardUndo).toHaveBeenCalledTimes(1);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("routes Shift+Ctrl/Cmd+Z to keyboardRedo when provided, and does not hit the internal planData redo", async () => {
+    const applyPlanData = vi.fn();
+    const keyboardUndo = vi.fn();
+    const keyboardRedo = vi.fn();
+    renderHook(() =>
+      useUndoRedo({
+        planId: 7,
+        csrf: "tok",
+        viewedWeekId: 5,
+        history: HISTORY_BOTH,
+        applyPlanData,
+        keyboardUndo,
+        keyboardRedo,
+      }),
+    );
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+    await act(async () => {
+      dispatch({ key: "Z", ctrlKey: true, shiftKey: true });
+      await Promise.resolve();
+    });
+    expect(keyboardRedo).toHaveBeenCalledTimes(1);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the internal planData undo when keyboardUndo/keyboardRedo are absent (unchanged behavior)", async () => {
+    setup(HISTORY_BOTH, 5);
+    globalThis.fetch = vi.fn().mockResolvedValue(res(planData())) as unknown as typeof fetch;
+    await act(async () => {
+      dispatch({ ctrlKey: true });
+      await Promise.resolve();
+    });
+    expect(globalThis.fetch).toHaveBeenCalledWith("/meso/api/plan/7/undo/", expect.anything());
+  });
 });

--- a/frontend/designer/src/hooks/useUndoRedo.ts
+++ b/frontend/designer/src/hooks/useUndoRedo.ts
@@ -14,6 +14,12 @@ export interface UseUndoRedoOptions {
   viewedWeekId: Id | null;
   history: HistoryState;
   applyPlanData: (data: PlanEnvelope) => void;
+  /** What the Ctrl/Cmd+Z window shortcut invokes; defaults to this hook's
+   * own planData undo/redo. DesignerRoot overrides these to the active
+   * view's handlers (e.g. the grid table's) so the keyboard shortcut
+   * follows the visible canvas. */
+  keyboardUndo?: () => void;
+  keyboardRedo?: () => void;
 }
 
 export function useUndoRedo(options: UseUndoRedoOptions) {
@@ -61,10 +67,10 @@ export function useUndoRedo(options: UseUndoRedoOptions) {
     }
   }, [history.can_redo, planId, viewedWeekId, csrf, applyPlanData, setUndoingBoth]);
 
-  const undoRef = useRef(undo);
-  undoRef.current = undo;
-  const redoRef = useRef(redo);
-  redoRef.current = redo;
+  const undoRef = useRef<() => void | Promise<void>>(options.keyboardUndo ?? undo);
+  undoRef.current = options.keyboardUndo ?? undo;
+  const redoRef = useRef<() => void | Promise<void>>(options.keyboardRedo ?? redo);
+  redoRef.current = options.keyboardRedo ?? redo;
 
   useEffect(() => {
     function handler(event: KeyboardEvent) {

--- a/frontend/designer/src/lib/api.ts
+++ b/frontend/designer/src/lib/api.ts
@@ -137,6 +137,75 @@ export interface HistoryCarrier {
 }
 
 /**
+ * P1 multi-week table grid (`serialize_mesocycle_grid`, backend
+ * `app/store_project/meso/serializers.py`) — the whole block at once: one row
+ * per live ExerciseSlot, one column per live Week, keyed by `str(week_id)`.
+ * Distinct from `PlanEnvelope`'s single-week `program` (see CONTRACT.md's
+ * useGrid section) — this is P1's own data shape, fetched/POSTed independently.
+ */
+export interface GridWeek {
+  id: number;
+  index: number;
+  label: string;
+  phase: string;
+  deload: boolean;
+  current: boolean;
+  delivered_at: string | null;
+}
+
+export interface GridCell {
+  prescription_id: number;
+  sets: string;
+  reps: string;
+  load: string;
+  load_type: "abs" | "pct";
+  rpe: string;
+  rest: string;
+  note: string;
+  skipped: boolean;
+  swap_name: string;
+  swap_exercise_id: number | null;
+}
+
+export interface GridRow {
+  exercise_slot_id: number;
+  /** The BLOCK identity (not swap-resolved) — a swapped cell shows its own
+   * `swap_name` alongside this. */
+  name: string;
+  exercise_id: number | null;
+  order: number;
+  tags: unknown[];
+  /** One cell per live week, keyed by `String(week.id)`. */
+  cells: Record<string, GridCell>;
+}
+
+export interface GridDay {
+  session_slot_id: number;
+  session_id: number | null;
+  day_number: number;
+  name: string;
+  bias: string;
+  order: number;
+  rows: GridRow[];
+}
+
+/** `serialize_plan_history`'s shape as ridden by the grid endpoints — labels
+ * are always strings (never null), unlike `HistoryState`. */
+export interface GridHistory {
+  can_undo: boolean;
+  can_redo: boolean;
+  undo_label: string;
+  redo_label: string;
+}
+
+export interface MesoGrid {
+  mesocycle: { id: number; plan_id: number; name: string; week_count: number };
+  weeks: GridWeek[];
+  days: GridDay[];
+  history: GridHistory;
+}
+
+/**
  * POST JSON to `url` with the CSRF header and same-origin credentials
  * (fetch's default), throwing on a non-ok response. `csrf` is an explicit
  * argument (the Alpine original read `this.csrf`); callers supply it from

--- a/frontend/designer/src/lib/api.ts
+++ b/frontend/designer/src/lib/api.ts
@@ -165,6 +165,11 @@ export interface GridCell {
   skipped: boolean;
   swap_name: string;
   swap_exercise_id: number | null;
+  /** Resolved one-week swap display name: `swap_name` if free-text, else the
+   * swapped catalog exercise's name, else "" (no swap). A catalog-only swap
+   * (swap_exercise_id set, swap_name blank) needs this to render a badge —
+   * swap_name alone is blank for that case. */
+  swap_display: string;
 }
 
 export interface GridRow {

--- a/frontend/designer/src/styles/designer-mesotable.css
+++ b/frontend/designer/src/styles/designer-mesotable.css
@@ -1,0 +1,152 @@
+/* MesoTable (P1 multi-week table) — one <table> per training day, week
+   columns across the top. Reuses several classes/tokens from
+   designer-grid.css / designer-weekstrip.css (.meso-cell, .meso-num-input,
+   .meso-note, .meso-remove-x, .meso-confirm-btn/.meso-cancel-btn,
+   .meso-week-strip-btn variants, .meso-add-row/.meso-add-day-btn) so the
+   table's controls read as the same design language as the week view. */
+
+.meso-table-view {
+  padding-bottom: 8px;
+}
+
+.meso-table-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-bottom: 16px;
+}
+
+.meso-table-day {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  overflow: hidden;
+  margin-bottom: 15px;
+  box-shadow: 0 1px 2px rgba(16, 18, 22, 0.03);
+}
+
+.meso-table-day-header {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 12px 15px;
+  border-bottom: 1px solid var(--line-2);
+}
+
+/* Horizontally scrollable inside its own container — a mesocycle can have
+   many week columns, but the page body must never scroll sideways. */
+.meso-table-scroll {
+  overflow-x: auto;
+}
+
+.meso-table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.meso-table-exercise-col {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  background: var(--rail);
+  text-align: left;
+}
+
+.meso-table thead th {
+  padding: 7px 12px;
+  background: var(--rail);
+  border-bottom: 1px solid var(--line-2);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--dim);
+  white-space: nowrap;
+  vertical-align: top;
+}
+
+.meso-table-week-col--current {
+  color: var(--accent-deep);
+}
+
+.meso-table-week-label {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11.5px;
+  text-transform: none;
+  letter-spacing: -0.01em;
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.meso-table-week-col--current .meso-table-week-label {
+  color: var(--accent-deep);
+}
+
+.meso-table-deload-marker {
+  color: var(--dim);
+}
+
+.meso-table-week-controls {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-top: 5px;
+  font-weight: 600;
+  text-transform: none;
+  letter-spacing: normal;
+}
+
+.meso-table tbody td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--line-2);
+  vertical-align: top;
+}
+
+.meso-table-row-name-col {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  background: var(--surface);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 160px;
+}
+
+.meso-table-cell {
+  min-width: 190px;
+}
+
+.meso-table-cell-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.meso-table-cell-setsreps,
+.meso-table-cell-load {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+}
+
+.meso-table-skipped {
+  display: inline-block;
+  color: var(--dim);
+  font-family: "IBM Plex Mono", monospace;
+  padding: 4px 2px;
+}
+
+.meso-table-swap-badge {
+  display: inline-block;
+  margin-top: 3px;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--accent-deep);
+  background: var(--soft);
+  border: 1px solid var(--soft-line);
+  border-radius: 4px;
+  padding: 0 5px;
+}


### PR DESCRIPTION
## P1 — multi-week table UI

Second phase of the fixed-lineup reshape ([#440](https://github.com/lancegoyke/fitness-store/issues/440), spec `docs/meso/fixed-selection-plan.md`). Renders the whole mesocycle at once — **one `<table>` per training day, exercise rows down the side, week columns across the top** — as the coach's default editing surface, so the context of previous/upcoming weeks is visible instead of hidden behind a week-at-a-time tab strip.

### Backend
- **`serialize_mesocycle_grid(mesocycle)`** — dense `days × rows × per-week cells` (cells keyed by `str(week_id)`): block identity from `ExerciseSlot`, per-week numbers incl. the new **`rest`** field, plus `skipped` / `swap_name` / `swap_exercise_id` / resolved `swap_display` display state and undo/redo history. Built in a fixed **7 queries** (no N+1).
- **`GET /meso/api/plan/<id>/grid/`** (`api_mesocycle_grid`) — ownership-gated refetch, optional `?mesocycle=<id>`. `MesoDesignerView` hydrates `grid_data`; `designer.html` emits `#meso-grid-data`.
- All slot-CRUD + cell-patch **write endpoints are reused from P0** (`prescription_patch` incl. `rest`, `session_add_exercise`, `prescription_delete`, `session_add/delete`, `week_add/delete/current`, `undo/redo`).

### Frontend (`frontend/designer/`)
- **`useGrid`** — self-contained grid state owner: optimistic fire-and-forget cell autosave (incl. `rest` + load-type), block rename (targets a non-swapped cell), add/remove exercise·day·week, set-current, undo/redo. Structural verbs refetch the grid behind one in-flight guard.
- **`MesoTable`** — editable cells (commit-on-blur/Enter, only-if-dirty), deload column marker (▽), skipped em-dash, swap badge; arm→confirm removes.
- **`DesignerRoot`** — parses `#meso-grid-data`, adds the **"Table" view** (default when a grid is present), composes `useGrid`. The table and the one-week fallback are kept in sync: Deliver targets the grid's current week in table view; each view refetches its source on activation; keyboard undo/redo routes to the active view.

### Deferred to later phases (documented in code)
dnd reorder, keyboard grid-nav, in-cell override/1RM, and the swap/skip/add-this-week **write** UX (that's P2). The one-week view (`WeekStrip`/`WeekGrid`/`DayCard`) stays reachable as a transitional fallback and will be removed once the table reaches parity.

### Review & tests
- **Codex review loop:** 1 blocker + 4 nits found across 3 iterations, all fixed (deliver/cross-view sync, rename-through-swap, catalog-swap visibility, deleted-viewed-week survival, keyboard-undo routing).
- Backend meso suite **1888 passed** (+31 new); frontend **522 passed** (+65 new); typecheck clean; vite build OK.

Refs #440 (P1).