### PR TITLE
fix(meso): P1 guided-tour usability fixes (#441)

### DIFF
--- a/app/store_project/meso/tests/test_tour.py
+++ b/app/store_project/meso/tests/test_tour.py
@@ -268,6 +268,63 @@ class TestBuildConfig:
         for step in config["steps"]:
             assert step["action"] is None
 
+    def test_config_carries_the_variant(self):
+        # #441 P1-1: the driver needs to know which audience it's rendering for
+        # so it can hide the sandbox-only "load everything" skip in the self
+        # variant (a real coach must never load fake demo athletes).
+        coach = _coach()
+        assert tour.build_config(coach, "sandbox")["variant"] == "sandbox"
+        assert tour.build_config(coach, "self")["variant"] == "self"
+
+
+class TestBuildConfigGotoReady:
+    """#441 P1-3: "Take me there" must not point at a page that'll bounce.
+
+    designer/deliver/results redirect back to the roster (an uncorrelated
+    flash + an infinite retry loop) when the coach has no plan / no logged
+    session yet. ``goto_ready`` mirrors the view's own redirect predicate — and
+    those view helpers are identity-blind, so the same flag works for both
+    variants. Steps that target the roster (welcome/profile/groups/finish)
+    never dead-end, so they're always ready.
+    """
+
+    def _goto(self, config, key):
+        return next(s for s in config["steps"] if s["key"] == key)["goto_ready"]
+
+    def test_sandbox_fresh_gates_the_data_dependent_gotos(self):
+        user = sandbox.create_sandbox()
+        config = tour.build_config(user, "sandbox")
+        assert self._goto(config, "designer") is False
+        assert self._goto(config, "deliver") is False
+        assert self._goto(config, "results") is False
+        assert self._goto(config, "agent") is False
+
+    def test_sandbox_full_demo_opens_the_gotos(self):
+        user = sandbox.create_sandbox()
+        demo.load_demo(user)
+        config = tour.build_config(user, "sandbox")
+        assert self._goto(config, "designer") is True
+        assert self._goto(config, "deliver") is True
+        assert self._goto(config, "results") is True
+        assert self._goto(config, "agent") is True
+
+    def test_roster_targeted_steps_are_always_ready(self):
+        user = sandbox.create_sandbox()
+        config = tour.build_config(user, "sandbox")
+        for key in ("welcome", "profile", "groups", "finish"):
+            assert self._goto(config, key) is True
+
+    def test_self_plan_opens_designer_deliver_agent_but_not_results(self):
+        coach = _coach()
+        link = CoachAthlete.add_self(coach)
+        link.create_plan()
+        config = tour.build_config(coach, "self")
+        assert self._goto(config, "designer") is True
+        assert self._goto(config, "deliver") is True
+        assert self._goto(config, "agent") is True
+        # No logged session yet → results still bounces.
+        assert self._goto(config, "results") is False
+
 
 class TestVariantFor:
     def test_sandbox_coach_is_sandbox(self):
@@ -389,6 +446,41 @@ class TestBuildConfigSelfVariant:
 
         agent = next(s for s in config["steps"] if s["key"] == "agent")
         assert agent["action"] is None
+
+    def test_agent_locked_copy_without_a_self_link_points_at_welcome(self):
+        # #441 P1-5: the locked copy must name the actual blocker. No self-link
+        # yet → do the welcome step first (mirrors the designer step).
+        coach = _coach()
+        config = tour.build_config(coach, "self")
+        agent = next(s for s in config["steps"] if s["key"] == "agent")
+        assert agent["action"] is None
+        assert "welcome step" in agent["body"]
+
+    def test_agent_locked_copy_when_a_plan_exists_points_at_the_designer(self):
+        # #441 P1-5: step 3 already created this plan, so the old copy ("start a
+        # free trial ... once you have an active program") told the coach to go
+        # acquire what they already have. Point them at the block instead.
+        coach = _coach()
+        link = CoachAthlete.add_self(coach)
+        link.create_plan()
+        config = tour.build_config(coach, "self")
+        agent = next(s for s in config["steps"] if s["key"] == "agent")
+        assert agent["action"] is None
+        assert "Designer" in agent["body"]
+        assert "trial" not in agent["body"].lower()
+
+    def test_agent_locked_copy_when_out_of_allowance_mentions_a_trial(self):
+        # #441 P1-5: a self-link + no plan + exhausted free allowance is the one
+        # case where "start a trial" is the right advice.
+        coach = _coach()
+        CoachAthlete.add_self(coach)  # link, but its own plan stays empty
+        other_plan = PlanFactory(relationship=CoachAthleteFactory(coach=coach))
+        for _ in range(CoachSubscription.FREE_AGENT_ALLOWANCE):
+            AgentProposalBatchFactory(plan=other_plan, coach=coach)
+        config = tour.build_config(coach, "self")
+        agent = next(s for s in config["steps"] if s["key"] == "agent")
+        assert agent["action"] is None
+        assert "trial" in agent["body"].lower()
 
     def test_finish_has_no_signup_gate_and_anchors_the_invite_control(self):
         coach = _coach()
@@ -880,3 +972,113 @@ class TestTourSkipEndpoint:
         client.post(reverse("meso:tour_skip"))
 
         assert CoachProfile.objects.filter(user=user).exists()
+
+    def test_self_variant_completes_without_loading_demo(self, client):
+        # #441 P1-1: a real (self-variant) coach must never get the 5 fake demo
+        # athletes on their live roster from the skip shortcut (O5). The skip
+        # form is hidden in the self variant, but the endpoint guards it too.
+        coach = _coach()
+        client.force_login(coach)
+
+        resp = client.post(reverse("meso:tour_skip"))
+
+        assert resp.status_code == 302
+        assert resp.url == reverse("meso:roster")
+        assert demo.has_demo(coach) is False
+        assert CoachProfile.objects.get(user=coach).tour_state["status"] == "completed"
+
+
+# ---------------------------------------------------------------------------
+# #441 P1-2: step 2 ("click into your profile") completion detection
+# ---------------------------------------------------------------------------
+
+
+class TestProfileStepAnchor:
+    def test_profile_step_anchors_the_first_row_not_the_whole_list(self):
+        # The spotlight named the whole roster list; re-anchor it to the single
+        # row the copy actually names.
+        profile_step = next(s for s in tour.STEPS if s["key"] == "profile")
+        assert profile_step["anchor"] == "roster-athlete-row-first"
+
+    def test_config_resolves_the_new_anchor_in_both_variants(self):
+        coach = _coach()
+        for variant in ("sandbox", "self"):
+            config = tour.build_config(coach, variant)
+            profile = next(s for s in config["steps"] if s["key"] == "profile")
+            assert profile["anchor"] == "roster-athlete-row-first"
+
+    def test_roster_marks_the_first_athlete_row(self, client):
+        coach = _coach()
+        CoachAthlete.add_self(coach)
+        tour.start_tour(coach.coach_profile)
+        client.force_login(coach)
+
+        body = client.get(reverse("meso:roster")).content.decode()
+
+        assert 'data-tour="roster-athlete-row-first"' in body
+
+
+class TestAdvanceIfOnStep:
+    """``tour.advance_if_on_step`` — page-visit completion for the profile step.
+
+    A no-op unless the coach is actively touring AND parked exactly on the
+    named step; then it advances one step forward.
+    """
+
+    def test_advances_a_touring_coach_parked_on_the_step(self):
+        coach = _coach()
+        tour.start_tour(coach.coach_profile)
+        tour.set_step(coach.coach_profile, 1)  # the profile step
+
+        assert tour.advance_if_on_step(coach, "profile") is True
+        assert tour.tour_status(coach)["step"] == 2
+
+    def test_noop_when_parked_on_a_different_step(self):
+        coach = _coach()
+        tour.start_tour(coach.coach_profile)  # step 0 (welcome)
+
+        assert tour.advance_if_on_step(coach, "profile") is False
+        assert tour.tour_status(coach)["step"] == 0
+
+    def test_noop_when_not_touring(self):
+        coach = _coach()  # never started → {} → not active
+
+        assert tour.advance_if_on_step(coach, "profile") is False
+
+    def test_noop_when_dismissed(self):
+        coach = _coach()
+        tour.start_tour(coach.coach_profile)
+        tour.set_step(coach.coach_profile, 1)
+        tour.dismiss(coach.coach_profile)
+
+        assert tour.advance_if_on_step(coach, "profile") is False
+
+    def test_noop_without_a_coach_profile(self):
+        # Defensive: an athlete with no CoachProfile visiting a profile page.
+        user = UserFactory()
+        assert tour.advance_if_on_step(user, "profile") is False
+
+
+class TestProfileVisitAdvance:
+    """The auto-advance wired into ``AthleteProfileView`` (#441 P1-2)."""
+
+    def test_visiting_an_athlete_profile_advances_the_profile_step(self, client):
+        coach = _coach()
+        CoachAthlete.add_self(coach)  # the coach's own athlete profile
+        tour.start_tour(coach.coach_profile)
+        tour.set_step(coach.coach_profile, 1)  # the profile step
+        client.force_login(coach)
+
+        client.get(reverse("meso:athlete", args=[coach.pk]))
+
+        assert tour.tour_status(coach)["step"] == 2
+
+    def test_visiting_a_profile_off_the_profile_step_does_not_advance(self, client):
+        coach = _coach()
+        CoachAthlete.add_self(coach)
+        tour.start_tour(coach.coach_profile)  # step 0 (welcome)
+        client.force_login(coach)
+
+        client.get(reverse("meso:athlete", args=[coach.pk]))
+
+        assert tour.tour_status(coach)["step"] == 0

--- a/app/store_project/meso/tests/test_tour.py
+++ b/app/store_project/meso/tests/test_tour.py
@@ -994,20 +994,24 @@ class TestTourSkipEndpoint:
 
 
 class TestProfileStepAnchor:
-    def test_profile_step_anchors_the_first_row_not_the_whole_list(self):
-        # The spotlight named the whole roster list; re-anchor it to the single
-        # row the copy actually names.
-        profile_step = next(s for s in tour.STEPS if s["key"] == "profile")
-        assert profile_step["anchor"] == "roster-athlete-row-first"
-
-    def test_config_resolves_the_new_anchor_in_both_variants(self):
+    def test_sandbox_profile_keeps_the_whole_list_spotlight(self):
+        # Maya (the athlete the copy names) can't be identified row-by-row at
+        # this step — the roster sorts by name so the first row is Devon, and
+        # her demo program only loads later — so the sandbox spotlights the
+        # whole list rather than mis-targeting a row.
         coach = _coach()
-        for variant in ("sandbox", "self"):
-            config = tour.build_config(coach, variant)
-            profile = next(s for s in config["steps"] if s["key"] == "profile")
-            assert profile["anchor"] == "roster-athlete-row-first"
+        config = tour.build_config(coach, "sandbox")
+        profile = next(s for s in config["steps"] if s["key"] == "profile")
+        assert profile["anchor"] == "roster-athlete-rows"
 
-    def test_roster_marks_the_first_athlete_row(self, client):
+    def test_self_profile_anchors_the_coachs_own_row(self):
+        # The self variant has exactly one row (the coach) — spotlight it.
+        coach = _coach()
+        config = tour.build_config(coach, "self")
+        profile = next(s for s in config["steps"] if s["key"] == "profile")
+        assert profile["anchor"] == "roster-athlete-row-first"
+
+    def test_roster_marks_the_self_row_for_the_spotlight(self, client):
         coach = _coach()
         CoachAthlete.add_self(coach)
         tour.start_tour(coach.coach_profile)

--- a/app/store_project/meso/tour.py
+++ b/app/store_project/meso/tour.py
@@ -78,7 +78,13 @@ STEPS = [
     {
         "key": "profile",
         "url_name": "meso:roster",
-        "anchor": "roster-athlete-row-first",
+        # Sandbox spotlights the whole list: the athlete the copy names (Maya)
+        # can't be picked out row-by-row here — the roster is sorted by name
+        # (Devon sorts first) and her demo program only loads at a later step,
+        # so there's no row-level signal for "Maya" yet (#441 P1-2). The self
+        # variant has exactly one row (the coach's own) and re-anchors to it
+        # for a precise spotlight.
+        "anchor": "roster-athlete-rows",
         "sandbox": {
             "title": "One athlete, one record",
             "body": "Click into Maya to see her contraindications, training "
@@ -88,6 +94,7 @@ STEPS = [
             "title": "One athlete, one record",
             "body": "Click into your own profile to see the same contraindications, "
             "training history, and program view every athlete gets.",
+            "anchor": "roster-athlete-row-first",
         },
     },
     {

--- a/app/store_project/meso/tour.py
+++ b/app/store_project/meso/tour.py
@@ -78,7 +78,7 @@ STEPS = [
     {
         "key": "profile",
         "url_name": "meso:roster",
-        "anchor": "roster-athlete-rows",
+        "anchor": "roster-athlete-row-first",
         "sandbox": {
             "title": "One athlete, one record",
             "body": "Click into Maya to see her contraindications, training "
@@ -182,12 +182,16 @@ STEPS = [
             "body": "The agent reads your fatigue and adherence and drafts "
             "next week's adjustments. Draft your next block with it now.",
             "action_label": "Draft next block with AI",
-            # Shown when the action isn't offered (no self-link yet, no agent
-            # allowance left, or a working plan already exists) — one generic
-            # explanation rather than three separate reasons (keep it simple).
-            "locked_body": "The agent drafts your next training block once "
-            "you're on your own roster with an active program — start a free "
-            "trial if you're not seeing this yet.",
+            # Shown when the action isn't offered — one of three distinct
+            # blockers (#441 P1-5: the old single generic explanation didn't
+            # name the actual reason, so it could tell a coach who already had
+            # a plan to go get one).
+            "locked_body_no_link": "Add yourself as an athlete first (the "
+            "welcome step) — then the agent can draft a training block for you.",
+            "locked_body_has_plan": "Your block is already drafted — open it in "
+            "the Program Designer, where the agent can adapt it from here.",
+            "locked_body_no_allowance": "You're out of free AI drafts for now — "
+            "start a trial to keep drafting next blocks with the agent.",
         },
     },
     {
@@ -332,6 +336,33 @@ def complete(profile):
     return profile.tour_state
 
 
+def advance_if_on_step(user, step_key):
+    """Auto-advance a touring coach off ``step_key`` on a page visit (#441 P1-2).
+
+    The button-less ``profile`` step has no data action to flip a
+    ``loaded`` flag — it completes when the coach actually opens an athlete
+    profile, so the server advances the tour when that visit happens
+    (``AthleteProfileView``). A strict no-op unless the coach is *actively*
+    touring (status ``active`` — not dismissed/completed/never-started)
+    **and** parked exactly on ``step_key``: revisiting the page later, or
+    visiting while parked elsewhere, does nothing. Advances one step and
+    records the ``advanced`` funnel event (mirroring ``tour_state``'s
+    goto/advance path). Returns whether it advanced.
+    """
+    profile = CoachProfile.objects.filter(user=user).first()
+    if profile is None:
+        return False
+    state = profile.tour_state or {}
+    if state.get("status") != "active":
+        return False
+    current = _clamp(state.get("step", 0))
+    if STEPS[current]["key"] != step_key or current >= len(STEPS) - 1:
+        return False
+    set_step(profile, current + 1)
+    record_advanced(user, variant_for(user), STEPS[current + 1]["key"])
+    return True
+
+
 def _segment_loaded(user, segment):
     """Whether ``segment``'s data already exists for ``user`` (O7), or ``None``."""
     predicate = _HAS_PREDICATES.get(segment)
@@ -427,14 +458,18 @@ def _self_step_fields(step, ctx):
         else:
             body = spec["locked_body"]
     elif key == "agent":
-        if ctx["has_self_link"] and ctx["can_use_agent"] and not ctx["has_plan"]:
+        if not ctx["has_self_link"]:
+            body = spec["locked_body_no_link"]
+        elif ctx["has_plan"]:
+            body = spec["locked_body_has_plan"]
+        elif not ctx["can_use_agent"]:
+            body = spec["locked_body_no_allowance"]
+        else:
             action = {
                 "url": ctx["plan_create_url"],
                 "label": spec["action_label"],
                 "fields": {"draft": "agent"},
             }
-        else:
-            body = spec["locked_body"]
 
     return {
         "title": title,
@@ -442,6 +477,38 @@ def _self_step_fields(step, ctx):
         "anchor": anchor,
         "action": action,
         "loaded": loaded,
+    }
+
+
+def _goto_ready_map(user):
+    """Per-step "Take me there" readiness — does the target render, or bounce?
+
+    designer/deliver/results redirect back to the roster (an uncorrelated
+    flash, then the tour re-offers the same dead-end link — the #441 bounce
+    loop) until the coach has a plan / a logged session. Gate the link on
+    the exact predicate each view uses; those helpers are identity-blind,
+    so one map serves both variants. Steps that target the roster aren't in
+    the map (``build_config`` defaults them to ready — the roster never
+    dead-ends).
+
+    Deferred import: ``views`` imports this module at the top level, so the
+    reverse import must happen at call time (both are loaded once a request
+    builds a config).
+    """
+    from .models import Plan
+    from .views import _coach_latest_logged_session
+    from .views import _coach_working_plan
+
+    has_editable_plan = (
+        _coach_working_plan(user, plans=Plan.objects.editable_by(user)) is not None
+    )
+    has_working_plan = _coach_working_plan(user) is not None
+    has_logged_session = _coach_latest_logged_session(user) is not None
+    return {
+        "designer": has_editable_plan,
+        "agent": has_editable_plan,
+        "deliver": has_working_plan,
+        "results": has_logged_session,
     }
 
 
@@ -462,6 +529,7 @@ def build_config(user, variant):
         return None
     state = profile.tour_state or {}
     self_ctx = _self_context(user) if variant == "self" else None
+    goto_map = _goto_ready_map(user)
     steps = []
     for step in STEPS:
         fields = (
@@ -481,10 +549,12 @@ def build_config(user, variant):
                 "signup_gate": fields.get("signup_gate", False),
                 "action": fields.get("action"),
                 "loaded": fields.get("loaded"),
+                "goto_ready": goto_map.get(step["key"], True),
             }
         )
     return {
         "steps": steps,
+        "variant": variant,
         "step": _clamp(state.get("step", 0)),
         "status": state.get("status", "active"),
         "state_url": reverse("meso:tour_state"),

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -481,6 +481,9 @@ class AthleteProfileView(LoginRequiredMixin, TemplateView):
         )
         if link is None:
             raise Http404("Unknown athlete")
+        # #441 P1-2: the button-less "profile" tour step completes on the
+        # visit itself — advance the tour if this coach is parked on it.
+        meso_tour.advance_if_on_step(self.request.user, "profile")
         ctx["active"] = "roster"
         # The relationship's working program (first-time-UX Phase 1): when one
         # exists the CTAs open it in the designer; when not, they create one.
@@ -1039,24 +1042,28 @@ def tour_skip(request):
     """The O6 "skip · load everything" shortcut: the full aggregate demo, tour marked done.
 
     Reuses the exact pre-tour ``demo_load`` behavior (the whole workspace, one
-    shot) and additionally marks the tour ``completed`` so it doesn't
-    resurface on the next page load — the tour is meant to be a helpful
-    default, never a wall (O6). Records a **skipped** funnel event (not
-    **completed** — distinct from actually walking the tour to the end, even
-    though both leave ``tour_state`` parked on the same ``completed`` status),
-    keyed to whichever step the coach skipped from.
+    shot) for the **sandbox** variant only, and always marks the tour
+    ``completed`` so it doesn't resurface on the next page load — the tour is
+    meant to be a helpful default, never a wall (O6). Records a **skipped**
+    funnel event (not **completed** — distinct from actually walking the tour
+    to the end, even though both leave ``tour_state`` parked on the same
+    ``completed`` status), keyed to whichever step the coach skipped from.
     """
     profile, _ = CoachProfile.objects.get_or_create(user=request.user)
     current_step = (profile.tour_state or {}).get("step", 0)
     variant = meso_tour.variant_for(request.user)
-    meso_demo.load_demo(request.user)
+    # Only the anonymous sandbox loads the fake demo workspace; a real
+    # (self-variant) coach must never get fake athletes on their live
+    # roster (#441 P1-1, O5) — for them "skip" just ends the tour.
+    if variant == "sandbox":
+        meso_demo.load_demo(request.user)
+        messages.success(
+            request,
+            "Demo data loaded — explore a populated workspace. Remove it any time.",
+        )
     meso_tour.complete(profile)
     meso_tour.record_skipped(
         request.user, variant, meso_tour.STEPS[current_step]["key"]
-    )
-    messages.success(
-        request,
-        "Demo data loaded — explore a populated workspace. Remove it any time.",
     )
     return redirect("meso:roster")
 

--- a/app/store_project/static/js/meso_tour.js
+++ b/app/store_project/static/js/meso_tour.js
@@ -136,6 +136,32 @@
     );
   }
 
+  // #441 P1-1: the sandbox-only "load everything" skip must never render for
+  // a real (self-variant) coach — it would drop 5 fake demo athletes onto
+  // their live roster. Hidden whenever the variant isn't explicitly sandbox.
+  function shouldShowSkipLoad(config) {
+    return !!config && config.variant === "sandbox";
+  }
+
+  // #441 P1-3: show "Take me there" only when the browser isn't already on
+  // the step's page AND the server says the target will actually render — a
+  // step whose data doesn't exist yet redirects to the roster, an infinite
+  // bounce loop. A missing `goto_ready` means "no prerequisite" (the
+  // roster-targeted steps), so it defaults to ready.
+  function shouldShowGoto(step, currentPath) {
+    if (!step) return false;
+    if (step.goto_ready === false) return false;
+    return !isCurrentPage(step.url, currentPath);
+  }
+
+  // #441 P1-4: a zero-area rect means the anchor is hidden/collapsed (e.g.
+  // the deliver step's control inside Alpine's `x-show="!delivered"` once a
+  // delivery is sent). Treat it as "anchor gone" so the driver hides the
+  // spotlight instead of drawing a 12x12 hole at the viewport origin.
+  function isUsableRect(rect) {
+    return !!rect && (rect.width > 0 || rect.height > 0);
+  }
+
   // The card's accessible name (issue #430 Phase 4, a11y): `aria-label` on
   // the dialog and the text of the `aria-live` announcement on step change
   // both read "Step 3 of 8: Program Designer" — the step position plus its
@@ -233,7 +259,7 @@
     var step = config.steps[index];
     var total = config.steps.length;
     var action = resolveActionState(step);
-    var showGoto = !isCurrentPage(step.url, root.location.pathname);
+    var showGoto = shouldShowGoto(step, root.location.pathname);
     var csrf = escapeHtml(getCookie("csrftoken") || "");
 
     var dots = config.steps
@@ -358,14 +384,16 @@
       (isLastStep(index, total) ? "Finish" : "Next") +
       "</button>" +
       "</div>" +
-      '<form method="post" action="' +
-      escapeHtml(config.skip_url) +
-      '" class="meso-tour-skip-form">' +
-      '<input type="hidden" name="csrfmiddlewaretoken" value="' +
-      csrf +
-      '">' +
-      '<button type="submit" class="meso-tour-skip">Skip tour · load everything</button>' +
-      "</form>" +
+      (shouldShowSkipLoad(config)
+        ? '<form method="post" action="' +
+          escapeHtml(config.skip_url) +
+          '" class="meso-tour-skip-form">' +
+          '<input type="hidden" name="csrfmiddlewaretoken" value="' +
+          csrf +
+          '">' +
+          '<button type="submit" class="meso-tour-skip">Skip tour · load everything</button>' +
+          "</form>"
+        : "") +
       "</div>"
     );
   }
@@ -390,6 +418,10 @@
       return;
     }
     var rect = el.getBoundingClientRect();
+    if (!isUsableRect(rect)) {
+      spotlight.style.display = "none";
+      return;
+    }
     var pad = 6;
     spotlight.style.display = "block";
     spotlight.style.top = Math.max(rect.top - pad, 0) + "px";
@@ -559,6 +591,9 @@
       buildStepAnnouncement: buildStepAnnouncement,
       prefersReducedMotion: prefersReducedMotion,
       scrollBehaviorFor: scrollBehaviorFor,
+      shouldShowSkipLoad: shouldShowSkipLoad,
+      shouldShowGoto: shouldShowGoto,
+      isUsableRect: isUsableRect,
     };
   }
 })(typeof window !== "undefined" ? window : this);

--- a/app/store_project/templates/meso/roster.html
+++ b/app/store_project/templates/meso/roster.html
@@ -93,7 +93,7 @@
           </div>
           <div data-tour="roster-athlete-rows">
             {% for a in athletes %}
-              <a class="meso-row" href="{% url 'meso:athlete' a.id %}"{% if forloop.first %} data-tour="roster-athlete-row-first"{% endif %}>
+              <a class="meso-row" href="{% url 'meso:athlete' a.id %}"{% if a.is_self %} data-tour="roster-athlete-row-first"{% endif %}>
                 <div class="meso-avatar {% if a.tone == 'accent' %}meso-avatar--accent{% endif %}">{{ a.initials }}</div>
                 <div style="min-width:0;">
                   <div class="meso-row-name">{{ a.name }}</div>

--- a/app/store_project/templates/meso/roster.html
+++ b/app/store_project/templates/meso/roster.html
@@ -93,7 +93,7 @@
           </div>
           <div data-tour="roster-athlete-rows">
             {% for a in athletes %}
-              <a class="meso-row" href="{% url 'meso:athlete' a.id %}">
+              <a class="meso-row" href="{% url 'meso:athlete' a.id %}"{% if forloop.first %} data-tour="roster-athlete-row-first"{% endif %}>
                 <div class="meso-avatar {% if a.tone == 'accent' %}meso-avatar--accent{% endif %}">{{ a.initials }}</div>
                 <div style="min-width:0;">
                   <div class="meso-row-name">{{ a.name }}</div>

--- a/frontend/meso_tour.test.js
+++ b/frontend/meso_tour.test.js
@@ -20,6 +20,9 @@ import {
   buildStepAnnouncement,
   prefersReducedMotion,
   scrollBehaviorFor,
+  shouldShowSkipLoad,
+  shouldShowGoto,
+  isUsableRect,
 } from "../app/store_project/static/js/meso_tour.js";
 
 describe("clampStep", () => {
@@ -360,5 +363,90 @@ describe("scrollBehaviorFor", () => {
 
   it("is smooth otherwise", () => {
     expect(scrollBehaviorFor(false)).toBe("smooth");
+  });
+});
+
+// #441 P1-1: the "Skip tour · load everything" shortcut loads the 5 fake demo
+// athletes — right for the anonymous sandbox, but a data leak onto a real
+// coach's live roster (O5). The driver only renders that form for the sandbox
+// variant; the self variant never offers a "load everything" escape hatch.
+describe("shouldShowSkipLoad", () => {
+  it("shows the load-everything skip in the sandbox variant", () => {
+    expect(shouldShowSkipLoad({ variant: "sandbox" })).toBe(true);
+  });
+
+  it("hides it in the self variant (no fake data for real coaches)", () => {
+    expect(shouldShowSkipLoad({ variant: "self" })).toBe(false);
+  });
+
+  it("hides it when the variant is missing or the config is empty", () => {
+    expect(shouldShowSkipLoad({})).toBe(false);
+    expect(shouldShowSkipLoad(null)).toBe(false);
+  });
+});
+
+// #441 P1-3: "Take me there" on a step whose target page has no data yet
+// (designer with no plan, deliver with no plan, results with no log) redirects
+// straight back to the roster — an infinite bounce loop. The server flags each
+// step's readiness (`goto_ready`); the link only shows when the target will
+// actually render AND the browser isn't already on that page.
+describe("shouldShowGoto", () => {
+  it("shows the link when off-page and the target is ready", () => {
+    expect(
+      shouldShowGoto(
+        { url: "/meso/designer/", goto_ready: true },
+        "/meso/",
+      ),
+    ).toBe(true);
+  });
+
+  it("hides the link when the target isn't ready (would bounce back)", () => {
+    expect(
+      shouldShowGoto(
+        { url: "/meso/designer/", goto_ready: false },
+        "/meso/",
+      ),
+    ).toBe(false);
+  });
+
+  it("hides the link when already on the target page", () => {
+    expect(
+      shouldShowGoto(
+        { url: "/meso/designer/", goto_ready: true },
+        "/meso/designer/107/",
+      ),
+    ).toBe(false);
+  });
+
+  it("defaults to ready when goto_ready is absent (roster-targeted steps)", () => {
+    expect(shouldShowGoto({ url: "/meso/deliver/" }, "/meso/")).toBe(true);
+  });
+
+  it("returns false for a missing step", () => {
+    expect(shouldShowGoto(null, "/meso/")).toBe(false);
+  });
+});
+
+// #441 P1-4: the self-variant deliver step's anchor lives inside Alpine's
+// `x-show="!delivered"`; delivering hides it, so `getBoundingClientRect()`
+// returns a zero rect and the driver would draw a 12x12 spotlight hole at the
+// viewport origin. A zero rect is treated as "anchor gone" — no spotlight.
+describe("isUsableRect", () => {
+  it("accepts a rect with real dimensions", () => {
+    expect(isUsableRect({ width: 120, height: 40 })).toBe(true);
+  });
+
+  it("accepts a rect with only one non-zero dimension", () => {
+    expect(isUsableRect({ width: 0, height: 40 })).toBe(true);
+    expect(isUsableRect({ width: 120, height: 0 })).toBe(true);
+  });
+
+  it("rejects a zero rect (a hidden/collapsed anchor)", () => {
+    expect(isUsableRect({ width: 0, height: 0 })).toBe(false);
+  });
+
+  it("rejects a missing rect", () => {
+    expect(isUsableRect(null)).toBe(false);
+    expect(isUsableRect(undefined)).toBe(false);
   });
 });


### PR DESCRIPTION
## Meso guided tour — P1 usability fixes (#441)

The tour audit in #441 found the tour "renders state but never reacts to what the user does." This PR fixes the five **P1 (broken / actively wrong)** findings. P2/P3 (adaptive copy, restart affordance, mobile sheet, pronouns, etc.) are left as follow-ups.

Developed red→green: every fix landed a failing test first.

### Fixes

- **P1-1 — `tour_skip` no longer leaks fake demo athletes onto real coaches.** The "Skip tour · load everything" shortcut called `load_demo` unconditionally, dropping Maya/Devon/Priya/Marcus/Lena + a demo plan + the "Strength Squad" group onto a real (self-variant) coach's live roster (violated decision O5). Now the demo load + its flash fire only for the anonymous sandbox variant; for a real coach, skip just ends the tour. The driver also hides the "load everything" form entirely in the self variant (`config.variant` → `shouldShowSkipLoad`), with the endpoint guarding it as defense-in-depth.

- **P1-2 — step 2 ("click into your profile") now has completion detection.** The tour never advanced when you clicked a row. `AthleteProfileView` now auto-advances the tour server-side when a touring coach parked on the profile step opens an athlete profile (`tour.advance_if_on_step`). The self variant also gets a precise spotlight on the coach's own row (`is_self`); the sandbox keeps the whole-list spotlight because the athlete the copy names (Maya) can't be identified row-by-row at that step — a subtlety Codex review caught after an initial `forloop.first` anchor would have mis-targeted Devon.

- **P1-3 — "Take me there" no longer dead-ends into a bounce loop.** designer/deliver/results redirect back to the roster when there's no plan / no logged session — the tour then re-offered the same dead-end link forever. Each step now carries a `goto_ready` flag computed from the *same* identity-blind view predicates the target views use (`_coach_working_plan` / `_coach_latest_logged_session`), and the driver only shows "Take me there" when the target will actually render.

- **P1-4 — deliver-step spotlight no longer collapses to a 12×12 glitch.** The `deliver-send` anchor lives inside Alpine's `x-show="!delivered"`; once delivered, `getBoundingClientRect()` returns a zero rect and the driver drew a tiny spotlight hole at the viewport origin. A zero rect is now treated as "anchor gone" → no spotlight (`isUsableRect` guard in `positionSpotlight`).

- **P1-5 — self-variant agent step locked copy no longer misdiagnoses.** Step 3 creates the coach's plan, so anyone following the tour in order hit step 7 with the action locked and copy telling them to go acquire a plan they already had. The locked copy now branches on the real blocker: no self-link → do the welcome step; plan already exists → open it in the Designer; out of free allowance → start a trial.

### Tests

- `frontend/meso_tour.test.js`: `shouldShowSkipLoad`, `shouldShowGoto`, `isUsableRect` (pure-logic unit tests).
- `app/store_project/meso/tests/test_tour.py`: config `variant`, `goto_ready` per-step readiness (both variants), agent locked-copy branches, skip-without-demo for self, profile-step anchor + first-row template marker, `advance_if_on_step` + the `AthleteProfileView` auto-advance integration.

Closes part of #441 (P1 items).
