### PR TITLE
feat(meso): P5 — whole-block group delivery + group table adjusts (#440)

### DIFF
--- a/app/store_project/meso/demo.py
+++ b/app/store_project/meso/demo.py
@@ -18,7 +18,7 @@ the requesting coach** so two coaches never collide. Guardrails (Q3):
   trips the paywall;
 - **no outbound email/push** — demo athletes are fake people: their address is
   non-routable and namespaced per coach, they carry the delivery-email opt-out,
-  and the load delivers weeks at the **model layer** (``deliver_current_week`` /
+  and the load delivers weeks at the **model layer** (``deliver_block`` /
   a direct ``delivered_at`` stamp), which — unlike the deliver *views* — notifies
   nobody.
 """
@@ -505,7 +505,7 @@ def _ensure_demo_overrides(group, memberships):
 
 
 def _ensure_demo_group_delivery(group):
-    """Deliver the shared current week to members once (model layer — no notify)."""
+    """Deliver the shared current block to members once (model layer — no notify)."""
     from .serializers import current_week
 
     plan = group.shared_plan()
@@ -514,4 +514,4 @@ def _ensure_demo_group_delivery(group):
     week = current_week(plan)
     if week is None or week.delivered_at is not None:
         return
-    group.deliver_current_week()
+    group.deliver_block()

--- a/app/store_project/meso/management/commands/seed_meso_demo.py
+++ b/app/store_project/meso/management/commands/seed_meso_demo.py
@@ -789,12 +789,12 @@ class Command(BaseCommand):
             memberships["marcus"].set_override(second, sets="2", reps="8")
 
     def _ensure_group_delivery(self, group):
-        """Deliver the group's shared current week to its members once (Phase 4).
+        """Deliver the group's whole shared current block to its members once (P5).
 
-        Idempotent: skipped once the shared week is stamped delivered, so a reseed
-        never re-fans-out or piles up snapshots. Gives the three demo members a
-        real, *resolved* delivered plan on their own athlete surface (Devon's load
-        %, Priya's swap, Marcus's volume tweak all applied).
+        Idempotent: skipped once the shared block's current week is stamped
+        delivered, so a reseed never re-fans-out or piles up snapshots. Gives the
+        three demo members a real, *resolved* delivered block on their own athlete
+        surface (Devon's load %, Priya's swap, Marcus's volume tweak all applied).
         """
         from store_project.meso.serializers import current_week
 
@@ -804,8 +804,8 @@ class Command(BaseCommand):
         week = current_week(plan)
         if week is None or week.delivered_at is not None:
             return
-        group.deliver_current_week()
-        self.stdout.write(f"  - delivered shared week to group '{group.name}' members")
+        group.deliver_block()
+        self.stdout.write(f"  - delivered shared block to group '{group.name}' members")
 
     # -- the sample plan --------------------------------------------------
 

--- a/app/store_project/meso/models.py
+++ b/app/store_project/meso/models.py
@@ -2322,8 +2322,12 @@ class MesoGroup(models.Model):
             .order_by("relationship__athlete__name", "relationship__athlete__email")
         )
 
-    def deliver_current_week(self, plan=None):
-        """Fan the shared program's current week out to every active member (Phase 4).
+    def deliver_block(self, plan=None):
+        """Fan the shared program's whole current BLOCK out to every member (P5).
+
+        The group peer of the P3 individual whole-block delivery: the current
+        block (``current_week(plan).mesocycle``, every one of its live weeks) is
+        released at once, not one week at a time.
 
         ``plan`` pins *which* of the group's plans to deliver — the endpoint passes
         the exact plan the request addressed so it can't drift to a different one
@@ -2331,16 +2335,19 @@ class MesoGroup(models.Model):
         (the canonical current one) for the seed / server button. A plan that
         isn't this group's is rejected.
 
-        Each active member gets their *resolved* week (the shared template + their
-        override diffs) materialized into their own individual plan and stamped
-        ``delivered_at``, plus a ``WeekDelivery`` snapshot; the shared (group) week
-        is stamped too as the coach-side record. Returns ``(now, [(member_plan,
-        member_week), ...])`` so a caller (the view) can notify each athlete — the
-        model layer stays request-free so the seed can reuse it.
+        Each active member gets their *resolved* block (the shared template + their
+        override diffs) materialized into their own individual plan; every live
+        member week is stamped ``delivered_at`` (one shared timestamp) with a
+        ``WeekDelivery`` snapshot. Every live week of the shared block is stamped
+        + snapshotted too, as the coach-side record. Returns ``(now,
+        [(member_plan, member_weeks), ...])`` so a caller (the view) can notify
+        each athlete once at block level — the model layer stays request-free so
+        the seed can reuse it.
 
         Raises ``InvalidTransition`` when there is nothing to deliver: no shared
-        program, no current week, or no active members (delivering to nobody is a
-        coach mistake, surfaced as a 400 / flashed error rather than a silent no-op).
+        program, no live week in the block, or no active members (delivering to
+        nobody is a coach mistake, surfaced as a 400 / flashed error rather than a
+        silent no-op).
         """
         # Local import avoids a models→serializers cycle at module load.
         from .serializers import current_week
@@ -2350,9 +2357,10 @@ class MesoGroup(models.Model):
             plan = self.shared_plan()
         if plan is None or plan.group_id != self.pk:
             raise InvalidTransition("The group has no shared program to deliver.")
-        group_week = current_week(plan)
-        if group_week is None:
+        target_week = current_week(plan)
+        if target_week is None:
             raise InvalidTransition("The shared program has no week to deliver.")
+        src_meso = target_week.mesocycle
         memberships = self.active_memberships()
         if not memberships:
             raise InvalidTransition("The group has no members to deliver to.")
@@ -2360,22 +2368,27 @@ class MesoGroup(models.Model):
         now = timezone.now()
         delivered = []
         for membership in memberships:
-            member_plan, member_week = membership.sync_delivered_plan(group_week)
-            member_week.delivered_at = now
-            member_week.save(update_fields=["delivered_at"])
+            member_plan, member_weeks = membership.sync_delivered_plan(src_meso)
+            for member_week in member_weeks:
+                member_week.delivered_at = now
+                member_week.save(update_fields=["delivered_at"])
+                WeekDelivery.objects.create(
+                    week=member_week,
+                    delivered_at=now,
+                    payload=serialize_week_snapshot(member_week),
+                )
+            delivered.append((member_plan, member_weeks))
+        # Stamp + snapshot every live week of the shared block (coach-side record).
+        for group_week in src_meso.weeks.filter(deleted_at__isnull=True).order_by(
+            "index"
+        ):
+            group_week.delivered_at = now
+            group_week.save(update_fields=["delivered_at"])
             WeekDelivery.objects.create(
-                week=member_week,
+                week=group_week,
                 delivered_at=now,
-                payload=serialize_week_snapshot(member_week),
+                payload=serialize_week_snapshot(group_week),
             )
-            delivered.append((member_plan, member_week))
-        group_week.delivered_at = now
-        group_week.save(update_fields=["delivered_at"])
-        WeekDelivery.objects.create(
-            week=group_week,
-            delivered_at=now,
-            payload=serialize_week_snapshot(group_week),
-        )
         # Bump the shared plan so it stays the coach's working plan after a deliver.
         plan.save(update_fields=["modified"])
         return now, delivered
@@ -2491,36 +2504,42 @@ class GroupMembership(models.Model):
 
     # -- delivery fan-out (groups Phase 4) --------------------------------
 
-    def sync_delivered_plan(self, group_week):
-        """Materialize/refresh this member's resolved copy of ``group_week`` (Phase 4).
+    def sync_delivered_plan(self, src_meso):
+        """Materialize/refresh this member's resolved copy of the whole block (P5).
 
         Get-or-creates the member's individual plan for this group (rooted at
         their relationship, tagged ``source_group``) and syncs it *in place* to
-        the resolved group week — the shared lineup (slots + exercise rows)
-        **+** this member's override diffs (``resolve_prescription``), written
-        onto the member's own mirrored ``SessionSlot``/``ExerciseSlot`` rows and
-        this delivery's ``Week``.
+        the resolved shared block — every live ``Week`` of ``src_meso``, each the
+        shared lineup (slots + exercise rows) **+** this member's override diffs
+        (``resolve_prescription``), written onto the member's own mirrored
+        ``SessionSlot``/``ExerciseSlot`` rows and this block's ``Week``s.
 
         Mirrors the coach's live ``SessionSlot``s onto the member's mesocycle
-        (matched by ``day_number`` — the P0 fixed-lineup's natural key),
-        live ``ExerciseSlot``s onto each (matched by ``(slot, order)``), then
-        upserts a ``Prescription`` cell on the member's slot for this
-        delivery's week — a swap override becomes the cell's ``swap_name``
-        (block identity stays the shared slot's); load/sets/reps/note
-        overrides become the cell's numbers. Syncing in place this way
-        preserves any ``SessionLog`` the athlete already wrote against an
-        unchanged slot while propagating the coach's edits; a slot/row dropped
-        from the shared program is soft-deleted on the member's side too
-        (never hard-deleted: ``SessionLog.session`` cascades, so a hard delete
-        would erase the member's logged history on re-delivery — a dropped
-        source row that comes back, e.g. via undo, revives the member's hidden
-        copy in place via ``deleted_at: None`` in the upsert defaults).
-        Returns ``(member_plan, member_week)`` — the week is *not* yet stamped
-        delivered (``deliver_current_week`` stamps + snapshots it).
+        (matched by ``day_number`` — the P0 fixed-lineup's natural key) once,
+        block-wide; live ``ExerciseSlot``s onto each (matched by ``(slot,
+        order)``); and, for **every** live source week, upserts a member
+        ``Week`` (matched by ``index``) and a ``Prescription`` cell per exercise
+        slot on that week — a swap override becomes the cell's ``swap_name``
+        (block identity stays the shared slot's); load/sets/reps/note overrides
+        become the cell's numbers. Each member week's ``is_current`` MIRRORS its
+        source week's (post-P3 ``is_current`` = the week the athlete is on), so
+        the athlete's home anchors on the same week the coach points to — never a
+        block that flags every week current.
+
+        Syncing in place this way preserves any ``SessionLog`` the athlete
+        already wrote against an unchanged slot while propagating the coach's
+        edits; a slot/row/**week** dropped from the shared block is soft-deleted
+        on the member's side too (never hard-deleted: ``SessionLog.session``
+        cascades, so a hard delete would erase the member's logged history on
+        re-delivery — a dropped source row that comes back, e.g. via undo,
+        revives the member's hidden copy in place via ``deleted_at: None`` in the
+        upsert defaults). Returns ``(member_plan, member_weeks)`` — the weeks, in
+        ``index`` order, are *not* yet stamped delivered (``deliver_block`` stamps
+        + snapshots each).
         """
         from .serializers import resolve_prescription
 
-        shared_plan = group_week.mesocycle.plan
+        shared_plan = src_meso.plan
         member_plan, _ = Plan.objects.get_or_create(
             relationship=self.relationship,
             source_group=self.group,
@@ -2540,23 +2559,37 @@ class GroupMembership(models.Model):
         member_plan.status = Plan.Status.ACTIVE
         member_plan.save()
 
-        src_meso = group_week.mesocycle
         member_meso, _ = Mesocycle.objects.update_or_create(
             plan=member_plan,
             order=src_meso.order,
             defaults={"name": src_meso.name, "week_count": src_meso.week_count},
         )
-        member_week, _ = Week.objects.update_or_create(
-            mesocycle=member_meso,
-            index=group_week.index,
-            defaults={
-                "phase": group_week.phase,
-                "volume": group_week.volume,
-                "intensity": group_week.intensity,
-                "is_deload": group_week.is_deload,
-                "is_current": True,
-            },
+        # Mirror every live source week onto the member's block (matched by
+        # ``index``); ``deleted_at: None`` revives a member week whose source
+        # week was dropped then returned. ``week_pairs`` keeps each source week
+        # beside its member copy so the per-cell upsert below writes onto the
+        # right column.
+        src_weeks = list(
+            src_meso.weeks.filter(deleted_at__isnull=True).order_by("index")
         )
+        member_weeks = []
+        week_pairs = []
+        for src_week in src_weeks:
+            member_week, _ = Week.objects.update_or_create(
+                mesocycle=member_meso,
+                index=src_week.index,
+                defaults={
+                    "phase": src_week.phase,
+                    "volume": src_week.volume,
+                    "intensity": src_week.intensity,
+                    "is_deload": src_week.is_deload,
+                    # Mirror the source pointer — do NOT hardcode ``True`` (P3).
+                    "is_current": src_week.is_current,
+                    "deleted_at": None,
+                },
+            )
+            member_weeks.append(member_week)
+            week_pairs.append((src_week, member_week))
 
         overrides = {o.prescription_id: o for o in self.overrides.all()}
         # Source-side reads are live-only — a soft-deleted slot/row on the
@@ -2577,20 +2610,25 @@ class GroupMembership(models.Model):
                     "deleted_at": None,
                 },
             )
-            Session.objects.update_or_create(
-                week=member_week,
-                session_slot=member_slot,
-                defaults={"deleted_at": None},
-            )
+            # This day's ``Session`` join row per live member week (block-wide).
+            for member_week in member_weeks:
+                Session.objects.update_or_create(
+                    week=member_week,
+                    session_slot=member_slot,
+                    defaults={"deleted_at": None},
+                )
 
             # Filtered in Python so this still reads from the prefetch cache above.
             src_exercise_slots = [
                 es for es in src_slot.exercise_slots.all() if es.deleted_at is None
             ]
-            src_cells_by_slot = {
-                c.exercise_slot_id: c
+            # One query for every live source cell of this day's rows across the
+            # whole block, grouped by ``(exercise_slot, week)`` so the per-week
+            # upsert below reads it without a per-cell query.
+            src_cells_by_key = {
+                (c.exercise_slot_id, c.week_id): c
                 for c in Prescription.objects.filter(
-                    exercise_slot__in=src_exercise_slots, week=group_week
+                    exercise_slot__in=src_exercise_slots, week__in=src_weeks
                 )
             }
             for src_es in src_exercise_slots:
@@ -2604,33 +2642,40 @@ class GroupMembership(models.Model):
                         "deleted_at": None,
                     },
                 )
-                src_cell = src_cells_by_slot.get(src_es.pk)
-                if src_cell is None:
-                    # No cell for this week yet (shouldn't normally happen —
-                    # every live slot gets a blank cell per live week — but
-                    # skip defensively rather than materialize a bad row).
-                    continue
-                resolved = resolve_prescription(src_cell, overrides.get(src_cell.pk))
-                # A swap means the effective name no longer matches the slot's.
-                swapped = resolved["name"] != src_es.name
-                Prescription.objects.update_or_create(
-                    exercise_slot=member_es,
-                    week=member_week,
-                    defaults={
-                        "sets": resolved["sets"],
-                        "reps": resolved["reps"],
-                        "load": resolved["load"],
-                        "load_type": resolved["load_type"],
-                        "rpe": resolved["rpe"],
-                        "rest": src_cell.rest,
-                        "note": resolved["note"],
-                        # A week the coach skipped for the shared lineup stays
-                        # skipped for every member — don't resurrect it per athlete.
-                        "skipped": src_cell.skipped,
-                        "swap_name": resolved["name"] if swapped else "",
-                        "swap_exercise": None,
-                    },
-                )
+                for src_week, member_week in week_pairs:
+                    src_cell = src_cells_by_key.get((src_es.pk, src_week.pk))
+                    if src_cell is None:
+                        # No cell for this week yet (shouldn't normally happen —
+                        # every live slot gets a blank cell per live week — but
+                        # skip defensively rather than materialize a bad row).
+                        continue
+                    # An override targets a specific *cell* (one week), so it
+                    # resolves per week: the same exercise slot in another week
+                    # gets the shared base unless it too carries an override.
+                    resolved = resolve_prescription(
+                        src_cell, overrides.get(src_cell.pk)
+                    )
+                    # A swap means the effective name no longer matches the slot's.
+                    swapped = resolved["name"] != src_es.name
+                    Prescription.objects.update_or_create(
+                        exercise_slot=member_es,
+                        week=member_week,
+                        defaults={
+                            "sets": resolved["sets"],
+                            "reps": resolved["reps"],
+                            "load": resolved["load"],
+                            "load_type": resolved["load_type"],
+                            "rpe": resolved["rpe"],
+                            "rest": src_cell.rest,
+                            "note": resolved["note"],
+                            # A week the coach skipped for the shared lineup stays
+                            # skipped for every member — don't resurrect it per
+                            # athlete.
+                            "skipped": src_cell.skipped,
+                            "swap_name": resolved["name"] if swapped else "",
+                            "swap_exercise": None,
+                        },
+                    )
             # Soft-delete member exercise rows dropped from this day's source
             # lineup (matched by the same (slot, order) natural key).
             member_slot.exercise_slots.exclude(
@@ -2644,7 +2689,15 @@ class GroupMembership(models.Model):
             day_number__in=src_day_numbers
         ).filter(deleted_at__isnull=True):
             dropped_slot.soft_delete()
-        return member_plan, member_week
+        # Soft-delete member weeks whose source week is no longer live — a whole
+        # column the coach removed from the shared block disappears from the
+        # member's copy too (``Week.soft_delete`` cascades to its sessions).
+        src_indexes = [w.index for w in src_weeks]
+        for dropped_week in member_meso.weeks.exclude(index__in=src_indexes).filter(
+            deleted_at__isnull=True
+        ):
+            dropped_week.soft_delete()
+        return member_plan, member_weeks
 
     def clean(self):
         """Backstop ``add_athlete``'s contract on the admin inline (raw FKs).

--- a/app/store_project/meso/serializers.py
+++ b/app/store_project/meso/serializers.py
@@ -1025,6 +1025,13 @@ def serialize_mesocycle_grid(mesocycle):
         ).select_related("swap_exercise")
     }
 
+    # A GROUP plan carries the per-athlete adjust overlay on each cell (P5): the
+    # same per-row ``adj`` badge ``serialize_plan``'s single-week ``program``
+    # shows, driven by the members' real override diffs — one query over the
+    # block's cells, keyed by prescription pk. An individual plan has no members,
+    # so its cells get no ``adj`` keys.
+    adj_map = group_adjustments(plan, cells_by_key.values()) if plan.is_group else {}
+
     days = []
     for slot in session_slots:
         rows = []
@@ -1044,7 +1051,7 @@ def serialize_mesocycle_grid(mesocycle):
                     swap_display = cell.swap_exercise.name
                 else:
                     swap_display = ""
-                cells[str(week.pk)] = {
+                cell_data = {
                     "prescription_id": cell.pk,
                     "sets": cell.sets,
                     "reps": cell.reps,
@@ -1058,6 +1065,15 @@ def serialize_mesocycle_grid(mesocycle):
                     "swap_exercise_id": cell.swap_exercise_id,
                     "swap_display": swap_display,
                 }
+                # The per-athlete adjust overlay (group plans only) — set exactly
+                # as ``serialize_plan``'s adj-merge does: only when the cell has an
+                # effective adjust. An individual plan's ``adj_map`` is empty, so
+                # its cells never carry ``adj``/``adjusts``.
+                entry = adj_map.get(cell.pk)
+                if entry:
+                    cell_data["adj"] = entry["adj"]
+                    cell_data["adjusts"] = entry["adjusts"]
+                cells[str(week.pk)] = cell_data
             rows.append(
                 {
                     "exercise_slot_id": exercise_slot.pk,

--- a/app/store_project/meso/tests/test_designer_delete.py
+++ b/app/store_project/meso/tests/test_designer_delete.py
@@ -637,7 +637,8 @@ class TestGroupPlanDelete:
         )
         assert resp.status_code == 200
 
-        member_plan, member_week = membership.sync_delivered_plan(week)
+        member_plan, member_weeks = membership.sync_delivered_plan(week.mesocycle)
+        member_week = member_weeks[0]
         day_numbers = [s.day_number for s in member_week.sessions.all()]
         assert session.day_number not in day_numbers
         assert survivor.day_number in day_numbers
@@ -657,7 +658,8 @@ class TestGroupRedeliverySoftDelete:
     def test_redelivery_hides_member_session_and_keeps_its_logs(self, client):
         group, plan, week, session, cell = seed_group_plan()
         membership = GroupMembershipFactory(group=group)
-        _, member_week = membership.sync_delivered_plan(week)
+        _, member_weeks = membership.sync_delivered_plan(week.mesocycle)
+        member_week = member_weeks[0]
         member_session = member_week.sessions.get(
             session_slot__day_number=session.day_number
         )
@@ -673,7 +675,7 @@ class TestGroupRedeliverySoftDelete:
             )
         )
         assert resp.status_code == 200
-        membership.sync_delivered_plan(week)
+        membership.sync_delivered_plan(week.mesocycle)
 
         member_session.refresh_from_db()
         assert member_session.deleted_at is not None
@@ -691,7 +693,7 @@ class TestGroupRedeliverySoftDelete:
         source_slot.save(update_fields=["deleted_at"])
         source_slot.exercise_slots.update(deleted_at=None)
         source_slot.sessions.update(deleted_at=None)
-        membership.sync_delivered_plan(week)
+        membership.sync_delivered_plan(week.mesocycle)
         member_session.refresh_from_db()
         assert member_session.deleted_at is None
         assert (
@@ -705,7 +707,8 @@ class TestGroupRedeliverySoftDelete:
         group, plan, week, session, cell = seed_group_plan()
         extra = presc(session, name="Curl", order=7)
         membership = GroupMembershipFactory(group=group)
-        _, member_week = membership.sync_delivered_plan(week)
+        _, member_weeks = membership.sync_delivered_plan(week.mesocycle)
+        member_week = member_weeks[0]
         member_session = member_week.sessions.get(
             session_slot__day_number=session.day_number
         )
@@ -719,7 +722,7 @@ class TestGroupRedeliverySoftDelete:
             )
         )
         assert resp.status_code == 200
-        membership.sync_delivered_plan(week)
+        membership.sync_delivered_plan(week.mesocycle)
 
         member_extra.exercise_slot.refresh_from_db()
         assert member_extra.exercise_slot.deleted_at is not None

--- a/app/store_project/meso/tests/test_group_deliver.py
+++ b/app/store_project/meso/tests/test_group_deliver.py
@@ -1,10 +1,15 @@
-"""Groups slice (S1) Phase 4 — deliver to all members.
+"""Groups slice — deliver the whole shared BLOCK to all members (P5).
 
-Delivering a group's shared week **fans out** a per-athlete *resolved* program:
-each active member gets their effective week (the shared template + their
-override diffs) materialized into their own individual plan, stamped delivered,
-so they see it through the unchanged athlete surface (`/meso/me/` + the session
-logger) and get the same delivery email/push the individual slice built.
+Delivering a group's shared program **fans out** a per-athlete *resolved* copy of
+the whole block: each active member gets every live week of the shared mesocycle
+(the shared template + their override diffs) materialized into their own
+individual plan, stamped delivered, so they see it through the unchanged athlete
+surface (`/meso/me/` + the session logger) and get a single "your block is ready"
+email/push — one per member, not one per week.
+
+This is the group peer of the P3 individual whole-block delivery: both release
+the whole mesocycle at once, and both mirror the source's ``is_current`` pointer
+(the week the athlete is on) rather than flagging every delivered week current.
 
 The modeling: a materialized plan is rooted at the member's `CoachAthlete`
 relationship (an ordinary individual plan to the athlete surface) and tagged
@@ -14,8 +19,8 @@ individual surfaces never see it.
 These tests cover:
 
 - `GroupMembership.sync_delivered_plan` — materializes one resolved plan per
-  member, idempotently, preserving logs while propagating edits;
-- `MesoGroup.deliver_current_week` — the fan-out + its empty-state guards;
+  member, block-wide, idempotently, preserving logs while propagating edits;
+- `MesoGroup.deliver_block` — the whole-block fan-out + its empty-state guards;
 - the queryset tenancy (`for_coach`/`editable_by` hide it, `for_athlete` shows it)
   and the athlete-surface reuse;
 - `plan_deliver` (the group-aware JSON endpoint) + its notifications + guards;
@@ -64,9 +69,24 @@ def seed_group(coach=None, *, member_count=2, focus="Strength"):
     return group, plan, memberships
 
 
+def shared_meso(plan):
+    """The shared program's (only) mesocycle — the block delivery targets."""
+    return plan.mesocycles.get()
+
+
+def append_shared_week(plan):
+    """Grow the shared block to a second live week so a block has ≥2 to deliver.
+
+    ``append_week`` adds a non-current, undelivered draft column — exactly what
+    the multi-week designer does — so the block now holds week 1 (the scaffold's
+    current week) plus week 2. Returns the new ``Week``.
+    """
+    return shared_meso(plan).append_week()
+
+
 def shared_prescriptions(plan):
     """The shared program's current-week prescription cells, in (day, row) order."""
-    week = plan.mesocycles.get().weeks.get()
+    week = shared_meso(plan).weeks.get(is_current=True)
     return list(
         Prescription.objects.filter(week=week)
         .select_related("exercise_slot", "exercise_slot__session_slot")
@@ -74,27 +94,78 @@ def shared_prescriptions(plan):
     )
 
 
+def live_weeks(plan):
+    """The shared block's live weeks, in ``index`` order."""
+    return list(
+        shared_meso(plan).weeks.filter(deleted_at__isnull=True).order_by("index")
+    )
+
+
 def deliver_url(plan):
     return reverse("meso:api_plan_deliver", kwargs={"plan_id": plan.pk})
 
 
-# -- model: sync_delivered_plan (per-member materialization) ------------------
+# -- model: sync_delivered_plan (per-member block materialization) ------------
 
 
 class TestSyncDeliveredPlan:
     def test_materializes_one_plan_per_member_rooted_at_relationship(self):
         group, plan, [m] = seed_group(member_count=1)
-        group_week = plan.mesocycles.get().weeks.get()
+        meso = shared_meso(plan)
 
-        member_plan, member_week = m.sync_delivered_plan(group_week)
+        member_plan, member_weeks = m.sync_delivered_plan(meso)
 
         assert member_plan.relationship_id == m.relationship_id
         assert member_plan.source_group_id == group.pk
         assert member_plan.group_id is None  # rooted at the relationship, not the group
         assert member_plan.athlete == m.relationship.athlete
-        # The materialized week mirrors the shared week's structure.
-        assert member_week.index == group_week.index
-        assert member_week.sessions.count() == group_week.sessions.count()
+        # The single scaffold week is materialized, mirroring its structure.
+        assert [w.index for w in member_weeks] == [1]
+        src_week = meso.weeks.get()
+        assert member_weeks[0].sessions.count() == src_week.sessions.count()
+
+    def test_materializes_every_live_week_of_the_block(self):
+        group, plan, [m] = seed_group(member_count=1)
+        append_shared_week(plan)  # a second live week
+        meso = shared_meso(plan)
+
+        _, member_weeks = m.sync_delivered_plan(meso)
+
+        assert [w.index for w in member_weeks] == [1, 2]
+        src_weeks = meso.weeks.filter(deleted_at__isnull=True).order_by("index")
+        for member_week, src_week in zip(member_weeks, src_weeks):
+            assert member_week.sessions.count() == src_week.sessions.count()
+
+    def test_member_week_is_current_mirrors_the_source(self):
+        # Post-P3, ``is_current`` means "the week the athlete is on"; the member's
+        # copy must mirror the source pointer (week 1), NOT flag every week current.
+        group, plan, [m] = seed_group(member_count=1)
+        append_shared_week(plan)
+        meso = shared_meso(plan)
+
+        _, member_weeks = m.sync_delivered_plan(meso)
+
+        by_index = {w.index: w for w in member_weeks}
+        assert by_index[1].is_current is True
+        assert by_index[2].is_current is False
+
+    def test_member_week_is_current_follows_a_moved_source_pointer(self):
+        # When the coach moves the shared current pointer to week 2, the member's
+        # copy follows on the next sync.
+        group, plan, [m] = seed_group(member_count=1)
+        week2 = append_shared_week(plan)
+        meso = shared_meso(plan)
+        week1 = meso.weeks.get(index=1)
+        week1.is_current = False
+        week1.save(update_fields=["is_current"])
+        week2.is_current = True
+        week2.save(update_fields=["is_current"])
+
+        _, member_weeks = m.sync_delivered_plan(meso)
+
+        by_index = {w.index: w for w in member_weeks}
+        assert by_index[1].is_current is False
+        assert by_index[2].is_current is True
 
     def test_resolves_override_for_the_member(self):
         group, plan, [m] = seed_group(member_count=1)
@@ -103,8 +174,9 @@ class TestSyncDeliveredPlan:
         first.save(update_fields=["load"])
         m.set_override(first, load_pct=90, swap_name="Box Squat")
 
-        _, member_week = m.sync_delivered_plan(first.week)
+        _, member_weeks = m.sync_delivered_plan(shared_meso(plan))
 
+        member_week = next(w for w in member_weeks if w.index == first.week.index)
         materialized = (
             member_week.sessions.get(
                 session_slot__day_number=first.exercise_slot.session_slot.day_number
@@ -115,6 +187,40 @@ class TestSyncDeliveredPlan:
         assert materialized.name == "Box Squat"
         assert materialized.load == "90"  # 90% of 100, round-to-2.5
 
+    def test_override_resolves_per_week(self):
+        # An override targets one week's *cell*; only that week's materialized row
+        # carries the diff, the other weeks stay on the shared base.
+        group, plan, [m] = seed_group(member_count=1)
+        week2 = append_shared_week(plan)
+        meso = shared_meso(plan)
+        # The same exercise slot in week 1 (current) and week 2.
+        wk1_cell = shared_prescriptions(plan)[0]
+        wk1_cell.load = "100"
+        wk1_cell.save(update_fields=["load"])
+        wk2_cell = Prescription.objects.get(
+            exercise_slot=wk1_cell.exercise_slot, week=week2
+        )
+        wk2_cell.load = "100"
+        wk2_cell.save(update_fields=["load"])
+        # Override only week 2's cell.
+        m.set_override(wk2_cell, load_pct=50)
+
+        _, member_weeks = m.sync_delivered_plan(meso)
+
+        by_index = {w.index: w for w in member_weeks}
+
+        def cell_for(week):
+            return (
+                week.sessions.get(
+                    session_slot__day_number=wk1_cell.exercise_slot.session_slot.day_number
+                )
+                .cells()
+                .get(exercise_slot__order=wk1_cell.exercise_slot.order)
+            )
+
+        assert cell_for(by_index[1]).load == "100"  # untouched week
+        assert cell_for(by_index[2]).load == "50"  # 50% of 100 on the overridden week
+
     def test_unadjusted_member_gets_the_shared_base(self):
         group, plan, [adjusted, plain] = seed_group(member_count=2)
         first = shared_prescriptions(plan)[0]
@@ -122,8 +228,9 @@ class TestSyncDeliveredPlan:
         first.save(update_fields=["load"])
         adjusted.set_override(first, load_pct=80)
 
-        _, plain_week = plain.sync_delivered_plan(first.week)
+        _, member_weeks = plain.sync_delivered_plan(shared_meso(plan))
 
+        plain_week = next(w for w in member_weeks if w.index == first.week.index)
         row = (
             plain_week.sessions.get(
                 session_slot__day_number=first.exercise_slot.session_slot.day_number
@@ -142,8 +249,9 @@ class TestSyncDeliveredPlan:
         first.skipped = True
         first.save(update_fields=["skipped"])
 
-        _, member_week = m.sync_delivered_plan(first.week)
+        _, member_weeks = m.sync_delivered_plan(shared_meso(plan))
 
+        member_week = next(w for w in member_weeks if w.index == first.week.index)
         materialized = (
             member_week.sessions.get(
                 session_slot__day_number=first.exercise_slot.session_slot.day_number
@@ -155,10 +263,10 @@ class TestSyncDeliveredPlan:
 
     def test_redelivery_reuses_the_same_plan(self):
         group, plan, [m] = seed_group(member_count=1)
-        group_week = plan.mesocycles.get().weeks.get()
+        meso = shared_meso(plan)
 
-        first_plan, _ = m.sync_delivered_plan(group_week)
-        second_plan, _ = m.sync_delivered_plan(group_week)
+        first_plan, _ = m.sync_delivered_plan(meso)
+        second_plan, _ = m.sync_delivered_plan(meso)
 
         assert first_plan.pk == second_plan.pk
         assert (
@@ -168,16 +276,16 @@ class TestSyncDeliveredPlan:
 
     def test_redelivery_preserves_an_athletes_log(self):
         group, plan, [m] = seed_group(member_count=1)
-        group_week = plan.mesocycles.get().weeks.get()
-        _, member_week = m.sync_delivered_plan(group_week)
-        session = member_week.sessions.first()
+        meso = shared_meso(plan)
+        _, member_weeks = m.sync_delivered_plan(meso)
+        session = member_weeks[0].sessions.first()
         log = SessionLogFactory(
             session=session, athlete=m.relationship.athlete, status="done"
         )
 
         # The coach re-delivers (no structural change) — the session row survives,
         # so the athlete's log isn't cascade-deleted.
-        m.sync_delivered_plan(group_week)
+        m.sync_delivered_plan(meso)
 
         assert SessionLog.objects.filter(pk=log.pk).exists()
 
@@ -186,12 +294,13 @@ class TestSyncDeliveredPlan:
         first = shared_prescriptions(plan)[0]
         first.load = "100"
         first.save(update_fields=["load"])
-        group_week = first.week
+        meso = shared_meso(plan)
 
-        m.sync_delivered_plan(group_week)
+        m.sync_delivered_plan(meso)
         m.set_override(first, load_pct=50)
-        _, member_week = m.sync_delivered_plan(group_week)
+        _, member_weeks = m.sync_delivered_plan(meso)
 
+        member_week = next(w for w in member_weeks if w.index == first.week.index)
         row = (
             member_week.sessions.get(
                 session_slot__day_number=first.exercise_slot.session_slot.day_number
@@ -203,61 +312,96 @@ class TestSyncDeliveredPlan:
 
     def test_dropped_shared_prescription_hides_on_member_week(self):
         group, plan, [m] = seed_group(member_count=1)
-        group_week = plan.mesocycles.get().weeks.get()
-        m.sync_delivered_plan(group_week)
+        meso = shared_meso(plan)
+        m.sync_delivered_plan(meso)
         # Drop a row from the shared program, then re-deliver.
         first = shared_prescriptions(plan)[0]
         day_number = first.exercise_slot.session_slot.day_number
         order = first.exercise_slot.order
         first.exercise_slot.soft_delete()
 
-        _, member_week = m.sync_delivered_plan(group_week)
+        _, member_weeks = m.sync_delivered_plan(meso)
 
+        member_week = member_weeks[0]
         member_slot = member_week.mesocycle.session_slots.get(day_number=day_number)
         # The member's copy is *hidden*, never hard-deleted (soft delete,
         # designer framework Phase 0): the member's LoggedSets may reference
         # it, and a source row that returns revives it in place.
         dropped = member_slot.exercise_slots.get(order=order)
         assert dropped.deleted_at is not None
-        live_group_day = group_week.sessions.get(session_slot__day_number=day_number)
+        src_week = meso.weeks.get()
+        live_src_day = src_week.sessions.get(session_slot__day_number=day_number)
         assert (
             member_slot.exercise_slots.filter(deleted_at__isnull=True).count()
-            == live_group_day.cells().count()
+            == live_src_day.cells().count()
         )
 
+    def test_dropped_shared_week_hides_on_member_side(self):
+        # A whole week removed from the shared block soft-deletes the member's
+        # matching week (never hard-deletes — logged history stays recoverable).
+        group, plan, [m] = seed_group(member_count=1)
+        week2 = append_shared_week(plan)
+        meso = shared_meso(plan)
+        member_plan, _ = m.sync_delivered_plan(meso)
+        member_meso = member_plan.mesocycles.get()
+        assert member_meso.weeks.filter(deleted_at__isnull=True).count() == 2
 
-# -- model: deliver_current_week (the fan-out) -------------------------------
+        week2.soft_delete()
+        m.sync_delivered_plan(meso)
+
+        dropped = member_meso.weeks.get(index=2)
+        assert dropped.deleted_at is not None
+        assert member_meso.weeks.filter(deleted_at__isnull=True).count() == 1
 
 
-class TestDeliverCurrentWeek:
-    def test_stamps_every_member_week_and_the_group_week(self):
+# -- model: deliver_block (the whole-block fan-out) --------------------------
+
+
+class TestDeliverBlock:
+    def test_stamps_every_member_week_and_every_shared_week(self):
         group, plan, memberships = seed_group(member_count=2)
-        group_week = plan.mesocycles.get().weeks.get()
+        append_shared_week(plan)  # a two-week block
+        shared_live = live_weeks(plan)
+        assert len(shared_live) == 2
 
-        now, delivered = group.deliver_current_week()
+        now, delivered = group.deliver_block()
 
         assert len(delivered) == 2
-        for member_plan, member_week in delivered:
-            assert member_week.delivered_at == now
-            assert WeekDelivery.objects.filter(week=member_week).count() == 1
-        group_week.refresh_from_db()
-        assert group_week.delivered_at == now
+        for member_plan, member_weeks in delivered:
+            assert len(member_weeks) == 2
+            for member_week in member_weeks:
+                assert member_week.delivered_at == now
+                assert WeekDelivery.objects.filter(week=member_week).count() == 1
+        for shared_week in shared_live:
+            shared_week.refresh_from_db()
+            assert shared_week.delivered_at == now
+            assert WeekDelivery.objects.filter(week=shared_week).count() == 1
+
+    def test_member_weeks_mirror_the_source_current_pointer(self):
+        group, plan, [m] = seed_group(member_count=1)
+        append_shared_week(plan)
+
+        group.deliver_block()
+
+        member_meso = Plan.objects.get(source_group=group).mesocycles.get()
+        assert member_meso.weeks.get(index=1).is_current is True
+        assert member_meso.weeks.get(index=2).is_current is False
 
     def test_raises_without_a_shared_plan(self):
         group = MesoGroupFactory()
         with pytest.raises(InvalidTransition):
-            group.deliver_current_week()
+            group.deliver_block()
 
     def test_raises_without_members(self):
         group, _, _ = seed_group(member_count=0)
         with pytest.raises(InvalidTransition):
-            group.deliver_current_week()
+            group.deliver_block()
 
     def test_skips_a_member_whose_link_ended(self):
         group, plan, [stays, leaves] = seed_group(member_count=2)
         leaves.relationship.end()
 
-        _, delivered = group.deliver_current_week()
+        _, delivered = group.deliver_block()
 
         athletes = {p.athlete for p, _ in delivered}
         assert stays.relationship.athlete in athletes
@@ -272,7 +416,7 @@ class TestDeliverCurrentWeek:
         newer = group.create_shared_plan()
         assert group.shared_plan().pk == newer.pk
 
-        group.deliver_current_week(older)
+        group.deliver_block(older)
 
         materialized = Plan.objects.get(source_group=group, relationship=m.relationship)
         assert materialized.title == older.title
@@ -285,7 +429,7 @@ class TestMaterializedPlanScoping:
     def test_hidden_from_coach_surfaces_visible_to_athlete(self):
         group, plan, [m] = seed_group(member_count=1)
         coach = group.coach
-        group.deliver_current_week()
+        group.deliver_block()
         member_plan = Plan.objects.get(source_group=group)
 
         # The coach manages the group only through the shared program — the
@@ -297,7 +441,7 @@ class TestMaterializedPlanScoping:
 
     def test_member_sees_delivered_week_on_athlete_home(self, client):
         group, plan, [m] = seed_group(member_count=1)
-        group.deliver_current_week()
+        group.deliver_block()
         athlete = m.relationship.athlete
         client.force_login(athlete)
 
@@ -307,7 +451,7 @@ class TestMaterializedPlanScoping:
 
     def test_member_can_open_a_delivered_session(self, client):
         group, plan, [m] = seed_group(member_count=1)
-        group.deliver_current_week()
+        group.deliver_block()
         member_plan = Plan.objects.get(source_group=group)
         session = Session.objects.get(
             week__mesocycle__plan=member_plan, session_slot__day_number=1
@@ -323,7 +467,7 @@ class TestMaterializedPlanScoping:
         # materialized snapshot — a coach posting its id directly to deliver /
         # autosave must not be able to mutate the athlete-facing copy.
         group, plan, [m] = seed_group(member_count=1)
-        group.deliver_current_week()
+        group.deliver_block()
         member_plan = Plan.objects.get(source_group=group)
         assert member_plan.is_editable_by(group.coach) is False
         client.force_login(group.coach)
@@ -336,7 +480,7 @@ class TestMaterializedPlanScoping:
 class TestRemovedMemberLosesAccess:
     def test_remove_athlete_archives_their_materialized_plan(self):
         group, plan, [stays, leaves] = seed_group(member_count=2)
-        group.deliver_current_week()
+        group.deliver_block()
         gone = leaves.relationship.athlete
         leaves_plan = Plan.objects.get(source_group=group, relationship__athlete=gone)
 
@@ -371,11 +515,33 @@ class TestPlanDeliverGroup:
         assert data["ok"] is True
         assert data["members"] == 2
         assert data["delivered_at"]
+        assert data["week_count"] == 1
         assert Plan.objects.filter(source_group=group).count() == 2
 
-    def test_group_ignores_a_week_id_and_fans_out_current(self, client):
+    def test_group_plan_fans_out_the_whole_block(self, client):
+        group, plan, memberships = seed_group(member_count=2)
+        append_shared_week(plan)  # a two-week block
+        client.force_login(group.coach)
+
+        resp = client.post(deliver_url(plan))
+
+        assert resp.status_code == 201
+        assert resp.json()["week_count"] == 2
+        # Each member's materialized plan carries both delivered weeks.
+        for m in memberships:
+            member_plan = Plan.objects.get(
+                source_group=group, relationship=m.relationship
+            )
+            assert (
+                member_plan.mesocycles.get()
+                .weeks.filter(delivered_at__isnull=False)
+                .count()
+                == 2
+            )
+
+    def test_group_ignores_a_week_id_and_fans_out_the_block(self, client):
         # Per-week delivery is an individual-designer affordance; a group plan
-        # always fans out its current week, so a stray ``week_id`` in the body is
+        # always fans out its whole block, so a stray ``week_id`` in the body is
         # ignored (the group branch short-circuits before the body is read).
         import json
 
@@ -392,18 +558,21 @@ class TestPlanDeliverGroup:
         assert resp.json()["members"] == 2
         assert Plan.objects.filter(source_group=group).count() == 2
 
-    def test_notifies_each_member_once(
+    def test_notifies_each_member_once_for_the_whole_block(
         self, client, mailoutbox, django_capture_on_commit_callbacks
     ):
+        # A two-week block delivers ONE nudge per member (the block notifier),
+        # never one email per week — so member_count emails, not member_count×weeks.
         coach = UserFactory(name="Coach Lance", email="coach@example.com")
         group, plan, memberships = seed_group(coach=coach, member_count=2)
+        append_shared_week(plan)  # two live weeks
         emails = {m.relationship.athlete.email for m in memberships}
         client.force_login(coach)
 
         with django_capture_on_commit_callbacks(execute=True):
             client.post(deliver_url(plan))
 
-        assert len(mailoutbox) == 2
+        assert len(mailoutbox) == 2  # one per member, NOT one per member per week
         assert {m.to[0] for m in mailoutbox} == emails
 
     def test_group_without_members_400(self, client):
@@ -455,6 +624,25 @@ class TestGroupDeliverView:
         assert resp.url == reverse("meso:group", kwargs={"pk": group.pk})
         assert Plan.objects.filter(source_group=group).count() == 2
 
+    def test_flash_names_the_block_and_week_count(self, client):
+        group, plan, memberships = seed_group(member_count=2)
+        append_shared_week(plan)  # two live weeks
+        client.force_login(group.coach)
+
+        resp = client.post(group_deliver_url(group), follow=True)
+
+        body = resp.content.decode()
+        assert "Delivered the block (2 weeks) to 2 members." in body
+
+    def test_flash_singular_block_and_member(self, client):
+        group, plan, [m] = seed_group(member_count=1)
+        client.force_login(group.coach)
+
+        resp = client.post(group_deliver_url(group), follow=True)
+
+        body = resp.content.decode()
+        assert "Delivered the block (1 week) to 1 member." in body
+
     def test_requires_a_shared_program(self, client):
         coach = UserFactory()
         group = MesoGroupFactory(coach=coach)
@@ -491,6 +679,8 @@ class TestGroupDeliverView:
             reverse("meso:group", kwargs={"pk": group.pk})
         ).content.decode()
         assert group_deliver_url(group) in body
+        # The button names the whole block, not a single week (P5).
+        assert "Deliver this block" in body
 
     def test_detail_page_hides_deliver_button_without_members(self, client):
         coach = UserFactory()

--- a/app/store_project/meso/tests/test_load_type.py
+++ b/app/store_project/meso/tests/test_load_type.py
@@ -225,7 +225,7 @@ class TestGroupFanOutLoadType:
         shared.load_type = LoadType.PERCENT
         shared.save(update_fields=["load", "load_type"])
 
-        group.deliver_current_week(plan)
+        group.deliver_block(plan)
 
         member_plan = Plan.objects.get(
             relationship=membership.relationship, source_group=group

--- a/app/store_project/meso/tests/test_serializers.py
+++ b/app/store_project/meso/tests/test_serializers.py
@@ -750,3 +750,85 @@ class TestSerializeMesocycleGrid:
         result = serialize_mesocycle_grid(f.meso)
         day1_data = result["days"][0]
         assert day1_data["session_id"] == f.day1_wk2.pk
+
+    def test_individual_grid_cells_carry_no_adj_overlay(self):
+        # The per-athlete ``adj`` overlay is a GROUP-only concern; an individual
+        # plan's grid cells never carry ``adj``/``adjusts``.
+        f = _build_grid_meso()
+        result = serialize_mesocycle_grid(f.meso)
+        for day_data in result["days"]:
+            for row in day_data["rows"]:
+                for cell in row["cells"].values():
+                    assert "adj" not in cell
+                    assert "adjusts" not in cell
+
+
+def _build_group_grid_meso():
+    """A one-day, two-row, single-week GROUP block with one member override.
+
+    Day 1 (order 0): Back Squat (order 0, load 100, overridden for the member)
+    + Bench Press (order 1, no override). The member's adjust — a swap + a load %
+    — is the ``adj`` overlay the grid must attach to the overridden cell only.
+    """
+    from store_project.meso.factories import GroupMembershipFactory
+    from store_project.meso.factories import GroupPlanFactory
+    from store_project.meso.factories import MesoGroupFactory
+
+    group = MesoGroupFactory()
+    plan = GroupPlanFactory(group=group, status=Plan.Status.ACTIVE)
+    meso = MesocycleFactory(plan=plan, name="Hypertrophy", order=0)
+    week = WeekFactory(mesocycle=meso, index=1, is_current=True)
+    day1 = day(week, day_number=1, name="Lower", order=0)
+    squat_cell = presc(day1, name="Back Squat", order=0, load="100")
+    bench_cell = presc(day1, name="Bench Press", order=1, load="60")
+    membership = GroupMembershipFactory(group=group)
+    membership.set_override(squat_cell, load_pct=90, swap_name="Box Squat")
+    return SimpleNamespace(
+        group=group,
+        plan=plan,
+        meso=meso,
+        week=week,
+        day1=day1,
+        squat_cell=squat_cell,
+        bench_cell=bench_cell,
+        membership=membership,
+    )
+
+
+class TestSerializeMesocycleGridGroupAdj:
+    """A group plan's grid cells carry the per-athlete ``adj`` overlay (P5).
+
+    The multi-week table must show the same per-row adjust badge the single-week
+    ``serialize_plan`` overlay does — driven by the members' real override diffs —
+    so a coach editing the whole block still sees who diverges from the shared base.
+    """
+
+    def _cell(self, result, *, day_index, row_index, week):
+        return result["days"][day_index]["rows"][row_index]["cells"][str(week.pk)]
+
+    def test_overridden_cell_carries_adj_and_adjusts(self):
+        f = _build_group_grid_meso()
+        result = serialize_mesocycle_grid(f.meso)
+        cell = self._cell(result, day_index=0, row_index=0, week=f.week)
+        assert "adj" in cell
+        assert "adjusts" in cell
+        # The raw stored diff round-trips so the in-grid editor can pre-fill it.
+        adjust = cell["adjusts"][0]
+        assert adjust["swap"] == "Box Squat"
+        assert adjust["load_pct"] == 90
+
+    def test_unadjusted_cell_has_no_adj(self):
+        f = _build_group_grid_meso()
+        result = serialize_mesocycle_grid(f.meso)
+        cell = self._cell(result, day_index=0, row_index=1, week=f.week)
+        assert "adj" not in cell
+        assert "adjusts" not in cell
+
+    def test_dropped_member_leaves_no_adj(self):
+        # ``group_adjustments`` scopes to *active* members — an ended link's adjust
+        # drops off the grid, matching the single-week overlay.
+        f = _build_group_grid_meso()
+        f.membership.relationship.end()
+        result = serialize_mesocycle_grid(f.meso)
+        cell = self._cell(result, day_index=0, row_index=0, week=f.week)
+        assert "adj" not in cell

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -1182,14 +1182,14 @@ def sandbox_signup(request):
 @login_required
 @require_POST
 def group_deliver(request, pk):
-    """Deliver a group's shared current week to every active member (Phase 4).
+    """Deliver a group's whole shared current block to every active member (P5).
 
     The coach-facing entry — a plain form POST from the group-detail page's
-    "Deliver this week to all members" button. Coach-scoped (a foreign or unknown
+    "Deliver this block to all members" button. Coach-scoped (a foreign or unknown
     group is a flat 404). Requires a shared program (else a flashed prompt to
     design one) and at least one member (else a flashed error from the fan-out);
-    on success it flashes how many members were delivered to. Always lands back on
-    the group-detail page.
+    on success it flashes the block's week count + how many members were delivered
+    to. Always lands back on the group-detail page.
     """
     group = MesoGroup.objects.for_coach(request.user).filter(pk=pk).first()
     if group is None:
@@ -1207,9 +1207,11 @@ def group_deliver(request, pk):
         messages.error(request, error)
     else:
         n = summary["members"]
+        w = summary["week_count"]
         messages.success(
             request,
-            f"Delivered this week to {n} member{'' if n == 1 else 's'}.",
+            f"Delivered the block ({w} week{'' if w == 1 else 's'}) to "
+            f"{n} member{'' if n == 1 else 's'}.",
         )
     return redirect("meso:group", pk=group.pk)
 
@@ -3571,25 +3573,38 @@ def coach_set_one_rm(request, plan_id, pk):
 
 
 def _fan_out_group_delivery(request, plan):
-    """Deliver a group plan's current week to every active member (groups Phase 4).
+    """Deliver a group plan's whole current block to every active member (P5).
 
-    Runs the model fan-out (``MesoGroup.deliver_current_week``) — each member's
-    *resolved* week materialized + stamped + snapshotted — then notifies each
-    athlete (email + push, best-effort on commit), reusing the individual deliver
-    hook. Returns ``(summary, error)``: ``error`` is a human message when there is
-    nothing to deliver (no week / no members), which the callers map to a 400 /
-    flashed error. The whole fan-out runs inside the request's transaction
-    (``ATOMIC_REQUESTS``), so a partial fan-out can't half-commit.
+    Runs the model fan-out (``MesoGroup.deliver_block``) — each member's
+    *resolved* block materialized + every live week stamped + snapshotted — then
+    notifies each athlete ONCE at block level (email + push, best-effort on
+    commit), reusing the P3 individual block deliver hook (one nudge per member,
+    not one per week). Returns ``(summary, error)``: ``error`` is a human message
+    when there is nothing to deliver (no live week / no members), which the
+    callers map to a 400 / flashed error. ``summary["week_count"]`` is the shared
+    block's live-week count. The whole fan-out runs inside the request's
+    transaction (``ATOMIC_REQUESTS``), so a partial fan-out can't half-commit.
     """
     try:
         # Deliver the *requested* plan, not whichever the group reselects, so a
         # group holding more than one program can't drift to a different one.
-        now, delivered = plan.group.deliver_current_week(plan)
+        now, delivered = plan.group.deliver_block(plan)
     except InvalidTransition as exc:
         return None, str(exc)
-    for member_plan, member_week in delivered:
-        _notify_athlete_delivered(request, member_plan, member_week)
-    return {"members": len(delivered), "delivered_at": now.isoformat()}, None
+    for member_plan, member_weeks in delivered:
+        # One block notification per member (the whole block delivered at once),
+        # not one per week — reuse the P3 block notifier.
+        _notify_athlete_block_delivered(
+            request, member_plan, member_weeks[0].mesocycle, len(member_weeks)
+        )
+    # Every member mirrors the same shared block, so its live-week count is the
+    # member's week count; the fan-out guarantees at least one member.
+    week_count = len(delivered[0][1])
+    return {
+        "members": len(delivered),
+        "delivered_at": now.isoformat(),
+        "week_count": week_count,
+    }, None
 
 
 @login_required
@@ -3606,16 +3621,16 @@ def plan_deliver(request, plan_id):
     week must belong to the plan (a foreign week is a 404). Re-delivering re-stamps
     every week and writes fresh ``WeekDelivery`` rows. Delivering never changes
     ``is_current`` — releasing a block doesn't move the live pointer. A group plan
-    still fans out its current week per-member (per-week delivery is a group-path
-    affordance a later phase rewrites), so its branch is unchanged.
+    fans out its whole current block per-member (P5 brought group delivery to the
+    same whole-block parity), so its branch also releases every live week at once.
     """
     plan, forbidden = _editable_plan_or_response(request, plan_id)
     if forbidden is not None:
         return forbidden
     if plan.is_group:
-        # A group plan fans its current week out to every active member (each
-        # member's *resolved* program), groups Phase 4. ``week_id`` is ignored —
-        # the group always sends its current week.
+        # A group plan fans its whole current block out to every active member
+        # (each member's *resolved* program), P5. ``week_id`` is ignored — the
+        # group always sends its whole block.
         summary, error = _fan_out_group_delivery(request, plan)
         if error is not None:
             return HttpResponseBadRequest(error)

--- a/app/store_project/templates/meso/group_detail.html
+++ b/app/store_project/templates/meso/group_detail.html
@@ -51,7 +51,7 @@
             {% if group.member_count %}
               <form method="post" action="{% url 'meso:group_deliver' group.id %}" style="margin-top:10px;">
                 {% csrf_token %}
-                <button type="submit" class="meso-btn">Deliver this week to all {{ group.member_count }} member{{ group.member_count|pluralize }}</button>
+                <button type="submit" class="meso-btn">Deliver this block to all {{ group.member_count }} member{{ group.member_count|pluralize }}</button>
               </form>
             {% endif %}
           {% else %}

--- a/frontend/designer/CONTRACT.md
+++ b/frontend/designer/CONTRACT.md
@@ -253,6 +253,40 @@ adjusts: data.adjusts ?? []})`, `adoptHistory(data)`, close; on failure,
 editor stays open (`ex` on `program` is untouched either way, matching
 "keeps the editor open ... row unchanged" in `meso.test.js`).
 
+#### P5: per-athlete adjust on the multi-week table (`MesoTable`)
+
+The broader multi-week grid subsystem (`useGrid`, `MesoTable`, `GridCell`/
+`GridRow`/`GridDay`/`MesoGrid`) postdates this contract and is specified in
+`docs/meso/fixed-selection-plan.md` — only the P5 group-adjust slice is
+pinned here, since it reuses the override machinery above.
+
+`GridCell` (in `lib/api.ts`) gains two optional group-only fields, emitted
+by `serialize_mesocycle_grid` on a GROUP plan for each cell that has an
+effective adjust (individual plans never carry them, so `cell.adj` is
+`undefined`): `adj?: string | null` — the cell's badge summary (e.g.
+`"MO -10%"` / `"2 adjusts"`) — and `adjusts?: OverrideAdjust[]` — every
+member's stored diff. They mirror `Exercise.adj`/`Exercise.adjusts` on the
+one-week path.
+
+`MesoTable` gains `group: GroupIdentity | null` and
+`onOpenOverride(row: GridRow, cell: GridCell)`. When `group` has members,
+every NON-skipped cell renders the same `.meso-adjust-badge` /
+`.meso-adjust-empty` "+ adjust"/`cell.adj` control `ExerciseRow` uses (testid
+`cell-override-badge-{prescription_id}`); a click hands `(row, cell)` up.
+No control renders for an individual plan (`group === null`) or a skipped cell.
+
+`DesignerRoot` synthesizes an `Exercise` from the `(row, cell)` pair
+(`id: cell.prescription_id`, `name: row.name`, the cell's numbers, plus
+`adj`/`adjusts`) and opens a SECOND, grid-scoped `useOverrideEditor` — same
+hook, same `OverrideModal`, but wired `patchExercise: gridState.patchCellAdj`
+(repaints the cell's `adj`/`adjusts` in place, no grid refetch) and
+`adoptHistory: gridState.adoptGridHistory` (adopts the reply's
+`serialize_plan_history` into the grid's own undo history). Only one of the
+two override modals is ever open at a time (each opens from its own view).
+`useGrid` exposes `patchCellAdj(cellId, {adj, adjusts})` (a local, POST-free
+cell repaint — the grid analog of `patchExercise`) and `adoptGridHistory`
+(now coercing `string | null` labels so the override reply adopts cleanly).
+
 ### useOneRmEditor
 
 ```ts

--- a/frontend/designer/src/DesignerRoot.test.tsx
+++ b/frontend/designer/src/DesignerRoot.test.tsx
@@ -362,6 +362,89 @@ describe("hydration: #meso-grid-data / P1 table view default", () => {
   });
 });
 
+// === P5 group: per-cell per-athlete adjust on the multi-week table. The
+// table (gridState) is a sibling data owner to planData, so it gets its own
+// grid-scoped useOverrideEditor whose patchExercise/adoptHistory route into
+// gridState — a cell's adjust badge repaints (and the grid's undo history
+// updates) straight from the override reply, no grid refetch. Mounted at the
+// DesignerRoot level because these specs exercise the real modal + POST wiring
+// that MesoTable only reaches through DesignerRoot.
+function groupPlanPayload(overrides: Record<string, unknown> = {}) {
+  return planPayload({
+    group: {
+      id: 3,
+      name: "Squad",
+      member_count: 2,
+      members: [
+        { id: "a1", name: "Maya Okonkwo", initials: "MO" },
+        { id: "a2", name: "Aaron Adams", initials: "AA" },
+      ],
+      flags: [],
+    },
+    athlete: null,
+    ...overrides,
+  });
+}
+
+describe("P5 group: per-cell adjust on the table", () => {
+  it("shows the adjust badge on a group table cell and opens the override editor for that cell on click", async () => {
+    const user = userEvent.setup();
+    jsonScript("meso-plan-data", groupPlanPayload());
+    jsonScript("meso-chat-thread", []);
+    csrfSpan();
+    jsonScript("meso-designer-flags", flagsPayload());
+    jsonScript("meso-grid-data", gridPayload());
+
+    render(<DesignerRoot />);
+
+    const badge = screen.getByTestId("cell-override-badge-100");
+    expect(badge).toHaveTextContent("+ adjust");
+
+    await user.click(badge);
+
+    // The override modal is open, scoped to this cell's row (name "Squat")
+    // with the group's members selectable.
+    expect(screen.getByText("Per-athlete adjust")).toBeInTheDocument();
+    expect(screen.getByTestId("override-member-a1")).toBeInTheDocument();
+    expect(screen.getByTestId("override-member-a2")).toBeInTheDocument();
+    expect(screen.getByText("Squat")).toBeInTheDocument();
+  });
+
+  it("saving an adjust POSTs to the cell's /prescription/{id}/override/ and repaints the badge without a grid refetch", async () => {
+    const user = userEvent.setup();
+    jsonScript("meso-plan-data", groupPlanPayload());
+    jsonScript("meso-chat-thread", []);
+    csrfSpan();
+    jsonScript("meso-designer-flags", flagsPayload());
+    jsonScript("meso-grid-data", gridPayload());
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        adj: "MO -10%",
+        adjusts: [
+          { id: "a1", name: "Maya Okonkwo", initials: "MO", label: "-10%", swap: "", load_pct: 90, sets: "", reps: "", note: "" },
+        ],
+        history: { can_undo: true, can_redo: false, undo_label: "Adjusted Squat", redo_label: "" },
+      }),
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<DesignerRoot />);
+    await user.click(screen.getByTestId("cell-override-badge-100"));
+    await user.type(screen.getByTestId("override-load-pct-input"), "90");
+    await user.click(screen.getByTestId("override-save-button"));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith("/meso/api/plan/7/prescription/100/override/", expect.anything()),
+    );
+    // Only the override POST — no follow-up /grid/ refetch (repaint is local).
+    expect(fetchMock).not.toHaveBeenCalledWith("/meso/api/plan/7/grid/");
+    await waitFor(() => expect(screen.getByTestId("cell-override-badge-100")).toHaveTextContent("MO -10%"));
+  });
+});
+
 describe("hydration: missing or malformed payload", () => {
   it("renders nothing when #meso-plan-data is absent", () => {
     const { container } = render(<DesignerRoot />);

--- a/frontend/designer/src/DesignerRoot.tsx
+++ b/frontend/designer/src/DesignerRoot.tsx
@@ -33,6 +33,9 @@ import { useCoachmarks } from "./hooks/useCoachmarks";
 import type {
   AthleteIdentity,
   Day,
+  Exercise,
+  GridCell,
+  GridRow,
   GroupIdentity,
   HistoryState,
   MesoGrid,
@@ -185,6 +188,27 @@ function readHydration(): Hydrated | null {
   };
 }
 
+/** P5 group: the override editor's `openOverride(ex)` takes an `Exercise`, but
+ * the multi-week table works in (GridRow, GridCell) pairs — each cell IS a
+ * Prescription. Synthesize the Exercise the editor needs from that pair: the
+ * cell's own numbers under the row's block name, carrying `adj`/`adjusts` so
+ * the modal preselects the adjusted member and seeds their draft. `id` is the
+ * cell's `prescription_id` — the same id the override reply patches back. */
+function synthesizeCellExercise(row: GridRow, cell: GridCell): Exercise {
+  return {
+    id: cell.prescription_id,
+    name: row.name,
+    sets: cell.sets,
+    reps: cell.reps,
+    load: cell.load,
+    load_type: cell.load_type,
+    rpe: cell.rpe,
+    note: cell.note,
+    adj: cell.adj ?? null,
+    adjusts: cell.adjusts ?? [],
+  };
+}
+
 export function DesignerRoot() {
   const [hydrated] = useState<Hydrated | null>(() => readHydration());
   const [mode, setMode] = useState<DesignerMode>(hydrated?.initialMode ?? "individual");
@@ -256,6 +280,19 @@ export function DesignerRoot() {
     group: planData.group,
     adoptHistory: planData.adoptHistory,
     patchExercise: planData.patchExercise,
+  });
+  // P5 group: a SECOND override editor scoped to the table's data owner
+  // (gridState) rather than planData — same hook, same modal, but its
+  // save/clear reply repaints the grid cell (patchCellAdj) and adopts the
+  // grid's own undo history. Keeps the two sibling data owners independent
+  // (an adjust made in the table doesn't touch planData's one-week program,
+  // and vice-versa), matching how gridState and planData already diverge.
+  const gridOverrideEditor = useOverrideEditor({
+    planId,
+    csrf,
+    group: planData.group,
+    adoptHistory: gridState.adoptGridHistory,
+    patchExercise: gridState.patchCellAdj,
   });
   const oneRmEditor = useOneRmEditor({
     planId,
@@ -394,6 +431,8 @@ export function DesignerRoot() {
                 history={gridState.history}
                 busy={gridState.busy}
                 unit={unit}
+                group={planData.group}
+                onOpenOverride={(row, cell) => gridOverrideEditor.openOverride(synthesizeCellExercise(row, cell))}
                 onPatchCell={gridState.patchCell}
                 onRenameExercise={gridState.renameExercise}
                 onAddExercise={gridState.addExercise}
@@ -500,6 +539,20 @@ export function DesignerRoot() {
         onClose={overrideEditor.closeOverride}
         onSave={overrideEditor.saveOverride}
         onClear={overrideEditor.clearOverride}
+      />
+
+      {/* P5 group: the table view's own override modal (grid-scoped editor).
+          Portal-free like its sibling above; only one is ever non-null at a
+          time since each opens from its own view (WeekGrid vs MesoTable). */}
+      <OverrideModal
+        override={gridOverrideEditor.override}
+        overrideHasExisting={gridOverrideEditor.overrideHasExisting}
+        unit={unit}
+        onSelectMember={gridOverrideEditor.selectOverrideMember}
+        onUpdateDraft={gridOverrideEditor.updateDraft}
+        onClose={gridOverrideEditor.closeOverride}
+        onSave={gridOverrideEditor.saveOverride}
+        onClear={gridOverrideEditor.clearOverride}
       />
     </div>
   );

--- a/frontend/designer/src/components/MesoTable.test.tsx
+++ b/frontend/designer/src/components/MesoTable.test.tsx
@@ -7,7 +7,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MesoTable } from "./MesoTable";
-import type { GridCell, GridDay, GridRow, GridWeek, MesoGrid } from "../lib/api";
+import type { GridCell, GridDay, GridRow, GridWeek, GroupIdentity, MesoGrid } from "../lib/api";
 
 function week(overrides: Partial<GridWeek> = {}): GridWeek {
   return {
@@ -75,6 +75,20 @@ function grid(overrides: Partial<MesoGrid> = {}): MesoGrid {
   };
 }
 
+function group(overrides: Partial<GroupIdentity> = {}): GroupIdentity {
+  return {
+    id: 3,
+    name: "Squad",
+    member_count: 2,
+    members: [
+      { id: "a1", name: "Maya Okonkwo", initials: "MO" },
+      { id: "a2", name: "Aaron Adams", initials: "AA" },
+    ],
+    flags: [],
+    ...overrides,
+  };
+}
+
 const HISTORY_NONE = { can_undo: false, can_redo: false, undo_label: "", redo_label: "" };
 
 function baseProps(overrides: Partial<Parameters<typeof MesoTable>[0]> = {}) {
@@ -83,6 +97,8 @@ function baseProps(overrides: Partial<Parameters<typeof MesoTable>[0]> = {}) {
     history: HISTORY_NONE,
     busy: false,
     unit: "kg",
+    group: null,
+    onOpenOverride: vi.fn(),
     onPatchCell: vi.fn(),
     onRenameExercise: vi.fn(),
     onAddExercise: vi.fn(),
@@ -509,5 +525,65 @@ describe("add exercise this week", () => {
     await user.click(screen.getByTestId("add-this-week-1"));
     await user.click(screen.getByTestId("add-this-week-1-2"));
     expect(onAddExerciseThisWeek).toHaveBeenCalledWith(expect.objectContaining({ session_slot_id: 1 }), 2);
+  });
+});
+
+// --- P5 group: per-cell per-athlete adjust badge ---------------------------
+// Mirrors ExerciseRow's group "+ adjust"/`ex.adj` badge (.meso-adjust-badge /
+// .meso-adjust-empty, testid override-badge-<id>), but scoped PER CELL on the
+// multi-week table — testid `cell-override-badge-<prescription_id>`. Only
+// shown when a `group` with members is passed (individual plans carry no
+// group) and never on a skipped cell. Clicking it hands (row, cell) up to
+// DesignerRoot, which synthesizes an Exercise and opens the override editor.
+describe("group per-athlete adjust badge", () => {
+  const adjustsFor = (id: string) => [
+    { id, name: "Maya Okonkwo", initials: "MO", label: "-10%", swap: "", load_pct: 90, sets: "", reps: "", note: "" },
+  ];
+
+  it("renders the adj summary as the badge text for a group cell that has one", () => {
+    render(
+      <MesoTable
+        {...baseProps({
+          group: group(),
+          grid: grid({
+            days: [day({ rows: [row({ cells: { "1": cell({ adj: "MO -10%", adjusts: adjustsFor("a1") }) } })] })],
+          }),
+        })}
+      />,
+    );
+    expect(screen.getByTestId("cell-override-badge-100")).toHaveTextContent("MO -10%");
+  });
+
+  it('renders a "+ adjust" affordance for a group cell with no adj', () => {
+    render(<MesoTable {...baseProps({ group: group() })} />);
+    expect(screen.getByTestId("cell-override-badge-100")).toHaveTextContent("+ adjust");
+  });
+
+  it("renders NO adjust control for an individual plan (group is null)", () => {
+    render(<MesoTable {...baseProps({ group: null })} />);
+    expect(screen.queryByTestId("cell-override-badge-100")).not.toBeInTheDocument();
+  });
+
+  it("renders no adjust control for a skipped cell", () => {
+    render(
+      <MesoTable
+        {...baseProps({
+          group: group(),
+          grid: grid({ days: [day({ rows: [row({ cells: { "1": cell({ skipped: true }) } })] })] }),
+        })}
+      />,
+    );
+    expect(screen.queryByTestId("cell-override-badge-100")).not.toBeInTheDocument();
+  });
+
+  it("clicking the badge calls onOpenOverride with the owning row and cell", async () => {
+    const user = userEvent.setup();
+    const onOpenOverride = vi.fn();
+    render(<MesoTable {...baseProps({ group: group(), onOpenOverride })} />);
+    await user.click(screen.getByTestId("cell-override-badge-100"));
+    expect(onOpenOverride).toHaveBeenCalledWith(
+      expect.objectContaining({ exercise_slot_id: 9 }),
+      expect.objectContaining({ prescription_id: 100 }),
+    );
   });
 });

--- a/frontend/designer/src/components/MesoTable.tsx
+++ b/frontend/designer/src/components/MesoTable.tsx
@@ -17,7 +17,7 @@
 // one-rm editor, agent-chat wiring, coachmarks. Swap/skip/add-this-week
 // WRITE UX is P2 — this file only ever DISPLAYS swap_name/skipped.
 import { useEffect, useRef, useState } from "react";
-import type { GridCell, GridDay, GridHistory, GridRow, GridWeek, MesoGrid } from "../lib/api";
+import type { GridCell, GridDay, GridHistory, GridRow, GridWeek, GroupIdentity, MesoGrid } from "../lib/api";
 import type { GridCellPatch, Id } from "../hooks/useGrid";
 
 export interface MesoTableProps {
@@ -25,6 +25,13 @@ export interface MesoTableProps {
   history: GridHistory;
   busy: boolean;
   unit: string;
+  // P5 group: the plan's group identity (null for an individual plan). When
+  // it has members, every non-skipped cell gains a per-athlete adjust badge
+  // (mirroring ExerciseRow's group "+ adjust"/`ex.adj` badge on the one-week
+  // path); clicking it hands (row, cell) up so DesignerRoot can open the
+  // shared override editor scoped to that cell.
+  group: GroupIdentity | null;
+  onOpenOverride(row: GridRow, cell: GridCell): void;
   onPatchCell(cellId: Id, patch: GridCellPatch): void;
   onRenameExercise(exerciseSlotId: Id, name: string): void;
   onAddExercise(day: GridDay): void;
@@ -412,6 +419,8 @@ export function MesoTable(props: MesoTableProps) {
     history,
     busy,
     unit,
+    group,
+    onOpenOverride,
     onPatchCell,
     onRenameExercise,
     onAddExercise,
@@ -432,6 +441,10 @@ export function MesoTable(props: MesoTableProps) {
   const [armed, setArmed] = useState<Armed>(null);
   const isArmed = (type: ArmedKind, id: Id) => !!armed && armed.type === type && armed.id === id;
   const disarm = () => setArmed(null);
+
+  // P5 group: the per-cell adjust badge only exists on a GROUP plan with
+  // members — an individual plan carries no `group`, so no cell ever shows it.
+  const showAdjust = !!(group && group.members.length);
 
   if (!grid) return null;
 
@@ -637,6 +650,22 @@ export function MesoTable(props: MesoTableProps) {
                                         ×
                                       </button>
                                     </span>
+                                  )}
+                                  {showAdjust && (
+                                    <button
+                                      type="button"
+                                      data-testid={`cell-override-badge-${cell.prescription_id}`}
+                                      data-hover="brighten"
+                                      className="meso-adjust-badge"
+                                      onClick={() => onOpenOverride(row, cell)}
+                                      title={
+                                        cell.adj
+                                          ? (cell.adjusts || []).map((a) => (a.name || "") + ": " + (a.label || "")).join("\n")
+                                          : "Set a per-athlete adjust"
+                                      }
+                                    >
+                                      {cell.adj ? cell.adj : <span className="meso-adjust-empty">+ adjust</span>}
+                                    </button>
                                   )}
                                   <CellActions
                                     cell={cell}

--- a/frontend/designer/src/hooks/useGrid.ts
+++ b/frontend/designer/src/hooks/useGrid.ts
@@ -28,8 +28,24 @@ export type GridCellPatch = Partial<
   Pick<GridCell, "sets" | "reps" | "load" | "load_type" | "rpe" | "rest" | "note">
 >;
 
+/** P5 group: the adj/adjusts a group override save/clear returns for one cell
+ * — patched into that cell (matched by prescription_id) so its adjust badge
+ * repaints without a full grid refetch. The grid analog of usePlanData's
+ * `patchExercise({adj, adjusts})` on the single-week path. */
+export type GridCellAdjPatch = Pick<GridCell, "adj" | "adjusts">;
+
+/** Any payload carrying a fresh plan history — accepts BOTH the grid
+ * endpoints' `GridHistory` (string labels) AND the override editor's
+ * `serialize_plan_history` reply routed through `useOverrideEditor`
+ * (`undo_label`/`redo_label` typed `string | null`). Coerced to `GridHistory`
+ * on adoption below, so either convention lands cleanly. */
 interface GridHistoryCarrier {
-  history?: GridHistory;
+  history?: {
+    can_undo: boolean;
+    can_redo: boolean;
+    undo_label: string | null;
+    redo_label: string | null;
+  };
 }
 
 const EMPTY_GRID_HISTORY: GridHistory = {
@@ -84,8 +100,10 @@ function currentWeekId(grid: MesoGrid | null): Id | undefined {
 
 /** Immutably patch every cell (across every day/row/week) whose
  * prescription_id matches — in practice exactly one, since prescription_id
- * is unique per (row, week). */
-function updateCellInGrid(grid: MesoGrid, cellId: Id, patch: GridCellPatch): MesoGrid {
+ * is unique per (row, week). Takes a `Partial<GridCell>` so both a typed-in
+ * field patch (GridCellPatch) and a group adjust repaint (GridCellAdjPatch)
+ * route through the same immutable walk. */
+function updateCellInGrid(grid: MesoGrid, cellId: Id, patch: Partial<GridCell>): MesoGrid {
   return {
     ...grid,
     days: grid.days.map((day) => ({
@@ -135,7 +153,14 @@ export function useGrid(options: UseGridOptions) {
   const pendingWritesRef = useRef<Set<Promise<unknown>>>(new Set());
 
   const adoptGridHistory = useCallback((data: GridHistoryCarrier) => {
-    if (data && data.history) setHistory(data.history);
+    const h = data?.history;
+    if (!h) return;
+    setHistory({
+      can_undo: h.can_undo,
+      can_redo: h.can_redo,
+      undo_label: h.undo_label ?? "",
+      redo_label: h.redo_label ?? "",
+    });
   }, []);
 
   const flushPendingWrites = useCallback(async () => {
@@ -177,6 +202,17 @@ export function useGrid(options: UseGridOptions) {
     },
     [planId, csrf, adoptGridHistory],
   );
+
+  // P5 group: repaint one cell's per-athlete adjust badge from a group
+  // override save/clear reply. Purely local (no POST) — useOverrideEditor
+  // already POSTed to prescription/<id>/override/ and hands back {adj,
+  // adjusts, history}; DesignerRoot routes its `patchExercise` here and its
+  // `adoptHistory` to adoptGridHistory above. Matches on prescription_id, so
+  // it no-ops harmlessly when the edited row lives on the OTHER data owner
+  // (planData) rather than the grid.
+  const patchCellAdj = useCallback((cellId: Id, patch: GridCellAdjPatch) => {
+    setGrid((prev) => (prev ? updateCellInGrid(prev, cellId, patch) : prev));
+  }, []);
 
   const renameExercise = useCallback(
     (exerciseSlotId: Id, name: string) => {
@@ -399,6 +435,8 @@ export function useGrid(options: UseGridOptions) {
     history,
     busy,
     patchCell,
+    patchCellAdj,
+    adoptGridHistory,
     renameExercise,
     addExercise,
     removeExercise,

--- a/frontend/designer/src/lib/api.ts
+++ b/frontend/designer/src/lib/api.ts
@@ -176,6 +176,15 @@ export interface GridCell {
    * (swap_exercise_id set, swap_name blank) needs this to render a badge —
    * swap_name alone is blank for that case. */
   swap_display: string;
+  /** P5 group: this cell's per-athlete adjust badge summary (e.g. "MO -10%"
+   * or "2 adjusts"), or absent when no member has an effective adjust here.
+   * Only attached for a GROUP plan (serialize_mesocycle_grid) — individual
+   * plans never carry it, so `cell.adj` is `undefined` and MesoTable renders
+   * no adjust control. Mirrors `Exercise.adj` on the single-week path. */
+  adj?: string | null;
+  /** P5 group: every member's stored diff on this cell (drives the override
+   * editor's member dots + draft). Present alongside `adj`; absent otherwise. */
+  adjusts?: OverrideAdjust[];
 }
 
 export interface GridRow {


### PR DESCRIPTION
## P5 — Group (the final phase of the fixed-selection reshape · #440)

Two deliverables, per the epic's `Slot/cell-based sync_delivered_plan; group table view`:

### 1. Whole-block group delivery (P3 parity)
P3 made **individual** delivery whole-block; **group** delivery still fanned out only the *current week* per member. P5 brings it to parity:
- `GroupMembership.sync_delivered_plan` rewritten to materialize the member's resolved copy of the **whole shared block** (every live week), mirroring slots/rows once and upserting each week's cell through the member's override. Each member week's `is_current` now **mirrors the source pointer** (the P3 re-meaning: the week the athlete is on) instead of being hardcoded `True`. A shared week dropped from the block soft-deletes on the member side (never hard-deleted — `SessionLog` cascade), alongside the existing dropped-slot/row handling.
- `MesoGroup.deliver_current_week` → **`deliver_block`**: stamps + snapshots every live week of each member's block **and** the shared block; one block-level notification per member (`_notify_athlete_block_delivered`, not per-week).
- Coach-facing copy: the group-detail button reads **"Deliver this block to all N members"** and the flash **"Delivered the block (N weeks) to M members."** `plan_deliver`'s group branch returns `week_count`.
- Demo/seed callers (`demo.py`, `seed_meso_demo.py`) updated.

### 2. Group table view — per-athlete adjusts in the multi-week table
The P1 `MesoTable` (the default designer surface) previously showed **no** per-athlete adjust overlay — only the older single-week `WeekGrid` did.
- `serialize_mesocycle_grid` attaches `adj`/`adjusts` per **cell** for group plans, mirroring `serialize_plan`'s adj-merge exactly (individual plans carry none).
- `MesoTable` renders a per-cell adjust badge (group plans only) that opens the existing `OverrideModal` scoped to that week's cell, via a grid-scoped `useOverrideEditor` that repaints the cell in place and adopts the grid's own undo history.

Overrides stay **cell-scoped** (one `PrescriptionOverride` per week+row) — no schema change, no migration — matching the table's per-cell editing granularity.

## Testing
- **Backend:** 2022 meso tests pass; `ruff` clean. `test_group_deliver.py` rewritten for whole-block behavior (multi-week blocks, `is_current` mirrors + follows a moved pointer, per-cell-per-week override resolution, dropped-week hiding, one notification per member); new `TestSerializeMesocycleGridGroupAdj`.
- **Frontend:** 569 vitest pass; `npm run build` + strict `tsc` clean. New MesoTable + DesignerRoot tests (badge present/absent, individual-plan has none, click opens the modal, save POSTs to the right `/prescription/{id}/override/` URL and repaints without a grid refetch).
- **Browser-verified end-to-end** (real hydrated island): group multi-week table renders the adjust badge, the modal opens pre-filled from an existing override, saving repaints the badge in place, "Deliver this block" delivers all 3 weeks to both members with the correct flash, and a group member sees the whole 3-week block on their athlete home with their swap applied.
- **Codex review:** CLEAN (0 blocking, 0 nits).

## Migrations
None.

Closes the last box on #440.
