### PR TITLE
fix(meso): P3 guided-tour polish + TourEvent funnel dashboard (#441)

### DIFF
--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -13,11 +13,13 @@ import math
 from collections import defaultdict
 from types import SimpleNamespace
 
+from django.db.models import Count
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.timesince import timesince
 
 from . import adherence
+from . import tour
 from .billing import access as billing_access
 from .billing import agent_usage_report
 from .models import AgentProposalBatch
@@ -27,6 +29,7 @@ from .models import CoachSubscription
 from .models import LoadType
 from .models import Plan
 from .models import SessionLog
+from .models import TourEvent
 from .models import Week
 from .models import WeekDelivery
 from .one_rm import one_rm_values
@@ -1374,4 +1377,98 @@ def usage_dashboard(report, *, threshold):
         "by_tier": agent_usage_report.sorted_totals(report.by_tier),
         "by_model": agent_usage_report.sorted_totals(report.by_model),
         "by_trigger": agent_usage_report.sorted_totals(report.by_trigger),
+    }
+
+
+def tour_funnel(*, variant=None, since=None):
+    """Aggregate :class:`TourEvent` rows into the staff funnel dashboard's context.
+
+    The read side of the guided-tour analytics (#441 P3-6): the ``record_*``
+    helpers write one row per funnel moment; this rolls them up per-kind,
+    per-variant, and per-advance-step, plus a compact Started → Opt-in →
+    Completed funnel. Everything is ORM-aggregated (``values(...).annotate(
+    Count(...))``) — no row ever loads into Python. Optional ``variant`` /
+    ``since`` narrow the scope; the default is all-time, all-variants.
+
+    Contract (the view + tests read these exact keys):
+
+    - ``event_counts`` — every ``Kind`` 0-filled → count.
+    - ``by_variant`` — ``{"sandbox": {...}, "self": {...}}``, both present, each
+      kind 0-filled (so a variant with no events still renders a full row).
+    - ``step_advances`` — ``[{"step_key", "count"}]`` for ADVANCED events, in the
+      tour ``STEPS`` order. Only steps that actually appear are emitted (0-count
+      steps are intentionally omitted — the table lists what happened, ordered
+      canonically, not every possible step).
+    - ``funnel`` — ordered display stages, each ``{"label", "count", "pct"}``.
+      ``count`` is the raw event total for the stage (Started / Opt-in /
+      Completed) so reaped null-coach sandbox rows are never dropped; ``pct`` is
+      that count over Started, clamped to <= 100% (one sandbox tour emits several
+      ``opt_in`` rows, so opt-in events can exceed starts).
+    - ``total_events`` — all events in scope.
+    """
+    qs = TourEvent.objects.all()
+    if variant is not None:
+        qs = qs.filter(variant=variant)
+    if since is not None:
+        qs = qs.filter(created__gte=since)
+
+    kinds = [value for value, _ in TourEvent.Kind.choices]
+    variants = [value for value, _ in TourEvent.Variant.choices]
+
+    event_counts = {kind: 0 for kind in kinds}
+    for row in qs.values("kind").annotate(n=Count("id")):
+        if row["kind"] in event_counts:
+            event_counts[row["kind"]] = row["n"]
+
+    by_variant = {v: {kind: 0 for kind in kinds} for v in variants}
+    for row in qs.values("variant", "kind").annotate(n=Count("id")):
+        bucket = by_variant.get(row["variant"])
+        if bucket is not None and row["kind"] in bucket:
+            bucket[row["kind"]] = row["n"]
+
+    # ADVANCED counts per step, re-ordered into the canonical tour STEP order.
+    advance_counts = {
+        row["step_key"]: row["n"]
+        for row in qs.filter(kind=TourEvent.Kind.ADVANCED)
+        .values("step_key")
+        .annotate(n=Count("id"))
+    }
+    step_order = [step["key"] for step in tour.STEPS]
+    step_advances = [
+        {"step_key": key, "count": advance_counts[key]}
+        for key in step_order
+        if key in advance_counts
+    ]
+
+    # Funnel = raw event counts per stage, NOT distinct coaches: the sandbox
+    # expiry sweep reaps throwaway coaches to ``coach = NULL`` (SET_NULL), and a
+    # distinct-coach count would silently drop all that historical sandbox
+    # traffic. Raw counts keep every row. The tradeoff — one sandbox tour emits
+    # several ``opt_in`` rows, so opt-in events can exceed starts — is handled by
+    # clamping the displayed conversion to <= 100%.
+    started = event_counts["started"]
+
+    def _pct(n):
+        return min(100, round(100 * n / started)) if started else 0
+
+    funnel = [
+        {"label": "Started", "count": started, "pct": 100 if started else 0},
+        {
+            "label": "Opt-in",
+            "count": event_counts["opt_in"],
+            "pct": _pct(event_counts["opt_in"]),
+        },
+        {
+            "label": "Completed",
+            "count": event_counts["completed"],
+            "pct": _pct(event_counts["completed"]),
+        },
+    ]
+
+    return {
+        "event_counts": event_counts,
+        "by_variant": by_variant,
+        "step_advances": step_advances,
+        "funnel": funnel,
+        "total_events": qs.count(),
     }

--- a/app/store_project/meso/tests/test_pronouns.py
+++ b/app/store_project/meso/tests/test_pronouns.py
@@ -1,0 +1,92 @@
+"""Issue #441 P3-4 — pronoun de-hardcoding on the deliver + review screens.
+
+Both screens only carry ``{{ athlete.name }}`` in their presenter context (no
+``is_self``/gender), so the fix swaps the hard-coded she/her copy for name
+interpolation + singular they/them/their — no presenter plumbing. These tests
+GET each *real* rendered page for a delivered plan / a proposed-change batch and
+assert the neutral phrasing is present and the gendered phrasing is gone.
+
+Pre-implementation this is RED: ``deliver.html``/``review.html`` still say
+"she"/"her" today, so the neutral assertions fail (and the gendered ones would
+fail once the templates are fixed).
+"""
+
+import pytest
+from django.urls import reverse
+
+from store_project.meso.factories import AgentProposalBatchFactory
+from store_project.meso.factories import CoachAthleteFactory
+from store_project.meso.factories import MesocycleFactory
+from store_project.meso.factories import PlanFactory
+from store_project.meso.factories import ProposedChangeFactory
+from store_project.meso.factories import WeekFactory
+from store_project.meso.models import Plan
+from store_project.users.factories import UserFactory
+
+from ._helpers import day
+
+pytestmark = pytest.mark.django_db
+
+# A gender-neutral athlete name (no "she"/"her"/"his" substrings) so the
+# interpolated-name assertions can't be satisfied by coincidence. Rendered by
+# ``athlete.name`` (== ``user.display_name()``) on both screens.
+ATHLETE_NAME = "Robin Alvarez"
+
+
+def _plan(athlete_name=ATHLETE_NAME):
+    """A minimal owned, active plan with one current week + day."""
+    rel = CoachAthleteFactory(athlete=UserFactory(name=athlete_name))
+    plan = PlanFactory(
+        relationship=rel, title="Hypertrophy Block", status=Plan.Status.ACTIVE
+    )
+    meso = MesocycleFactory(plan=plan, name="Hypertrophy", order=0)
+    week1 = WeekFactory(mesocycle=meso, index=1, is_current=True)
+    day(week1, day_number=1, name="Lower")
+    return plan, meso, week1
+
+
+class TestDeliverPronouns:
+    def _get(self, client, plan, **params):
+        url = reverse("meso:deliver_plan", kwargs={"plan_id": plan.pk})
+        return client.get(url, params)
+
+    def test_head_and_success_copy_are_gender_neutral(self, client):
+        # NB: the whole-block deliver copy (#447) is what's rendered here — the
+        # head ("sees the whole block in their app") and the post-deliver success
+        # ("Block delivered … will see all N weeks … on their phone"). This test
+        # pins that all of it stays gender-neutral (name + they/their).
+        plan, _, _ = _plan()
+        client.force_login(plan.relationship.coach)
+
+        body = self._get(client, plan).content.decode()
+
+        # Neutral phrasing (name + they/their) is present…
+        assert "sees the whole block in their app" in body
+        assert f"Block delivered to {ATHLETE_NAME}" in body
+        assert "on their phone" in body
+        assert "Track sessions" in body
+        # …and the hard-coded she/her copy is gone.
+        assert "sees the whole block in her app" not in body
+        assert "She'll see all" not in body
+        assert "on her phone" not in body
+        assert "Track her sessions" not in body
+
+
+class TestReviewPronouns:
+    def _batch(self):
+        rel = CoachAthleteFactory(athlete=UserFactory(name=ATHLETE_NAME))
+        plan = PlanFactory(relationship=rel, status=Plan.Status.ACTIVE)
+        batch = AgentProposalBatchFactory(plan=plan, coach=plan.relationship.coach)
+        ProposedChangeFactory(batch=batch)
+        return plan, batch
+
+    def test_grounding_line_is_gender_neutral(self, client):
+        plan, batch = self._batch()
+        client.force_login(plan.relationship.coach)
+
+        url = reverse("meso:review_batch", kwargs={"batch_id": batch.pk})
+        body = client.get(url).content.decode()
+
+        # "Grounded on <name>'s profile, contraindications, …"
+        assert f"{ATHLETE_NAME}'s profile" in body
+        assert "Grounded on her profile" not in body

--- a/app/store_project/meso/tests/test_tour_events.py
+++ b/app/store_project/meso/tests/test_tour_events.py
@@ -466,6 +466,39 @@ class TestRosterAddSelfOptIn:
         assert resp.status_code == 302
         assert CoachAthlete.objects.filter(coach=coach, athlete=coach).exists()
 
+    # #441 P3-2: the organic twin carries no ``tour=1``, so a coach who takes the
+    # action *while actively touring & parked on the matching step* was never
+    # counted — undercounting tour conversion. Record it too, keyed off the
+    # parked step, without double-recording the marked path.
+    def test_organic_post_while_touring_on_welcome_records_opt_in(self, client):
+        coach = _coach()
+        tour.set_step(CoachProfile.objects.get(user=coach), 0)  # active, on welcome
+        client.force_login(coach)
+
+        client.post(reverse("meso:roster_add_self"))  # organic — no tour=1
+
+        event = TourEvent.objects.get(kind=TourEvent.Kind.OPT_IN)
+        assert event.variant == "self"
+        assert event.step_key == "welcome"
+        assert event.segment == "roster_add_self"
+        # The real action still happens.
+        assert CoachAthlete.objects.filter(coach=coach, athlete=coach).exists()
+
+    def test_organic_post_while_touring_on_a_non_welcome_step_records_nothing(
+        self, client
+    ):
+        # Parked on a step other than welcome → the organic action is not the
+        # welcome-step opt-in, so nothing is recorded (guards against
+        # over-recording); the self link is still added.
+        coach = _coach()
+        tour.set_step(CoachProfile.objects.get(user=coach), 2)  # active, on designer
+        client.force_login(coach)
+
+        client.post(reverse("meso:roster_add_self"))  # organic — no tour=1
+
+        assert TourEvent.objects.count() == 0
+        assert CoachAthlete.objects.filter(coach=coach, athlete=coach).exists()
+
 
 # ---------------------------------------------------------------------------
 # plan_create — tour=1-gated opt-in, step key from `draft`
@@ -514,4 +547,76 @@ class TestPlanCreateOptIn:
         client.post(reverse("meso:plan_create", args=[link.athlete_id]))
 
         assert TourEvent.objects.count() == 0
+        assert link.working_plan() is not None
+
+    # #441 P3-2: organic ``plan_create`` while touring & parked on the designer
+    # step (no draft) records the designer opt-in, keyed off the parked step.
+    def test_organic_post_while_touring_on_designer_records_opt_in(self, client):
+        link = CoachAthleteFactory()
+        tour.set_step(CoachProfile.objects.create(user=link.coach), 2)  # designer
+        client.force_login(link.coach)
+
+        client.post(reverse("meso:plan_create", args=[link.athlete_id]))  # no tour=1
+
+        event = TourEvent.objects.get(kind=TourEvent.Kind.OPT_IN)
+        assert event.variant == "self"
+        assert event.step_key == "designer"
+        assert event.segment == "plan_create"
+        assert link.working_plan() is not None
+
+    # …and a draft while parked on the agent step records the agent opt-in.
+    def test_organic_draft_post_while_touring_on_agent_records_the_agent_step(
+        self, client, monkeypatch
+    ):
+        class _FakeDraftClient:
+            model = "fake"
+
+            def propose(self, *, context, instruction):
+                return {"summary": "drafted", "changes": []}
+
+        from store_project.meso.agent import client as client_module
+
+        link = CoachAthleteFactory()
+        tour.set_step(CoachProfile.objects.create(user=link.coach), 6)  # agent
+        monkeypatch.setattr(
+            client_module, "get_default_client", lambda: _FakeDraftClient()
+        )
+        client.force_login(link.coach)
+
+        client.post(
+            reverse("meso:plan_create", args=[link.athlete_id]),
+            {"draft": "agent"},  # organic (no tour=1) but a draft request
+        )
+
+        event = TourEvent.objects.get(kind=TourEvent.Kind.OPT_IN)
+        assert event.variant == "self"
+        assert event.step_key == "agent"
+        assert event.segment == "plan_create"
+
+    # …but a plain (non-draft) organic plan_create while parked on the *agent*
+    # step must NOT be miscounted as an agent opt-in — the AI-draft action was
+    # never taken, so the action shape doesn't match the step (Codex review nit).
+    def test_organic_plain_post_while_touring_on_agent_records_nothing(self, client):
+        link = CoachAthleteFactory()
+        tour.set_step(CoachProfile.objects.create(user=link.coach), 6)  # agent
+        client.force_login(link.coach)
+
+        # No draft, no tour=1 — a manual "New program" while parked on agent.
+        client.post(reverse("meso:plan_create", args=[link.athlete_id]))
+
+        assert TourEvent.objects.count() == 0
+        assert link.working_plan() is not None
+
+    # Codex review: a *sandbox* coach's organic "+ New program" posts here with
+    # no tour=1; the sandbox opt-in path is demo_load(segment=program), so this
+    # must NOT log a self-variant plan_create opt-in even while parked on designer.
+    def test_organic_sandbox_plan_create_records_no_self_optin(self, client):
+        coach = sandbox.create_sandbox()  # sandbox variant; tour armed at step 0
+        link = CoachAthlete.add_self(coach)  # a self athlete to build a plan for
+        tour.set_step(CoachProfile.objects.get(user=coach), 2)  # designer step
+        client.force_login(coach)
+
+        client.post(reverse("meso:plan_create", args=[link.athlete_id]))  # organic
+
+        assert not TourEvent.objects.filter(kind=TourEvent.Kind.OPT_IN).exists()
         assert link.working_plan() is not None

--- a/app/store_project/meso/tests/test_tour_funnel.py
+++ b/app/store_project/meso/tests/test_tour_funnel.py
@@ -1,0 +1,199 @@
+"""Issue #441 P3-6 — the staff-gated TourEvent funnel dashboard.
+
+Mirrors the agent usage dashboard's staff gate (anon → login, non-staff → 403,
+staff → 200) and pins the presenter's aggregation contract: per-kind totals
+(every ``Kind`` value 0-filled), the per-variant breakdown (both variants
+present, each kind 0-filled), the per-step advance counts (ordered by the tour
+``STEPS`` order), and the total. There's both a rendered-view context test and a
+direct ``presenters.tour_funnel`` unit test.
+
+Pre-implementation this is RED: ``meso:tour_funnel`` has no URL/view yet (the
+gate + context tests fail with ``NoReverseMatch``) and ``presenters`` has no
+``tour_funnel`` (the presenter unit test fails with ``AttributeError``).
+"""
+
+import pytest
+from django.urls import reverse
+
+from store_project.meso import tour
+from store_project.meso.models import TourEvent
+from store_project.users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _url():
+    # Called inside each test (not at module scope) so a missing route fails
+    # the individual test rather than erroring collection of the whole module.
+    return reverse("meso:tour_funnel")
+
+
+def _event(kind, *, variant, step_key="", segment=""):
+    return TourEvent.objects.create(
+        kind=kind, variant=variant, step_key=step_key, segment=segment
+    )
+
+
+def _seed_events():
+    """A fixed mix across both variants / several kinds / several advance steps.
+
+    sandbox: started, advanced×2 (designer), advanced (deliver), opt_in, completed
+    self:    started, advanced (agent), dismissed, skipped
+    """
+    sb = TourEvent.Variant.SANDBOX
+    sf = TourEvent.Variant.SELF
+    _event(TourEvent.Kind.STARTED, variant=sb, step_key="welcome")
+    _event(TourEvent.Kind.ADVANCED, variant=sb, step_key="designer")
+    _event(TourEvent.Kind.ADVANCED, variant=sb, step_key="designer")
+    _event(TourEvent.Kind.ADVANCED, variant=sb, step_key="deliver")
+    _event(TourEvent.Kind.OPT_IN, variant=sb, step_key="welcome", segment="athletes")
+    _event(TourEvent.Kind.COMPLETED, variant=sb, step_key="finish")
+    _event(TourEvent.Kind.STARTED, variant=sf, step_key="welcome")
+    _event(TourEvent.Kind.ADVANCED, variant=sf, step_key="agent")
+    _event(TourEvent.Kind.DISMISSED, variant=sf, step_key="results")
+    _event(TourEvent.Kind.SKIPPED, variant=sf, step_key="profile")
+
+
+# Expected aggregation for ``_seed_events`` (kind → count), every Kind 0-filled.
+EXPECTED_EVENT_COUNTS = {
+    "started": 2,
+    "advanced": 4,
+    "opt_in": 1,
+    "dismissed": 1,
+    "completed": 1,
+    "skipped": 1,
+}
+EXPECTED_BY_VARIANT = {
+    "sandbox": {
+        "started": 1,
+        "advanced": 3,
+        "opt_in": 1,
+        "dismissed": 0,
+        "completed": 1,
+        "skipped": 0,
+    },
+    "self": {
+        "started": 1,
+        "advanced": 1,
+        "opt_in": 0,
+        "dismissed": 1,
+        "completed": 0,
+        "skipped": 1,
+    },
+}
+# ADVANCED events, ordered by the tour STEP order.
+EXPECTED_STEP_ADVANCES = [("designer", 2), ("deliver", 1), ("agent", 1)]
+EXPECTED_TOTAL = 10
+
+
+def _nonzero_advances(step_advances):
+    """The non-zero advance rows as (key, count), preserving order.
+
+    Robust to whichever the impl chose per the spec's "including 0-count steps
+    is optional" — the meaningful data + its STEP-order ordering are asserted
+    either way.
+    """
+    return [(d["step_key"], d["count"]) for d in step_advances if d["count"]]
+
+
+# ---------------------------------------------------------------------------
+# staff gate (mirrors UsageDashboardView / test_agent_usage_dashboard)
+# ---------------------------------------------------------------------------
+
+
+class TestTourFunnelGate:
+    def test_anonymous_is_redirected_to_login(self, client):
+        resp = client.get(_url())
+        assert resp.status_code == 302
+        assert "/accounts/login/" in resp["Location"]
+
+    def test_authenticated_non_staff_is_forbidden(self, client):
+        client.force_login(UserFactory())
+        resp = client.get(_url())
+        assert resp.status_code == 403
+
+    def test_staff_gets_the_dashboard(self, client):
+        client.force_login(UserFactory(is_staff=True))
+        resp = client.get(_url())
+        assert resp.status_code == 200
+        assert resp.templates[0].name == "meso/tour_funnel.html"
+
+
+# ---------------------------------------------------------------------------
+# the view: aggregation context contract
+# ---------------------------------------------------------------------------
+
+
+class TestTourFunnelContext:
+    def test_context_aggregates_the_constructed_events(self, client):
+        _seed_events()
+        client.force_login(UserFactory(is_staff=True))
+
+        ctx = client.get(_url()).context
+
+        assert ctx["event_counts"] == EXPECTED_EVENT_COUNTS
+        assert ctx["by_variant"] == EXPECTED_BY_VARIANT
+        assert _nonzero_advances(ctx["step_advances"]) == EXPECTED_STEP_ADVANCES
+        assert ctx["total_events"] == EXPECTED_TOTAL
+
+
+# ---------------------------------------------------------------------------
+# the presenter, directly
+# ---------------------------------------------------------------------------
+
+
+class TestTourFunnelPresenter:
+    def test_aggregation(self):
+        from store_project.meso import presenters
+
+        _seed_events()
+
+        result = presenters.tour_funnel()
+
+        assert result["event_counts"] == EXPECTED_EVENT_COUNTS
+        assert result["by_variant"] == EXPECTED_BY_VARIANT
+        assert _nonzero_advances(result["step_advances"]) == EXPECTED_STEP_ADVANCES
+        assert result["total_events"] == EXPECTED_TOTAL
+
+    def test_funnel_uses_raw_event_counts_with_pct_clamped_to_100(self):
+        """Raw event counts (null-coach-safe) with the conversion bar capped.
+
+        Codex review: a distinct-coach funnel would drop reaped sandbox rows
+        (coach → NULL on expiry). So the funnel counts raw events — which means
+        one sandbox tour's several opt-in rows can exceed starts — and clamps the
+        displayed conversion to <= 100%. These events carry no coach (as reaped
+        rows don't), proving null-coach rows are still counted.
+        """
+        from store_project.meso import presenters
+
+        sb = TourEvent.Variant.SANDBOX
+        _event(TourEvent.Kind.STARTED, variant=sb)
+        for seg in ("athletes", "program", "delivery", "log", "group"):
+            _event(TourEvent.Kind.OPT_IN, variant=sb, segment=seg)
+        _event(TourEvent.Kind.COMPLETED, variant=sb)
+
+        funnel = {s["label"]: s for s in presenters.tour_funnel()["funnel"]}
+
+        assert funnel["Started"]["count"] == 1
+        assert funnel["Opt-in"]["count"] == 5  # raw events, not deduped
+        assert funnel["Opt-in"]["pct"] == 100  # 5/1 → 500 → clamped to 100
+        assert funnel["Completed"]["count"] == 1
+        assert all(0 <= s["pct"] <= 100 for s in funnel.values())
+
+    def test_step_advances_are_ordered_by_the_tour_step_order(self):
+        """Advances recorded out of STEP order still come back in STEP order."""
+        from store_project.meso import presenters
+
+        sf = TourEvent.Variant.SELF
+        # Recorded agent-first, then designer — the presenter must re-order.
+        _event(TourEvent.Kind.ADVANCED, variant=sf, step_key="agent")
+        _event(TourEvent.Kind.ADVANCED, variant=sf, step_key="designer")
+
+        keys = [
+            d["step_key"]
+            for d in presenters.tour_funnel()["step_advances"]
+            if d["count"]
+        ]
+        step_order = [s["key"] for s in tour.STEPS]
+        assert keys == sorted(keys, key=step_order.index)
+        assert keys.index("designer") < keys.index("agent")

--- a/app/store_project/meso/tour.py
+++ b/app/store_project/meso/tour.py
@@ -399,6 +399,25 @@ def advance_if_on_step(user, step_key):
     return True
 
 
+def current_step_key(user):
+    """The key of the step a coach is *actively* parked on, else ``None``.
+
+    Mirrors ``advance_if_on_step``'s guards (and ``_clamp``): only a live tour
+    (``tour_state.status == "active"``) reports a parked step — a dismissed,
+    completed, or never-started tour returns ``None``. Used by the organic
+    ``roster_add_self``/``plan_create`` twins (#441 P3-2) to count a coach who
+    takes the action while touring but whose POST carries no ``tour=1`` marker,
+    without over-recording when they're parked on some other step.
+    """
+    profile = CoachProfile.objects.filter(user=user).first()
+    if profile is None:
+        return None
+    state = profile.tour_state or {}
+    if state.get("status") != "active":
+        return None
+    return STEPS[_clamp(state.get("step", 0))]["key"]
+
+
 def _segment_loaded(user, segment):
     """Whether ``segment``'s data already exists for ``user`` (O7), or ``None``."""
     predicate = _HAS_PREDICATES.get(segment)

--- a/app/store_project/meso/urls.py
+++ b/app/store_project/meso/urls.py
@@ -29,6 +29,8 @@ urlpatterns = [
     # Owner-facing agent usage + margin dashboard (agent-usage Phase 4) —
     # staff-gated, all-coach; the web read-out of meso_agent_usage_report.
     path("usage/", UsageDashboardView.as_view(), name="usage_dashboard"),
+    # Owner-facing guided-tour funnel dashboard (#441 P3-6) — staff-gated, all-coach.
+    path("tour/funnel/", views.TourFunnelView.as_view(), name="tour_funnel"),
     path("designer/<int:plan_id>/", MesoDesignerView.as_view(), name="designer_plan"),
     path("review/", ChangeReviewView.as_view(), name="review"),
     path(

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -583,6 +583,59 @@ class UsageDashboardView(UserPassesTestMixin, TemplateView):
         return usage_report.current_month_bounds()
 
 
+class TourFunnelView(UserPassesTestMixin, TemplateView):
+    """Owner-facing guided-tour funnel dashboard (#441 P3-6).
+
+    The staff read-out of the ``TourEvent`` funnel: per-kind totals, the
+    per-variant (sandbox vs. self) breakdown, the per-advance-step table, and a
+    Started → Opt-in → Completed funnel — the web complement to reading the raw
+    rows in the admin. Aggregation lives in ``presenters.tour_funnel``.
+
+    Gate mirrors ``UsageDashboardView`` exactly: anonymous bounces to login
+    (``UserPassesTestMixin`` default); an authenticated non-staff user gets a
+    flat 403, so a logged-in coach can't probe org-wide tour analytics.
+
+    Optional ``?variant=sandbox|self`` narrows to one audience and ``?days=N``
+    to a trailing window; the default is all-time, all-variants.
+    """
+
+    template_name = "meso/tour_funnel.html"
+
+    def test_func(self):
+        return self.request.user.is_staff
+
+    def handle_no_permission(self):
+        if self.request.user.is_authenticated:
+            raise PermissionDenied
+        return super().handle_no_permission()
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx["active"] = "tour_funnel"
+        variant = self.request.GET.get("variant")
+        if variant not in ("sandbox", "self"):
+            variant = None
+        since = None
+        days = None
+        raw_days = self.request.GET.get("days")
+        if raw_days:
+            try:
+                parsed = int(raw_days)
+            except (TypeError, ValueError):
+                parsed = 0
+            if parsed > 0:
+                # Cap to ~10 years so an enormous value can't OverflowError the
+                # timedelta; only surface ``days`` once a real window applies, so
+                # the heading never claims to show "last abc days".
+                parsed = min(parsed, 3650)
+                since = timezone.now() - datetime.timedelta(days=parsed)
+                days = parsed
+        ctx["variant"] = variant
+        ctx["days"] = days
+        ctx.update(presenters.tour_funnel(variant=variant, since=since))
+        return ctx
+
+
 class CoachBillingView(LoginRequiredMixin, TemplateView):
     """Coach-facing billing & plan page (agent-usage — coach surface).
 
@@ -780,10 +833,27 @@ def plan_create(request, pk):
     if draft_batch is not None:
         agent_jobs.dispatch_proposal(draft_batch.pk)
         _touch_plan(plan)
+    # The tour marker (``tour=1``) picks the step from ``draft`` ("agent" vs
+    # "designer"). #441 P3-2 also counts the organic twin while touring — but
+    # only when this POST's action shape (``draft`` → agent, plain → designer)
+    # matches the step the coach is parked on, so a manual "New program" on the
+    # agent step isn't miscounted as an AI-draft opt-in. One ``record_opt_in``
+    # call, never double-recorded.
+    natural_step = "agent" if draft else "designer"
     if request.POST.get("tour") == "1":
-        meso_tour.record_opt_in(
-            request.user, "self", "agent" if draft else "designer", "plan_create"
-        )
+        tour_step = natural_step
+    elif (
+        meso_tour.variant_for(request.user) == "self"
+        and meso_tour.current_step_key(request.user) == natural_step
+    ):
+        # Organic twin, self variant only: the sandbox opt-in path is
+        # demo_load(segment=program), not plan_create, so a sandbox coach's
+        # organic "+ New program" must not log a self-variant plan_create opt-in.
+        tour_step = natural_step
+    else:
+        tour_step = None
+    if tour_step is not None:
+        meso_tour.record_opt_in(request.user, "self", tour_step, "plan_create")
     return redirect("meso:designer_plan", plan_id=plan.pk)
 
 
@@ -979,7 +1049,14 @@ def roster_add_self(request):
         request,
         "You're on your roster — build a program for yourself like any athlete.",
     )
-    if request.POST.get("tour") == "1":
+    # The tour marker (``tour=1``) counts an in-tour opt-in; #441 P3-2 also counts
+    # the organic twin when the coach is actively touring & parked on the matching
+    # (welcome) step. The organic fallback is self-variant only — a sandbox coach
+    # opts in via demo_load, not roster_add_self. One call, never double-recorded.
+    if request.POST.get("tour") == "1" or (
+        meso_tour.variant_for(request.user) == "self"
+        and meso_tour.current_step_key(request.user) == "welcome"
+    ):
         meso_tour.record_opt_in(request.user, "self", "welcome", "roster_add_self")
     return redirect("meso:roster")
 

--- a/app/store_project/static/js/meso_tour.js
+++ b/app/store_project/static/js/meso_tour.js
@@ -190,6 +190,21 @@
     return reducedMotion ? "auto" : "smooth";
   }
 
+  // #441 P3-1: the step card is a bottom sheet on narrow viewports (the
+  // `@media (max-width:640px)` block in `_tour.html`, height `min(75vh,520px)`
+  // pinned `bottom:0`), which covers viewport center and buries a
+  // `block:"center"` scrolled anchor behind it. This returns the sheet's height
+  // in px so `scrollAnchorIntoView` can lift the anchor's resting position out
+  // from under it — 0 off the sheet layout (or when `matchMedia`/`innerHeight`
+  // is missing), so a rotate-to-desktop leaves no stale margin. A plain px value
+  // (not the `min(75vh,520px)` CSS string) so CSSOM accepts it as-is.
+  function bottomSheetInset(win) {
+    if (!win || typeof win.matchMedia !== "function") return 0;
+    if (typeof win.innerHeight !== "number") return 0;
+    if (!win.matchMedia("(max-width: 640px)").matches) return 0;
+    return Math.round(Math.min(win.innerHeight * 0.75, 520));
+  }
+
   // ---- DOM wiring (browser only) ----
 
   var MAX_ANCHOR_ATTEMPTS = 10;
@@ -444,6 +459,12 @@
     var selector = '[data-tour="' + anchorValue.replace(/"/g, '\\"') + '"]';
     var el = doc.querySelector(selector);
     if (!el || typeof el.scrollIntoView !== "function") return;
+    // #441 P3-1: lift the anchor's resting position out from behind the mobile
+    // bottom sheet before scrolling (with `block:"center"` a `scroll-margin-
+    // bottom` of S raises the anchor by ~S/2). Cleared to "" off the sheet
+    // layout so a rotate-to-desktop leaves no stale margin.
+    var inset = bottomSheetInset(win);
+    el.style.scrollMarginBottom = inset ? inset + "px" : "";
     el.scrollIntoView({
       behavior: scrollBehaviorFor(prefersReducedMotion(win)),
       block: "center",
@@ -546,6 +567,7 @@
       if (reposition) {
         win.removeEventListener("resize", reposition);
         win.removeEventListener("scroll", reposition, true);
+        doc.removeEventListener("toggle", reposition, true);
       }
       doc.removeEventListener("keydown", onKeydown);
       mount.innerHTML = "";
@@ -558,6 +580,10 @@
     }, 100);
     win.addEventListener("resize", reposition);
     win.addEventListener("scroll", reposition, true);
+    // #441 P3-3: a spotlighted `<details>` (step 8's roster-invite) fires a
+    // non-bubbling `toggle` on expand — listen in capture so the spotlight
+    // re-measures instead of going stale at the collapsed size.
+    doc.addEventListener("toggle", reposition, true);
     doc.addEventListener("keydown", onKeydown);
 
     render();
@@ -594,6 +620,9 @@
       shouldShowSkipLoad: shouldShowSkipLoad,
       shouldShowGoto: shouldShowGoto,
       isUsableRect: isUsableRect,
+      bottomSheetInset: bottomSheetInset,
+      scrollAnchorIntoView: scrollAnchorIntoView,
+      initTour: initTour,
     };
   }
 })(typeof window !== "undefined" ? window : this);

--- a/app/store_project/templates/meso/_meso_base.html
+++ b/app/store_project/templates/meso/_meso_base.html
@@ -73,6 +73,7 @@
             {% endif %}
             {% if request.user.is_staff %}
               <a class="meso-navlink {% if active == 'usage' %}is-active{% endif %}" href="{% url 'meso:usage_dashboard' %}">Usage</a>
+              <a class="meso-navlink {% if active == 'tour_funnel' %}is-active{% endif %}" href="{% url 'meso:tour_funnel' %}">Tour funnel</a>
             {% endif %}
           {% endblock %}
         </div>

--- a/app/store_project/templates/meso/deliver.html
+++ b/app/store_project/templates/meso/deliver.html
@@ -20,7 +20,7 @@
       <div>
         <p class="meso-eyebrow">Publish</p>
         <h1 class="meso-h1">Deliver {{ deliver.block_name|default:"block" }}</h1>
-        <p class="meso-sub">{{ deliver.week_count }} week{{ deliver.week_count|pluralize }} · to {{ athlete.name }} · once delivered she sees the whole block in her app.</p>
+        <p class="meso-sub">{{ deliver.week_count }} week{{ deliver.week_count|pluralize }} · to {{ athlete.name }} · once delivered, {{ athlete.name }} sees the whole block in their app.</p>
       </div>
     </div>
 
@@ -127,10 +127,10 @@
     <div x-show="delivered" x-cloak class="meso-card meso-card--pad" style="text-align:center;padding:36px 24px;">
       <div style="width:46px;height:46px;border-radius:50%;background:var(--ok);display:flex;align-items:center;justify-content:center;color:#fff;font-size:22px;margin:0 auto 14px;">✓</div>
       <h2 style="margin:0 0 4px;font-size:19px;font-weight:800;letter-spacing:-0.02em;">Block delivered to {{ athlete.name }}</h2>
-      <p class="meso-sub" style="margin-bottom:20px;">She'll see all {{ deliver.week_count }} week{{ deliver.week_count|pluralize }} — Day 1 on her phone.</p>
+      <p class="meso-sub" style="margin-bottom:20px;">{{ athlete.name }} will see all {{ deliver.week_count }} week{{ deliver.week_count|pluralize }} — Day 1 on their phone.</p>
       <div style="display:flex;gap:10px;justify-content:center;">
         <a class="meso-btn" href="{% url 'meso:roster' %}">Back to roster</a>
-        <a class="meso-btn meso-btn--primary" href="{% url 'meso:results' %}">Track her sessions →</a>
+        <a class="meso-btn meso-btn--primary" href="{% url 'meso:results' %}">Track sessions →</a>
       </div>
     </div>
   </div>

--- a/app/store_project/templates/meso/review.html
+++ b/app/store_project/templates/meso/review.html
@@ -19,7 +19,7 @@
       <div>
         <p class="meso-eyebrow">Agent · proposed edits</p>
         <h1 class="meso-h1">{{ changes|length }} changes for {{ athlete.name }}</h1>
-        <p class="meso-sub">Grounded on her profile, contraindications, and last block's logged sessions.</p>
+        <p class="meso-sub">Grounded on {{ athlete.name }}'s profile, contraindications, and last block's logged sessions.</p>
       </div>
     </div>
 

--- a/app/store_project/templates/meso/tour_funnel.html
+++ b/app/store_project/templates/meso/tour_funnel.html
@@ -1,0 +1,128 @@
+{% extends "meso/_meso_base.html" %}
+
+{% block title %}Tour funnel · Meso{% endblock %}
+
+{% block content %}
+  <div class="meso-page">
+    <div class="meso-crumbs">
+      <a href="{% url 'meso:roster' %}">Roster</a> <span>/</span> <span>Tour funnel</span>
+    </div>
+
+    <div class="meso-pagehead">
+      <div>
+        <p class="meso-eyebrow">Owner · guided-tour funnel</p>
+        <h1 class="meso-h1">Tour engagement</h1>
+        <p class="meso-sub">
+          {{ total_events }} event{{ total_events|pluralize }} in scope
+          {% if variant %}· variant <b>{{ variant }}</b>{% endif %}
+          {% if days %}· last {{ days }} day{{ days|pluralize }}{% endif %}
+        </p>
+      </div>
+      <div style="display:flex;align-items:center;gap:8px;">
+        <a class="meso-btn meso-btn--ghost" href="?">All</a>
+        <a class="meso-btn meso-btn--ghost" href="?variant=sandbox">Sandbox</a>
+        <a class="meso-btn meso-btn--ghost" href="?variant=self">Self</a>
+      </div>
+    </div>
+
+    <!-- Funnel: Started → Opt-in → Completed event counts, pct vs. Started (capped). -->
+    <div class="meso-card meso-card--pad" style="margin-bottom:14px;">
+      <p class="meso-eyebrow">Funnel</p>
+      <p class="meso-sub" style="margin:2px 0 0;font-size:11.5px;">events per stage; conversion bar capped at 100%</p>
+      <div style="display:flex;flex-direction:column;gap:10px;margin-top:10px;">
+        {% for stage in funnel %}
+          <div>
+            <div style="display:flex;align-items:baseline;gap:8px;margin-bottom:3px;">
+              <b style="font-size:13.5px;">{{ stage.label }}</b>
+              <span class="meso-row-meta">{{ stage.count }} · {{ stage.pct }}%</span>
+            </div>
+            <div style="height:10px;border-radius:999px;background:var(--line-2);overflow:hidden;">
+              <div style="height:100%;width:{{ stage.pct }}%;background:var(--accent);border-radius:999px;"></div>
+            </div>
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+
+    <div class="meso-grid meso-grid--profile">
+      <!-- left rail: per-step advances -->
+      <div style="display:flex;flex-direction:column;gap:14px;">
+        <div class="meso-card">
+          <div style="padding:13px 16px;border-bottom:1px solid var(--line-2);">
+            <p class="meso-eyebrow" style="margin:0;">Advances by step</p>
+          </div>
+          {% for step in step_advances %}
+            <div style="display:flex;align-items:center;gap:10px;padding:10px 16px;border-bottom:1px solid var(--line-2);">
+              <span class="meso-row-name" style="font-size:13.5px;">{{ step.step_key }}</span>
+              <div class="meso-spacer"></div>
+              <span class="meso-row-meta"><b style="color:var(--ink);">{{ step.count }}</b></span>
+            </div>
+          {% empty %}
+            <div class="meso-row" style="color:var(--dim);padding:16px;">
+              No step advances yet.
+            </div>
+          {% endfor %}
+        </div>
+      </div>
+
+      <!-- main: per-kind totals, split by variant -->
+      <div style="display:flex;flex-direction:column;gap:14px;">
+        <div class="meso-card">
+          <div style="padding:13px 16px;border-bottom:1px solid var(--line-2);">
+            <p class="meso-eyebrow" style="margin:0;">Events by kind &amp; variant</p>
+          </div>
+          <div style="overflow-x:auto;">
+            <table style="width:100%;border-collapse:collapse;font-size:13px;">
+              <thead>
+                <tr style="text-align:left;color:var(--dim);">
+                  <th style="padding:9px 16px;font-weight:650;">Kind</th>
+                  <th style="padding:9px 16px;font-weight:650;text-align:right;">All</th>
+                  <th style="padding:9px 16px;font-weight:650;text-align:right;">Sandbox</th>
+                  <th style="padding:9px 16px;font-weight:650;text-align:right;">Self</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr style="border-top:1px solid var(--line-2);">
+                  <td style="padding:9px 16px;">Started</td>
+                  <td style="padding:9px 16px;text-align:right;"><b>{{ event_counts.started }}</b></td>
+                  <td style="padding:9px 16px;text-align:right;color:var(--dim);">{{ by_variant.sandbox.started }}</td>
+                  <td style="padding:9px 16px;text-align:right;color:var(--dim);">{{ by_variant.self.started }}</td>
+                </tr>
+                <tr style="border-top:1px solid var(--line-2);">
+                  <td style="padding:9px 16px;">Step advanced</td>
+                  <td style="padding:9px 16px;text-align:right;"><b>{{ event_counts.advanced }}</b></td>
+                  <td style="padding:9px 16px;text-align:right;color:var(--dim);">{{ by_variant.sandbox.advanced }}</td>
+                  <td style="padding:9px 16px;text-align:right;color:var(--dim);">{{ by_variant.self.advanced }}</td>
+                </tr>
+                <tr style="border-top:1px solid var(--line-2);">
+                  <td style="padding:9px 16px;">Opt-in</td>
+                  <td style="padding:9px 16px;text-align:right;"><b>{{ event_counts.opt_in }}</b></td>
+                  <td style="padding:9px 16px;text-align:right;color:var(--dim);">{{ by_variant.sandbox.opt_in }}</td>
+                  <td style="padding:9px 16px;text-align:right;color:var(--dim);">{{ by_variant.self.opt_in }}</td>
+                </tr>
+                <tr style="border-top:1px solid var(--line-2);">
+                  <td style="padding:9px 16px;">Dismissed</td>
+                  <td style="padding:9px 16px;text-align:right;"><b>{{ event_counts.dismissed }}</b></td>
+                  <td style="padding:9px 16px;text-align:right;color:var(--dim);">{{ by_variant.sandbox.dismissed }}</td>
+                  <td style="padding:9px 16px;text-align:right;color:var(--dim);">{{ by_variant.self.dismissed }}</td>
+                </tr>
+                <tr style="border-top:1px solid var(--line-2);">
+                  <td style="padding:9px 16px;">Completed</td>
+                  <td style="padding:9px 16px;text-align:right;"><b>{{ event_counts.completed }}</b></td>
+                  <td style="padding:9px 16px;text-align:right;color:var(--dim);">{{ by_variant.sandbox.completed }}</td>
+                  <td style="padding:9px 16px;text-align:right;color:var(--dim);">{{ by_variant.self.completed }}</td>
+                </tr>
+                <tr style="border-top:1px solid var(--line-2);">
+                  <td style="padding:9px 16px;">Skipped</td>
+                  <td style="padding:9px 16px;text-align:right;"><b>{{ event_counts.skipped }}</b></td>
+                  <td style="padding:9px 16px;text-align:right;color:var(--dim);">{{ by_variant.sandbox.skipped }}</td>
+                  <td style="padding:9px 16px;text-align:right;color:var(--dim);">{{ by_variant.self.skipped }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/docs/meso/tour-auto-advance-model.md
+++ b/docs/meso/tour-auto-advance-model.md
@@ -1,0 +1,87 @@
+# Meso guided tour — auto-advance model (decision note)
+
+Status: **decided, implementation deferred.** Written for issue #441 P3. This records
+the consistent advance model the audit asked us to settle "before patching steps
+individually." No tour-flow code changes in the P3 PR that ships this note.
+
+## The problem the audit named
+
+The tour renders state but "never reacts to what the user actually does." Today advance is
+almost entirely manual (the **Next** button). The *only* server-side auto-advance is
+`tour.advance_if_on_step(user, "profile")`, called from `AthleteProfileView` (a page-visit
+signal for step 2). Everything else relies on the coach clicking Next, even right after they
+complete the step's action.
+
+Existing predicates are uneven across variants:
+
+| step | key | sandbox predicate (`loaded`) | self predicate (`loaded`) |
+|------|-----|------------------------------|---------------------------|
+| 0 | welcome | `has_athletes` | `has_self_link` |
+| 1 | profile | — (visit-advance) | — (visit-advance) |
+| 2 | designer | `has_program` | `has_plan` |
+| 3 | deliver | `has_delivery` | **none** |
+| 4 | results | `has_log` | **none** |
+| 5 | groups | `has_group` | (static) |
+| 6 | agent | — | (`has_plan` gates lock copy, no `loaded`) |
+| 7 | finish | — (terminal) | — (terminal) |
+
+Two gaps fall out of that table: the **self variant has no `has_delivery`/`has_log`
+predicate at all**, and even where a predicate exists, `loaded` only flips the action
+button to a done state — it never advances the step.
+
+## The model
+
+Classify each step by its **goal event**, then bind the matching signal:
+
+1. **Visit-goal steps** — the goal is to *land on a page*. Only step 1 (profile).
+   Signal: page GET while parked on the step → `advance_if_on_step`. Already implemented for
+   profile; this is the pattern to generalize, not replace.
+
+2. **Action-goal steps** — the goal is to *complete a data-producing action*: welcome,
+   designer, deliver, results, groups, agent. Signal: the step's own `has_*` predicate
+   flips true. Advance at the **action-completion site** (the POST handler that produces the
+   data — the same `demo_load` / `roster_add_self` / `plan_create` / deliver / log endpoints
+   that already record the opt-in), gated on `current_step_key(user) == <step>`, calling the
+   generalized `advance_if_on_step(user, <step>)`.
+
+   Advancing at the action site (not on a later page visit) is what makes the tour *react to
+   what the user did* — the audit's through-line. It also means the organic twin and the
+   tour button both advance, matching the funnel fix (P3-2) that already records the opt-in
+   from either path.
+
+3. **Terminal step** — step 7 (finish) does not advance.
+
+### Why not client-side advance
+
+Advance stays server-authoritative: the funnel events (`TourEvent`) and tour resumability
+already live in `tour_state`. A client-side advance would desync the recorded funnel and the
+resumed step. Keep the single source of truth on the server.
+
+### The `current == step` guard prevents skips
+
+`advance_if_on_step` only advances when the coach is parked *exactly* on the named step and
+that step is not the last. Because step 2 (designer) creates the plan that step 6 (agent)
+inspects, a coach who runs the tour in order is never mid-flight on step 6 when step 2's
+action fires, so no step is skipped. Each action advances only its own step index.
+
+## What the follow-up implementation must do (as one coherent unit)
+
+1. **Fill the self-variant predicate gaps first.** Add self-variant `has_delivery` /
+   `has_log` (the self athlete's plan delivery + a logged session), so deliver/results can
+   action-advance in the self variant. Without these the deliver/results steps have no signal
+   and must stay manual.
+2. **Generalize the advance hook.** Call `advance_if_on_step(user, <step>)` from each
+   action-completion site, right where the opt-in is recorded, for welcome / designer /
+   deliver / results / groups / agent, gated on `current_step_key`.
+3. **Keep the profile visit-advance** as the one visit-goal case.
+4. **Leave finish terminal.**
+
+Do this in a single change so the flow is coherent — not per-step patches — exactly as the
+audit warned. Ship it behind the same red/green + browser-walkthrough verification the P1/P2
+fixes used, because it changes the mainline tour progression.
+
+## Decision for P3
+
+Documented, **not implemented** in the P3 PR. The predicate-gap + action-hook work is a
+focused follow-up (roughly: one presenter/predicate change per variant + one `advance_if_on_step`
+call per action site + tests). Tracked under issue #441.

--- a/frontend/meso_tour.test.js
+++ b/frontend/meso_tour.test.js
@@ -24,6 +24,12 @@ import {
   shouldShowGoto,
   isUsableRect,
 } from "../app/store_project/static/js/meso_tour.js";
+// The pure-logic helpers above are named exports; the DOM-level helpers the P3
+// tests exercise (`bottomSheetInset`, `scrollAnchorIntoView`, `initTour`) are
+// pulled in as a namespace so a not-yet-exported symbol reads as `undefined`
+// (a clean "feature missing" failure) rather than breaking module collection
+// for the whole suite.
+import * as tourDriver from "../app/store_project/static/js/meso_tour.js";
 
 describe("clampStep", () => {
   it("keeps an in-range step unchanged", () => {
@@ -448,5 +454,158 @@ describe("isUsableRect", () => {
   it("rejects a missing rect", () => {
     expect(isUsableRect(null)).toBe(false);
     expect(isUsableRect(undefined)).toBe(false);
+  });
+});
+
+// #441 P3-1: on a phone the step card is a bottom sheet (min(75vh,520px), pinned
+// bottom:0) that covers viewport center, so `scrollIntoView({block:"center"})`
+// buries the spotlighted anchor behind it. The fix computes the sheet height in
+// px and sets `scroll-margin-bottom` on the anchor before scrolling, lifting its
+// resting position out from behind the sheet — and clears the margin on desktop
+// so a rotate-to-wide doesn't leave a stale offset.
+//
+// A `window`-like fake whose `matchMedia` answers both the sheet-layout query
+// and the reduced-motion query `scrollAnchorIntoView` reads, mirroring the
+// existing `prefersReducedMotion` `fakeWin` helper. The sheet query is matched
+// space-insensitively so it holds whether the impl writes "(max-width:640px)"
+// or "(max-width: 640px)".
+function sheetWin({ innerHeight = 800, sheet = false, reducedMotion = false } = {}) {
+  return {
+    innerHeight,
+    matchMedia(query) {
+      const q = String(query).replace(/\s+/g, "");
+      if (q === "(max-width:640px)") return { matches: sheet };
+      if (q.indexOf("prefers-reduced-motion") !== -1) {
+        return { matches: reducedMotion };
+      }
+      return { matches: false };
+    },
+  };
+}
+
+describe("bottomSheetInset (P3-1 mobile bottom-sheet height)", () => {
+  it("returns the sheet height min(innerHeight*0.75, 520) on the sheet layout", () => {
+    // 800 * 0.75 = 600, clamped to the 520px cap.
+    expect(tourDriver.bottomSheetInset(sheetWin({ sheet: true, innerHeight: 800 }))).toBe(
+      520,
+    );
+  });
+
+  it("uses the 75vh branch on a shorter viewport", () => {
+    // 600 * 0.75 = 450, under the 520 cap.
+    expect(tourDriver.bottomSheetInset(sheetWin({ sheet: true, innerHeight: 600 }))).toBe(
+      450,
+    );
+  });
+
+  it("is 0 on desktop (not the sheet layout)", () => {
+    expect(
+      tourDriver.bottomSheetInset(sheetWin({ sheet: false, innerHeight: 800 })),
+    ).toBe(0);
+  });
+
+  it("is 0 when matchMedia is unavailable", () => {
+    expect(tourDriver.bottomSheetInset({ innerHeight: 800 })).toBe(0);
+  });
+});
+
+describe("scrollAnchorIntoView (P3-1 sets scroll-margin-bottom for the sheet)", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  function anchor(name) {
+    const el = document.createElement("div");
+    el.setAttribute("data-tour", name);
+    // jsdom's scrollIntoView is a no-op stub; keep it a function so the driver's
+    // `typeof el.scrollIntoView === "function"` guard passes.
+    el.scrollIntoView = () => {};
+    document.body.appendChild(el);
+    return el;
+  }
+
+  it("sets the anchor's scrollMarginBottom to the sheet inset on mobile (520px)", () => {
+    const el = anchor("roster-invite");
+    tourDriver.scrollAnchorIntoView(
+      document,
+      sheetWin({ sheet: true, innerHeight: 800 }),
+      "roster-invite",
+    );
+    expect(el.style.scrollMarginBottom).toBe("520px");
+  });
+
+  it("uses the 75vh branch inset on a shorter mobile viewport (450px)", () => {
+    const el = anchor("roster-invite");
+    tourDriver.scrollAnchorIntoView(
+      document,
+      sheetWin({ sheet: true, innerHeight: 600 }),
+      "roster-invite",
+    );
+    expect(el.style.scrollMarginBottom).toBe("450px");
+  });
+
+  it("clears scrollMarginBottom on desktop (never leaves a stale margin)", () => {
+    const el = anchor("roster-invite");
+    el.style.scrollMarginBottom = "999px"; // a stale mobile margin
+    tourDriver.scrollAnchorIntoView(
+      document,
+      sheetWin({ sheet: false, innerHeight: 800 }),
+      "roster-invite",
+    );
+    expect(el.style.scrollMarginBottom).toBe("");
+  });
+});
+
+// #441 P3-3: the driver repositions its spotlight on throttled resize + a
+// capture-phase scroll listener only. Step 8 (self) spotlights a
+// `<details data-tour="roster-invite">`; expanding it fires a `toggle` event
+// that doesn't bubble, so the spotlight never re-measures and goes stale. The
+// fix registers the same throttled reposition as a capture-phase `toggle`
+// listener on mount and tears it down with the rest.
+describe("initTour toggle reposition listener (P3-3)", () => {
+  const CONFIG = {
+    steps: [
+      { key: "welcome", title: "Welcome", body: "Hi", anchor: "roster-individuals" },
+      { key: "finish", title: "Done", body: "Bye", anchor: "roster-invite" },
+    ],
+    variant: "self",
+    step: 0,
+    status: "active",
+    state_url: "/meso/tour/state/",
+    skip_url: "/meso/tour/skip/",
+    demo_load_url: "/meso/demo/load/",
+    signup_url: "/meso/demo/signup/",
+  };
+
+  function mount() {
+    document.body.innerHTML =
+      '<div id="meso-tour" aria-hidden="true"></div>' +
+      '<script type="application/json" id="meso-tour-config">' +
+      JSON.stringify(CONFIG) +
+      "</script>";
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("registers a capture-phase toggle listener on the document on mount", () => {
+    mount();
+    const addSpy = vi.spyOn(document, "addEventListener");
+    tourDriver.initTour(document, window);
+    expect(addSpy).toHaveBeenCalledWith("toggle", expect.any(Function), true);
+  });
+
+  it("removes the capture-phase toggle listener on teardown", async () => {
+    mount();
+    window.fetch = vi.fn().mockResolvedValue({ ok: true });
+    const removeSpy = vi.spyOn(document, "removeEventListener");
+    tourDriver.initTour(document, window);
+    // Dismiss tears the tour down once the (mocked) state POST settles.
+    document.querySelector("[data-tour-dismiss]").click();
+    await vi.waitFor(() => {
+      expect(removeSpy).toHaveBeenCalledWith("toggle", expect.any(Function), true);
+    });
   });
 });


### PR DESCRIPTION
The **P3 (polish / measurement)** tranche of the guided-tour usability audit (#441). P1 (#443) and P2 (#445) shipped the broken/wrong and confusing-state fixes; this closes out the polish + measurement items. Developed **red → green**, then two rounds of a local OpenAI Codex review (converged clean).

## What's in it

- **P3-1 · mobile bottom-sheet scroll** — `scrollAnchorIntoView` now sets `scroll-margin-bottom` to the sheet height (`min(75vh, 520px)`) on the narrow-viewport sheet layout, so a `block:"center"` anchor lifts out from behind the bottom sheet instead of hiding under it. Verified in a real Chrome layout engine (harness at 390px): without the fix the anchor's bottom `513` sat below the sheet top `459` (buried); with it, `421 ≤ 459` (clears).
- **P3-3 · spotlighted `<details>` reposition** — the driver now listens for the non-bubbling `toggle` event in **capture** phase, so expanding step 8's `roster-invite` `<details>` re-measures the spotlight instead of leaving it stale at the collapsed size.
- **P3-4 · pronoun de-hardcoding** — `deliver.html` / `review.html` drop she/her for `{{ athlete.name }}` + singular they/their, so the copy reads right in the self variant (and for any athlete).
- **P3-2 · organic-control funnel undercount** — `roster_add_self` / `plan_create` now record the opt-in when the coach takes the action via the **organic twin** while actively touring on the matching step (new `tour.current_step_key`), not only when the POST carries `tour=1`. The organic path is gated to the **self variant** and, for `plan_create`, to a **matching action shape** (draft→agent, plain→designer) so a sandbox `+ New program` or a manual plan on the agent step isn't miscounted. No double-recording.
- **P3-6 · TourEvent funnel dashboard** — a staff-gated `TourFunnelView` + `presenters.tour_funnel` (per-kind totals, per-variant breakdown, per-step advances, and a Started→Opt-in→Completed funnel), mirroring `UsageDashboardView`'s gating exactly. Reachable from the staff nav. Funnel stages use **raw event counts** (so reaped null-coach sandbox rows aren't dropped) with the conversion bar **clamped to ≤100%**.
- **P3-5 · auto-advance model** — **documented, not implemented** (per the audit's "decide before patching individually"): `docs/meso/tour-auto-advance-model.md` records the consistent advance model and the self-variant predicate gaps a follow-up must fill.

## Tests

- **vitest** — `frontend/meso_tour.test.js`: `bottomSheetInset` + `scrollAnchorIntoView` scroll-margin (P3-1) and the capture-phase `toggle` listener add/remove (P3-3). **71 passed.**
- **pytest** — new `test_pronouns.py` (P3-4), `test_tour_funnel.py` (dashboard gate + aggregation + raw-count/clamp), and organic-opt-in cases in `test_tour_events.py` (P3-2, incl. action-shape and sandbox-variant guards). Full meso suite **1971 passed**, ruff clean.

## Review

Developed red→green; passed a local OpenAI Codex review loop — iter 1 fixed 3 nits (agent-step action-shape, funnel >100%, `?days` validation), iter 2 fixed 2 nits (funnel null-coach data-loss, sandbox opt-in variant gate), iter 3 **clean**. Each fix carries a regression test.

**P3 auto-advance implementation + any further tour work** remain tracked under #441.

Closes the P3 tranche of #441.