### PR TITLE
fix(meso): P2 state-aware guided-tour copy (#441)

### DIFF
--- a/app/store_project/meso/tests/test_tour.py
+++ b/app/store_project/meso/tests/test_tour.py
@@ -1086,3 +1086,271 @@ class TestProfileVisitAdvance:
         client.get(reverse("meso:athlete", args=[coach.pk]))
 
         assert tour.tour_status(coach)["step"] == 0
+
+
+# ---------------------------------------------------------------------------
+# #441 P2: state-aware copy — steps' bodies react to what the coach has
+# actually done (data-derived from the same predicates the tour already
+# computes), rather than always reading as an unstarted call to action.
+# ---------------------------------------------------------------------------
+
+
+def _step(config, key):
+    return next(s for s in config["steps"] if s["key"] == key)
+
+
+class TestAdaptiveDoneCopySandbox:
+    """A loaded sandbox segment swaps its step body to a "done" variant (P2-1)."""
+
+    def test_welcome_body_adapts_to_loaded_state(self):
+        coach = _coach()
+        welcome = _step(tour.build_config(coach, "sandbox"), "welcome")
+        assert "Add 5 sample athletes" in welcome["body"]
+
+        demo.load_athletes(coach)
+
+        welcome = _step(tour.build_config(coach, "sandbox"), "welcome")
+        assert "are here now" in welcome["body"]
+        assert "Add 5 sample athletes" not in welcome["body"]
+
+    def test_designer_body_shows_done_after_load_program(self):
+        coach = _coach()
+        demo.load_program(coach)
+        designer = _step(tour.build_config(coach, "sandbox"), "designer")
+        assert "sample program is loaded" in designer["body"]
+
+    def test_deliver_body_shows_done_after_load_delivery(self):
+        coach = _coach()
+        demo.load_delivery(coach)
+        deliver = _step(tour.build_config(coach, "sandbox"), "deliver")
+        assert "Delivered" in deliver["body"]
+
+    def test_results_body_shows_done_after_load_log(self):
+        coach = _coach()
+        demo.load_log(coach)
+        results = _step(tour.build_config(coach, "sandbox"), "results")
+        assert "is logged" in results["body"]
+
+    def test_groups_body_shows_done_after_load_group(self):
+        coach = _coach()
+        demo.load_group(coach)
+        groups = _step(tour.build_config(coach, "sandbox"), "groups")
+        assert "Sample group added" in groups["body"]
+
+
+class TestAdaptiveDoneCopySelf:
+    """The self variant's welcome/designer bodies flip to "done" too (P2-1)."""
+
+    def test_welcome_body_adapts_to_loaded_state(self):
+        coach = _coach()
+        welcome = _step(tour.build_config(coach, "self"), "welcome")
+        assert "Add yourself as your first athlete" in welcome["body"]
+
+        CoachAthlete.add_self(coach)
+
+        welcome = _step(tour.build_config(coach, "self"), "welcome")
+        assert "on it now" in welcome["body"]
+        assert "Add yourself as your first athlete" not in welcome["body"]
+
+    def test_designer_body_shows_done_after_plan(self):
+        coach = _coach()
+        link = CoachAthlete.add_self(coach)
+        link.create_plan()
+        designer = _step(tour.build_config(coach, "self"), "designer")
+        assert "program is started" in designer["body"]
+
+
+class TestProfilePrerequisiteCopy:
+    """The profile step's body is gated on its prerequisite existing (P2-2)."""
+
+    def test_sandbox_profile_locked_without_athletes(self):
+        coach = _coach()
+        profile = _step(tour.build_config(coach, "sandbox"), "profile")
+        assert "Add the sample athletes first" in profile["body"]
+        assert "Click into Maya" not in profile["body"]
+        assert profile["loaded"] is None
+
+    def test_sandbox_profile_unlocked_after_load_athletes(self):
+        coach = _coach()
+        demo.load_athletes(coach)
+        profile = _step(tour.build_config(coach, "sandbox"), "profile")
+        assert "Click into Maya" in profile["body"]
+
+    def test_self_profile_locked_without_a_self_link(self):
+        coach = _coach()
+        profile = _step(tour.build_config(coach, "self"), "profile")
+        assert "Add yourself as an athlete first" in profile["body"]
+        assert "Click into your own profile" not in profile["body"]
+        assert profile["action"] is None
+        assert profile["loaded"] is None
+
+    def test_self_profile_unlocked_after_add_self(self):
+        coach = _coach()
+        CoachAthlete.add_self(coach)
+        profile = _step(tour.build_config(coach, "self"), "profile")
+        assert "Click into your own profile" in profile["body"]
+
+
+class TestFinishCopyBranchesOnHasDemo:
+    """The sandbox finish's copy branches on whether there's demo data (P2-4).
+
+    It only promises "remove the demo data" when there's some to remove, and
+    never claims a tour "start over".
+    """
+
+    def test_no_demo_copy_omits_the_removal_promise(self):
+        coach = _coach()
+        finish = _step(tour.build_config(coach, "sandbox"), "finish")
+        assert "Create a free account" in finish["body"]
+        assert "sample data" not in finish["body"]
+        assert "remove" not in finish["body"].lower()
+        assert "start over" not in finish["body"].lower()
+
+    def test_has_demo_copy_offers_removal(self):
+        coach = _coach()
+        demo.load_demo(coach)
+        finish = _step(tour.build_config(coach, "sandbox"), "finish")
+        assert "remove it any time" in finish["body"]
+        assert "start over" not in finish["body"].lower()
+
+
+class TestDemoBannerDecoupling:
+    """The demo-removal banner and the mounted tour are mutually exclusive.
+
+    P2-5a: during an active tour with demo loaded neither the banner nor the
+    Get-started card renders.
+    """
+
+    def test_banner_suppressed_while_touring(self, client):
+        user = sandbox.create_sandbox()
+        demo.load_athletes(user)
+        client.force_login(user)
+
+        body = client.get(reverse("meso:roster")).content.decode()
+
+        assert "Demo workspace" not in body
+        assert reverse("meso:demo_clear") not in body
+
+    def test_banner_shows_for_a_non_touring_real_coach(self, client):
+        coach = _coach()
+        demo.load_demo(coach)
+        client.force_login(coach)
+
+        body = client.get(reverse("meso:roster")).content.decode()
+
+        assert "Demo workspace" in body
+
+
+class TestDemoClearResetsTour:
+    """Clearing the demo mid-tour restarts the tour at step 0 (P2-5b).
+
+    Removing the demo data the tour was walking you through would otherwise
+    park the step index on a now-empty workspace, so an actively-touring coach
+    is reset; a dismissed/completed tour is left alone.
+    """
+
+    def test_resets_a_mid_flight_tour_to_step_zero(self, client):
+        user = sandbox.create_sandbox()
+        profile = CoachProfile.objects.get(user=user)
+        tour.set_step(profile, 3)
+        demo.load_athletes(user)
+        client.force_login(user)
+
+        client.post(reverse("meso:demo_clear"))
+
+        assert tour.tour_status(user) == {"step": 0, "status": "active"}
+
+    def test_leaves_a_non_touring_tour_alone(self, client):
+        coach = _coach()
+        tour.complete(coach.coach_profile)
+        demo.load_demo(coach)
+        client.force_login(coach)
+
+        client.post(reverse("meso:demo_clear"))
+
+        assert tour.tour_status(coach)["status"] == "completed"
+
+
+class TestSandboxFallbackCardCopy:
+    """The Get-started card's fallback copy is sandbox-aware (P2-6).
+
+    It never dangles a real-invite offer at a sandbox coach, who can't invite
+    real athletes; the real-coach copy is unchanged.
+    """
+
+    def test_sandbox_hides_the_invite_copy(self, client):
+        user = sandbox.create_sandbox()
+        tour.dismiss(CoachProfile.objects.get(user=user))
+        client.force_login(user)
+
+        body = client.get(reverse("meso:roster")).content.decode()
+
+        assert "inviting real athletes is off in the demo" in body
+        assert "invite your first athlete below" not in body
+
+    def test_real_coach_keeps_the_invite_copy(self, client):
+        coach = _coach()
+        tour.start_tour(coach.coach_profile)
+        tour.dismiss(coach.coach_profile)
+        client.force_login(coach)
+
+        body = client.get(reverse("meso:roster")).content.decode()
+
+        assert "invite your first athlete below" in body
+
+
+class TestDurableRestartAffordance:
+    """An always-available tour restart lives in the sidebar (P2-3).
+
+    It appears once the empty-state entry card is gone (data added, or the tour
+    dismissed/completed), and is hidden while the tour is mounted or on the
+    fresh first run. Its "Restart" label is distinct from the entry card's
+    "Start" button so the two never collide in body assertions.
+    """
+
+    def test_present_after_completing_the_tour(self, client):
+        coach = _coach()
+        tour.start_tour(coach.coach_profile)
+        tour.complete(coach.coach_profile)
+        client.force_login(coach)
+
+        body = client.get(reverse("meso:roster")).content.decode()
+
+        assert "Restart the guided tour" in body
+        assert reverse("meso:tour_state") in body
+        assert 'value="restart"' in body
+
+    def test_survives_having_workspace_data(self, client):
+        coach = _coach()
+        CoachAthleteFactory(coach=coach)
+        client.force_login(coach)
+
+        body = client.get(reverse("meso:roster")).content.decode()
+
+        assert "Restart the guided tour" in body
+
+    def test_hidden_while_the_tour_is_mounted(self, client):
+        user = sandbox.create_sandbox()
+        client.force_login(user)
+
+        body = client.get(reverse("meso:roster")).content.decode()
+
+        assert "Restart the guided tour" not in body
+
+    def test_absent_on_the_fresh_empty_first_run(self, client):
+        coach = _coach()
+        client.force_login(coach)
+
+        body = client.get(reverse("meso:roster")).content.decode()
+
+        assert "Start the guided tour" in body
+        assert "Restart the guided tour" not in body
+
+    def test_restored_for_a_dismissed_sandbox_coach(self, client):
+        user = sandbox.create_sandbox()
+        tour.dismiss(CoachProfile.objects.get(user=user))
+        client.force_login(user)
+
+        body = client.get(reverse("meso:roster")).content.decode()
+
+        assert "Restart the guided tour" in body

--- a/app/store_project/meso/tour.py
+++ b/app/store_project/meso/tour.py
@@ -65,6 +65,8 @@ STEPS = [
             "title": "Where your clients live",
             "body": "This is your roster — every athlete you coach, at a glance. "
             "Add 5 sample athletes to see it in action.",
+            "body_done": "This is your roster — every athlete you coach, at a "
+            "glance. Your five sample athletes are here now.",
             "segment": "athletes",
             "action_label": "Add 5 sample athletes",
         },
@@ -72,6 +74,8 @@ STEPS = [
             "title": "Where your clients live",
             "body": "This is your roster — every athlete you coach, at a glance. "
             "Add yourself as your first athlete to see it in action.",
+            "body_done": "This is your roster — every athlete you coach, at a "
+            "glance. You're on it now as your first athlete.",
             "action_label": "Add yourself as your first athlete",
         },
     },
@@ -89,11 +93,20 @@ STEPS = [
             "title": "One athlete, one record",
             "body": "Click into Maya to see her contraindications, training "
             "history, and program — everything you need before you build for her.",
+            # Gated: there's no athlete to click into until the welcome step
+            # loads them, so the copy asks for that first (#441 P2-2).
+            "requires_segment": "athletes",
+            "body_locked": "Add the sample athletes first (the welcome step), "
+            "then click into one to see contraindications, training history, "
+            "and program.",
         },
         "self": {
             "title": "One athlete, one record",
             "body": "Click into your own profile to see the same contraindications, "
             "training history, and program view every athlete gets.",
+            "body_locked": "Add yourself as an athlete first (the welcome step), "
+            "then open your profile to see the contraindications, training "
+            "history, and program view every athlete gets.",
             "anchor": "roster-athlete-row-first",
         },
     },
@@ -105,6 +118,8 @@ STEPS = [
             "title": "Program Designer",
             "body": "The flagship: lay out a mesocycle week by week. Load a "
             "sample program to see a full block.",
+            "body_done": "The flagship: lay out a mesocycle week by week. The "
+            "sample program is loaded — here's a full block, week by week.",
             "segment": "program",
             "action_label": "Load a sample mesocycle",
         },
@@ -112,6 +127,8 @@ STEPS = [
             "title": "Program Designer",
             "body": "The flagship: lay out a mesocycle week by week. Start a "
             "program for yourself to see a full block take shape.",
+            "body_done": "The flagship: lay out a mesocycle week by week. Your "
+            "program is started — here's a full block taking shape.",
             "action_label": "Start a program for yourself",
             # Shown instead of ``body`` when there's no self-link yet (the
             # action itself is omitted too — step 1 has to come first).
@@ -127,6 +144,8 @@ STEPS = [
             "title": "Deliver to their phone",
             "body": "Push the current week straight to the athlete's phone — "
             "she sees it the moment you send it.",
+            "body_done": "Delivered — the athlete sees this week on her phone "
+            "now, exactly as you sent it.",
             "segment": "delivery",
             "action_label": "Deliver the sample week",
         },
@@ -144,6 +163,8 @@ STEPS = [
             "title": "What actually happened",
             "body": "Logged sets, adherence, and estimated 1RM flow back here "
             "the moment she logs a session.",
+            "body_done": "A sample session is logged — here are the sets, "
+            "adherence, and estimated 1RM flowing back.",
             "segment": "log",
             "action_label": "Log a sample session",
         },
@@ -161,6 +182,8 @@ STEPS = [
             "title": "Program a whole group at once",
             "body": "Groups share one program with per-athlete auto-adjusts — "
             "build it once, tune it per person.",
+            "body_done": "Sample group added — one shared program with "
+            "per-athlete auto-adjusts, built once and tuned per person.",
             "segment": "group",
             "action_label": "Add a sample group",
         },
@@ -207,8 +230,14 @@ STEPS = [
         "anchor": None,
         "sandbox": {
             "title": "You're ready",
-            "body": "Create a free account to keep coaching for real — or "
-            "remove this demo data and start over.",
+            # Default (has-demo) copy: only promise removal when there's demo
+            # data to remove, and never imply a tour "start over" — the real
+            # restart path is the durable sidebar affordance (#441 P2-4/P2-3).
+            "body": "You've seen the whole workflow. Create a free account to "
+            "keep coaching for real — your sample data stays private and you "
+            "can remove it any time.",
+            "body_no_demo": "You've seen the whole workflow. Create a free "
+            "account to keep coaching for real.",
             "signup_gate": True,
         },
         "self": {
@@ -376,25 +405,39 @@ def _segment_loaded(user, segment):
     return bool(predicate(user)) if predicate else None
 
 
-def _sandbox_step_fields(step, user):
-    """Resolve one step's sandbox-variant fields — byte-identical to Phase 2.
+def _sandbox_step_fields(step, user, *, has_demo=False):
+    """Resolve one step's sandbox-variant fields.
 
     Produces the same ``segment``/``action_label``/``signup_gate``/``loaded``
     keys the JS driver has always read; ``action`` (the Phase 3 generic form
     action) is always ``None`` here, so ``resolveActionState`` never takes
     that branch for a sandbox step.
+
+    The ``body`` is state-aware (#441 P2): once a step's segment is loaded it
+    swaps to the step's ``body_done`` ("here's the thing you just built");
+    a step gated on another segment (``requires_segment`` — ``profile`` needs
+    ``athletes`` first) shows its ``body_locked`` prerequisite prompt until
+    that data exists; and the signup-gated ``finish`` drops its removal promise
+    when the workspace has no demo data to remove (``has_demo``).
     """
     spec = step["sandbox"]
     segment = spec.get("segment")
+    loaded = _segment_loaded(user, segment)
+    body = spec["body_done"] if (loaded and spec.get("body_done")) else spec["body"]
+    requires = spec.get("requires_segment")
+    if requires and not _segment_loaded(user, requires):
+        body = spec.get("body_locked", body)
+    if not has_demo and spec.get("body_no_demo"):
+        body = spec["body_no_demo"]
     return {
         "title": spec["title"],
-        "body": spec["body"],
+        "body": body,
         "anchor": step["anchor"],
         "segment": segment,
         "action_label": spec.get("action_label"),
         "signup_gate": spec.get("signup_gate", False),
         "action": None,
-        "loaded": _segment_loaded(user, segment),
+        "loaded": loaded,
     }
 
 
@@ -449,14 +492,23 @@ def _self_step_fields(step, ctx):
 
     if key == "welcome":
         loaded = ctx["has_self_link"]
+        if loaded and spec.get("body_done"):
+            body = spec["body_done"]
         action = {
             "url": reverse("meso:roster_add_self"),
             "label": spec["action_label"],
             "fields": {},
         }
+    elif key == "profile":
+        # Same prerequisite gate as the sandbox profile step (#441 P2-2): no
+        # own row to open until the welcome step adds the coach's self-link.
+        if not ctx["has_self_link"]:
+            body = spec.get("body_locked", body)
     elif key == "designer":
         loaded = ctx["has_plan"]
         if ctx["has_self_link"]:
+            if loaded and spec.get("body_done"):
+                body = spec["body_done"]
             action = {
                 "url": ctx["plan_create_url"],
                 "label": spec["action_label"],
@@ -536,13 +588,16 @@ def build_config(user, variant):
         return None
     state = profile.tour_state or {}
     self_ctx = _self_context(user) if variant == "self" else None
+    # #441 P2-4: the sandbox finish step's copy branches on whether there's any
+    # demo data to remove; resolved once here (has_demo == has_athletes).
+    sandbox_has_demo = meso_demo.has_demo(user) if variant == "sandbox" else False
     goto_map = _goto_ready_map(user)
     steps = []
     for step in STEPS:
         fields = (
             _self_step_fields(step, self_ctx)
             if variant == "self"
-            else _sandbox_step_fields(step, user)
+            else _sandbox_step_fields(step, user, has_demo=sandbox_has_demo)
         )
         steps.append(
             {

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -937,8 +937,18 @@ def demo_load(request):
 @login_required
 @require_POST
 def demo_clear(request):
-    """Remove exactly this coach's demo data (never their real data) — the teardown."""
+    """Remove exactly this coach's demo data (never their real data) — the teardown.
+
+    Removing the demo data a mid-flight tour was walking you through would leave
+    the step index parked on a now-empty workspace (e.g. the profile step with
+    no athlete to open), so an actively-touring coach is restarted at step 0
+    (#441 P2-5b). A dismissed/completed tour is left alone — only a live tour
+    is out of sync with the cleared workspace.
+    """
     meso_demo.clear_demo(request.user)
+    if meso_tour.is_touring(request.user):
+        profile = CoachProfile.objects.get(user=request.user)
+        meso_tour.start_tour(profile)
     messages.success(request, "Demo data removed.")
     return redirect("meso:roster")
 

--- a/app/store_project/templates/meso/roster.html
+++ b/app/store_project/templates/meso/roster.html
@@ -16,9 +16,17 @@
       <!-- main column -->
       <div style="display:flex;flex-direction:column;gap:18px;">
 
-        {% if has_demo %}
+        {% if has_demo and not show_meso_tour %}
           <!-- Demo workspace banner (first-time-UX Phase 2, Q3): clearly labeled,
-               one-click removable. -->
+               one-click removable. Suppressed while the guided tour is mounted
+               (#441 P2-5a): the tour is already narrating the demo data it loaded
+               step by step, so the standalone "remove it" banner would double up
+               (and its Remove button would yank the workspace out from under a
+               live tour). -->
+          <!-- (When has_demo AND show_meso_tour are both true the elif below
+               won't fire either — is_empty is false — so during an active tour
+               with demo loaded neither the banner nor the Get-started card
+               renders.) -->
           <div class="meso-card meso-card--pad" style="display:flex;align-items:center;gap:14px;flex-wrap:wrap;">
             <div style="min-width:0;flex:1;">
               <p class="meso-eyebrow" style="margin:0 0 3px;">Demo workspace</p>
@@ -78,7 +86,13 @@
                   {% csrf_token %}
                   <button type="submit" class="meso-btn meso-btn--primary">Load a demo athlete &amp; program</button>
                 </form>
-                <span class="meso-sub" style="margin:0;">Not sure yet? Explore a populated workspace first — or invite your first athlete below.</span>
+                {% if is_sandbox %}
+                  <!-- A sandbox coach can't invite real athletes (S4), so the
+                       fallback must not dangle that offer at them (#441 P2-6). -->
+                  <span class="meso-sub" style="margin:0;">Not sure yet? Load a populated workspace to explore — inviting real athletes is off in the demo.</span>
+                {% else %}
+                  <span class="meso-sub" style="margin:0;">Not sure yet? Explore a populated workspace first — or invite your first athlete below.</span>
+                {% endif %}
               </div>
             {% endif %}
           </div>
@@ -365,6 +379,29 @@
           <hr class="meso-hr" />
           <a class="meso-btn meso-btn--ghost" href="{% url 'meso:results' %}">View latest session results →</a>
         </div>
+
+        {% if not show_meso_tour %}
+          {% if not is_empty or not tour_entry_available %}
+            <!-- Durable tour restart (#441 P2): the empty-state entry card disappears
+                 once the workspace has data or the tour is dismissed/completed, so this
+                 is the always-available way back into the guided tour. Hidden while the
+                 tour is already mounted, and suppressed on the fresh empty state where
+                 the Get-started card already offers the guided-tour entry button (no
+                 dup). Its label reads "Restart" — distinct from that entry button — so
+                 the two never collide in a test's body assertions. -->
+            <div class="meso-card meso-card--pad" style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;">
+              <div style="min-width:0;flex:1;">
+                <p class="meso-eyebrow" style="margin:0 0 2px;">Guided tour</p>
+                <p class="meso-sub" style="margin:0;">Walk through Meso's core workflow again any time.</p>
+              </div>
+              <form method="post" action="{% url 'meso:tour_state' %}" style="margin:0;">
+                {% csrf_token %}
+                <input type="hidden" name="action" value="restart" />
+                <button type="submit" class="meso-btn meso-btn--ghost">Restart the guided tour</button>
+              </form>
+            </div>
+          {% endif %}
+        {% endif %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
## What & why

The Meso guided tour rendered state but **never reacted to what the coach actually did** — copy stayed static, prerequisite-free steps dead-ended, and several state combinations produced contradictory instructions. P1 (broken/wrong items) shipped in #443; this delivers the **P2 batch** — the six "confusing state combinations" from #441.

All copy is derived from predicates the tour already computes. **No JS changes** — `meso_tour.js` renders `step.title`/`step.body` verbatim, so the driver is untouched.

## Changes (P2 items 1–6)

1. **Adaptive "done" copy** — sandbox `welcome/designer/deliver/results/groups` and self `welcome/designer` step bodies flip to a `body_done` variant once their data is loaded, instead of only the button flipping to "Added ✓".
2. **Prerequisite-gated `profile` step** — no more "Click into Maya" / "click into your own profile" before an athlete/self-link exists. Sandbox gates on `requires_segment: "athletes"`; self gates on `has_self_link`; both show a "do the welcome step first" body until then.
3. **`finish` copy branches on `has_demo`** — the sandbox finish drops the "remove this demo data and start over" promise when nothing was loaded, and never implies a tour restart (`body_no_demo`).
4. **Demo banner decoupled from the tour** — the "Demo workspace · Remove demo data" banner is suppressed while the tour is mounted (`has_demo and not show_meso_tour`), so it no longer stacks contradictorily against a step still asking you to add data.
5. **`demo_clear` resets a mid-flight tour to step 0** — clearing the demo the tour was narrating no longer parks the step index on a now-empty workspace; a dismissed/completed tour is left alone.
6. **Sandbox-specific fallback copy** (drops the impossible "invite your first athlete" in the demo) **+ a durable "Restart the guided tour" sidebar affordance** that survives having data or dismissal/completion — the empty-state entry card was the only way in, and it vanished the moment the workspace had any data.

## Testing

- **24 new tests** in `test_tour.py` (8 classes) covering every state transition and both presence *and* absence of copy, plus the nested-`{% if %}` restart-affordance visibility matrix.
- Developed strict **red→green** (17 failing → all passing).
- `test_tour` + `test_demo` → **151 passed**; full meso suite → **1955 passed**, 0 regressions.
- `just lint` clean.
- Local **OpenAI Codex review**: CLEAN (0 blocking, 0 nits).

## Scope note

P3 polish (mobile bottom-sheet scroll offset, pronoun de-hardcoding, funnel undercount, `<details>` reposition, auto-advance model) and the TourEvent funnel dashboard remain open on #441 for a follow-up.

Refs #441.