### PR TITLE
fix(meso): self deliver/results tour steps visibly auto-advance (#451)

### DIFF
--- a/app/store_project/meso/tests/test_tour.py
+++ b/app/store_project/meso/tests/test_tour.py
@@ -269,6 +269,9 @@ class TestBuildConfig:
         assert config["skip_url"] == reverse("meso:tour_skip")
         assert config["demo_load_url"] == reverse("meso:demo_load")
         assert config["signup_url"] == reverse("meso:sandbox_signup")
+        # #451: the read-only endpoint the driver re-reads after a fetch action
+        # (self-variant deliver/results) to mirror the server-side auto-advance.
+        assert config["config_url"] == reverse("meso:tour_config")
 
     def test_sandbox_steps_never_carry_a_generic_action(self):
         # The additive Phase 3 `action` field must stay null for every sandbox
@@ -942,6 +945,59 @@ class TestTourStateEndpoint:
         )
 
         assert CoachProfile.objects.filter(user=user).exists()
+
+
+# ---------------------------------------------------------------------------
+# meso:tour_config — read-only authoritative-config snapshot (#451)
+# ---------------------------------------------------------------------------
+
+
+class TestTourConfigEndpoint:
+    """The GET-only endpoint the driver re-reads after a fetch action (#451).
+
+    The self-variant deliver/results steps take their real action via ``fetch``
+    (no page reload), so the already-mounted ``meso_tour.js`` card can't see the
+    server-side auto-advance until the coach next navigates. This endpoint hands
+    the driver the same ``build_config`` snapshot the template embeds via
+    ``json_script`` so it can re-render at whatever step the server now reports —
+    a display mirror, never a state write (advance stays server-authoritative).
+    """
+
+    def test_get_returns_the_authoritative_config_json(self, client):
+        coach = _coach()  # a real (non-sandbox) coach → the self variant
+        client.force_login(coach)
+
+        resp = client.get(reverse("meso:tour_config"))
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data["steps"], list) and data["steps"]
+        assert "step" in data
+        assert data["variant"] == "self"
+        assert data["state_url"] == reverse("meso:tour_state")
+        assert data["config_url"] == reverse("meso:tour_config")
+
+    def test_step_reflects_the_coachs_current_progress(self, client):
+        coach = _coach()
+        tour.set_step(coach.coach_profile, 3)
+        client.force_login(coach)
+
+        resp = client.get(reverse("meso:tour_config"))
+
+        assert resp.json()["step"] == 3
+
+    def test_anonymous_is_redirected_to_login(self, client):
+        resp = client.get(reverse("meso:tour_config"))
+        assert resp.status_code == 302
+        assert reverse("account_login") in resp.url
+
+    def test_post_is_rejected_get_only(self, client):
+        coach = _coach()
+        client.force_login(coach)
+
+        resp = client.post(reverse("meso:tour_config"))
+
+        assert resp.status_code == 405
 
 
 # ---------------------------------------------------------------------------

--- a/app/store_project/meso/tour.py
+++ b/app/store_project/meso/tour.py
@@ -781,6 +781,10 @@ def build_config(user, variant):
         "skip_url": reverse("meso:tour_skip"),
         "demo_load_url": reverse("meso:demo_load"),
         "signup_url": reverse("meso:sandbox_signup"),
+        # #451: the read-only GET the mounted driver re-reads after a fetch
+        # action (self-variant deliver/results advance the tour server-side
+        # without a page reload) so it can re-render at the server's new step.
+        "config_url": reverse("meso:tour_config"),
     }
 
 

--- a/app/store_project/meso/urls.py
+++ b/app/store_project/meso/urls.py
@@ -107,6 +107,10 @@ urlpatterns = [
     # everything" shortcut (O6).
     path("tour/state/", views.tour_state, name="tour_state"),
     path("tour/skip/", views.tour_skip, name="tour_skip"),
+    # Read-only snapshot of the coach's authoritative tour config (issue #451):
+    # the mounted driver re-reads it after a self-variant deliver/results fetch
+    # action to mirror the server-side auto-advance without a page reload.
+    path("tour/config/", views.tour_config, name="tour_config"),
     path("group/new/", views.group_create, name="group_create"),
     path("group/<int:pk>/", GroupDetailView.as_view(), name="group"),
     path("group/<int:pk>/design/", views.group_design, name="group_design"),

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -1185,6 +1185,34 @@ def tour_skip(request):
     return redirect("meso:roster")
 
 
+@login_required
+@require_GET
+def tour_config(request):
+    """Read-only snapshot of the coach's authoritative tour config (issue #451).
+
+    The self-variant deliver/results steps take their data-producing action via
+    ``fetch`` (delivering the coach's own block / logging their own session) —
+    no page reload — so the server advances ``tour_state`` (via
+    ``advance_self_step_if_complete`` in ``plan_deliver``/``athlete_log_session``)
+    but the already-mounted ``meso_tour.js`` card can't see it until the coach
+    next navigates. This endpoint hands the driver the *same* ``build_config``
+    the roster template embeds via ``json_script`` so it can re-read the
+    authoritative ``tour_state`` and re-render at whatever step the server now
+    reports.
+
+    Advance stays server-authoritative — the ``TourEvent`` funnel and the resume
+    state both live in ``tour_state``, written only at the tour's own POST
+    endpoints; the client just mirrors them here, never advancing locally. A
+    plain read, so ``@require_GET`` (a state change would be a POST). Returns
+    ``{}`` for a coach with no ``CoachProfile`` (``build_config`` returns
+    ``None`` there — the driver treats an empty/steps-less config as "no tour"
+    and simply leaves the card where it is).
+    """
+    variant = meso_tour.variant_for(request.user)
+    config = meso_tour.build_config(request.user, variant)
+    return JsonResponse(config if config is not None else {})
+
+
 @require_GET
 def sandbox_signup(request):
     """The sandbox's conversion hop into a real account (issue #389, S1).

--- a/app/store_project/static/js/meso_athlete.js
+++ b/app/store_project/static/js/meso_athlete.js
@@ -247,12 +247,15 @@ function createLogger() {
         this.status = data.log.status;
         this.syncFromLog(data.log);
         this.saved = true;
-        // Only a completed log (`markDone`) advances the self-variant "results"
-        // tour step server-side (`advance_self_step_if_complete("results")`), so
-        // only that path nudges the mounted tour to re-render (#451). A pending
-        // "Save progress" — and the offline `flushQueue` path — must not fire a
-        // spurious re-render / screen-reader re-announcement.
-        if (markDone) notifyTourRefresh();
+        // Key the tour nudge off the log status the *server* persisted, not the
+        // button pressed (#451): the self-variant "results" step advances on a
+        // `done` log (`advance_self_step_if_complete("results")`), and a "Save
+        // progress" on an already-completed session still writes `done` — so
+        // `markDone` alone would leave the card stale after re-saving a logged
+        // session. A pending save returns `pending` → no spurious re-render /
+        // screen-reader re-announcement (the offline `flushQueue` path stays
+        // silent regardless — it never calls this).
+        if (data.log.status === "done") notifyTourRefresh();
         setTimeout(() => {
           this.saved = false;
         }, 2400);

--- a/app/store_project/static/js/meso_athlete.js
+++ b/app/store_project/static/js/meso_athlete.js
@@ -54,6 +54,22 @@ function loadForPercent(oneRm, percent) {
   return roundToStep((one * pct) / 100, 2.5);
 }
 
+// Issue #451: after a fetch action that can auto-advance the guided tour
+// server-side (logging the coach's own session), nudge the mounted
+// meso_tour.js driver to re-read the authoritative step and re-render — the
+// tour card would otherwise stay on the results step until the coach's next
+// navigation. Best-effort + guarded: a real page has `document`, but the
+// vitest import that pulls in the factory does not.
+function notifyTourRefresh() {
+  if (
+    typeof document !== "undefined" &&
+    typeof document.dispatchEvent === "function" &&
+    typeof CustomEvent === "function"
+  ) {
+    document.dispatchEvent(new CustomEvent("meso:tour-refresh"));
+  }
+}
+
 function createLogger() {
   return {
     logUrl: "",
@@ -231,6 +247,12 @@ function createLogger() {
         this.status = data.log.status;
         this.syncFromLog(data.log);
         this.saved = true;
+        // Only a completed log (`markDone`) advances the self-variant "results"
+        // tour step server-side (`advance_self_step_if_complete("results")`), so
+        // only that path nudges the mounted tour to re-render (#451). A pending
+        // "Save progress" — and the offline `flushQueue` path — must not fire a
+        // spurious re-render / screen-reader re-announcement.
+        if (markDone) notifyTourRefresh();
         setTimeout(() => {
           this.saved = false;
         }, 2400);

--- a/app/store_project/static/js/meso_deliver.js
+++ b/app/store_project/static/js/meso_deliver.js
@@ -4,6 +4,22 @@
  * deliver a built-ahead week without first making it current. Scheduling and
  * push/email notifications arrive with the athlete app.
  */
+// Issue #451: after a fetch action that can auto-advance the guided tour
+// server-side (delivering the coach's own self-link block), nudge the
+// mounted meso_tour.js driver to re-read the authoritative step and
+// re-render — the tour card would otherwise stay on the deliver step until
+// the coach's next navigation. Best-effort + guarded: a real page has
+// `document`, but the vitest import that pulls in the factory does not.
+function notifyTourRefresh() {
+  if (
+    typeof document !== "undefined" &&
+    typeof document.dispatchEvent === "function" &&
+    typeof CustomEvent === "function"
+  ) {
+    document.dispatchEvent(new CustomEvent("meso:tour-refresh"));
+  }
+}
+
 function createMesoDeliver(planId, csrf, weekId) {
   return {
     planId: planId,
@@ -28,6 +44,9 @@ function createMesoDeliver(planId, csrf, weekId) {
         });
         if (!res.ok) throw new Error("Request failed: " + res.status);
         this.delivered = true;
+        // Success only (not the error/network paths below): the server may have
+        // just advanced the coach's self-variant "deliver" tour step (#451).
+        notifyTourRefresh();
       } catch (e) {
         this.error = true;
         console.error("Deliver failed", e);

--- a/app/store_project/static/js/meso_tour.js
+++ b/app/store_project/static/js/meso_tour.js
@@ -570,9 +570,64 @@
         doc.removeEventListener("toggle", reposition, true);
       }
       doc.removeEventListener("keydown", onKeydown);
+      doc.removeEventListener("meso:tour-refresh", onTourRefresh);
       mount.innerHTML = "";
       mount.setAttribute("aria-hidden", "true");
       if (liveRegion.parentNode) liveRegion.parentNode.removeChild(liveRegion);
+    }
+
+    // #451: the self-variant deliver/results steps take their real,
+    // data-producing action via a `fetch` (deliver the coach's own block / log
+    // their own session) with no page reload — so the server advances
+    // `tour_state` (`advance_self_step_if_complete` in
+    // `plan_deliver`/`athlete_log_session`) but this already-mounted card keeps
+    // its local `index` until the next navigation. `meso_deliver.js` /
+    // `meso_athlete.js` dispatch a `meso:tour-refresh` document event after a
+    // successful fetch action; on it we re-read the authoritative config from
+    // the read-only `config_url` and re-render at whatever step the server now
+    // reports. Advance stays server-authoritative — the `TourEvent` funnel and
+    // the resume step both live in `tour_state`, written only at the tour's own
+    // POST endpoints — so this is a DISPLAY update only and MUST NOT `postState`
+    // (the server already advanced; posting would double-count/fight it).
+    function onTourRefresh() {
+      // Older configs (served before this endpoint existed) carry no
+      // `config_url` — nothing to re-read, so leave the card exactly as it is.
+      if (!config.config_url) return;
+      root
+        .fetch(config.config_url, {
+          headers: { "X-Requested-With": "XMLHttpRequest" },
+        })
+        .then(function (res) {
+          return res.json();
+        })
+        .then(function (fresh) {
+          // A steps-less / empty snapshot means "no tour" (e.g. no
+          // CoachProfile) — nothing to show, so don't disturb the card.
+          if (
+            !fresh ||
+            !Array.isArray(fresh.steps) ||
+            fresh.steps.length === 0
+          ) {
+            return;
+          }
+          // The tour ended out from under us (the coach finished or dismissed
+          // it elsewhere) — tear down rather than re-render a dead tour.
+          if (fresh.status === "dismissed" || fresh.status === "completed") {
+            teardown();
+            return;
+          }
+          // Adopt the fresh config + step and re-render. `render`/`goTo`/the
+          // `reposition` throttle all close over these same `config`/`index`
+          // vars (declared with `var` above), so reassigning them here updates
+          // every subsequent read — a display mirror of the server's state.
+          config = fresh;
+          index = clampStep(fresh.step, fresh.steps.length);
+          render();
+        })
+        .catch(function () {
+          /* best-effort — a lost read just leaves the card on its current step;
+             the coach's next navigation resumes from the last-saved step */
+        });
     }
 
     reposition = throttle(function () {
@@ -585,6 +640,9 @@
     // re-measures instead of going stale at the collapsed size.
     doc.addEventListener("toggle", reposition, true);
     doc.addEventListener("keydown", onKeydown);
+    // #451: re-read the server's authoritative step after a fetch action that
+    // auto-advanced the tour without a page reload (self deliver/results).
+    doc.addEventListener("meso:tour-refresh", onTourRefresh);
 
     render();
   }

--- a/app/store_project/static/js/meso_tour.js
+++ b/app/store_project/static/js/meso_tour.js
@@ -483,6 +483,10 @@
 
     var index = clampStep(config.step, config.steps.length);
     var reposition = null;
+    // #451: set once `teardown()` runs so an in-flight `meso:tour-refresh` GET
+    // that resolves *after* a concurrent dismiss/complete can't reassign
+    // `config`/`index` and `render()` a torn-down tour back onto the page.
+    var torndown = false;
 
     // A persistent `aria-live` region (issue #430 Phase 4 a11y) — created
     // once and only ever text-updated, never recreated, unlike the card
@@ -571,6 +575,7 @@
       }
       doc.removeEventListener("keydown", onKeydown);
       doc.removeEventListener("meso:tour-refresh", onTourRefresh);
+      torndown = true;
       mount.innerHTML = "";
       mount.setAttribute("aria-hidden", "true");
       if (liveRegion.parentNode) liveRegion.parentNode.removeChild(liveRegion);
@@ -601,6 +606,10 @@
           return res.json();
         })
         .then(function (fresh) {
+          // The tour was dismissed/completed while this read was in flight —
+          // its listener + mount are already gone; applying a stale (still
+          // "active") snapshot now would resurrect the torn-down card (#451).
+          if (torndown) return;
           // A steps-less / empty snapshot means "no tour" (e.g. no
           // CoachProfile) — nothing to show, so don't disturb the card.
           if (

--- a/frontend/meso_athlete.test.js
+++ b/frontend/meso_athlete.test.js
@@ -195,6 +195,78 @@ describe("save", () => {
   });
 });
 
+// Issue #451: logging the coach's own session can auto-advance the guided tour
+// server-side (`advance_self_step_if_complete("results")` in
+// `athlete_log_session`), but the log POST is a fetch (no reload), so the
+// mounted meso_tour.js driver can't see it. Only a *completed* log (save(true))
+// advances the "results" step, so only that path nudges the driver via a
+// `meso:tour-refresh` document event — a pending "save progress", an offline
+// queue, or an outright failure must stay silent (no spurious re-render / SR
+// re-announcement).
+describe("save → tour refresh nudge (#451)", () => {
+  it("dispatches meso:tour-refresh after a completed log (save(true))", async () => {
+    vi.useFakeTimers();
+    const c = makeLogger();
+    c.exercises[0].set_rows[0].done = true;
+    const handler = vi.fn();
+    document.addEventListener("meso:tour-refresh", handler);
+    global.fetch = vi.fn().mockResolvedValue(
+      res({
+        body: {
+          log: { status: "done", sets: [{ prescription: 1, set_number: 1 }] },
+        },
+      }),
+    );
+    await c.save(true);
+    document.removeEventListener("meso:tour-refresh", handler);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not dispatch for a pending 'save progress' (save(false))", async () => {
+    vi.useFakeTimers();
+    const c = makeLogger();
+    c.exercises[0].set_rows[0].done = true;
+    const handler = vi.fn();
+    document.addEventListener("meso:tour-refresh", handler);
+    global.fetch = vi.fn().mockResolvedValue(
+      res({
+        body: {
+          log: {
+            status: "pending",
+            sets: [{ prescription: 1, set_number: 1 }],
+          },
+        },
+      }),
+    );
+    await c.save(false);
+    document.removeEventListener("meso:tour-refresh", handler);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("does not dispatch when the save fails (HTTP error)", async () => {
+    const c = makeLogger();
+    c.exercises[0].set_rows[0].done = true;
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const handler = vi.fn();
+    document.addEventListener("meso:tour-refresh", handler);
+    global.fetch = vi.fn().mockResolvedValue(res({ ok: false, status: 500 }));
+    await c.save(true);
+    document.removeEventListener("meso:tour-refresh", handler);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("does not dispatch when the save is queued offline", async () => {
+    const c = makeLogger();
+    c.exercises[0].set_rows[0].done = true;
+    const handler = vi.fn();
+    document.addEventListener("meso:tour-refresh", handler);
+    global.fetch = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"));
+    await c.save(true);
+    document.removeEventListener("meso:tour-refresh", handler);
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
 describe("flushQueue", () => {
   it("replays a queued save and clears it on success", async () => {
     vi.useFakeTimers();

--- a/frontend/meso_athlete.test.js
+++ b/frontend/meso_athlete.test.js
@@ -198,11 +198,12 @@ describe("save", () => {
 // Issue #451: logging the coach's own session can auto-advance the guided tour
 // server-side (`advance_self_step_if_complete("results")` in
 // `athlete_log_session`), but the log POST is a fetch (no reload), so the
-// mounted meso_tour.js driver can't see it. Only a *completed* log (save(true))
-// advances the "results" step, so only that path nudges the driver via a
-// `meso:tour-refresh` document event — a pending "save progress", an offline
-// queue, or an outright failure must stay silent (no spurious re-render / SR
-// re-announcement).
+// mounted meso_tour.js driver can't see it. The "results" step advances on a
+// `done` log, so the nudge keys off the log status the *server returned*, not
+// the button pressed: a completed save fires the `meso:tour-refresh` document
+// event; a re-save of an already-done session (which persists `done` even via
+// "Save progress") fires too; a pending save, an offline queue, or an outright
+// failure stays silent (no spurious re-render / SR re-announcement).
 describe("save → tour refresh nudge (#451)", () => {
   it("dispatches meso:tour-refresh after a completed log (save(true))", async () => {
     vi.useFakeTimers();
@@ -241,6 +242,28 @@ describe("save → tour refresh nudge (#451)", () => {
     await c.save(false);
     document.removeEventListener("meso:tour-refresh", handler);
     expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("dispatches when a 'save progress' re-saves an already-done session", async () => {
+    // Codex #451: on an already-completed session, `buildPayload(false)`
+    // preserves `status: "done"`, so the server still persists a done log and
+    // can advance the "results" step — keying off `data.log.status` (not the
+    // button) keeps the card from going stale.
+    vi.useFakeTimers();
+    const c = makeLogger({ status: "done" });
+    c.exercises[0].set_rows[0].done = true;
+    const handler = vi.fn();
+    document.addEventListener("meso:tour-refresh", handler);
+    global.fetch = vi.fn().mockResolvedValue(
+      res({
+        body: {
+          log: { status: "done", sets: [{ prescription: 1, set_number: 1 }] },
+        },
+      }),
+    );
+    await c.save(false);
+    document.removeEventListener("meso:tour-refresh", handler);
+    expect(handler).toHaveBeenCalledTimes(1);
   });
 
   it("does not dispatch when the save fails (HTTP error)", async () => {

--- a/frontend/meso_deliver.test.js
+++ b/frontend/meso_deliver.test.js
@@ -133,3 +133,42 @@ describe("deliver", () => {
     expect(c.delivered).toBe(true); // failure doesn't unset a prior success
   });
 });
+
+// Issue #451: delivering the coach's own self-link block can auto-advance the
+// guided tour server-side, but this is a fetch (no page reload), so the mounted
+// meso_tour.js driver can't see it. On a *successful* deliver the screen nudges
+// the driver to re-read the authoritative step via a `meso:tour-refresh`
+// document event; a failed deliver (no advance) must stay silent.
+describe("deliver → tour refresh nudge (#451)", () => {
+  it("dispatches meso:tour-refresh on a successful deliver", async () => {
+    const c = createMesoDeliver(PLAN_ID, CSRF, null);
+    const handler = vi.fn();
+    document.addEventListener("meso:tour-refresh", handler);
+    global.fetch = vi.fn().mockResolvedValue(res());
+    await c.deliver();
+    document.removeEventListener("meso:tour-refresh", handler);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not dispatch when the deliver fails (HTTP error)", async () => {
+    const c = createMesoDeliver(PLAN_ID, CSRF, null);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const handler = vi.fn();
+    document.addEventListener("meso:tour-refresh", handler);
+    global.fetch = vi.fn().mockResolvedValue(res({ ok: false, status: 500 }));
+    await c.deliver();
+    document.removeEventListener("meso:tour-refresh", handler);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("does not dispatch when the deliver fails (network error)", async () => {
+    const c = createMesoDeliver(PLAN_ID, CSRF, null);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const handler = vi.fn();
+    document.addEventListener("meso:tour-refresh", handler);
+    global.fetch = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"));
+    await c.deliver();
+    document.removeEventListener("meso:tour-refresh", handler);
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/meso_tour.test.js
+++ b/frontend/meso_tour.test.js
@@ -724,4 +724,36 @@ describe("initTour tour-refresh listener (#451)", () => {
 
     expect(window.fetch).not.toHaveBeenCalled();
   });
+
+  it("discards an in-flight refresh that resolves after teardown", async () => {
+    // Codex #451: a `config_url` GET still in flight when the coach dismisses
+    // the tour must not resurrect the torn-down card with a stale (still
+    // "active") snapshot.
+    mount();
+    let resolveConfig;
+    const pending = new Promise((r) => {
+      resolveConfig = r;
+    });
+    window.fetch = vi.fn((url) =>
+      // Hold the refresh read open; let the dismiss state POST settle at once.
+      url === CONFIG.config_url ? pending : Promise.resolve({ ok: true }),
+    );
+    tourDriver.initTour(document, window);
+    const mountEl = document.getElementById("meso-tour");
+
+    // Kick the refresh off (its fetch stays pending)...
+    document.dispatchEvent(new CustomEvent("meso:tour-refresh"));
+    // ...then dismiss, tearing the tour down while that read is still open.
+    mountEl.querySelector("[data-tour-dismiss]").click();
+    await vi.waitFor(() => expect(mountEl.innerHTML).toBe(""));
+
+    // The in-flight read now resolves with a still-active config — the
+    // torn-down guard must keep it from re-rendering onto the page.
+    resolveConfig({ json: () => Promise.resolve({ ...CONFIG, step: 1 }) });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mountEl.innerHTML).toBe("");
+    expect(mountEl.getAttribute("aria-hidden")).toBe("true");
+  });
 });

--- a/frontend/meso_tour.test.js
+++ b/frontend/meso_tour.test.js
@@ -609,3 +609,119 @@ describe("initTour toggle reposition listener (P3-3)", () => {
     });
   });
 });
+
+// #451: the self-variant deliver/results steps take their real action via a
+// `fetch` (no page reload), so the server auto-advances `tour_state` but the
+// mounted driver keeps its local step until the next navigation. On a
+// `meso:tour-refresh` document event (dispatched by meso_deliver.js /
+// meso_athlete.js after a successful fetch action) the driver re-reads the
+// authoritative config from `config_url` (a read-only GET) and re-renders at
+// whatever step the server now reports — a DISPLAY update only, never a state
+// POST (advance stays server-authoritative: the funnel + resume live in
+// `tour_state`, the client just mirrors it).
+describe("initTour tour-refresh listener (#451)", () => {
+  const CONFIG = {
+    steps: [
+      { key: "welcome", title: "Welcome", body: "Hi", anchor: "roster-individuals" },
+      { key: "finish", title: "Done", body: "Bye", anchor: "roster-invite" },
+    ],
+    variant: "self",
+    step: 0,
+    status: "active",
+    state_url: "/meso/tour/state/",
+    skip_url: "/meso/tour/skip/",
+    demo_load_url: "/meso/demo/load/",
+    signup_url: "/meso/demo/signup/",
+    config_url: "/meso/tour/config/",
+  };
+
+  function mount(config = CONFIG) {
+    document.body.innerHTML =
+      '<div id="meso-tour" aria-hidden="true"></div>' +
+      '<script type="application/json" id="meso-tour-config">' +
+      JSON.stringify(config) +
+      "</script>";
+  }
+
+  // A fetch stub whose resolved response exposes `.json()` (the refresh path
+  // reads `res.json()`, unlike `postState` which only ever checks `.ok`).
+  function configFetch(fresh) {
+    return vi.fn().mockResolvedValue({ json: () => Promise.resolve(fresh) });
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("re-reads config_url and re-renders at the server's advanced step", async () => {
+    mount();
+    const fresh = { ...CONFIG, step: 1 };
+    window.fetch = configFetch(fresh);
+    tourDriver.initTour(document, window);
+    const eyebrow = () =>
+      document.getElementById("meso-tour").querySelector(".meso-eyebrow")
+        .textContent;
+    expect(eyebrow()).toBe("Step 1 of 2"); // mounted at step 0
+
+    document.dispatchEvent(new CustomEvent("meso:tour-refresh"));
+
+    await vi.waitFor(() => {
+      expect(eyebrow()).toBe("Step 2 of 2"); // advanced, from the server
+    });
+    // A display mirror: it read config_url, never POSTed state_url.
+    expect(window.fetch).toHaveBeenCalledWith(
+      CONFIG.config_url,
+      expect.any(Object),
+    );
+    expect(window.fetch).not.toHaveBeenCalledWith(
+      CONFIG.state_url,
+      expect.anything(),
+    );
+  });
+
+  it("tears the tour down when the fresh config is completed", async () => {
+    mount();
+    const fresh = { ...CONFIG, status: "completed", step: 1 };
+    window.fetch = configFetch(fresh);
+    tourDriver.initTour(document, window);
+    const mountEl = document.getElementById("meso-tour");
+    expect(mountEl.innerHTML).not.toBe("");
+
+    document.dispatchEvent(new CustomEvent("meso:tour-refresh"));
+
+    await vi.waitFor(() => {
+      expect(mountEl.innerHTML).toBe("");
+      expect(mountEl.getAttribute("aria-hidden")).toBe("true");
+    });
+  });
+
+  it("no-ops when the config has no config_url (older configs)", async () => {
+    const { config_url, ...legacy } = CONFIG;
+    mount(legacy);
+    window.fetch = vi.fn();
+    tourDriver.initTour(document, window);
+
+    document.dispatchEvent(new CustomEvent("meso:tour-refresh"));
+    await Promise.resolve();
+
+    expect(window.fetch).not.toHaveBeenCalled();
+  });
+
+  it("stops refreshing after teardown (listener removed on dismiss)", async () => {
+    mount();
+    window.fetch = vi.fn().mockResolvedValue({ ok: true });
+    tourDriver.initTour(document, window);
+    // Dismiss tears the tour down once the (mocked) state POST settles.
+    document.querySelector("[data-tour-dismiss]").click();
+    await vi.waitFor(() => {
+      expect(document.getElementById("meso-tour").innerHTML).toBe("");
+    });
+    window.fetch.mockClear();
+
+    document.dispatchEvent(new CustomEvent("meso:tour-refresh"));
+    await Promise.resolve();
+
+    expect(window.fetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #451.

## Problem

The self-variant `deliver` and `results` guided-tour steps take their real, data-producing action via `fetch` (deliver the coach's own block / log their own session) with **no page reload**. The server already advances `tour_state` (`advance_self_step_if_complete` in `plan_deliver`/`athlete_log_session`), but the already-mounted `meso_tour.js` card kept its local step index until the coach's *next* navigation — so the tour card visibly stayed on the same step. (Most other steps reload, so they advance visibly at once.)

## Approach — Option A (server-authoritative refresh)

Advance stays **server-authoritative** — the `TourEvent` funnel and resume step both live in `tour_state`, written only at the tour's own POST endpoints. The client never advances locally; it re-reads and mirrors the server:

- **New read-only `GET meso:tour_config`** returns the live `build_config`; `build_config` gains a `config_url`.
- `meso_deliver.js` (on a successful deliver) and `meso_athlete.js` (on a server-persisted `done` log) dispatch a `meso:tour-refresh` document event.
- `meso_tour.js` listens, re-reads the authoritative config from `config_url`, and re-renders at whatever step the server now reports — a **display update only, never a state POST**. A `dismissed`/`completed` snapshot tears the tour down; a payload without `config_url` (older configs) no-ops; an in-flight read that resolves after teardown is discarded (torn-down guard).

Option B (bolting `tour_state` onto the `plan_deliver`/`athlete_log_session` JSON responses) was rejected — it couples those data endpoints to the tour, which the issue flagged as a downside.

## Changed

- `meso/tour.py` — `build_config` returns `config_url`.
- `meso/urls.py` — `tour/config/` route.
- `meso/views.py` — `tour_config` view (`@login_required` + `@require_GET`, read-only).
- `static/js/meso_deliver.js`, `static/js/meso_athlete.js` — dispatch `meso:tour-refresh` on a successful fetch action (log path keys off the server-returned `data.log.status === "done"`, not the button).
- `static/js/meso_tour.js` — driver refresh (`onTourRefresh`) + torn-down guard.

## Testing

- **Red/green TDD.** New backend endpoint tests (`test_tour.py`) + frontend dispatch/refresh tests across `meso_deliver.test.js`, `meso_athlete.test.js`, `meso_tour.test.js`.
- Full suites green: **2056** meso pytest, **582** vitest. `ruff` clean.
- **Browser-verified end to end** (real self-coaching coach on `/meso/deliver/`): clicking the real Deliver button advanced the card **Step 4 → Step 5** in-place — URL unchanged, single `navigate` performance entry (no reload). Network: `POST …/deliver/` **201** → `GET /meso/tour/config/` **200**, and **no** `POST /meso/tour/state/` (the server-authoritative, display-mirror invariant).
- **Codex review loop: CLEAN** (0 blocking / 0 nits) after one fix round (server-status refresh key + teardown race guard, each test-covered).