### PR TITLE
feat(meso): P4 — agent structural rescope + whole-block grounding (#440)

### DIFF
--- a/app/store_project/meso/agent/apply.py
+++ b/app/store_project/meso/agent/apply.py
@@ -200,6 +200,16 @@ def _apply_swap(change, name):
     slot.name = name
     slot.exercise = None
     slot.save(update_fields=["name", "exercise"])
+    # The block grounding serializes each cell's *effective* name, so the model
+    # can target a cell that already carries a one-week ``swap_*`` exception. That
+    # override shadows the slot's name, so without clearing it the reviewed week
+    # would silently keep the old lift while every other week changed. Clear the
+    # target cell's exception so the swap the coach approved shows through here
+    # too; sibling weeks' own exceptions are left untouched (still block-wide).
+    if presc.swap_name or presc.swap_exercise_id:
+        presc.swap_name = ""
+        presc.swap_exercise = None
+        presc.save(update_fields=["swap_name", "swap_exercise"])
     return {"id": change.pk, "kind": change.kind, "field": "name", "value": name}
 
 

--- a/app/store_project/meso/agent/apply.py
+++ b/app/store_project/meso/agent/apply.py
@@ -3,8 +3,7 @@
 The review screen is the human gate; once a coach approves changes, this module
 performs the structured edit each ``ProposedChange`` describes:
 
-- **swap**     → set the prescription cell's one-week ``swap_name`` to the
-  introduced exercise (this week only; a block-wide rename is a later phase);
+- **swap**     → rename the block-shared ``ExerciseSlot`` (every week follows);
 - **progress** → set the prescription's ``load``;
 - **volume**   → set the prescription's set count (``sets``);
 - **deload**   → flag the target week (``is_deload``);
@@ -185,21 +184,22 @@ def _apply_deload(change):
 
 
 def _apply_swap(change, name):
-    """Write a one-week swap onto the change's prescription cell.
+    """Rename the exercise for the WHOLE block (P4 structural rescope).
 
-    A cell's effective name delegates to its ``ExerciseSlot`` (block-wide
-    identity) unless this week carries its own ``swap_name`` — a swap change is
-    scoped to *this week only* (the same scope the old per-week
-    ``ExercisePrescription.name`` write had), so it sets the cell's ``swap_*``
-    fields rather than the (now read-only) ``name`` property. A block-wide
-    rename of the slot itself is a later phase (P4).
+    Under fixed selection the lineup is shared across every week, so an agent
+    swap changes identity on the block-shared ``ExerciseSlot`` — every week's
+    cell follows (``Prescription.name`` resolves to the slot). A one-week-only
+    substitute stays the coach's manual exception (a cell ``swap_*``), not an
+    agent verb. A free-text rename severs the slot's catalog link so the row
+    isn't mis-keyed to the old exercise.
     """
     presc = change.prescription
     if presc is None or not name:
         return None
-    presc.swap_name = name
-    presc.swap_exercise = None
-    presc.save(update_fields=["swap_name", "swap_exercise"])
+    slot = presc.exercise_slot
+    slot.name = name
+    slot.exercise = None
+    slot.save(update_fields=["name", "exercise"])
     return {"id": change.pk, "kind": change.kind, "field": "name", "value": name}
 
 

--- a/app/store_project/meso/agent/client.py
+++ b/app/store_project/meso/agent/client.py
@@ -78,15 +78,18 @@ def normalize_result(result):
 PROPOSE_TOOL = {
     "name": TOOL_NAME,
     "description": (
-        "Propose a batch of edits to the CURRENT training week. Each change must "
-        "target a real session or exercise by the id given in the plan context (an "
-        "'add' introduces a NEW exercise row into a session, so it targets a "
-        "session_id, not a prescription). For a GROUP's shared program you have an "
-        "extra verb: 'adjust' diverges ONE member from the shared row (a "
-        "per-athlete auto-adjust) — it targets that member by member_id plus the "
-        "shared prescription_id, and the other members are unaffected. Honor every "
-        "active contraindication and the coach's avoid-rules — never introduce a "
-        "movement a contraindication flags."
+        "Propose a batch of edits to the athlete's whole training BLOCK. The plan "
+        "context gives every week's rows and numbers; target a real session or "
+        "exercise by the id given there. A 'swap' changes the exercise for the "
+        "WHOLE block (every week follows), so it targets any week's "
+        "prescription_id. A 'progress', 'volume', or 'deload' acts on the specific "
+        "week's row/day you target by id. An 'add' introduces a NEW exercise row "
+        "into a session, so it targets a session_id, not a prescription. For a "
+        "GROUP's shared program you have an extra verb: 'adjust' diverges ONE "
+        "member from the shared row (a per-athlete auto-adjust) — it targets that "
+        "member by member_id plus the shared prescription_id, and the other "
+        "members are unaffected. Honor every active contraindication and the "
+        "coach's avoid-rules — never introduce a movement a contraindication flags."
     ),
     "input_schema": {
         "type": "object",
@@ -117,15 +120,18 @@ PROPOSE_TOOL = {
                         "session_id": {
                             "type": ["integer", "null"],
                             "description": (
-                                "Target session id from the plan context (required "
-                                "for an 'add', which creates a row in that session)."
+                                "Target session id from the plan context — may be "
+                                "any week's day (required for an 'add', which "
+                                "creates a row in that session)."
                             ),
                         },
                         "prescription_id": {
                             "type": ["integer", "null"],
                             "description": (
-                                "Target exercise row id from the plan context "
-                                "(required for swap/progress)."
+                                "Target exercise-row cell id from the plan context "
+                                "(any week). A swap renames that exercise for the "
+                                "WHOLE block; a progress sets that specific week's "
+                                "load."
                             ),
                         },
                         "day_label": {
@@ -153,7 +159,9 @@ PROPOSE_TOOL = {
                             "type": "string",
                             "description": (
                                 "swap/add: the exercise name to set on the row "
-                                "(defaults to introduces_exercise if omitted)."
+                                "(defaults to introduces_exercise if omitted). A "
+                                "swap renames the exercise for the whole block — "
+                                "every week follows."
                             ),
                         },
                         "new_load": {
@@ -215,16 +223,24 @@ PROPOSE_TOOL = {
 SYSTEM_PROMPT = (
     "You are an expert strength & conditioning programming assistant working "
     "inside a coach's program designer. A coach gives you an instruction and the "
-    "current state of one athlete's training plan. Propose concrete edits to the "
-    "athlete's CURRENT week.\n\n"
+    "current state of one athlete's training plan. The plan context includes the "
+    "athlete's FULL training block — every week's session rows and numbers "
+    "(sets/reps/load/RPE/rest) plus each week's volume/intensity/phase and which "
+    "week is current. Propose concrete edits, programming progression ACROSS the "
+    "weeks of the block.\n\n"
     "Rules:\n"
     "- Emit edits ONLY through the propose_program_changes tool.\n"
-    "- Target real rows by the ids in the plan context. Do not invent ids.\n"
+    "- Target real rows by the ids in the plan context. Do not invent ids. Each "
+    "row/day id belongs to a specific week — a progress, volume, or deload acts "
+    "on the week you target by id, so address each week's rows by that week's "
+    "ids.\n"
+    "- A swap changes the exercise for the WHOLE block: renaming a row updates "
+    "every week's copy of it, so swap once, not per week.\n"
     "- Honor every active contraindication and the coach's avoid-rules. If a "
     "contraindication flags a movement, do not introduce it — choose a safe "
     "alternative and name it in introduces_exercise.\n"
     "- Anchor load progressions to the values already in the plan; prefer small, "
-    "defensible steps.\n"
+    "defensible steps from one week to the next.\n"
     "- Use the 'add' kind to introduce a NEW exercise into a day: target the day "
     "by session_id, give the exercise in new_name, and set new_sets/new_reps/"
     "new_rpe (and new_load only if you want a starting weight). This is how you "
@@ -236,7 +252,8 @@ SYSTEM_PROMPT = (
     "weight in the plan's unit (kg/lb); 'pct' means the load is a percentage of "
     "1RM. When you progress a 'pct' lift, new_load is a percentage (keep it in a "
     "sane range, typically at or below 100%) — never convert it into an absolute "
-    "weight, and never convert an absolute lift into a percentage.\n"
+    "weight, and never convert an absolute lift into a percentage. rest is a "
+    "per-week field like load and RPE.\n"
     "- Give the value to apply: new_name for a swap, new_load for a progress, "
     "new_sets for a volume change. A deload needs no value.\n"
     "- Set 'honors' to the specific contraindication or coaching rule each change "
@@ -249,9 +266,11 @@ SYSTEM_PROMPT = (
 _GROUP_FRAMING = (
     "This is a GROUP's SHARED program — every listed member trains off it. You "
     "can edit it two ways:\n"
-    "- A SHARED edit (swap/progress/volume/deload/add) changes the one shared week "
-    "for EVERYONE. Honor every member's contraindications (group.contraindications "
-    "folds them together) — a shared movement must be safe for all of them.\n"
+    "- A SHARED edit (swap/progress/volume/deload/add) changes the shared program "
+    "for EVERYONE — a swap changes that exercise across the WHOLE block, and "
+    "progress/volume/deload act on the week you target by id. Honor every member's "
+    "contraindications (group.contraindications folds them together) — a shared "
+    "movement must be safe for all of them.\n"
     "- A per-athlete ADJUST diverges ONE member from the shared row (a swap, a "
     "load %, or a volume tweak just for them). Use it when the instruction is "
     "about a single athlete or when one member's constraint differs from the "

--- a/app/store_project/meso/agent/service.py
+++ b/app/store_project/meso/agent/service.py
@@ -116,10 +116,16 @@ def build_context(plan):
     recent logs). A **group** plan grounds on the group instead (members + the
     contraindications folded across them); there is no single athlete log stream,
     so ``recent_logs`` is empty for a group.
+
+    Both paths carry the whole current **block** (``serialize_agent_block``): every
+    live week of the plan's current mesocycle with its full session/cell grid and
+    per-week volume/intensity/phase/current flags, so the agent programs
+    progression across the block, not one week in isolation (P4).
     """
     context = {
         "plan": serializers.serialize_plan(plan),
         "coach_style": _coach_style(plan.coach),
+        "block": serializers.serialize_agent_block(plan),
     }
     if plan.is_group:
         context["group"] = _group_context(plan.group)

--- a/app/store_project/meso/agent/validation.py
+++ b/app/store_project/meso/agent/validation.py
@@ -23,7 +23,6 @@ from ..models import LoadType
 from ..models import Prescription
 from ..models import PrescriptionOverride
 from ..models import Session
-from ..serializers import current_week
 
 VALID_KINDS = {"swap", "progress", "volume", "deload", "add", "adjust"}
 
@@ -202,7 +201,7 @@ def _resolve(model, value, label, errors, **scope):
         return None
     obj = model.objects.filter(pk=pk, **scope).first()
     if obj is None:
-        errors.append(f"{label} {pk} is not in this plan's current week")
+        errors.append(f"{label} {pk} is not in this plan")
     return obj
 
 
@@ -296,23 +295,28 @@ def clean_change(raw, plan, *, forbidden=None):
     rationale = raw.get("rationale", "")
     cleaned["rationale"] = rationale.strip() if isinstance(rationale, str) else ""
 
-    # Structural: targets must belong to the plan's CURRENT week — the agent is
-    # grounded on (and only edits) that week, so an id from another week is out
-    # of contract even if it belongs to the same plan.
-    week = current_week(plan)
+    # Structural: targets must belong to the plan, in any LIVE week (P4 block-wide
+    # semantics). The agent is now grounded on the whole block, so a structural
+    # swap renames the block-shared slot and numeric edits address a specific
+    # week — targets resolve within the whole plan (any live week/slot), not just
+    # the current week. A foreign-plan id is still dropped, never applied.
     presc = _resolve(
         Prescription,
         raw.get("prescription_id"),
         "prescription",
         errors,
-        week=week,
+        exercise_slot__session_slot__mesocycle__plan=plan,
+        exercise_slot__deleted_at__isnull=True,
+        week__deleted_at__isnull=True,
     )
     session = _resolve(
         Session,
         raw.get("session_id"),
         "session",
         errors,
-        week=week,
+        session_slot__mesocycle__plan=plan,
+        deleted_at__isnull=True,
+        week__deleted_at__isnull=True,
     )
     # A prescription's own session is authoritative: backfill it when no session
     # was given, and reject a session_id that points at a different day (the

--- a/app/store_project/meso/agent/validation.py
+++ b/app/store_project/meso/agent/validation.py
@@ -23,6 +23,7 @@ from ..models import LoadType
 from ..models import Prescription
 from ..models import PrescriptionOverride
 from ..models import Session
+from ..serializers import current_week
 
 VALID_KINDS = {"swap", "progress", "volume", "deload", "add", "adjust"}
 
@@ -201,7 +202,7 @@ def _resolve(model, value, label, errors, **scope):
         return None
     obj = model.objects.filter(pk=pk, **scope).first()
     if obj is None:
-        errors.append(f"{label} {pk} is not in this plan")
+        errors.append(f"{label} {pk} is not in this plan's current block")
     return obj
 
 
@@ -295,17 +296,21 @@ def clean_change(raw, plan, *, forbidden=None):
     rationale = raw.get("rationale", "")
     cleaned["rationale"] = rationale.strip() if isinstance(rationale, str) else ""
 
-    # Structural: targets must belong to the plan, in any LIVE week (P4 block-wide
-    # semantics). The agent is now grounded on the whole block, so a structural
-    # swap renames the block-shared slot and numeric edits address a specific
-    # week — targets resolve within the whole plan (any live week/slot), not just
-    # the current week. A foreign-plan id is still dropped, never applied.
+    # Structural: targets must belong to the plan's CURRENT block, in any LIVE
+    # week (P4 block-wide semantics). The agent is grounded on that one block
+    # (``serialize_agent_block`` serializes only ``current_week(plan).mesocycle``),
+    # so a structural swap renames the block-shared slot and numeric edits address
+    # any *week* of that block — but a target from another block of the same plan
+    # (a past/future mesocycle the coach did not review) is out of contract and is
+    # dropped, just like a foreign-plan id.
+    week = current_week(plan)
+    mesocycle = week.mesocycle if week is not None else None
     presc = _resolve(
         Prescription,
         raw.get("prescription_id"),
         "prescription",
         errors,
-        exercise_slot__session_slot__mesocycle__plan=plan,
+        exercise_slot__session_slot__mesocycle=mesocycle,
         exercise_slot__deleted_at__isnull=True,
         week__deleted_at__isnull=True,
     )
@@ -314,7 +319,7 @@ def clean_change(raw, plan, *, forbidden=None):
         raw.get("session_id"),
         "session",
         errors,
-        session_slot__mesocycle__plan=plan,
+        session_slot__mesocycle=mesocycle,
         deleted_at__isnull=True,
         week__deleted_at__isnull=True,
     )

--- a/app/store_project/meso/serializers.py
+++ b/app/store_project/meso/serializers.py
@@ -1104,3 +1104,26 @@ def serialize_mesocycle_grid(mesocycle):
         "days": days,
         "history": serialize_plan_history(plan),
     }
+
+
+def serialize_agent_block(plan):
+    """The whole current block for the agent's grounding (P4).
+
+    Every live week of the plan's current mesocycle with its full session/cell
+    grid (numbers incl. ``rest``) plus the week's phase/volume/intensity/deload/
+    current flags — so the agent programs progression across the block, not one
+    week in isolation. Reuses ``serialize_week_snapshot`` and adds ``is_current``.
+    A cell's pk is stable, so ids here match ``serialize_plan``'s single-week
+    ``program`` — any id the agent returns resolves the same either way.
+    """
+    week = current_week(plan)
+    mesocycle = week.mesocycle if week else None
+    if mesocycle is None:
+        return {"name": "", "weeks": []}
+    weeks = mesocycle.weeks.filter(deleted_at__isnull=True).order_by("index")
+    serialized = []
+    for w in weeks:
+        snap = serialize_week_snapshot(w)
+        snap["week"]["is_current"] = w.is_current
+        serialized.append(snap)
+    return {"name": mesocycle.name, "weeks": serialized}

--- a/app/store_project/meso/tests/test_agent_apply.py
+++ b/app/store_project/meso/tests/test_agent_apply.py
@@ -80,6 +80,34 @@ class TestApplyChange:
         assert cell_w1.swap_name == ""  # slot rename, NOT a cell swap
         assert cell_w1.exercise_slot.name == "Front Squat"
 
+    def test_swap_clears_target_cells_one_week_exception(self):
+        # If the reviewed cell already carried a one-week ``swap_*`` exception, a
+        # block-wide swap clears it so the new lift shows through on THIS week too
+        # — otherwise the reviewed week would silently keep the old override while
+        # every other week changed. Sibling weeks' own exceptions are preserved.
+        plan, session, cell_w1 = make_plan()  # week 1 (current)
+        week2 = WeekFactory(mesocycle=session.week.mesocycle, index=2)
+        day(week2, session_slot=session.session_slot)
+        cell_w2 = presc(
+            exercise_slot=cell_w1.exercise_slot, week=week2, swap_name="Leg Press"
+        )
+        cell_w1.swap_name = "Hack Squat"
+        cell_w1.save(update_fields=["swap_name"])
+        change = ProposedChangeFactory(
+            batch=_batch(plan),
+            kind=ProposedChange.Kind.SWAP,
+            prescription=cell_w1,
+            payload={"name": "Front Squat"},
+        )
+        agent_apply.apply_change(change)
+
+        cell_w1 = Prescription.objects.get(pk=cell_w1.pk)
+        cell_w2 = Prescription.objects.get(pk=cell_w2.pk)
+        assert cell_w1.swap_name == ""  # target exception cleared
+        assert cell_w1.name == "Front Squat"  # shows the block-wide identity
+        assert cell_w2.swap_name == "Leg Press"  # sibling exception preserved
+        assert cell_w2.name == "Leg Press"
+
     def test_swap_severs_catalog_link(self):
         # A free-text rename severs the slot's catalog FK so the row isn't
         # mis-keyed to the old exercise.

--- a/app/store_project/meso/tests/test_agent_apply.py
+++ b/app/store_project/meso/tests/test_agent_apply.py
@@ -10,11 +10,15 @@ seam over this (see ``test_agent_apply_endpoint``).
 
 import pytest
 
+from store_project.exercises.factories import ExerciseFactory
 from store_project.meso.agent import apply as agent_apply
 from store_project.meso.factories import AgentProposalBatchFactory
 from store_project.meso.factories import ProposedChangeFactory
+from store_project.meso.factories import WeekFactory
 from store_project.meso.models import AgentProposalBatch
+from store_project.meso.models import Prescription
 from store_project.meso.models import ProposedChange
+from store_project.meso.tests._helpers import day
 from store_project.meso.tests._helpers import presc
 from store_project.meso.tests.test_agent_validation import make_plan
 
@@ -51,6 +55,46 @@ class TestApplyChange:
         agent_apply.apply_change(change)
         presc.refresh_from_db()
         assert presc.name == "Goblet Squat"
+
+    def test_swap_is_block_wide(self):
+        # P4: an agent swap renames the block-shared ``ExerciseSlot``, so EVERY
+        # week's cell follows (``Prescription.name`` resolves to the slot). It is
+        # a slot rename, NOT a one-week cell ``swap_name`` write.
+        plan, session, cell_w1 = make_plan()  # week 1 (current)
+        week2 = WeekFactory(mesocycle=session.week.mesocycle, index=2)
+        day(week2, session_slot=session.session_slot)
+        cell_w2 = presc(exercise_slot=cell_w1.exercise_slot, week=week2)
+        change = ProposedChangeFactory(
+            batch=_batch(plan),
+            kind=ProposedChange.Kind.SWAP,
+            prescription=cell_w1,
+            payload={"name": "Front Squat"},
+        )
+        agent_apply.apply_change(change)
+
+        # Re-fetch fresh so the resolving ``name`` property reads the renamed slot.
+        cell_w1 = Prescription.objects.get(pk=cell_w1.pk)
+        cell_w2 = Prescription.objects.get(pk=cell_w2.pk)
+        assert cell_w1.name == "Front Squat"
+        assert cell_w2.name == "Front Squat"  # block-wide
+        assert cell_w1.swap_name == ""  # slot rename, NOT a cell swap
+        assert cell_w1.exercise_slot.name == "Front Squat"
+
+    def test_swap_severs_catalog_link(self):
+        # A free-text rename severs the slot's catalog FK so the row isn't
+        # mis-keyed to the old exercise.
+        plan, _, cell = make_plan()
+        cell.exercise_slot.exercise = ExerciseFactory()
+        cell.exercise_slot.save(update_fields=["exercise"])
+        change = ProposedChangeFactory(
+            batch=_batch(plan),
+            kind=ProposedChange.Kind.SWAP,
+            prescription=cell,
+            payload={"name": "Front Squat"},
+        )
+        agent_apply.apply_change(change)
+        cell.exercise_slot.refresh_from_db()
+        assert cell.exercise_slot.exercise is None
 
     def test_progress_sets_load(self):
         plan, _, presc = make_plan()

--- a/app/store_project/meso/tests/test_agent_grounding.py
+++ b/app/store_project/meso/tests/test_agent_grounding.py
@@ -13,10 +13,44 @@ import pytest
 from store_project.meso.agent import service
 from store_project.meso.factories import LoggedSetFactory
 from store_project.meso.factories import SessionLogFactory
+from store_project.meso.factories import WeekFactory
 from store_project.meso.models import SessionLog
+from store_project.meso.tests._helpers import day
+from store_project.meso.tests._helpers import presc
 from store_project.meso.tests.test_agent_validation import make_plan
 
 pytestmark = pytest.mark.django_db
+
+
+def test_context_includes_whole_block():
+    # P4 whole-block grounding: the agent sees EVERY live week of the current
+    # mesocycle — its full session/cell grid (numbers incl. ``rest``) plus each
+    # week's volume/intensity/is_current — so it can program across the block.
+    plan, session, _ = make_plan()  # week 1 (current) with a day + "Back Squat"
+    week2 = WeekFactory(mesocycle=session.week.mesocycle, index=2, is_current=False)
+    w2_session = day(week2, day_number=1, name="Lower")
+    presc(w2_session, name="Front Squat")
+
+    block = service.build_context(plan)["block"]
+
+    assert len(block["weeks"]) == 2
+    for w in block["weeks"]:
+        # Week meta exposes the progression levers.
+        assert "volume" in w["week"]
+        assert "intensity" in w["week"]
+        assert "is_current" in w["week"]
+        # Each cell exposes its full numbers, including ``rest``.
+        for s in w["sessions"]:
+            for ex in s["exercises"]:
+                assert "rest" in ex
+    # Week 2's cell is visible — the agent sees beyond the current week.
+    names = {
+        ex["name"]
+        for w in block["weeks"]
+        for s in w["sessions"]
+        for ex in s["exercises"]
+    }
+    assert "Front Squat" in names
 
 
 def test_context_has_empty_recent_logs_without_any():
@@ -58,11 +92,11 @@ def test_recent_logs_are_scoped_to_the_plans_athlete():
 
 def test_recent_logs_are_capped_and_newest_first():
     plan, session, _ = make_plan()
-    for day in range(1, 9):
+    for day_num in range(1, 9):
         SessionLogFactory(
             session=session,
             athlete=plan.athlete,
-            date=datetime.date(2026, 6, day),
+            date=datetime.date(2026, 6, day_num),
         )
 
     logs = service.build_context(plan)["recent_logs"]

--- a/app/store_project/meso/tests/test_agent_validation.py
+++ b/app/store_project/meso/tests/test_agent_validation.py
@@ -116,8 +116,9 @@ class TestCleanChange:
 
     def test_swap_can_target_any_week(self):
         # P4: the agent is grounded on the WHOLE block, so a swap targeting an
-        # off-(current-)week cell is now IN contract — targets resolve within
-        # the whole plan, any live week (a swap renames the block-shared slot).
+        # off-(current-)week cell of the SAME block is now IN contract — targets
+        # resolve within the current block, any live week (a swap renames the
+        # block-shared slot).
         plan, session, _ = make_plan()  # week index 1 is current
         week2 = WeekFactory(mesocycle=session.week.mesocycle, index=2, is_current=False)
         off_session = day(week2, day_number=1, name="Lower")
@@ -127,6 +128,36 @@ class TestCleanChange:
         )
         assert errors == []
         assert cleaned["prescription"] == off_presc
+
+    def test_target_from_another_block_rejected(self):
+        # P4 scope: the agent is grounded on ONE block (the current mesocycle),
+        # so a target from a DIFFERENT block of the same plan — never serialized
+        # for review — is out of contract and dropped, like a foreign-plan id.
+        # Guards both the prescription (swap) and the session (add) lookups.
+        plan, _, _ = make_plan()  # current block = mesocycle order 0
+        other_block = MesocycleFactory(plan=plan, order=1)
+        other_week = WeekFactory(mesocycle=other_block, index=1, is_current=False)
+        other_session = day(other_week, day_number=1, name="Lower")
+        other_presc = presc(other_session, name="Squat")
+
+        swap_cleaned, swap_errors = validation.clean_change(
+            base_change(prescription_id=other_presc.pk), plan
+        )
+        assert swap_cleaned is None
+        assert any("not in this plan" in e for e in swap_errors)
+
+        add_cleaned, add_errors = validation.clean_change(
+            {
+                "kind": "add",
+                "title": "Add Plank",
+                "rationale": "...",
+                "session_id": other_session.pk,
+                "new_name": "Plank",
+            },
+            plan,
+        )
+        assert add_cleaned is None
+        assert any("not in this plan" in e for e in add_errors)
 
     def test_progress_can_target_any_week(self):
         # P4: a progress can set a specific (future/other) week's load — the

--- a/app/store_project/meso/tests/test_agent_validation.py
+++ b/app/store_project/meso/tests/test_agent_validation.py
@@ -114,9 +114,10 @@ class TestCleanChange:
         assert cleaned is None
         assert any("not in this plan" in e for e in errors)
 
-    def test_off_week_target_rejected(self):
-        # The agent is grounded on the current week only; an id from another
-        # week of the same plan is out of contract.
+    def test_swap_can_target_any_week(self):
+        # P4: the agent is grounded on the WHOLE block, so a swap targeting an
+        # off-(current-)week cell is now IN contract — targets resolve within
+        # the whole plan, any live week (a swap renames the block-shared slot).
         plan, session, _ = make_plan()  # week index 1 is current
         week2 = WeekFactory(mesocycle=session.week.mesocycle, index=2, is_current=False)
         off_session = day(week2, day_number=1, name="Lower")
@@ -124,8 +125,25 @@ class TestCleanChange:
         cleaned, errors = validation.clean_change(
             base_change(prescription_id=off_presc.pk), plan
         )
-        assert cleaned is None
-        assert any("current week" in e for e in errors)
+        assert errors == []
+        assert cleaned["prescription"] == off_presc
+
+    def test_progress_can_target_any_week(self):
+        # P4: a progress can set a specific (future/other) week's load — the
+        # agent programs progression across the whole block.
+        plan, session, _ = make_plan()  # week index 1 is current
+        week2 = WeekFactory(mesocycle=session.week.mesocycle, index=2, is_current=False)
+        off_session = day(week2, day_number=1, name="Lower")
+        off_presc = presc(off_session, name="Squat")
+        cleaned, errors = validation.clean_change(
+            base_change(
+                kind="progress", prescription_id=off_presc.pk, new_load="100 kg"
+            ),
+            plan,
+        )
+        assert errors == []
+        assert cleaned["prescription"] == off_presc
+        assert cleaned["payload"] == {"load": "100 kg"}
 
     def test_non_integer_prescription_id_rejected(self):
         plan, _, _ = make_plan()
@@ -485,6 +503,10 @@ class TestPercentAwarePrompt:
         new_load = props["changes"]["items"]["properties"]["new_load"]
         assert "%" in new_load["description"] or "1RM" in new_load["description"]
 
+    def test_system_prompt_mentions_whole_block(self):
+        # P4: the agent is grounded on the whole block, not just the current week.
+        assert "block" in client.SYSTEM_PROMPT.lower()
+
 
 class TestAddKind:
     """The ``add`` kind introduces a NEW exercise row into a session.
@@ -588,8 +610,9 @@ class TestAddKind:
         assert cleaned is None
         assert any("contraindication" in e for e in errors)
 
-    def test_add_session_must_be_in_the_current_week(self):
-        # A session from another week is out of contract, like swap/progress.
+    def test_add_session_can_be_any_week(self):
+        # P4: whole-block grounding — an add can target any live week's day, not
+        # just the current week's.
         plan, _, _ = make_plan()
         other_week = WeekFactory(
             mesocycle=plan.mesocycles.first(), index=2, is_current=False
@@ -598,8 +621,8 @@ class TestAddKind:
         cleaned, errors = validation.clean_change(
             self.add_change(session_id=other_session.pk), plan
         )
-        assert cleaned is None
-        assert any("session" in e for e in errors)
+        assert errors == []
+        assert cleaned["session"] == other_session
 
     def test_add_field_values_are_length_capped(self):
         plan, session, _ = make_plan()
@@ -626,3 +649,10 @@ class TestAddAwareTool:
 
     def test_system_prompt_explains_add(self):
         assert "add" in client.SYSTEM_PROMPT.lower()
+
+    def test_swap_is_block_wide_in_tool(self):
+        # P4: the tool tells the model a swap renames the exercise for the WHOLE
+        # block (every week follows).
+        props = client.PROPOSE_TOOL["input_schema"]["properties"]
+        new_name = props["changes"]["items"]["properties"]["new_name"]
+        assert "block" in new_name["description"].lower()


### PR DESCRIPTION
## P4 — Agent structural rescope + whole-block grounding

Fourth phase of the fixed-exercise-selection epic (#440). Rescopes the Meso AI agent to the fixed-lineup model so the coach can drive block-level programming through the agent.

**Product decisions (confirmed with the coach):**
- **A swap is block-wide.** Under fixed selection the lineup is shared across the whole mesocycle, so an agent swap renames the block-shared `ExerciseSlot` (and severs its catalog link) — every week's cell follows. One-week-only swaps remain the coach's manual exception, not an agent verb.
- **The agent is grounded on the whole block.** So it can program progression with full context — every week's `sets/reps/load/rpe/rest` and each week's `volume/intensity/phase`.

### Changes
- **`agent/apply.py`** — `_apply_swap` renames the shared `ExerciseSlot` block-wide instead of writing a one-week cell `swap_name`. If the reviewed cell carried a one-week exception, it's cleared so the approved lift shows through on that week too (sibling weeks' own exceptions preserved).
- **`agent/validation.py`** — `clean_change` drops the hard "current-week only" target scope; a proposal's prescription/session now resolves within the plan's **current block** (any live week of that mesocycle). A target from another block of the same plan — never grounded for review — is dropped, like a foreign-plan id.
- **`serializers.py`** — new `serialize_agent_block(plan)`: every live week of the current mesocycle with its full session/cell grid (numbers incl. `rest`) plus per-week `volume/intensity/phase/current`. `serialize_plan` is untouched (the fake client + evals still read its single-week `program`).
- **`agent/service.py`** — `build_context` includes `"block"` on both individual and group paths.
- **`agent/client.py`** — tool schema, field descriptions, system prompt, and group framing reworded from current-week to whole-block semantics (block-wide swap; `progress`/`volume`/`deload` target a week by id; `rest` is per-week).

### Out of scope (later phases)
- Group delivery/sync rewrite around slots+cells+overrides and the group table view stay in **P5**. The group *agent* shares the block-wide swap + whole-block grounding here (model-correct), but no group delivery logic changes.

### Testing
- Red/green TDD. New/changed tests cover: block-wide swap propagation, catalog-link severing, target-cell exception clearing, cross-block rejection, any-week structural + numeric targets, and whole-block grounding.
- **Full meso suite green (1992+), ruff + format clean.**
- Independent end-to-end verify drove the real `propose → validate → apply` path and observed a swap propagating across every week.
- **OpenAI Codex review loop: converged, no blocking issues** (two P2 consistency findings fixed: block-scoping and target-cell exception clearing).

Refs #440 (P4). No migrations.
