### PR TITLE
feat(meso): P3 — whole-block delivery + athlete multi-week view (#440)

### DIFF
--- a/app/store_project/meso/adherence.py
+++ b/app/store_project/meso/adherence.py
@@ -36,7 +36,11 @@ def link_latest_delivered_week(link):
         )
         .exclude(mesocycle__plan__status=Plan.Status.ARCHIVED)
         .select_related("mesocycle")
-        .order_by("-delivered_at")
+        # A P3 block delivery stamps every week with one ``delivered_at``; break
+        # that tie toward the athlete's current week (then earliest index) so the
+        # meter is deterministic instead of DB-order dependent. (Per-week delivery
+        # has distinct timestamps, so this never changes its result.)
+        .order_by("-delivered_at", "-is_current", "index")
         .first()
     )
 

--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -26,7 +26,6 @@ from .models import CoachSubscription
 from .models import LoadType
 from .models import Plan
 from .models import SessionLog
-from .models import Week
 from .models import WeekDelivery
 from .one_rm import one_rm_values
 from .serializers import _fmt_num
@@ -605,79 +604,86 @@ def group_detail(group):
 
 
 def deliver_screen(plan, week=None):
-    """Context for the plan-bound deliver screen (Phase 4; per-week, multi-week).
+    """Context for the plan-bound deliver screen (P3; block delivery).
 
-    Summarizes the **target** week — the plan's current (live) week by default, or
-    an explicit ``week`` the coach chose in the designer's switcher. ``deliver.weeks``
-    lists every week (id / label / whether it's the live week / whether it's already
-    been delivered) so the screen offers a per-week selector, and ``is_current``
-    /``current_label`` let it warn when the coach is sending a week that isn't the
-    live one (delivering it won't move the live pointer). On a re-delivery,
-    ``deliver["changes"]`` is the diff of the target week's live grid against the
-    snapshot last delivered (``diff_week_snapshots``) so the coach reviews exactly
-    what's about to change for the athlete; it's ``None`` on a first delivery.
-    Scheduling stays a later-slice concern.
+    The individual deliver path releases the **whole block** — one ``Mesocycle``,
+    every one of its live weeks — at once (see ``plan_deliver``), so this screen
+    confirms the block, not a single week. The ``week`` argument (the plan's
+    current/live week by default, or an explicit ``?week=`` the coach picked in
+    the designer's switcher) only *selects which block* to send; ``block`` is
+    that week's mesocycle.
+
+    ``deliver["weeks"]`` carries one entry per live week of the block, each with
+    its OWN "changes since last delivery" diff: a re-delivered week (it has a
+    prior ``WeekDelivery``) diffs its live grid against its latest snapshot
+    (``diff_week_snapshots``), a never-delivered week has ``changes=None``. The
+    block-level ``is_redelivery`` / ``has_changes`` fold those per-week facts up
+    for the headline. ``week_id`` stays the target week's pk — the Alpine
+    ``mesoDeliver(planId, csrf, weekId)`` component still posts it to pick the
+    block. Scheduling stays a later-slice concern.
     """
     live = current_week(plan)
     target = week or live
-    # "Live" everywhere = the week ``current_week`` *resolves* to, not the raw
-    # ``is_current`` flag: a plan with no flagged week falls back to its earliest
-    # week as the live target, and the chip marker + the "not the live week"
-    # warning must agree with that fallback (else the screen contradicts itself —
-    # "sending Wk 1, not the live week (Wk 1)").
+    # The target week only *selects the block*; block delivery sends all its live
+    # weeks, so there's no "sending a week that isn't live" warning any more.
     live_id = live.pk if live else None
-    mesocycle = target.mesocycle if target else None
-    # Live rows only (soft delete, designer framework Phase 0): a removed day
-    # doesn't count toward "N sessions", and the selector below never offers a
-    # removed week (the deliver POST would 404 it).
-    session_count = (
-        target.sessions.filter(deleted_at__isnull=True).count() if target else 0
-    )
-    is_redelivery = target is not None and target.deliveries.exists()
+    block = target.mesocycle if target else None
 
-    # On a re-delivery, diff the live grid against the snapshot last delivered so
-    # the coach sees what's about to change for the athlete. A first delivery (no
-    # prior snapshot) has nothing to diff → None.
-    changes = None
-    if is_redelivery:
-        last_payload = (
-            WeekDelivery.objects.filter(week=target)
-            .order_by("-delivered_at")
-            .values_list("payload", flat=True)
-            .first()
-        )
-        if last_payload:
-            changes = diff_week_snapshots(serialize_week_snapshot(target), last_payload)
+    weeks = []
+    block_is_redelivery = False
+    block_has_changes = False
+    if block is not None:
+        # Live weeks only (soft delete, designer framework Phase 0): a removed
+        # week is never delivered (the POST 404s it), so it's not listed here.
+        for w in block.weeks.filter(deleted_at__isnull=True).order_by("index"):
+            # Live rows only: a removed day doesn't count toward "N sessions".
+            session_count = w.sessions.filter(deleted_at__isnull=True).count()
+            is_redelivery = w.deliveries.exists()
+            # On a re-delivery, diff the week's live grid against the snapshot it
+            # last went out as, so the coach sees what's about to change for the
+            # athlete. A first delivery (no prior snapshot) has nothing to diff.
+            changes = None
+            if is_redelivery:
+                last_payload = (
+                    WeekDelivery.objects.filter(week=w)
+                    .order_by("-delivered_at")
+                    .values_list("payload", flat=True)
+                    .first()
+                )
+                if last_payload:
+                    changes = diff_week_snapshots(
+                        serialize_week_snapshot(w), last_payload
+                    )
+            if is_redelivery:
+                block_is_redelivery = True
+            if changes is not None and changes["has_changes"]:
+                block_has_changes = True
+            weeks.append(
+                {
+                    "id": w.pk,
+                    "label": f"Wk {w.index}",
+                    "index": w.index,
+                    "is_current": w.pk == live_id,
+                    "is_delivered": w.delivered_at is not None,
+                    "session_count": session_count,
+                    "is_redelivery": is_redelivery,
+                    "changes": changes,
+                }
+            )
 
-    weeks = [
-        {
-            "id": w.pk,
-            "label": f"Wk {w.index}",
-            "is_current": w.pk == live_id,
-            "is_delivered": w.delivered_at is not None,
-            "is_target": target is not None and w.pk == target.pk,
-        }
-        for w in (
-            Week.objects.filter(mesocycle__plan=plan, deleted_at__isnull=True)
-            .select_related("mesocycle")
-            .order_by("mesocycle__order", "index")
-        )
-    ]
-
+    week_count = len(weeks)
     athlete = profile_athlete(plan.athlete)
-    athlete["block"] = mesocycle.name if mesocycle else ""
-    athlete["week"] = f"Wk {target.index}" if target else ""
+    athlete["block"] = block.name if block else ""
+    athlete["week"] = f"{week_count} week{'' if week_count == 1 else 's'}"
     return {
         "athlete": athlete,
         "deliver": {
             "what": plan.title,
-            "sessions": session_count,
-            "is_redelivery": is_redelivery,
-            "changes": changes,
+            "block_name": block.name if block else "",
+            "week_count": week_count,
+            "is_redelivery": block_is_redelivery,
+            "has_changes": block_has_changes,
             "week_id": target.pk if target else None,
-            "week_label": f"Wk {target.index}" if target else "",
-            "is_current": target is not None and target.pk == live_id,
-            "current_label": f"Wk {live.index}" if live else "",
             "weeks": weeks,
         },
     }

--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -11,6 +11,7 @@ until those surfaces grow their own slices.
 
 import math
 from collections import defaultdict
+from types import SimpleNamespace
 
 from django.urls import reverse
 from django.utils import timezone
@@ -36,6 +37,7 @@ from .serializers import diff_week_snapshots
 from .serializers import initials
 from .serializers import latest_delivered_week
 from .serializers import serialize_mesocycle
+from .serializers import serialize_mesocycle_grid
 from .serializers import serialize_prescription
 from .serializers import serialize_proposed_change
 from .serializers import serialize_week_snapshot
@@ -980,12 +982,96 @@ def _athlete_session_row(session, *, done):
     }
 
 
+def _cell_summary(cell, unit):
+    """A read-only prescription summary for one athlete-table cell.
+
+    Reads a ``serialize_mesocycle_grid`` cell dict (the athlete table is
+    transformed from that coach grid, not from ``Prescription`` rows) and reuses
+    the results screen's target label so the athlete reads the same "4×8 @ 100 kg
+    · RPE 8" shape everywhere. A ``%1RM`` load carries ``%``; an absolute one the
+    plan's ``unit``; "BW" no suffix.
+    """
+    return _results_target_label(
+        SimpleNamespace(
+            sets=cell["sets"],
+            reps=cell["reps"],
+            load=cell["load"],
+            load_type=cell["load_type"],
+            rpe=cell["rpe"],
+        ),
+        unit,
+    )
+
+
+def _athlete_block_grid(block, delivered_week_ids, focus_week_id, unit):
+    """The athlete's read-only multi-week table, transformed from the coach grid.
+
+    Reuses ``serialize_mesocycle_grid`` (one dense query set for the whole block —
+    no N+1 per cell) and strips it to what a read-only table needs: columns
+    filtered to the *delivered* weeks, each cell reduced to a display summary
+    (em-dash rendered by the template when ``skipped``; the swapped exercise name
+    surfaced), and every coach-editing internal (history / ``*_id`` /
+    ``prescription_id`` / ``session_id``) dropped. The focus (current) week's
+    column is flagged (``current``) so the template can highlight it.
+    """
+    grid = serialize_mesocycle_grid(block)
+    delivered = {str(wid) for wid in delivered_week_ids}
+    columns = [w for w in grid["weeks"] if str(w["id"]) in delivered]
+    col_keys = [str(w["id"]) for w in columns]
+    weeks = [
+        {
+            "index": w["index"],
+            "label": w["label"],
+            "deload": w["deload"],
+            "current": w["id"] == focus_week_id,
+        }
+        for w in columns
+    ]
+    days = []
+    for day in grid["days"]:
+        rows = []
+        for row in day["rows"]:
+            cells = []
+            has_any = False
+            for w, key in zip(columns, col_keys):
+                cell = row["cells"].get(key)
+                current = w["id"] == focus_week_id
+                if cell is None:
+                    cells.append({"present": False, "current": current})
+                    continue
+                has_any = True
+                cells.append(
+                    {
+                        "present": True,
+                        "current": current,
+                        "summary": _cell_summary(cell, unit),
+                        "skipped": cell["skipped"],
+                        "swap": cell["swap_display"],
+                    }
+                )
+            if has_any:
+                rows.append({"name": row["name"], "cells": cells})
+        if rows:
+            days.append(
+                {
+                    "name": day["name"],
+                    "bias": day["bias"],
+                    "day_number": day["day_number"],
+                    "rows": rows,
+                }
+            )
+    return {"weeks": weeks, "days": days}
+
+
 def athlete_home(user):
-    """The athlete's active programs, each with its latest delivered week.
+    """The athlete's active programs, each as its whole delivered block.
 
     One card per non-archived plan across the athlete's *active* coaches (D-a).
-    A plan with no delivered week is shown as awaiting; otherwise its delivered
-    sessions render with the athlete's own done/pending status.
+    A plan with no delivered week is shown as awaiting; otherwise the card opens
+    to the week the athlete is currently on (``is_current`` when it's delivered,
+    else the latest delivered week) — that focus week's sessions are the tappable
+    log rows — and carries a read-only multi-week table (``grid``) of the whole
+    delivered block so the athlete can see the weeks around them (P3).
     """
     plans = (
         Plan.objects.for_athlete(user)
@@ -995,31 +1081,62 @@ def athlete_home(user):
     )
     cards = []
     for plan in plans:
-        week = latest_delivered_week(plan)
-        sessions = []
-        if week is not None:
-            # Live rows only (soft delete, designer framework Phase 0): a day
-            # the coach removed after delivering is gone from the athlete's
-            # home too, and a removed exercise stops counting toward the row's
-            # "N exercises" chip (``_athlete_session_row`` reads it via
-            # ``session.cells()``, already live-filtered — P0 fixed-lineup
-            # cutover; a small per-session query, not prefetched).
-            session_objs = list(week.sessions.filter(deleted_at__isnull=True))
-            done = _done_session_ids([s.pk for s in session_objs], user)
-            sessions = [
-                _athlete_session_row(s, done=s.pk in done) for s in session_objs
-            ]
+        latest = latest_delivered_week(plan)
+        if latest is None:
+            cards.append(
+                {
+                    "id": plan.pk,
+                    "title": plan.title,
+                    "goal": plan.goal,
+                    "coach": plan.coach.display_name(),
+                    "block": "",
+                    "focus_index": None,
+                    "delivered_at": None,
+                    "sessions": [],
+                    "grid": None,
+                    "awaiting": True,
+                }
+            )
+            continue
+
+        block = latest.mesocycle
+        # The table columns: only DELIVERED live weeks of this block — a week the
+        # coach is building ahead (delivered_at is None) never reaches the athlete.
+        delivered_weeks = list(
+            block.weeks.filter(
+                deleted_at__isnull=True, delivered_at__isnull=False
+            ).order_by("index")
+        )
+        delivered_ids = {w.pk for w in delivered_weeks}
+        # Focus = the week the athlete is on (``is_current``) when it's a
+        # delivered week of THIS block; otherwise the latest delivered week.
+        current = current_week(plan)
+        focus = (
+            current if (current is not None and current.pk in delivered_ids) else latest
+        )
+
+        # The focus week's sessions are the tappable log rows. Live rows only
+        # (soft delete, designer framework Phase 0): a day the coach removed after
+        # delivering is gone from the athlete's home too, and a removed exercise
+        # stops counting toward the row's "N exercises" chip
+        # (``_athlete_session_row`` reads it via ``session.trainable_cells()``,
+        # already live-filtered — P0 fixed-lineup cutover).
+        session_objs = list(focus.sessions.filter(deleted_at__isnull=True))
+        done = _done_session_ids([s.pk for s in session_objs], user)
+        sessions = [_athlete_session_row(s, done=s.pk in done) for s in session_objs]
+
         cards.append(
             {
                 "id": plan.pk,
                 "title": plan.title,
                 "goal": plan.goal,
                 "coach": plan.coach.display_name(),
-                "block": week.mesocycle.name if week else "",
-                "week": f"Wk {week.index}" if week else "",
-                "delivered_at": week.delivered_at if week else None,
+                "block": block.name,
+                "focus_index": focus.index,
+                "delivered_at": focus.delivered_at,
                 "sessions": sessions,
-                "awaiting": week is None,
+                "grid": _athlete_block_grid(block, delivered_ids, focus.pk, plan.unit),
+                "awaiting": False,
             }
         )
     return cards

--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -1114,12 +1114,14 @@ def athlete_home(user):
             ).order_by("index")
         )
         delivered_ids = {w.pk for w in delivered_weeks}
-        # Focus = the week the athlete is on (``is_current``) when it's a
-        # delivered week of THIS block; otherwise the latest delivered week.
-        current = current_week(plan)
-        focus = (
-            current if (current is not None and current.pk in delivered_ids) else latest
-        )
+        # Focus (what the home opens to) = the latest delivered week. Its ordering
+        # already breaks the block-delivery timestamp tie toward the athlete's
+        # ``is_current`` week (see ``latest_delivered_week``), so for an individual
+        # block this IS the current week. Deriving it from ``latest`` rather than
+        # ``current_week`` also stays correct for a group-materialized plan, whose
+        # sync flags EVERY delivered week ``is_current`` — ``current_week`` would
+        # return the earliest of those and strand the athlete on week 1.
+        focus = latest
 
         # The focus week's sessions are the tappable log rows. Live rows only
         # (soft delete, designer framework Phase 0): a day the coach removed after

--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -1032,14 +1032,20 @@ def _athlete_block_grid(block, delivered_week_ids, focus_week_id, unit):
         rows = []
         for row in day["rows"]:
             cells = []
-            has_any = False
+            # Include the row only if the athlete actually trains it in some
+            # delivered week. An "add this week only" targeting an *undelivered*
+            # future week seeds skipped placeholder cells in the delivered weeks;
+            # counting any present cell would leak that build-ahead exercise's
+            # name across em-dash cells, so gate on a non-skipped delivered cell.
+            has_trainable = False
             for w, key in zip(columns, col_keys):
                 cell = row["cells"].get(key)
                 current = w["id"] == focus_week_id
                 if cell is None:
                     cells.append({"present": False, "current": current})
                     continue
-                has_any = True
+                if not cell["skipped"]:
+                    has_trainable = True
                 cells.append(
                     {
                         "present": True,
@@ -1049,7 +1055,7 @@ def _athlete_block_grid(block, delivered_week_ids, focus_week_id, unit):
                         "swap": cell["swap_display"],
                     }
                 )
-            if has_any:
+            if has_trainable:
                 rows.append({"name": row["name"], "cells": cells})
         if rows:
             days.append(

--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -27,6 +27,7 @@ from .models import CoachSubscription
 from .models import LoadType
 from .models import Plan
 from .models import SessionLog
+from .models import Week
 from .models import WeekDelivery
 from .one_rm import one_rm_values
 from .serializers import _fmt_num
@@ -1069,6 +1070,23 @@ def _athlete_block_grid(block, delivered_week_ids, focus_week_id, unit):
     return {"weeks": weeks, "days": days}
 
 
+def _single_current_week(plan):
+    """True when ``plan`` has exactly one live ``is_current`` week.
+
+    An individual plan keeps a single current pointer (``week_set_current``
+    clears the others), so its current week is trustworthy as "the week the
+    athlete is on." A group-materialized snapshot instead flags EVERY delivered
+    week ``is_current`` (``sync_delivered_plan``), so there ``current_week`` is
+    ambiguous — this is how ``athlete_home`` tells the two apart.
+    """
+    return (
+        Week.objects.filter(
+            mesocycle__plan=plan, is_current=True, deleted_at__isnull=True
+        ).count()
+        == 1
+    )
+
+
 def athlete_home(user):
     """The athlete's active programs, each as its whole delivered block.
 
@@ -1105,7 +1123,25 @@ def athlete_home(user):
             )
             continue
 
-        block = latest.mesocycle
+        # Anchor the card (both the block shown and the focus week) on the week
+        # the athlete is on. For an individual plan that's its single ``is_current``
+        # week, so a coach's "Make current" is honored even when it moves the
+        # athlete back to an earlier delivered block. A group-materialized snapshot
+        # flags every delivered week ``is_current``, so there ``current_week`` is
+        # ambiguous (it returns the earliest) — fall back to the latest delivered
+        # week, whose ordering already tracks the newest delivery. A current week
+        # the coach is still building (undelivered) also falls back to latest.
+        current = current_week(plan)
+        if (
+            current is not None
+            and current.delivered_at is not None
+            and _single_current_week(plan)
+        ):
+            anchor = current
+        else:
+            anchor = latest
+        block = anchor.mesocycle
+        focus = anchor
         # The table columns: only DELIVERED live weeks of this block — a week the
         # coach is building ahead (delivered_at is None) never reaches the athlete.
         delivered_weeks = list(
@@ -1114,14 +1150,6 @@ def athlete_home(user):
             ).order_by("index")
         )
         delivered_ids = {w.pk for w in delivered_weeks}
-        # Focus (what the home opens to) = the latest delivered week. Its ordering
-        # already breaks the block-delivery timestamp tie toward the athlete's
-        # ``is_current`` week (see ``latest_delivered_week``), so for an individual
-        # block this IS the current week. Deriving it from ``latest`` rather than
-        # ``current_week`` also stays correct for a group-materialized plan, whose
-        # sync flags EVERY delivered week ``is_current`` — ``current_week`` would
-        # return the earliest of those and strand the athlete on week 1.
-        focus = latest
 
         # The focus week's sessions are the tappable log rows. Live rows only
         # (soft delete, designer framework Phase 0): a day the coach removed after

--- a/app/store_project/meso/push.py
+++ b/app/store_project/meso/push.py
@@ -99,7 +99,51 @@ def notify_week_delivered(*, athlete, coach, plan, week, home_url):
         "url": home_url,
         "tag": f"meso-week-{week.pk}",
     }
+    return _fan_out(subscriptions, payload)
 
+
+def notify_block_delivered(*, athlete, coach, plan, mesocycle, week_count, home_url):
+    """Push a block-delivery notification to the athlete's devices (best-effort).
+
+    The block-level peer of ``notify_week_delivered`` (Meso P3): the individual
+    deliver path releases a whole mesocycle at once, so the athlete gets one
+    "your new block is ready" push, not one per week. Same contract — a no-op
+    (returns 0) when push is disabled or the athlete has no subscriptions, dead
+    subscriptions are pruned, other per-device failures are logged and skipped,
+    and nothing here ever raises to the caller. Returns the number of devices
+    actually pushed to.
+    """
+    # Imported here to avoid a models import at module load (push.py is imported
+    # from views before app loading settles in some paths).
+    from .models import PushSubscription
+
+    if not push_enabled():
+        return 0
+
+    subscriptions = list(PushSubscription.objects.filter(athlete=athlete))
+    if not subscriptions:
+        return 0
+
+    payload = {
+        "title": "Your new training block is ready",
+        "body": (
+            f"{coach.display_name()} delivered a new block "
+            f"({_week_count_label(week_count)}) of {plan.title}."
+        ),
+        "url": home_url,
+        "tag": f"meso-block-{mesocycle.pk}",
+    }
+    return _fan_out(subscriptions, payload)
+
+
+def _fan_out(subscriptions, payload):
+    """Send one ``payload`` to each subscription; return the count actually sent.
+
+    The shared per-device loop behind the delivery notifiers: dead endpoints
+    (404/410 Gone) are pruned, any other per-device failure is logged and
+    skipped, and nothing here ever raises — one bad endpoint never blocks the
+    others or fails the deliver.
+    """
     sent = 0
     for subscription in subscriptions:
         try:
@@ -121,3 +165,8 @@ def notify_week_delivered(*, athlete, coach, plan, week, home_url):
 
 def _week_label(week):
     return f"Week {week.index}"
+
+
+def _week_count_label(week_count):
+    """Pluralize-correct "N week(s)" for the block push copy."""
+    return f"{week_count} week" + ("" if week_count == 1 else "s")

--- a/app/store_project/meso/serializers.py
+++ b/app/store_project/meso/serializers.py
@@ -592,12 +592,17 @@ def latest_delivered_week(plan):
     and uses this week as the block anchor + the focus-week fallback when no
     delivered week is flagged current. See ``docs/archive/meso/athlete-plan.md``.
     """
+    # P3 delivers a whole block at once, so every live week of that block shares
+    # one ``delivered_at`` — ordering on it alone would tie non-deterministically.
+    # Break the tie toward the week the athlete is on (``is_current``), then the
+    # earliest index, so the anchor/fallback is stable and meaningful. (Per-week
+    # delivery gives distinct timestamps, so the tiebreak never engages there.)
     return (
         models.Week.objects.filter(
             mesocycle__plan=plan, delivered_at__isnull=False, deleted_at__isnull=True
         )
         .select_related("mesocycle")
-        .order_by("-delivered_at")
+        .order_by("-delivered_at", "-is_current", "index")
         .first()
     )
 

--- a/app/store_project/meso/serializers.py
+++ b/app/store_project/meso/serializers.py
@@ -587,7 +587,10 @@ def latest_delivered_week(plan):
     is reflected, by design; the frozen ``WeekDelivery`` snapshot is the
     historical record for the (deferred) "changes since last delivery" diff, not
     a separate athlete-facing view. Newest delivery wins so the athlete lands on
-    the week their coach just sent. See ``docs/archive/meso/athlete-plan.md``.
+    the week their coach just sent. Post-P3 the athlete home renders the whole
+    delivered *block* (this week's ``mesocycle``) as a read-only multi-week table
+    and uses this week as the block anchor + the focus-week fallback when no
+    delivered week is flagged current. See ``docs/archive/meso/athlete-plan.md``.
     """
     return (
         models.Week.objects.filter(
@@ -600,13 +603,14 @@ def latest_delivered_week(plan):
 
 
 def current_week(plan, week=None):
-    """The week the designer opens to.
+    """The week the designer opens to — and, post-P3, the week the athlete is on.
 
     An explicit ``week`` wins (callers are expected to have already checked it
     is live — the delete endpoints pin the response to the just-touched row's
     own, still-live, week); otherwise the flagged current week among the
     plan's **live** weeks, or — failing both — the earliest live week in the
-    plan.
+    plan. The athlete home focuses this week (when it's a delivered week of the
+    block it renders) so "today's session" comes from where the athlete is.
     """
     if week is not None:
         return week

--- a/app/store_project/meso/serializers.py
+++ b/app/store_project/meso/serializers.py
@@ -267,6 +267,10 @@ _PRESCRIPTION_DIFF_FIELDS = (
     ("rpe", "RPE"),
     ("rest", "Rest"),
     ("note", "Note"),
+    # A one-week skip (P2) is athlete-facing: applying/lifting it changes what she
+    # trains that week, so it diffs like any other field (rendered on/off, not the
+    # boolean "— → True" a |default fallback gives).
+    ("skipped", "Skipped"),
     ("tag", "Tag"),
 )
 
@@ -307,23 +311,37 @@ def _diff_exercises(current, previous):
     row reads as *changed* (with per-field before/after), a brand-new row as
     *added*, and a deleted one as *removed*. (A delete-then-re-add of the same
     movement honestly shows as remove + add, since it's a different row.)
+
+    Exception-aware (P2 → P3): the diff is *athlete-facing*, so one-week skips
+    don't manufacture phantom changes. The "add-this-week" action seeds a fresh
+    ``skipped`` placeholder cell in every non-target week; on a re-delivery its
+    new pk would otherwise read as an *added* exercise the athlete never trains.
+    So a row absent from the other snapshot counts as added/removed only when it
+    is actually trained (``skipped`` False), and a row skipped in *both*
+    snapshots suppresses its field edits (trained in neither delivery). A skip
+    *applied* or *lifted* (the flag flips) still surfaces — it changes her week.
     """
     prev_by_id = {e.get("id"): e for e in previous}
     cur_by_id = {e.get("id"): e for e in current}
     added = [
         {"label": _prescription_label(e)}
         for e in current
-        if e.get("id") not in prev_by_id
+        if e.get("id") not in prev_by_id and not e.get("skipped")
     ]
     removed = [
         {"label": _prescription_label(e)}
         for e in previous
-        if e.get("id") not in cur_by_id
+        if e.get("id") not in cur_by_id and not e.get("skipped")
     ]
     changed = []
     for e in current:
         prev_e = prev_by_id.get(e.get("id"))
         if prev_e is None:
+            continue
+        # Skipped in both snapshots → not trained in either delivery, so its
+        # field edits aren't athlete-facing (a flip out of/into skipped is,
+        # since ``skipped`` itself is one of the diffed fields below).
+        if prev_e.get("skipped") and e.get("skipped"):
             continue
         fields = _diff_fields(prev_e, e, _PRESCRIPTION_DIFF_FIELDS)
         if fields:

--- a/app/store_project/meso/tests/test_athlete_surface.py
+++ b/app/store_project/meso/tests/test_athlete_surface.py
@@ -303,6 +303,29 @@ class TestAthleteHome:
         assert "Front Squat" in body  # the swap
         assert "Box Squat" in body  # the underlying slot row still labels the row
 
+    def test_future_only_add_this_week_row_is_not_leaked(self, client):
+        """An exercise added only to an undelivered future week must not surface.
+
+        "Add this week only" seeds skipped placeholder cells in every other live
+        week; when the target is an undelivered future week, the athlete's block
+        table (delivered columns only) would otherwise render that build-ahead
+        exercise's name across em-dash cells. A row with no trainable delivered
+        cell is dropped.
+        """
+        b = seed_block()  # weeks 1 & 2 delivered, week 3 undelivered
+        future = ExerciseSlot.objects.create(
+            session_slot=b.slot, name="Front Squat (future only)", order=1
+        )
+        # Skipped placeholders in the delivered weeks; trainable only in the
+        # undelivered week 3 (the add-this-week-only-a-future-week shape).
+        make_presc(exercise_slot=future, week=b.w1, skipped=True)
+        make_presc(exercise_slot=future, week=b.w2, skipped=True)
+        make_presc(exercise_slot=future, week=b.w3, sets="3", reps="8", load="90")
+        client.force_login(b.athlete)
+        body = client.get(HOME).content.decode()
+        assert "Front Squat (future only)" not in body  # build-ahead not leaked
+        assert "Box Squat" in body  # the real delivered row still shows
+
     def test_block_table_comment_does_not_leak_onto_the_page(self, client):
         """The block table's template-author note stays out of the rendered HTML.
 

--- a/app/store_project/meso/tests/test_athlete_surface.py
+++ b/app/store_project/meso/tests/test_athlete_surface.py
@@ -323,6 +323,59 @@ class TestAthleteHome:
         assert session_url(b.s2) in body  # newest delivered week is the focus
         assert session_url(b.s1) not in body  # the earlier current week is not
 
+    def test_current_pointer_in_an_earlier_block_anchors_that_block(self, client):
+        """A "Make current" back to an earlier delivered block wins over latest.
+
+        ``latest_delivered_week`` points at the newest block, but when the coach
+        moves the (single) ``is_current`` pointer to a week in an earlier
+        delivered block, the individual athlete's home must open to THAT block and
+        week — not the most recent delivery.
+        """
+        coach = UserFactory()
+        athlete = UserFactory()
+        rel = CoachAthleteFactory(
+            coach=coach, athlete=athlete, status=CoachAthlete.Status.ACTIVE
+        )
+        plan = PlanFactory(
+            relationship=rel, title="Two-Block Plan", status=Plan.Status.ACTIVE
+        )
+        earlier = timezone.now() - timedelta(days=7)
+        now = timezone.now()
+        # Block A — delivered earlier, carries the athlete's current week.
+        meso_a = MesocycleFactory(plan=plan, name="Base", order=0)
+        slot_a = SessionSlot.objects.create(
+            mesocycle=meso_a, day_number=1, name="Squat Day", bias="Quad", order=0
+        )
+        ex_a = ExerciseSlot.objects.create(
+            session_slot=slot_a, name="Back Squat", order=0
+        )
+        w_a = WeekFactory(
+            mesocycle=meso_a, index=1, is_current=True, delivered_at=earlier
+        )
+        s_a = day(w_a, session_slot=slot_a)
+        make_presc(
+            exercise_slot=ex_a, week=w_a, sets="5", reps="5", load="100", rpe="8"
+        )
+        # Block B — delivered later, no current week.
+        meso_b = MesocycleFactory(plan=plan, name="Peak", order=1)
+        slot_b = SessionSlot.objects.create(
+            mesocycle=meso_b, day_number=1, name="Bench Day", bias="Push", order=0
+        )
+        ex_b = ExerciseSlot.objects.create(
+            session_slot=slot_b, name="Bench Press", order=0
+        )
+        w_b = WeekFactory(mesocycle=meso_b, index=1, is_current=False, delivered_at=now)
+        s_b = day(w_b, session_slot=slot_b)
+        make_presc(exercise_slot=ex_b, week=w_b, sets="3", reps="5", load="80", rpe="8")
+
+        client.force_login(athlete)
+        body = client.get(HOME).content.decode()
+        assert "Base" in body  # anchored on block A (the current pointer)
+        assert "Back Squat" in body
+        assert session_url(s_a) in body  # its week is the tappable log row
+        assert "Peak" not in body  # the newer block is not shown
+        assert session_url(s_b) not in body
+
     def test_future_only_add_this_week_row_is_not_leaked(self, client):
         """An exercise added only to an undelivered future week must not surface.
 

--- a/app/store_project/meso/tests/test_athlete_surface.py
+++ b/app/store_project/meso/tests/test_athlete_surface.py
@@ -303,6 +303,20 @@ class TestAthleteHome:
         assert "Front Squat" in body  # the swap
         assert "Box Squat" in body  # the underlying slot row still labels the row
 
+    def test_block_table_comment_does_not_leak_onto_the_page(self, client):
+        """The block table's template-author note stays out of the rendered HTML.
+
+        Django's ``{# #}`` comment is single-line only, so a multi-line one would
+        render verbatim onto the athlete's screen; the note must use
+        ``{% comment %}`` (regression guard).
+        """
+        b = seed_block()
+        client.force_login(b.athlete)
+        body = client.get(HOME).content.decode()
+        assert "Read-only multi-week" not in body
+        assert "server-rendered" not in body
+        assert "#}" not in body
+
 
 # -- athlete session detail ------------------------------------------------
 

--- a/app/store_project/meso/tests/test_athlete_surface.py
+++ b/app/store_project/meso/tests/test_athlete_surface.py
@@ -15,6 +15,7 @@ weeks, and never another athlete's data. Delivery — not plan status — is the
 publish gate; an undelivered week is invisible even to its own athlete.
 """
 
+from datetime import timedelta
 from types import SimpleNamespace
 
 import pytest
@@ -302,6 +303,25 @@ class TestAthleteHome:
         body = client.get(HOME).content.decode()
         assert "Front Squat" in body  # the swap
         assert "Box Squat" in body  # the underlying slot row still labels the row
+
+    def test_multiple_current_weeks_focus_the_latest_delivered(self, client):
+        """The home opens to the newest delivered week when several are current.
+
+        A group-materialized plan flags EVERY delivered week ``is_current``, so
+        the home must not focus the earliest of them (regression: focusing
+        ``current_week`` stranded the athlete on week 1 after week 2 was
+        delivered).
+        """
+        b = seed_block()  # w1 & w2 delivered at the same ``now``; w2 is_current
+        # Reproduce the group-sync anomaly: an earlier week is *also* current and
+        # was delivered before w2.
+        b.w1.is_current = True
+        b.w1.delivered_at = timezone.now() - timedelta(days=1)
+        b.w1.save(update_fields=["is_current", "delivered_at"])
+        client.force_login(b.athlete)
+        body = client.get(HOME).content.decode()
+        assert session_url(b.s2) in body  # newest delivered week is the focus
+        assert session_url(b.s1) not in body  # the earlier current week is not
 
     def test_future_only_add_this_week_row_is_not_leaked(self, client):
         """An exercise added only to an undelivered future week must not surface.

--- a/app/store_project/meso/tests/test_athlete_surface.py
+++ b/app/store_project/meso/tests/test_athlete_surface.py
@@ -28,8 +28,10 @@ from store_project.meso.factories import PlanFactory
 from store_project.meso.factories import SessionLogFactory
 from store_project.meso.factories import WeekFactory
 from store_project.meso.models import CoachAthlete
+from store_project.meso.models import ExerciseSlot
 from store_project.meso.models import Plan
 from store_project.meso.models import SessionLog
+from store_project.meso.models import SessionSlot
 from store_project.meso.tests._helpers import day
 from store_project.meso.tests._helpers import presc as make_presc
 from store_project.users.factories import UserFactory
@@ -71,6 +73,86 @@ def seed(
         week=week,
         session=session,
         presc=presc,
+    )
+
+
+def seed_block(
+    *,
+    coach=None,
+    athlete=None,
+    skip_first=False,
+    swap_second="",
+    third_delivered=False,
+):
+    """A three-week block of ONE day × ONE exercise row (P3 athlete multi-week).
+
+    All three weeks share one ``SessionSlot`` (the day) and one ``ExerciseSlot``
+    (the row), with a per-week ``Prescription`` cell carrying a distinct load so
+    each week's column is identifiable. Weeks 1 & 2 are delivered (the whole
+    block delivers at once); week 2 is the athlete's ``is_current`` week; week 3
+    is left undelivered unless ``third_delivered`` (a week the coach is still
+    building — invisible to the athlete).
+    """
+    coach = coach or UserFactory()
+    athlete = athlete or UserFactory()
+    rel = CoachAthleteFactory(
+        coach=coach, athlete=athlete, status=CoachAthlete.Status.ACTIVE
+    )
+    plan = PlanFactory(
+        relationship=rel, title="Hypertrophy Block", status=Plan.Status.ACTIVE
+    )
+    meso = MesocycleFactory(plan=plan, name="Hypertrophy", order=0)
+    now = timezone.now()
+    slot = SessionSlot.objects.create(
+        mesocycle=meso, day_number=1, name="Lower", bias="Quad", order=0
+    )
+    ex = ExerciseSlot.objects.create(session_slot=slot, name="Box Squat", order=0)
+    w1 = WeekFactory(mesocycle=meso, index=1, is_current=False, delivered_at=now)
+    w2 = WeekFactory(mesocycle=meso, index=2, is_current=True, delivered_at=now)
+    w3 = WeekFactory(
+        mesocycle=meso,
+        index=3,
+        is_current=False,
+        delivered_at=now if third_delivered else None,
+    )
+    s1 = day(w1, session_slot=slot)
+    s2 = day(w2, session_slot=slot)
+    s3 = day(w3, session_slot=slot)
+    c1 = make_presc(
+        exercise_slot=ex,
+        week=w1,
+        sets="4",
+        reps="8",
+        load="71",
+        rpe="7",
+        skipped=skip_first,
+    )
+    c2 = make_presc(
+        exercise_slot=ex,
+        week=w2,
+        sets="4",
+        reps="8",
+        load="101",
+        rpe="8",
+        swap_name=swap_second,
+    )
+    c3 = make_presc(exercise_slot=ex, week=w3, sets="4", reps="8", load="131", rpe="8")
+    return SimpleNamespace(
+        coach=coach,
+        athlete=athlete,
+        plan=plan,
+        meso=meso,
+        slot=slot,
+        ex=ex,
+        w1=w1,
+        w2=w2,
+        w3=w3,
+        s1=s1,
+        s2=s2,
+        s3=s3,
+        c1=c1,
+        c2=c2,
+        c3=c3,
     )
 
 
@@ -166,6 +248,60 @@ class TestAthleteHome:
         client.force_login(s.athlete)
         body = client.get(HOME).content.decode()
         assert "To do" in body
+
+    # -- multi-week block (P3) --------------------------------------------
+
+    def test_shows_every_delivered_week_of_the_block(self, client):
+        """The card renders the WHOLE delivered block, not just the latest week.
+
+        The read-only multi-week table has a column per delivered week, each
+        carrying that week's own prescription summary.
+        """
+        b = seed_block()
+        client.force_login(b.athlete)
+        body = client.get(HOME).content.decode()
+        # A column per delivered week (labels + their distinct per-week loads).
+        assert "Wk 1" in body
+        assert "Wk 2" in body
+        assert "71 kg" in body  # week-1 cell summary
+        assert "101 kg" in body  # week-2 cell summary
+
+    def test_undelivered_week_is_not_a_column(self, client):
+        """A week the coach hasn't delivered yet never becomes an athlete column."""
+        b = seed_block()  # week 3 undelivered
+        client.force_login(b.athlete)
+        body = client.get(HOME).content.decode()
+        assert "Wk 3" not in body
+        assert "131 kg" not in body  # its cell is never rendered
+
+    def test_home_focuses_the_current_delivered_week(self, client):
+        """The home opens to ``is_current``: only its sessions are tappable rows.
+
+        Earlier delivered weeks live in the read-only table — their sessions are
+        cells, not links to the logger.
+        """
+        b = seed_block()  # week 2 is_current + delivered
+        client.force_login(b.athlete)
+        body = client.get(HOME).content.decode()
+        assert session_url(b.s2) in body  # current week's session logs
+        assert session_url(b.s1) not in body  # earlier week is read-only
+
+    def test_skipped_cell_renders_em_dash(self, client):
+        """A one-week skip shows an em-dash in its cell, not a prescription."""
+        b = seed_block(skip_first=True)
+        client.force_login(b.athlete)
+        body = client.get(HOME).content.decode()
+        assert "—" in body  # em-dash present
+        assert "71 kg" not in body  # the skipped week shows no numbers
+        assert "101 kg" in body  # the other delivered week still does
+
+    def test_swapped_cell_shows_the_swapped_name(self, client):
+        """A one-week swap surfaces the swapped exercise's name in its cell."""
+        b = seed_block(swap_second="Front Squat")
+        client.force_login(b.athlete)
+        body = client.get(HOME).content.decode()
+        assert "Front Squat" in body  # the swap
+        assert "Box Squat" in body  # the underlying slot row still labels the row
 
 
 # -- athlete session detail ------------------------------------------------

--- a/app/store_project/meso/tests/test_deliver.py
+++ b/app/store_project/meso/tests/test_deliver.py
@@ -99,9 +99,10 @@ class TestDeliver:
         exercises = sessions[0]["exercises"]
         assert any(e["name"] == "Box Squat" and e["load"] == "70" for e in exercises)
 
-    def test_deliver_stamps_flagged_current_week_only(self, client):
+    def test_deliver_stamps_the_whole_block_not_just_current(self, client):
+        # P3 block delivery: sending a plan releases the whole mesocycle, so a
+        # second week in the same block is stamped too — not only the flagged one.
         plan, week1, _, _ = seed_plan()
-        # A second, current week in the same plan; week1 is no longer current.
         week1.is_current = False
         week1.save(update_fields=["is_current"])
         week2 = WeekFactory(mesocycle=week1.mesocycle, index=2, is_current=True)
@@ -113,10 +114,10 @@ class TestDeliver:
         assert resp.status_code == 201
         week1.refresh_from_db()
         week2.refresh_from_db()
-        assert week1.delivered_at is None
+        assert week1.delivered_at is not None
         assert week2.delivered_at is not None
         assert WeekDelivery.objects.filter(week=week2).count() == 1
-        assert WeekDelivery.objects.filter(week=week1).count() == 0
+        assert WeekDelivery.objects.filter(week=week1).count() == 1
 
     def test_redelivering_records_a_fresh_snapshot(self, client):
         plan, week, _, _ = seed_plan()
@@ -127,14 +128,16 @@ class TestDeliver:
 
         assert WeekDelivery.objects.filter(week=week).count() == 2
 
-    def test_response_reports_delivered_week(self, client):
+    def test_response_reports_delivered_block(self, client):
         plan, week, _, _ = seed_plan()
         client.force_login(plan.relationship.coach)
 
         data = client.post(deliver_url(plan)).json()
 
         assert data["ok"] is True
-        assert data["week"]["id"] == week.pk
+        assert data["mesocycle"]["id"] == week.mesocycle.pk
+        assert data["mesocycle"]["name"] == "Hypertrophy"
+        assert data["week_count"] == 1
         assert data["delivered_at"]
 
     def test_empty_json_body_delivers_current_week(self, client):
@@ -210,7 +213,7 @@ class TestDeliverChosenWeek:
     pointer is left untouched, and a foreign week is rejected.
     """
 
-    def test_delivers_the_chosen_non_current_week(self, client):
+    def test_choosing_a_week_delivers_its_whole_block(self, client):
         plan, week1, _, _ = seed_plan()
         week2 = add_week(plan, index=2, is_current=False)
         client.force_login(plan.relationship.coach)
@@ -218,14 +221,16 @@ class TestDeliverChosenWeek:
         resp = post_week(client, plan, week2.pk)
 
         assert resp.status_code == 201
-        assert resp.json()["week"]["id"] == week2.pk
+        assert resp.json()["mesocycle"]["id"] == week2.mesocycle.pk
+        assert resp.json()["week_count"] == 2
         week1.refresh_from_db()
         week2.refresh_from_db()
-        # Only the chosen week is delivered + snapshotted; the live week is not.
+        # Choosing any week delivers its whole mesocycle — both weeks are stamped
+        # + snapshotted, not just the one named in the body.
         assert week2.delivered_at is not None
-        assert week1.delivered_at is None
+        assert week1.delivered_at is not None
         assert WeekDelivery.objects.filter(week=week2).count() == 1
-        assert WeekDelivery.objects.filter(week=week1).count() == 0
+        assert WeekDelivery.objects.filter(week=week1).count() == 1
 
     def test_delivering_a_week_does_not_change_the_current_pointer(self, client):
         plan, week1, _, _ = seed_plan()
@@ -240,17 +245,18 @@ class TestDeliverChosenWeek:
         assert week1.is_current is True
         assert week2.is_current is False
 
-    def test_chosen_week_becomes_the_athletes_visible_week(self, client):
+    def test_delivering_a_block_makes_its_weeks_visible(self, client):
         from store_project.meso.serializers import latest_delivered_week
 
-        plan, _, _, _ = seed_plan()
+        plan, week1, _, _ = seed_plan()
         week2 = add_week(plan, index=2, is_current=False)
         client.force_login(plan.relationship.coach)
 
         post_week(client, plan, week2.pk)
 
-        # Newest delivery wins → the athlete lands on the week just sent.
-        assert latest_delivered_week(plan).pk == week2.pk
+        # The whole block is delivered at once, so a delivered block week is now
+        # visible to the athlete (both share one delivery timestamp).
+        assert latest_delivered_week(plan).pk in {week1.pk, week2.pk}
 
     def test_foreign_week_id_is_404_and_delivers_nothing(self, client):
         plan, _, _, _ = seed_plan()
@@ -327,6 +333,92 @@ class TestDeliverChosenWeek:
         assert resp.status_code == 402
         week2.refresh_from_db()
         assert week2.delivered_at is None
+
+
+class TestBlockDeliver:
+    """P3: the individual deliver path releases the whole block (one mesocycle).
+
+    Delivering stamps ``delivered_at`` + writes a ``WeekDelivery`` snapshot for
+    every *live* week of the target week's mesocycle at once — the athlete gets
+    the whole block in a single release, not one week at a time.
+    """
+
+    def test_delivers_every_live_week_in_the_block(self, client):
+        plan, week1, _, _ = seed_plan()
+        week2 = add_week(plan, index=2)
+        week3 = add_week(plan, index=3)
+        client.force_login(plan.relationship.coach)
+
+        resp = client.post(deliver_url(plan))
+
+        assert resp.status_code == 201
+        assert resp.json()["week_count"] == 3
+        for w in (week1, week2, week3):
+            w.refresh_from_db()
+            assert w.delivered_at is not None
+        # One shared timestamp across the whole block.
+        assert week1.delivered_at == week2.delivered_at == week3.delivered_at
+
+    def test_one_delivery_row_per_live_week(self, client):
+        plan, week1, _, _ = seed_plan()
+        week2 = add_week(plan, index=2)
+        client.force_login(plan.relationship.coach)
+
+        client.post(deliver_url(plan))
+
+        assert WeekDelivery.objects.filter(week=week1).count() == 1
+        assert WeekDelivery.objects.filter(week=week2).count() == 1
+        assert WeekDelivery.objects.count() == 2
+
+    def test_redeliver_restamps_and_adds_fresh_rows(self, client):
+        plan, week1, _, _ = seed_plan()
+        week2 = add_week(plan, index=2)
+        client.force_login(plan.relationship.coach)
+
+        client.post(deliver_url(plan))
+        week1.refresh_from_db()
+        first_stamp = week1.delivered_at
+
+        client.post(deliver_url(plan))
+        week1.refresh_from_db()
+
+        # Re-delivering re-stamps every week and writes a fresh snapshot each.
+        assert week1.delivered_at > first_stamp
+        assert WeekDelivery.objects.filter(week=week1).count() == 2
+        assert WeekDelivery.objects.filter(week=week2).count() == 2
+
+    def test_soft_deleted_week_is_not_delivered(self, client):
+        plan, week1, _, _ = seed_plan()
+        dead = add_week(plan, index=2)
+        dead.soft_delete()
+        client.force_login(plan.relationship.coach)
+
+        resp = client.post(deliver_url(plan))
+
+        assert resp.status_code == 201
+        assert resp.json()["week_count"] == 1  # only the live week counts
+        dead.refresh_from_db()
+        assert dead.delivered_at is None
+        assert WeekDelivery.objects.filter(week=dead).count() == 0
+
+    def test_a_week_of_a_different_block_is_not_delivered(self, client):
+        # A block == ONE mesocycle. Delivering the current week's block leaves a
+        # sibling mesocycle of the same plan untouched.
+        plan, week1, _, _ = seed_plan()
+        other_meso = MesocycleFactory(plan=plan, name="Strength", order=1)
+        other_week = WeekFactory(mesocycle=other_meso, index=1, is_current=False)
+        day(other_week, day_number=1, name="Push")
+        client.force_login(plan.relationship.coach)
+
+        resp = client.post(deliver_url(plan))
+
+        assert resp.status_code == 201
+        assert resp.json()["mesocycle"]["id"] == week1.mesocycle.pk
+        week1.refresh_from_db()
+        other_week.refresh_from_db()
+        assert week1.delivered_at is not None
+        assert other_week.delivered_at is None
+        assert WeekDelivery.objects.filter(week=other_week).count() == 0
 
 
 class TestDeliverScreen:

--- a/app/store_project/meso/tests/test_deliver.py
+++ b/app/store_project/meso/tests/test_deliver.py
@@ -460,48 +460,41 @@ class TestDeliverScreen:
 
         ctx = self._screen(client, plan).context["deliver"]
 
+        # The target week (which *selects the block*) defaults to the live week;
+        # ``is_current`` is now a per-week fact, not a block-level warning.
         assert ctx["week_id"] == week1.pk
-        assert ctx["is_current"] is True
+        live_chip = next(w for w in ctx["weeks"] if w["id"] == week1.pk)
+        assert live_chip["is_current"] is True
 
-    def test_screen_targets_the_week_query_param(self, client):
-        plan, _, _, _ = seed_plan()
-        week2 = add_week(plan, index=2, is_current=False)
+    def test_screen_targets_the_week_query_param_selects_the_block(self, client):
+        # ?week= picks which BLOCK to deliver (via one of its weeks); the whole
+        # block's live weeks are then listed.
+        plan, week1, _, _ = seed_plan()
+        meso2 = MesocycleFactory(plan=plan, name="Strength", order=1)
+        week2 = WeekFactory(mesocycle=meso2, index=1, is_current=False)
+        day(week2, day_number=1, name="Push")
         client.force_login(plan.relationship.coach)
 
         resp = self._screen(client, plan, week=week2.pk)
 
         ctx = resp.context["deliver"]
         assert ctx["week_id"] == week2.pk
-        # Targeting a non-current week flags it so the screen can warn the coach.
-        assert ctx["is_current"] is False
-        assert "Wk 2" in resp.content.decode()
+        assert ctx["block_name"] == "Strength"
+        # Only the selected block's weeks — week1 lives in the other block.
+        ids = {w["id"] for w in ctx["weeks"]}
+        assert ids == {week2.pk}
 
-    def test_screen_lists_every_week_for_the_selector(self, client):
+    def test_screen_lists_every_live_week_in_the_block(self, client):
         plan, week1, _, _ = seed_plan()
         week2 = add_week(plan, index=2, is_current=False)
         client.force_login(plan.relationship.coach)
 
         resp = self._screen(client, plan)
 
-        weeks = resp.context["deliver"]["weeks"]
-        ids = {w["id"] for w in weeks}
+        deliver = resp.context["deliver"]
+        ids = {w["id"] for w in deliver["weeks"]}
         assert ids == {week1.pk, week2.pk}
-        body = resp.content.decode()
-        # Each week is a link that re-targets the screen at that week.
-        assert f"?week={week1.pk}" in body
-        assert f"?week={week2.pk}" in body
-
-    def test_screen_warns_when_target_is_not_the_live_week(self, client):
-        plan, _, _, _ = seed_plan()
-        week2 = add_week(plan, index=2, is_current=False)
-        client.force_login(plan.relationship.coach)
-
-        on_current = self._screen(client, plan).content.decode()
-        on_other = self._screen(client, plan, week=week2.pk).content.decode()
-
-        # The "not the live week" notice shows only when sending a non-live week.
-        assert "live week" not in on_current.lower()
-        assert "live week" in on_other.lower()
+        assert deliver["week_count"] == 2
 
     def test_screen_foreign_week_param_falls_back_to_current(self, client):
         plan, week1, _, _ = seed_plan()
@@ -524,8 +517,8 @@ class TestDeliverScreen:
 
     def test_screen_no_flagged_week_treats_the_fallback_as_live(self, client):
         # When no week is flagged ``is_current``, ``current_week`` falls back to the
-        # earliest week as the live target. The screen must agree: default target ==
-        # that fallback, marked live, with no contradictory "not the live week" notice.
+        # earliest week as the live target. The screen must agree: the default
+        # target == that fallback, and it's the week marked live in the per-week list.
         plan, week1, _, _ = seed_plan()
         week1.is_current = False
         week1.save(update_fields=["is_current"])
@@ -536,8 +529,6 @@ class TestDeliverScreen:
 
         ctx = resp.context["deliver"]
         assert ctx["week_id"] == week1.pk
-        assert ctx["is_current"] is True
-        assert "live week" not in resp.content.decode().lower()
-        # The fallback week is the one marked live in the selector.
+        # The fallback week is the one marked live in the per-week list.
         live_chip = next(w for w in ctx["weeks"] if w["id"] == week1.pk)
         assert live_chip["is_current"] is True

--- a/app/store_project/meso/tests/test_delivery_diff.py
+++ b/app/store_project/meso/tests/test_delivery_diff.py
@@ -10,10 +10,14 @@ Three seams, mirroring the slice discipline:
 
 - ``diff_week_snapshots`` — the pure diff over two snapshot payloads (matched by
   stable pks): added / removed / changed exercise rows grouped by session, whole
-  sessions added/removed, and week-meta changes;
-- ``presenters.deliver_screen`` — surfaces ``deliver["changes"]`` (``None`` on a
-  first delivery; the diff on a re-delivery);
-- ``DeliverView`` — the screen renders the diff on a re-delivery.
+  sessions added/removed, and week-meta changes. Exception-aware (P2 → P3): a
+  one-week ``skipped`` flip surfaces, but skipped placeholder rows (the
+  "add-this-week" seed) never manufacture phantom added/removed/changed noise;
+- ``presenters.deliver_screen`` — block delivery, so every live week of the
+  target block carries its OWN ``changes`` (``None`` on a first delivery; the
+  diff on a re-delivery), folded up into block-level ``is_redelivery`` /
+  ``has_changes``;
+- ``DeliverView`` — the screen renders each week's diff on a re-delivery.
 """
 
 import pytest
@@ -32,6 +36,7 @@ from store_project.meso.serializers import serialize_week_snapshot
 from store_project.users.factories import UserFactory
 
 from ._helpers import day
+from ._helpers import make_slot
 from ._helpers import presc as presc_
 
 pytestmark = pytest.mark.django_db
@@ -52,6 +57,7 @@ def _presc(pk, name, **over):
         "load_type": "abs",
         "rpe": "7",
         "note": "",
+        "skipped": False,
     }
     row.update(over)
     return row
@@ -180,6 +186,79 @@ class TestDiffWeekSnapshots:
         assert field["before"] is False
         assert field["after"] is True
 
+    # -- one-week skip / add-this-week exceptions (P2 → P3 carry-over) -------- #
+
+    def test_skip_applied_is_a_skipped_field_change(self):
+        # Applying a one-week skip after delivery changes what she trains, so it
+        # surfaces as a ``skipped`` field flip (off → on).
+        prev = _snap([_session(1, 1, "Lower", [_presc(10, "Squat", skipped=False)])])
+        cur = _snap([_session(1, 1, "Lower", [_presc(10, "Squat", skipped=True)])])
+        diff = diff_week_snapshots(cur, prev)
+        assert diff["has_changes"] is True
+        (sess,) = diff["sessions"]
+        (changed,) = sess["changed"]
+        fields = {f["field"]: (f["before"], f["after"]) for f in changed["fields"]}
+        assert fields["skipped"] == (False, True)
+
+    def test_skip_lifted_is_a_skipped_field_change(self):
+        prev = _snap([_session(1, 1, "Lower", [_presc(10, "Squat", skipped=True)])])
+        cur = _snap([_session(1, 1, "Lower", [_presc(10, "Squat", skipped=False)])])
+        diff = diff_week_snapshots(cur, prev)
+        (sess,) = diff["sessions"]
+        (changed,) = sess["changed"]
+        fields = {f["field"]: (f["before"], f["after"]) for f in changed["fields"]}
+        assert fields["skipped"] == (True, False)
+
+    def test_added_skipped_placeholder_is_not_reported_as_added(self):
+        # The "add-this-week" action seeds a skipped placeholder cell (a fresh pk)
+        # in every non-target week. The athlete has no new work there, so a skipped
+        # row absent from the prior snapshot must NOT show as +added.
+        prev = _snap([_session(1, 1, "Lower", [_presc(10, "Squat")])])
+        cur = _snap(
+            [
+                _session(
+                    1,
+                    1,
+                    "Lower",
+                    [_presc(10, "Squat"), _presc(11, "RDL", skipped=True)],
+                )
+            ]
+        )
+        diff = diff_week_snapshots(cur, prev)
+        assert diff["sessions"] == []
+        assert diff["has_changes"] is False
+
+    def test_removed_skipped_placeholder_is_not_reported_as_removed(self):
+        # A skipped placeholder the athlete never trained, now gone, is not a
+        # −removed change from her perspective.
+        prev = _snap(
+            [
+                _session(
+                    1,
+                    1,
+                    "Lower",
+                    [_presc(10, "Squat"), _presc(11, "RDL", skipped=True)],
+                )
+            ]
+        )
+        cur = _snap([_session(1, 1, "Lower", [_presc(10, "Squat")])])
+        diff = diff_week_snapshots(cur, prev)
+        assert diff["sessions"] == []
+        assert diff["has_changes"] is False
+
+    def test_doubly_skipped_row_with_numeric_edit_reports_no_change(self):
+        # Skipped in BOTH snapshots → trained in neither delivery, so a numeric
+        # edit to it is not an athlete-facing change.
+        prev = _snap(
+            [_session(1, 1, "Lower", [_presc(10, "Squat", skipped=True, load="100")])]
+        )
+        cur = _snap(
+            [_session(1, 1, "Lower", [_presc(10, "Squat", skipped=True, load="150")])]
+        )
+        diff = diff_week_snapshots(cur, prev)
+        assert diff["sessions"] == []
+        assert diff["has_changes"] is False
+
 
 # --------------------------------------------------------------------------- #
 # Presenter + view (DB-backed)                                                 #
@@ -216,7 +295,18 @@ class TestDeliverScreenChanges:
         plan, _, _, _ = seed_plan()
         deliver = presenters.deliver_screen(plan)["deliver"]
         assert deliver["is_redelivery"] is False
-        assert deliver["changes"] is None
+        assert deliver["has_changes"] is False
+        # Every per-week entry carries its own (absent) diff on a first delivery.
+        assert all(w["changes"] is None for w in deliver["weeks"])
+        assert all(w["is_redelivery"] is False for w in deliver["weeks"])
+
+    def test_screen_reports_block_shape(self):
+        plan, week1, _, _ = seed_plan()
+        WeekFactory(mesocycle=plan.mesocycles.first(), index=2, is_current=False)
+        deliver = presenters.deliver_screen(plan)["deliver"]
+        assert deliver["week_count"] == 2
+        assert deliver["block_name"] == "Hypertrophy"
+        assert deliver["week_id"] == week1.pk
 
     def test_redelivery_after_edit_surfaces_the_change(self):
         plan, week, _, presc = seed_plan(load="111")
@@ -227,7 +317,10 @@ class TestDeliverScreenChanges:
         deliver = presenters.deliver_screen(plan)["deliver"]
 
         assert deliver["is_redelivery"] is True
-        changes = deliver["changes"]
+        assert deliver["has_changes"] is True
+        (wk,) = [w for w in deliver["weeks"] if w["id"] == week.pk]
+        assert wk["is_redelivery"] is True
+        changes = wk["changes"]
         assert changes is not None
         assert changes["has_changes"] is True
         (sess,) = changes["sessions"]
@@ -236,6 +329,24 @@ class TestDeliverScreenChanges:
         fields = {f["field"]: (f["before"], f["after"]) for f in changed["fields"]}
         assert fields["load"] == ("111", "222")
 
+    def test_redelivery_after_skip_surfaces_the_change(self):
+        # A one-week skip applied after delivery is athlete-facing (trained
+        # before, not now) → it surfaces on re-delivery as a ``skipped`` flip.
+        plan, week, _, presc = seed_plan()
+        record_delivery(week)
+        presc.skipped = True
+        presc.save(update_fields=["skipped"])
+
+        deliver = presenters.deliver_screen(plan)["deliver"]
+
+        assert deliver["is_redelivery"] is True
+        assert deliver["has_changes"] is True
+        (wk,) = deliver["weeks"]
+        (sess,) = wk["changes"]["sessions"]
+        (changed,) = sess["changed"]
+        fields = {f["field"]: (f["before"], f["after"]) for f in changed["fields"]}
+        assert fields["skipped"] == (False, True)
+
     def test_redelivery_with_no_edits_reports_no_changes(self):
         plan, week, _, _ = seed_plan()
         record_delivery(week)
@@ -243,12 +354,14 @@ class TestDeliverScreenChanges:
         deliver = presenters.deliver_screen(plan)["deliver"]
 
         assert deliver["is_redelivery"] is True
-        assert deliver["changes"] is not None
-        assert deliver["changes"]["has_changes"] is False
+        assert deliver["has_changes"] is False
+        (wk,) = deliver["weeks"]
+        assert wk["changes"] is not None
+        assert wk["changes"]["has_changes"] is False
 
-    def test_diff_targets_the_chosen_week(self):
-        # A coach can deliver a built-ahead week; the diff must compare *that*
-        # week's snapshot, not the live week's.
+    def test_each_week_carries_its_own_diff(self):
+        # Block delivery: every live week diffs against ITS OWN last-delivered
+        # snapshot — an edit on the built-ahead week surfaces on that week only.
         plan, week1, _, _ = seed_plan()
         meso = plan.mesocycles.first()
         week2 = WeekFactory(mesocycle=meso, index=2, is_current=False)
@@ -260,10 +373,44 @@ class TestDeliverScreenChanges:
 
         deliver = presenters.deliver_screen(plan, week=week2)["deliver"]
 
+        # ?week= only *selects the block* — both weeks are listed.
         assert deliver["week_id"] == week2.pk
-        (sess,) = deliver["changes"]["sessions"]
+        ids = {w["id"] for w in deliver["weeks"]}
+        assert ids == {week1.pk, week2.pk}
+        (wk2,) = [w for w in deliver["weeks"] if w["id"] == week2.pk]
+        (sess,) = wk2["changes"]["sessions"]
         (changed,) = sess["changed"]
         assert changed["name"] == "Bench"
+        # week1 was never delivered → no diff of its own.
+        (wk1,) = [w for w in deliver["weeks"] if w["id"] == week1.pk]
+        assert wk1["changes"] is None
+
+    def test_add_this_week_placeholder_is_not_a_phantom_add_on_other_weeks(self):
+        # "add-this-week" creates a new ExerciseSlot + a real cell on the target
+        # week and a ``skipped`` placeholder cell on every OTHER live week. On a
+        # re-delivery, the placeholder must not surface as a phantom +add on a
+        # non-target week the athlete has no new work in.
+        plan, week1, session1, _ = seed_plan()
+        meso = plan.mesocycles.first()
+        week2 = WeekFactory(mesocycle=meso, index=2, is_current=False)
+        day(week2, session_slot=session1.session_slot)
+        record_delivery(week1)
+        record_delivery(week2)
+
+        new_slot = make_slot(session1, name="Face Pull")
+        presc_(exercise_slot=new_slot, week=week1, skipped=False)
+        presc_(exercise_slot=new_slot, week=week2, skipped=True)
+
+        deliver = presenters.deliver_screen(plan)["deliver"]
+
+        (wk1,) = [w for w in deliver["weeks"] if w["id"] == week1.pk]
+        (wk2,) = [w for w in deliver["weeks"] if w["id"] == week2.pk]
+        # The target week legitimately gains Face Pull...
+        assert wk1["changes"]["has_changes"] is True
+        added = [a["label"] for s in wk1["changes"]["sessions"] for a in s["added"]]
+        assert any("Face Pull" in lbl for lbl in added)
+        # ...but the other week's skipped placeholder is invisible to her.
+        assert wk2["changes"]["has_changes"] is False
 
 
 class TestDeliverScreenRendersDiff:
@@ -290,6 +437,43 @@ class TestDeliverScreenRendersDiff:
         assert "111" in body
         assert "222" in body
 
+    def test_redelivery_screen_renders_per_week_change_headers(self, client):
+        # Two delivered weeks, each edited → each gets its own "Wk N" section.
+        plan, week1, _, presc1 = seed_plan(load="111")
+        meso = plan.mesocycles.first()
+        week2 = WeekFactory(mesocycle=meso, index=2, is_current=False)
+        session2 = day(week2, day_number=2, name="Upper")
+        presc2 = presc_(session2, name="Bench", sets="3", reps="5", load="80")
+        record_delivery(week1)
+        record_delivery(week2)
+        presc1.load = "222"
+        presc1.save(update_fields=["load"])
+        presc2.load = "90"
+        presc2.save(update_fields=["load"])
+        client.force_login(plan.relationship.coach)
+
+        body = self._screen(client, plan).content.decode()
+
+        assert "Wk 1" in body
+        assert "Wk 2" in body
+        assert "Box Squat" in body
+        assert "Bench" in body
+
+    def test_redelivery_screen_renders_a_skip_as_off_to_on(self, client):
+        # A ``skipped`` flip renders through the on/off (yesno) branch, never the
+        # boolean "— → True" the |default fallback would give.
+        plan, week, _, presc = seed_plan()
+        record_delivery(week)
+        presc.skipped = True
+        presc.save(update_fields=["skipped"])
+        client.force_login(plan.relationship.coach)
+
+        body = self._screen(client, plan).content.decode()
+
+        assert "Skipped" in body
+        assert ">on</span>" in body
+        assert ">True</span>" not in body
+
     def test_redelivery_screen_with_no_edits_says_no_changes(self, client):
         plan, week, _, _ = seed_plan()
         record_delivery(week)
@@ -297,6 +481,30 @@ class TestDeliverScreenRendersDiff:
 
         body = self._screen(client, plan).content.decode()
 
+        assert "No changes" in body
+
+    def test_add_this_week_placeholder_shows_no_phantom_add_on_other_weeks(
+        self, client
+    ):
+        # The skipped placeholder on a non-target week must not render a phantom
+        # + add. The target week (Face Pull added) does; the other week reads
+        # "No changes".
+        plan, week1, session1, _ = seed_plan()
+        meso = plan.mesocycles.first()
+        week2 = WeekFactory(mesocycle=meso, index=2, is_current=False)
+        day(week2, session_slot=session1.session_slot)
+        record_delivery(week1)
+        record_delivery(week2)
+        new_slot = make_slot(session1, name="Face Pull")
+        presc_(exercise_slot=new_slot, week=week1, skipped=False)
+        presc_(exercise_slot=new_slot, week=week2, skipped=True)
+        client.force_login(plan.relationship.coach)
+
+        body = self._screen(client, plan).content.decode()
+
+        # Face Pull surfaces exactly once (the target week's real add), and the
+        # non-target week reads as unchanged rather than a phantom add.
+        assert body.count("Face Pull") == 1
         assert "No changes" in body
 
     def test_redelivery_screen_renders_a_zero_week_value(self, client):

--- a/app/store_project/meso/tests/test_delivery_notifications.py
+++ b/app/store_project/meso/tests/test_delivery_notifications.py
@@ -81,12 +81,15 @@ class TestDeliveryNotification:
         assert len(mailoutbox) == 1
         assert mailoutbox[0].to == ["maya@example.com"]
 
-    def test_email_names_coach_plan_and_week(
+    def test_email_names_coach_plan_and_block(
         self, client, mailoutbox, django_capture_on_commit_callbacks
     ):
         coach = UserFactory(name="Coach Lance", email="coach@example.com")
         athlete = UserFactory(name="Maya Okonkwo", email="maya@example.com")
-        plan, _ = seed_plan(coach=coach, athlete=athlete)
+        plan, week = seed_plan(coach=coach, athlete=athlete)
+        # A three-week block; the block email names the count, not each week.
+        WeekFactory(mesocycle=week.mesocycle, index=2)
+        WeekFactory(mesocycle=week.mesocycle, index=3)
         client.force_login(coach)
 
         with django_capture_on_commit_callbacks(execute=True):
@@ -96,7 +99,26 @@ class TestDeliveryNotification:
         haystack = f"{email.subject}\n{email.body}"
         assert "Coach Lance" in haystack
         assert "Hypertrophy Block" in haystack
-        assert "Week 1" in haystack
+        assert "block" in haystack.lower()
+        assert "3 weeks" in haystack
+
+    def test_multi_week_block_emails_the_athlete_once(
+        self, client, mailoutbox, django_capture_on_commit_callbacks
+    ):
+        coach = UserFactory(name="Coach Lance", email="coach@example.com")
+        athlete = UserFactory(name="Maya Okonkwo", email="maya@example.com")
+        plan, week = seed_plan(coach=coach, athlete=athlete)
+        # Three live weeks in the block → still exactly one email, not one/week.
+        WeekFactory(mesocycle=week.mesocycle, index=2)
+        WeekFactory(mesocycle=week.mesocycle, index=3)
+        client.force_login(coach)
+
+        with django_capture_on_commit_callbacks(execute=True):
+            resp = client.post(deliver_url(plan))
+
+        assert resp.status_code == 201
+        assert len(mailoutbox) == 1
+        assert mailoutbox[0].to == ["maya@example.com"]
 
     def test_email_links_to_athlete_home(
         self, client, mailoutbox, django_capture_on_commit_callbacks
@@ -137,7 +159,7 @@ class TestDeliveryNotification:
 
         with (
             mock.patch(
-                "store_project.meso.views.send_week_delivered_email",
+                "store_project.meso.views.send_block_delivered_email",
                 side_effect=RuntimeError("SES is down"),
             ),
             django_capture_on_commit_callbacks(execute=True),

--- a/app/store_project/meso/tests/test_designer_delete.py
+++ b/app/store_project/meso/tests/test_designer_delete.py
@@ -759,4 +759,5 @@ class TestDeliverScreenSoftDelete:
         extra_session.deleted_at = timezone.now()
         extra_session.save(update_fields=["deleted_at"])
         deliver = presenters.deliver_screen(plan)["deliver"]
-        assert deliver["sessions"] == 1
+        (wk,) = deliver["weeks"]
+        assert wk["session_count"] == 1

--- a/app/store_project/meso/tests/test_push.py
+++ b/app/store_project/meso/tests/test_push.py
@@ -329,6 +329,71 @@ class TestNotifyWeekDelivered:
         assert endpoints == {"https://push/athlete"}
 
 
+class TestNotifyBlockDelivered:
+    """P3 block push: one nudge for the whole delivered mesocycle."""
+
+    def _call(self, athlete, plan, mesocycle, week_count):
+        return meso_push.notify_block_delivered(
+            athlete=athlete,
+            coach=plan.coach,
+            plan=plan,
+            mesocycle=mesocycle,
+            week_count=week_count,
+            home_url="http://testserver/meso/me/",
+        )
+
+    def test_pushes_block_payload_shape(self):
+        plan, week = seed_plan()
+        athlete = plan.athlete
+        mesocycle = week.mesocycle
+        make_sub(athlete, endpoint="https://push/1")
+        with mock.patch(PUSH_PATH) as webpush:
+            sent = self._call(athlete, plan, mesocycle, 3)
+        assert sent == 1
+        payload = json.loads(webpush.call_args.kwargs["data"])
+        assert payload["title"] == "Your new training block is ready"
+        assert plan.coach.display_name() in payload["body"]
+        assert plan.title in payload["body"]
+        assert "3 weeks" in payload["body"]
+        assert payload["url"] == "http://testserver/meso/me/"
+        assert payload["tag"] == f"meso-block-{mesocycle.pk}"
+
+    def test_singular_week_phrasing(self):
+        plan, week = seed_plan()
+        make_sub(plan.athlete, endpoint="https://push/1")
+        with mock.patch(PUSH_PATH) as webpush:
+            self._call(plan.athlete, plan, week.mesocycle, 1)
+        payload = json.loads(webpush.call_args.kwargs["data"])
+        # Pluralize-correct: "1 week" (not "1 weeks").
+        assert "(1 week)" in payload["body"]
+
+    def test_pushes_to_each_device_once(self):
+        plan, week = seed_plan()
+        athlete = plan.athlete
+        make_sub(athlete, endpoint="https://push/1")
+        make_sub(athlete, endpoint="https://push/2")
+        with mock.patch(PUSH_PATH) as webpush:
+            sent = self._call(athlete, plan, week.mesocycle, 2)
+        assert sent == 2
+        assert webpush.call_count == 2
+
+    def test_no_subscriptions_is_noop(self):
+        plan, week = seed_plan()
+        with mock.patch(PUSH_PATH) as webpush:
+            sent = self._call(plan.athlete, plan, week.mesocycle, 2)
+        assert sent == 0
+        webpush.assert_not_called()
+
+    @override_settings(**DISABLED)
+    def test_disabled_is_noop(self):
+        plan, week = seed_plan()
+        make_sub(plan.athlete, endpoint="https://push/1")
+        with mock.patch(PUSH_PATH) as webpush:
+            sent = self._call(plan.athlete, plan, week.mesocycle, 2)
+        assert sent == 0
+        webpush.assert_not_called()
+
+
 # -- the deliver hook ------------------------------------------------------
 
 
@@ -352,6 +417,23 @@ class TestDeliverTriggersPush:
             webpush.call_args.kwargs["subscription_info"]["endpoint"]
             == "https://push/athlete"
         )
+
+    def test_multi_week_block_pushes_once_per_device(
+        self, client, django_capture_on_commit_callbacks
+    ):
+        plan, week = seed_plan()
+        WeekFactory(mesocycle=week.mesocycle, index=2)
+        WeekFactory(mesocycle=week.mesocycle, index=3)
+        make_sub(plan.athlete, endpoint="https://push/athlete")
+        client.force_login(plan.coach)
+        with mock.patch(PUSH_PATH) as webpush:
+            with django_capture_on_commit_callbacks(execute=True):
+                resp = client.post(deliver_url(plan))
+        assert resp.status_code == 201
+        # One block delivery → one push per device, not one push per week.
+        assert webpush.call_count == 1
+        payload = json.loads(webpush.call_args.kwargs["data"])
+        assert payload["tag"] == f"meso-block-{week.mesocycle.pk}"
 
     def test_coach_is_not_pushed(self, client, django_capture_on_commit_callbacks):
         plan, _ = seed_plan()

--- a/app/store_project/meso/tests/test_unsubscribe.py
+++ b/app/store_project/meso/tests/test_unsubscribe.py
@@ -212,7 +212,7 @@ class TestDeliveryHonorsOptOut:
 
         with (
             mock.patch(
-                "store_project.meso.views.meso_push.notify_week_delivered"
+                "store_project.meso.views.meso_push.notify_block_delivered"
             ) as push,
             django_capture_on_commit_callbacks(execute=True),
         ):

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -2764,7 +2764,12 @@ def week_set_current(request, plan_id, week_id):
 
     The designer's "Make current": flips the live pointer to the viewed week so
     delivery (which sends ``current_week``) targets it and the designer opens onto
-    it next time. Exactly one week is current — the others in the plan are cleared.
+    it next time. Post-P3 this pointer also means "the week the athlete is on":
+    the athlete home (``presenters.athlete_home``) opens its block card onto the
+    current week (when it's delivered) and takes "today's session" from it — the
+    coach marks which week the athlete is on by setting it current here. (Setting
+    it stays manual; auto-advance is out of scope.) Exactly one week is current —
+    the others in the plan are cleared.
     Scoped + edit-gated (403 foreign, 402 over-limit); a foreign week is a 404.
     Row-locks the plan so concurrent set-currents serialize, and re-reads the
     week's liveness under that lock — a concurrent ``week_delete`` (which

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -39,6 +39,7 @@ from django.views.decorators.http import require_GET
 from django.views.decorators.http import require_POST
 from django.views.generic import TemplateView
 
+from store_project.notifications.emails import send_block_delivered_email
 from store_project.notifications.emails import send_coach_invite_email
 from store_project.notifications.emails import send_coach_request_email
 from store_project.notifications.emails import send_week_delivered_email
@@ -3512,17 +3513,19 @@ def _fan_out_group_delivery(request, plan):
 @login_required
 @require_POST
 def plan_deliver(request, plan_id):
-    """Deliver a week of the plan: stamp ``delivered_at`` + snapshot it (Phase 4).
+    """Deliver a **block** of the plan: stamp + snapshot its whole mesocycle (P3).
 
-    Delivers the plan's **current** (live) week by default, or a specific week
-    when the body carries a ``week_id`` — the multi-week designer's "send the week
-    I'm viewing". A coach can deliver a built-ahead week directly: delivering never
-    changes ``is_current``, so sending a future week doesn't move the live pointer.
-    Visibility is by newest ``delivered_at`` (``latest_delivered_week``), so the
-    athlete lands on the week just sent while the live pointer stays put. The chosen
-    week must belong to the plan (a foreign week is a 404). A group plan ignores
-    ``week_id`` and fans out its current week (per-week delivery is an
-    individual-designer affordance).
+    The individual deliver path releases the whole block (one ``Mesocycle``, all
+    its live weeks) at once, not one week at a time. The target week is resolved
+    exactly as before — the ``week_id`` in the body (the multi-week designer's
+    "send the week I'm viewing"), else the plan's **current** (live) week — but it
+    only *selects which block* to send: every live week of ``target.mesocycle`` is
+    stamped ``delivered_at`` (one shared timestamp) and snapshotted. The chosen
+    week must belong to the plan (a foreign week is a 404). Re-delivering re-stamps
+    every week and writes fresh ``WeekDelivery`` rows. Delivering never changes
+    ``is_current`` — releasing a block doesn't move the live pointer. A group plan
+    still fans out its current week per-member (per-week delivery is a group-path
+    affordance a later phase rewrites), so its branch is unchanged.
     """
     plan, forbidden = _editable_plan_or_response(request, plan_id)
     if forbidden is not None:
@@ -3535,33 +3538,37 @@ def plan_deliver(request, plan_id):
         if error is not None:
             return HttpResponseBadRequest(error)
         return JsonResponse({"ok": True, **summary}, status=201)
-    # An empty body (the bare deliver button) means "no week_id" — deliver the
-    # live week, as before; a present-but-malformed body is a 400, not a silent
-    # delivery of the wrong week.
+    # An empty body (the bare deliver button) means "no week_id" — target the
+    # live week's block, as before; a present-but-malformed body is a 400, not a
+    # silent delivery of the wrong block.
     week_id, bad = _body_week_id(request)
     if bad is not None:
         return bad
     if week_id is not None:
-        week = get_object_or_404(
+        target_week = get_object_or_404(
             Week, pk=week_id, mesocycle__plan=plan, deleted_at__isnull=True
         )
     else:
-        week = current_week(plan)
-    if week is None:
+        target_week = current_week(plan)
+    if target_week is None:
         return HttpResponseBadRequest("This plan has no week to deliver.")
+    block = target_week.mesocycle
     now = timezone.now()
-    week.delivered_at = now
-    week.save(update_fields=["delivered_at"])
-    WeekDelivery.objects.create(
-        week=week, delivered_at=now, payload=serialize_week_snapshot(week)
-    )
+    live_weeks = list(block.weeks.filter(deleted_at__isnull=True))
+    for week in live_weeks:
+        week.delivered_at = now
+        week.save(update_fields=["delivered_at"])
+        WeekDelivery.objects.create(
+            week=week, delivered_at=now, payload=serialize_week_snapshot(week)
+        )
     _touch_plan(plan)
-    _notify_athlete_delivered(request, plan, week)
+    _notify_athlete_block_delivered(request, plan, block, len(live_weeks))
     return JsonResponse(
         {
             "ok": True,
             "delivered_at": now.isoformat(),
-            "week": {"id": week.pk, "label": f"Wk {week.index}"},
+            "mesocycle": {"id": block.pk, "name": block.name},
+            "week_count": len(live_weeks),
         },
         status=201,
     )
@@ -3623,6 +3630,70 @@ def _notify_athlete_delivered(request, plan, week):
                 "Failed to send delivery push for plan %s week %s",
                 plan.pk,
                 week.pk,
+            )
+
+    transaction.on_commit(_send)
+
+
+def _notify_athlete_block_delivered(request, plan, mesocycle, week_count):
+    """Best-effort: ONE email + ONE push that a whole **block** was delivered.
+
+    The block-level peer of ``_notify_athlete_delivered`` (P3): the individual
+    deliver path releases the whole mesocycle at once, so the athlete gets a
+    single "your new block is ready" nudge — not one notification per week. Same
+    contract as the per-week notifier: sandbox-gated at the coach check, deferred
+    to ``transaction.on_commit`` (under ``ATOMIC_REQUESTS`` a rolled-back deliver
+    must not notify a false "your block is ready"), and each channel is
+    independently best-effort — a failure in one is swallowed and logged, never a
+    500 or a rolled-back deliver, and never blocks the other.
+
+    Sandbox gate (S4): a sandbox coach's deliveries never notify — there is no
+    real person behind a seeded demo athlete.
+    """
+    if meso_sandbox.is_sandbox(plan.coach):
+        return
+    home_url = request.build_absolute_uri(reverse("meso:athlete_home"))
+    unsubscribe_url = request.build_absolute_uri(
+        reverse(
+            "meso:unsubscribe_delivery_email",
+            kwargs={"token": make_unsubscribe_token(plan.athlete)},
+        )
+    )
+
+    def _send():
+        try:
+            # The athlete can opt out of delivery emails (the email's
+            # List-Unsubscribe link). Push is a separate, browser-opt-in channel
+            # and is never gated by the email opt-out.
+            if not athlete_opted_out(plan.athlete):
+                send_block_delivered_email(
+                    athlete=plan.athlete,
+                    coach=plan.coach,
+                    plan=plan,
+                    week_count=week_count,
+                    home_url=home_url,
+                    unsubscribe_url=unsubscribe_url,
+                )
+        except Exception:  # mail is best-effort; never fail a delivery on it
+            logger.exception(
+                "Failed to send block delivery email for plan %s mesocycle %s",
+                plan.pk,
+                mesocycle.pk,
+            )
+        try:
+            meso_push.notify_block_delivered(
+                athlete=plan.athlete,
+                coach=plan.coach,
+                plan=plan,
+                mesocycle=mesocycle,
+                week_count=week_count,
+                home_url=home_url,
+            )
+        except Exception:  # push is best-effort too; never fail a delivery on it
+            logger.exception(
+                "Failed to send block delivery push for plan %s mesocycle %s",
+                plan.pk,
+                mesocycle.pk,
             )
 
     transaction.on_commit(_send)

--- a/app/store_project/notifications/emails.py
+++ b/app/store_project/notifications/emails.py
@@ -296,3 +296,63 @@ def send_week_delivered_email(
     message.attach_alternative(msg_html, "text/html")
     message.send(fail_silently=False)
     return True
+
+
+def send_block_delivered_email(
+    *, athlete, coach, plan, week_count, home_url, unsubscribe_url=None
+) -> bool:
+    """Email an athlete that their coach delivered a whole new training block.
+
+    The block-level peer of ``send_week_delivered_email`` (Meso P3): the
+    individual deliver path releases a whole mesocycle at once, so the athlete
+    gets a single email naming the block's week count, not one per week. Same
+    ``List-Unsubscribe`` (RFC 8058 one-click) wiring and best-effort contract as
+    the per-week email — the caller gates the opt-out; this only advertises it.
+
+    Args:
+        athlete: the ``User`` who trains the plan (the recipient).
+        coach: the ``User`` who delivered the block.
+        plan: the delivered ``Plan`` (for its title).
+        week_count: how many live weeks were delivered (drives the "N weeks" copy).
+        home_url: absolute URL of the athlete's training surface (``/meso/me/``).
+        unsubscribe_url: absolute URL of the tokened, login-free unsubscribe
+            page; ``None`` omits the headers and footer.
+
+    Returns:
+        ``True`` if a message was sent, ``False`` if skipped because the athlete
+        has no email address on file.
+
+    Raises a mail backend exception (``fail_silently=False``); callers that must
+    not let a delivery fail on a bounced email should treat this as best-effort.
+    """
+    if not athlete.email:
+        return False
+    context = {
+        "athlete_name": athlete.display_name(),
+        "coach_name": coach.display_name(),
+        "plan_title": plan.title,
+        "week_count": week_count,
+        "home_url": home_url,
+        "unsubscribe_url": unsubscribe_url,
+    }
+    subject = render_to_string(
+        "notifications/block_delivered_subject.txt", context
+    ).strip()
+    msg_plain = render_to_string("notifications/block_delivered.md", context)
+    msg_html = render_to_string("notifications/block_delivered.html", context)
+    headers = {}
+    if unsubscribe_url:
+        # RFC 2369 + RFC 8058: a header List-Unsubscribe (https for one-click)
+        # plus List-Unsubscribe-Post turns it into a one-click mail-client button.
+        headers["List-Unsubscribe"] = f"<{unsubscribe_url}>"
+        headers["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click"
+    message = EmailMultiAlternatives(
+        subject=subject,
+        body=msg_plain,
+        from_email=None,  # defaults to settings.DEFAULT_FROM_EMAIL
+        to=[athlete.email],
+        headers=headers,
+    )
+    message.attach_alternative(msg_html, "text/html")
+    message.send(fail_silently=False)
+    return True

--- a/app/store_project/templates/meso/athlete_home.html
+++ b/app/store_project/templates/meso/athlete_home.html
@@ -127,11 +127,12 @@
       <div class="meso-card meso-card--pad" style="margin-bottom:14px;">
         <div style="display:flex;align-items:baseline;gap:10px;margin-bottom:4px;flex-wrap:wrap;">
           <span style="font-size:17px;font-weight:800;letter-spacing:-0.02em;">{{ plan.title }}</span>
-          {% if plan.block %}<span class="meso-row-meta">{{ plan.block }} · {{ plan.week }}</span>{% endif %}
+          {% if plan.block %}<span class="meso-row-meta">{{ plan.block }} · Week {{ plan.focus_index }}</span>{% endif %}
         </div>
         <p class="meso-row-meta" style="margin-bottom:12px;">Coach {{ plan.coach }}{% if plan.goal %} · {{ plan.goal }}{% endif %}</p>
 
         {% if plan.sessions %}
+          {# The focus (current) week's sessions — the "log today" affordance. #}
           <div class="meso-flex" style="flex-direction:column;gap:8px;">
             {% for s in plan.sessions %}
               <a class="meso-row" href="{{ s.url }}" style="display:flex;align-items:center;gap:12px;padding:12px 14px;border:1px solid var(--line);border-radius:11px;text-decoration:none;color:inherit;">
@@ -148,6 +149,46 @@
               </a>
             {% endfor %}
           </div>
+
+          {% if plan.grid.days %}
+            {# Read-only multi-week block table (P3). One compact table per
+               training day; rows = exercises, columns = delivered weeks. Each
+               table scrolls horizontally inside its own container so a narrow
+               phone screen never scrolls the whole page sideways. Pure
+               server-rendered — no JS. #}
+            <div style="margin-top:14px;">
+              <p class="meso-eyebrow" style="margin-bottom:8px;">Your block</p>
+              {% for day in plan.grid.days %}
+                <div style="margin-bottom:12px;">
+                  <div class="meso-row-meta" style="font-weight:700;margin-bottom:6px;">D{{ day.day_number }} · {{ day.name }}{% if day.bias %} · {{ day.bias }}{% endif %}</div>
+                  <div style="overflow-x:auto;-webkit-overflow-scrolling:touch;border:1px solid var(--line);border-radius:11px;">
+                    <table class="meso-mono" style="border-collapse:collapse;width:100%;font-size:12px;white-space:nowrap;">
+                      <thead>
+                        <tr>
+                          <th style="position:sticky;left:0;z-index:1;text-align:left;padding:7px 10px;font-weight:700;color:var(--dim);background:var(--surface);border-bottom:1px solid var(--line);">Exercise</th>
+                          {% for w in plan.grid.weeks %}
+                            <th style="text-align:left;padding:7px 10px;font-weight:700;border-bottom:1px solid var(--line);{% if w.current %}color:var(--accent-deep);background:var(--soft);{% else %}color:var(--dim);{% endif %}">{{ w.label }}{% if w.deload %} · DL{% endif %}</th>
+                          {% endfor %}
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {% for row in day.rows %}
+                          <tr>
+                            <td style="position:sticky;left:0;z-index:1;padding:7px 10px;font-weight:700;color:var(--ink);background:var(--surface);border-top:1px solid var(--line);">{{ row.name }}</td>
+                            {% for c in row.cells %}
+                              <td style="padding:7px 10px;color:var(--ink);border-top:1px solid var(--line);{% if c.current %}background:var(--soft);{% endif %}">
+                                {% if not c.present %}<span style="color:var(--dim);">·</span>{% elif c.skipped %}<span style="color:var(--dim);">—</span>{% else %}{% if c.swap %}<span style="display:block;color:var(--accent-deep);font-weight:700;">{{ c.swap }}</span>{% endif %}{{ c.summary }}{% endif %}
+                              </td>
+                            {% endfor %}
+                          </tr>
+                        {% endfor %}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              {% endfor %}
+            </div>
+          {% endif %}
         {% else %}
           <p class="meso-row-meta">Nothing delivered yet — your coach is still building this week.</p>
         {% endif %}

--- a/app/store_project/templates/meso/athlete_home.html
+++ b/app/store_project/templates/meso/athlete_home.html
@@ -151,11 +151,15 @@
           </div>
 
           {% if plan.grid.days %}
-            {# Read-only multi-week block table (P3). One compact table per
-               training day; rows = exercises, columns = delivered weeks. Each
-               table scrolls horizontally inside its own container so a narrow
-               phone screen never scrolls the whole page sideways. Pure
-               server-rendered — no JS. #}
+            {% comment %}
+              Read-only multi-week block table (P3). One compact table per
+              training day; rows = exercises, columns = delivered weeks. Each
+              table scrolls horizontally inside its own container so a narrow
+              phone screen never scrolls the whole page sideways. Pure
+              server-rendered — no JS. (A multi-line {# #} comment is NOT
+              stripped by Django — its tokenizer is single-line — so it would
+              leak onto the athlete's screen; use {% comment %} here.)
+            {% endcomment %}
             <div style="margin-top:14px;">
               <p class="meso-eyebrow" style="margin-bottom:8px;">Your block</p>
               {% for day in plan.grid.days %}

--- a/app/store_project/templates/meso/deliver.html
+++ b/app/store_project/templates/meso/deliver.html
@@ -19,8 +19,8 @@
     <div class="meso-pagehead">
       <div>
         <p class="meso-eyebrow">Publish</p>
-        <h1 class="meso-h1">Deliver {{ deliver.what }}</h1>
-        <p class="meso-sub">{{ deliver.sessions }} sessions · to {{ athlete.name }} · once delivered she sees it in her app.</p>
+        <h1 class="meso-h1">Deliver {{ deliver.block_name|default:"block" }}</h1>
+        <p class="meso-sub">{{ deliver.week_count }} week{{ deliver.week_count|pluralize }} · to {{ athlete.name }} · once delivered she sees the whole block in her app.</p>
       </div>
     </div>
 
@@ -38,88 +38,72 @@
         </div>
       </div>
 
-      {% if deliver.weeks|length > 1 %}
-      <!-- Multi-week designer: pick which week to send. Each chip re-targets the
-           screen at that week (?week=) — server-rendered so the summary stays
-           consistent — and the "Deliver" button sends the highlighted one. -->
-        <div class="meso-card meso-card--pad">
-          <p class="meso-eyebrow">Which week</p>
-          <div style="display:flex;gap:7px;flex-wrap:wrap;">
-            {% for w in deliver.weeks %}
-              <a href="?week={{ w.id }}"
-                 title="{% if w.is_current %}Live · the deliver target{% else %}Deliver {{ w.label }}{% endif %}"
-                 style="text-decoration:none;font:inherit;display:inline-flex;align-items:center;gap:5px;font-size:11.5px;font-weight:650;padding:6px 11px;border-radius:999px;border:1px solid {% if w.is_target %}var(--accent){% else %}var(--line){% endif %};background:{% if w.is_target %}var(--accent){% else %}var(--surface){% endif %};color:{% if w.is_target %}var(--accent-ink){% else %}var(--ink){% endif %};">
-                <span>{{ w.label }}</span>
-                {% if w.is_current %}<span style="opacity:0.8;">&#183; live</span>{% endif %}
-                {% if w.is_delivered %}<span title="Already delivered" aria-label="already delivered" style="opacity:0.8;">&#10003;</span>{% endif %}
-              </a>
-            {% endfor %}
-          </div>
-        </div>
-      {% endif %}
-
-      {% if not deliver.is_current %}
-      <!-- The coach chose a week that isn't the live one. Delivering it makes it
-           visible to the athlete (newest delivery wins) without moving the live
-           pointer — make that explicit so it's never a surprise. -->
-        <div class="meso-card meso-card--pad" style="border-color:var(--warn);">
-          <p class="meso-sub" style="margin:0;font-size:12.5px;line-height:1.4;">
-            You&#8217;re sending <strong>{{ deliver.week_label }}</strong> — not {{ athlete.name }}&#8217;s live week ({{ deliver.current_label }}). Delivering this week makes it visible to her without changing which week is current.
-          </p>
-        </div>
-      {% endif %}
-
       <div class="meso-card meso-card--pad">
         <p class="meso-eyebrow">Changes since last delivery</p>
         {% if not deliver.is_redelivery %}
-        <!-- First delivery: nothing to diff against. -->
-          <span style="font-size:12.5px;line-height:1.35;color:var(--dim);">First delivery — {{ athlete.week }} ({{ deliver.sessions }} session{{ deliver.sessions|pluralize }}) is sent to {{ athlete.name }}.</span>
-        {% elif not deliver.changes.has_changes %}
-        <!-- Re-delivering the same week with no edits since it last went out. -->
-          <span style="font-size:12.5px;line-height:1.35;color:var(--dim);">No changes since you last delivered {{ athlete.week }} — re-delivering it as-is.</span>
+        <!-- First delivery of the block: nothing to diff against. -->
+          <span style="font-size:12.5px;line-height:1.35;color:var(--dim);">First delivery — the whole block ({{ deliver.week_count }} week{{ deliver.week_count|pluralize }}) is sent to {{ athlete.name }}.</span>
         {% else %}
-        <!-- The week's live grid diffed against the snapshot last delivered: per
-             session, each edited row's fields (before &#8594; after), rows added
-             (+) or removed (&#8722;), then whole days and week-meta changes. -->
-          <div style="display:flex;flex-direction:column;gap:12px;">
-            {% for s in deliver.changes.sessions %}
+        <!-- Block delivery sends every live week; each week carries its own diff
+             against the snapshot it last went out as. A never-delivered week is
+             new this delivery; a delivered week with no edits since is unchanged;
+             otherwise its live grid is diffed per session (edited rows'
+             before &#8594; after, rows added (+) or removed (&#8722;), whole days,
+             week-meta). -->
+          <div style="display:flex;flex-direction:column;gap:18px;">
+            {% for wk in deliver.weeks %}
               <div>
-                <div style="font-size:10.5px;font-weight:700;letter-spacing:0.05em;text-transform:uppercase;color:var(--dim);margin-bottom:4px;">{{ s.name }}</div>
-                <div style="display:flex;flex-direction:column;gap:3px;">
-                  {% for c in s.changed %}
-                    <div style="font-size:12.5px;line-height:1.45;">
-                      <span style="font-weight:650;">{{ c.name }}</span><span style="color:var(--dim);"> &#183; </span>{% for f in c.fields %}{% if not forloop.first %}<span style="color:var(--dim);">, </span>{% endif %}<span style="color:var(--dim);">{{ f.label }}</span> {% if f.field == 'is_deload' %}{{ f.before|yesno:"on,off" }} &#8594; <span style="font-weight:650;">{{ f.after|yesno:"on,off" }}</span>{% else %}<span style="text-decoration:line-through;opacity:0.6;">{{ f.before|default:"&#8212;" }}</span> &#8594; <span style="font-weight:650;">{{ f.after|default:"&#8212;" }}</span>{% endif %}{% endfor %}
-                    </div>
-                  {% endfor %}
-                  {% for a in s.added %}
-                    <div style="font-size:12.5px;line-height:1.45;color:var(--ok);"><span style="font-weight:700;">+</span> {{ a.label }}</div>
-                  {% endfor %}
-                  {% for r in s.removed %}
-                    <div style="font-size:12.5px;line-height:1.45;color:var(--warn);"><span style="font-weight:700;">&#8722;</span> <span style="text-decoration:line-through;opacity:0.8;">{{ r.label }}</span></div>
-                  {% endfor %}
-                </div>
+                <div style="font-size:11px;font-weight:800;letter-spacing:0.04em;text-transform:uppercase;color:var(--ink);margin-bottom:6px;">{{ wk.label }}</div>
+                {% if not wk.changes %}
+                <!-- Never delivered before — first time this week is sent. -->
+                  <span style="font-size:12.5px;line-height:1.35;color:var(--dim);">New this delivery — first time {{ wk.label }} is sent to {{ athlete.name }}.</span>
+                {% elif not wk.changes.has_changes %}
+                <!-- Re-delivering this week with no edits since it last went out. -->
+                  <span style="font-size:12.5px;line-height:1.35;color:var(--dim);">No changes since you last delivered {{ wk.label }} — re-delivering it as-is.</span>
+                {% else %}
+                  <div style="display:flex;flex-direction:column;gap:12px;">
+                    {% for s in wk.changes.sessions %}
+                      <div>
+                        <div style="font-size:10.5px;font-weight:700;letter-spacing:0.05em;text-transform:uppercase;color:var(--dim);margin-bottom:4px;">{{ s.name }}</div>
+                        <div style="display:flex;flex-direction:column;gap:3px;">
+                          {% for c in s.changed %}
+                            <div style="font-size:12.5px;line-height:1.45;">
+                              <span style="font-weight:650;">{{ c.name }}</span><span style="color:var(--dim);"> &#183; </span>{% for f in c.fields %}{% if not forloop.first %}<span style="color:var(--dim);">, </span>{% endif %}<span style="color:var(--dim);">{{ f.label }}</span> {% if f.field == 'is_deload' or f.field == 'skipped' %}{{ f.before|yesno:"on,off" }} &#8594; <span style="font-weight:650;">{{ f.after|yesno:"on,off" }}</span>{% else %}<span style="text-decoration:line-through;opacity:0.6;">{{ f.before|default:"&#8212;" }}</span> &#8594; <span style="font-weight:650;">{{ f.after|default:"&#8212;" }}</span>{% endif %}{% endfor %}
+                            </div>
+                          {% endfor %}
+                          {% for a in s.added %}
+                            <div style="font-size:12.5px;line-height:1.45;color:var(--ok);"><span style="font-weight:700;">+</span> {{ a.label }}</div>
+                          {% endfor %}
+                          {% for r in s.removed %}
+                            <div style="font-size:12.5px;line-height:1.45;color:var(--warn);"><span style="font-weight:700;">&#8722;</span> <span style="text-decoration:line-through;opacity:0.8;">{{ r.label }}</span></div>
+                          {% endfor %}
+                        </div>
+                      </div>
+                    {% endfor %}
+
+                    {% for a in wk.changes.added_sessions %}
+                      <div style="font-size:12.5px;line-height:1.45;color:var(--ok);"><span style="font-weight:700;">+</span> New day &#183; {{ a.name }} ({{ a.count }} exercise{{ a.count|pluralize }})</div>
+                    {% endfor %}
+                    {% for r in wk.changes.removed_sessions %}
+                      <div style="font-size:12.5px;line-height:1.45;color:var(--warn);"><span style="font-weight:700;">&#8722;</span> Removed day &#183; {{ r.name }}</div>
+                    {% endfor %}
+
+                    {% if wk.changes.week %}
+                      <div>
+                        <div style="font-size:10.5px;font-weight:700;letter-spacing:0.05em;text-transform:uppercase;color:var(--dim);margin-bottom:4px;">Week</div>
+                        <div style="display:flex;flex-direction:column;gap:3px;">
+                          {% for f in wk.changes.week %}
+                            <!-- volume/intensity are ints where 0 is valid — default_if_none
+                                 (not default) so a real 0 isn't shown as the em-dash. -->
+                            <div style="font-size:12.5px;line-height:1.45;"><span style="color:var(--dim);">{{ f.label }}</span> {% if f.field == 'is_deload' or f.field == 'skipped' %}{{ f.before|yesno:"on,off" }} &#8594; <span style="font-weight:650;">{{ f.after|yesno:"on,off" }}</span>{% else %}<span style="text-decoration:line-through;opacity:0.6;">{{ f.before|default_if_none:"&#8212;" }}</span> &#8594; <span style="font-weight:650;">{{ f.after|default_if_none:"&#8212;" }}</span>{% endif %}</div>
+                          {% endfor %}
+                        </div>
+                      </div>
+                    {% endif %}
+                  </div>
+                {% endif %}
               </div>
             {% endfor %}
-
-            {% for a in deliver.changes.added_sessions %}
-              <div style="font-size:12.5px;line-height:1.45;color:var(--ok);"><span style="font-weight:700;">+</span> New day &#183; {{ a.name }} ({{ a.count }} exercise{{ a.count|pluralize }})</div>
-            {% endfor %}
-            {% for r in deliver.changes.removed_sessions %}
-              <div style="font-size:12.5px;line-height:1.45;color:var(--warn);"><span style="font-weight:700;">&#8722;</span> Removed day &#183; {{ r.name }}</div>
-            {% endfor %}
-
-            {% if deliver.changes.week %}
-              <div>
-                <div style="font-size:10.5px;font-weight:700;letter-spacing:0.05em;text-transform:uppercase;color:var(--dim);margin-bottom:4px;">Week</div>
-                <div style="display:flex;flex-direction:column;gap:3px;">
-                  {% for f in deliver.changes.week %}
-                    <!-- volume/intensity are ints where 0 is valid — default_if_none
-                         (not default) so a real 0 isn't shown as the em-dash. -->
-                    <div style="font-size:12.5px;line-height:1.45;"><span style="color:var(--dim);">{{ f.label }}</span> {% if f.field == 'is_deload' %}{{ f.before|yesno:"on,off" }} &#8594; <span style="font-weight:650;">{{ f.after|yesno:"on,off" }}</span>{% else %}<span style="text-decoration:line-through;opacity:0.6;">{{ f.before|default_if_none:"&#8212;" }}</span> &#8594; <span style="font-weight:650;">{{ f.after|default_if_none:"&#8212;" }}</span>{% endif %}</div>
-                  {% endfor %}
-                </div>
-              </div>
-            {% endif %}
           </div>
         {% endif %}
       </div>
@@ -134,7 +118,7 @@
         <div class="meso-spacer"></div>
         <span x-show="error" x-cloak style="font-size:12.5px;color:var(--warn);">Delivery failed — try again.</span>
         <button data-testid="deliver-send" class="meso-btn meso-btn--primary" @click="deliver()" :disabled="sending" style="font-size:13.5px;padding:10px 18px;">
-          <span x-text="sending ? 'Delivering…' : 'Deliver to {{ athlete.name }}'"></span>
+          <span x-text="sending ? 'Delivering…' : 'Deliver block to {{ athlete.name }}'"></span>
         </button>
       </div>
     </div>
@@ -142,8 +126,8 @@
     <!-- post-deliver -->
     <div x-show="delivered" x-cloak class="meso-card meso-card--pad" style="text-align:center;padding:36px 24px;">
       <div style="width:46px;height:46px;border-radius:50%;background:var(--ok);display:flex;align-items:center;justify-content:center;color:#fff;font-size:22px;margin:0 auto 14px;">✓</div>
-      <h2 style="margin:0 0 4px;font-size:19px;font-weight:800;letter-spacing:-0.02em;">Delivered to {{ athlete.name }}</h2>
-      <p class="meso-sub" style="margin-bottom:20px;">{{ deliver.what }} is live — she'll see Day 1 on her phone.</p>
+      <h2 style="margin:0 0 4px;font-size:19px;font-weight:800;letter-spacing:-0.02em;">Block delivered to {{ athlete.name }}</h2>
+      <p class="meso-sub" style="margin-bottom:20px;">She'll see all {{ deliver.week_count }} week{{ deliver.week_count|pluralize }} — Day 1 on her phone.</p>
       <div style="display:flex;gap:10px;justify-content:center;">
         <a class="meso-btn" href="{% url 'meso:roster' %}">Back to roster</a>
         <a class="meso-btn meso-btn--primary" href="{% url 'meso:results' %}">Track her sessions →</a>

--- a/app/store_project/templates/notifications/block_delivered.html
+++ b/app/store_project/templates/notifications/block_delivered.html
@@ -1,0 +1,17 @@
+<p>Hi {{ athlete_name }},</p>
+
+<p>{{ coach_name }} just delivered a new block ({{ week_count }} week{{ week_count|pluralize }}) of
+  <strong>{{ plan_title }}</strong> to your training app.</p>
+
+<p><a href="{{ home_url }}">Open your training</a> to see your sessions and log
+  your work.</p>
+
+<p>Train hard,<br>Mastering Fitness</p>
+
+{% if unsubscribe_url %}
+  <hr>
+  <p style="font-size:12px;color:#888;">
+    You're getting this because {{ coach_name }} coaches you on Mastering Fitness.
+    <a href="{{ unsubscribe_url }}">Unsubscribe from training-delivery emails</a>.
+  </p>
+{% endif %}

--- a/app/store_project/templates/notifications/block_delivered.md
+++ b/app/store_project/templates/notifications/block_delivered.md
@@ -1,0 +1,15 @@
+Hi {{ athlete_name }},
+
+{{ coach_name }} just delivered a new block ({{ week_count }} week{{ week_count|pluralize }}) of "{{ plan_title }}" to your training app.
+
+Open it to see your sessions and log your training:
+
+{{ home_url }}
+
+Train hard,
+Mastering Fitness
+{% if unsubscribe_url %}
+--
+You're getting this because {{ coach_name }} coaches you on Mastering Fitness.
+Unsubscribe from training-delivery emails: {{ unsubscribe_url }}
+{% endif %}

--- a/app/store_project/templates/notifications/block_delivered_subject.txt
+++ b/app/store_project/templates/notifications/block_delivered_subject.txt
@@ -1,0 +1,1 @@
+{{ coach_name }} delivered a new training block


### PR DESCRIPTION
## P3 — Whole-block delivery + athlete multi-week view

Fourth phase of the fixed-selection reshape (epic #440, spec `docs/meso/fixed-selection-plan.md`). Delivery moves from **one week at a time** to **the whole block at once**, the athlete home becomes a **read-only multi-week table**, and the delivery diff finally becomes **exception-aware** (the P2→P3 carry-over). No schema changes / no migrations.

### What changed

**1. Block-level delivery (write path).** `plan_deliver` now delivers the whole block — every live week of the target week's `Mesocycle` — stamping `delivered_at` (one shared timestamp) + one `WeekDelivery` snapshot per week; re-delivering re-stamps. `is_current` is untouched (delivering never moves the live pointer). The **group** path is unchanged (a later phase rewrites it).

**2. Block notification.** One email + one push per block delivery — *"your new block is ready (N weeks)"* — via new `_notify_athlete_block_delivered` / `send_block_delivered_email` / `notify_block_delivered` (+ `block_delivered.*` templates). The per-week variants stay for the group path.

**3. Block deliver screen.** `deliver_screen` + `deliver.html` reframed from single-week to the block: per-week "Wk N" change sections, *"Deliver block (N weeks)"*, block-flavored success copy. (Kept on Alpine deliberately — per the designer-framework plan the deliver screen stays Alpine; only the designer grid became a React island.)

**4. Delivery diff is now exception-aware (P2→P3 carry-over).** `skipped` joins `_PRESCRIPTION_DIFF_FIELDS` and renders **off/on** (not the `default` em-dash); `_diff_exercises` is athlete-facing — an *add-this-week* skipped placeholder no longer reads as a phantom **added** on non-target weeks, a row skipped in both snapshots suppresses its field edits, and a skip flip still surfaces.

**5. Athlete multi-week home + `is_current` re-meaning.** `/meso/me/` now shows the whole delivered block as a **read-only multi-week table** (exercises × delivered weeks, one horizontally-scrolling table per day, focus week highlighted, skipped = em-dash, swaps named) plus the focus week's tappable log rows. Pure server-rendered HTML/CSS — **no JS added**. `is_current` now means *the week the athlete is on*; the home anchors on it (block + focus) when it's a single, delivered current week, falling back to the latest delivered week for group snapshots (which flag every delivered week current) and still-undelivered current weeks.

### Design decisions (all spec-supported)
- **"Block" = one mesocycle** (all its live weeks). Group delivery stays per-week (deferred to P5). `append_week` clean-cell behavior unchanged (documented P0 decision).

### Verification
- **Full suite: 2240 passed** (+4 new regression tests, no regressions). Red/green throughout; each of the three implementation slices was TDD'd.
- **Drove the real app** (seeded demo, port 8034): coach block-deliver screen renders block framing → delivering stamps all 4 weeks + a `WeekDelivery` each (`is_current` preserved) → athlete home renders the 4-column table with the current week highlighted, the seeded skip (em-dash) and swap (Cable Crunch) visible, deload marked. This caught a real bug the unit tests missed — a multi-line `{# #}` comment leaking onto the athlete's screen (Django's `{# #}` is single-line only) — fixed + guarded (`b972f7d`).

### Review
Converged through a **Codex review loop** (`codex review`, local): 4 nits fixed across 3 iterations (build-ahead row leak; deterministic latest-week selection; group-plan focus regression; earlier-block current pointer), 1 declined with rationale (non-atomic block delivery — `ATOMIC_REQUESTS=True` already wraps the request). Final pass: **CLEAN**.

Part of #440 (P0–P2 shipped; P4 agent rescope + P5 group remain).
