### PR TITLE
fix(meso): hide the landing walkthrough video (#454)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,6 +106,13 @@ MESO_AGENT_FAKE=false
 # with DEBUG=False unless --force.
 MESO_DEMO_COACH_EMAIL=demo-coach@demo.invalid
 MESO_DEMO_COACH_PASSWORD=meso-demo-recording
+# Landing page walkthrough video (issue #415 follow-up to #388): hidden by
+# default per issue #454 (recording quality/redundancy — the live no-signup
+# sandbox at /meso/demo/ is the walkthrough now). Unset = landing page shows
+# no walkthrough video. To re-enable: `just record-demo && just
+# publish-demo-video`, then uncomment and set these to the published S3 URLs.
+# MESO_DEMO_VIDEO_URL=https://masterfit.s3.amazonaws.com/meso/demo/meso-walkthrough.mp4
+# MESO_DEMO_VIDEO_POSTER_URL=https://masterfit.s3.amazonaws.com/meso/demo/meso-walkthrough-poster.webp
 #
 # Web push (PWA). Generate a VAPID keypair (`vapid --gen`, or py_vapid): PUBLIC is
 # the base64url uncompressed point, PRIVATE the base64url raw key. Blank => push is

--- a/app/config/settings/base.py
+++ b/app/config/settings/base.py
@@ -344,22 +344,23 @@ MESO_SANDBOX_TTL_HOURS = int(os.environ.get("MESO_SANDBOX_TTL_HOURS", "48"))
 MESO_SANDBOX_PER_IP_PER_HOUR = int(os.environ.get("MESO_SANDBOX_PER_IP_PER_HOUR", "5"))
 MESO_SANDBOX_MAX_CONCURRENT = int(os.environ.get("MESO_SANDBOX_MAX_CONCURRENT", "100"))
 
-# Public walkthrough video (issue #415 follow-up to #388). `just record-demo`
-# regenerates docs/demo/out/meso-walkthrough.mp4 (git-ignored); `just
-# publish-demo-video` (scripts/publish_demo_video.py) uploads it — plus a
-# poster frame — to the `masterfit` S3 bucket at a fixed public key, so these
-# defaults work with zero config in every environment (the bucket serves
-# public-read objects unsigned; see AWS_S3_OBJECT_PARAMETERS above). Override
-# to "" to hide the landing page's video section entirely (e.g. mid-refresh,
-# before a first upload).
-MESO_DEMO_VIDEO_URL = os.environ.get(
-    "MESO_DEMO_VIDEO_URL",
-    "https://masterfit.s3.amazonaws.com/meso/demo/meso-walkthrough.mp4",
-)
-MESO_DEMO_VIDEO_POSTER_URL = os.environ.get(
-    "MESO_DEMO_VIDEO_POSTER_URL",
-    "https://masterfit.s3.amazonaws.com/meso/demo/meso-walkthrough-poster.webp",
-)
+# Public walkthrough video (issue #415 follow-up to #388) — OFF by default
+# (issue #454). The recording's quality wasn't good enough and it was
+# confusing/repetitive with the other visuals already on the landing page
+# (the hero shot + the how-it-works stills); the live, no-signup public
+# sandbox at /meso/demo/ (issue #389) is the walkthrough we point cold
+# visitors at now. The landing template's `{% if demo_video_url %}` gate is
+# unchanged, so this is purely a default flip, not a removal — the
+# recording/publishing tooling (`just record-demo`, `just
+# publish-demo-video` / scripts/publish_demo_video.py) still works. To
+# re-enable a future, better recording: `just record-demo && just
+# publish-demo-video` (uploads the video + a poster frame to the
+# `masterfit` S3 bucket at the fixed public keys
+# meso/demo/meso-walkthrough.mp4 and meso/demo/meso-walkthrough-poster.webp),
+# then set MESO_DEMO_VIDEO_URL (and optionally MESO_DEMO_VIDEO_POSTER_URL) in
+# the environment.
+MESO_DEMO_VIDEO_URL = os.environ.get("MESO_DEMO_VIDEO_URL", "")
+MESO_DEMO_VIDEO_POSTER_URL = os.environ.get("MESO_DEMO_VIDEO_POSTER_URL", "")
 
 # Cache
 

--- a/app/store_project/meso/tests/test_landing.py
+++ b/app/store_project/meso/tests/test_landing.py
@@ -159,26 +159,67 @@ class TestLandingContent:
 
 
 # ---------------------------------------------------------------------------
-# Hosted walkthrough video (issue #415 follow-up to #388)
+# Hosted walkthrough video — hidden by default (issue #454, follow-up to
+# #415/#388)
 # ---------------------------------------------------------------------------
 
 
 class TestLandingDemoVideo:
+    """The recorded walkthrough is OFF by default (issue #454).
+
+    #415 put a recorded coach-flow video on the landing page; #454 turned it
+    back off — the recording's quality wasn't good enough, and it was
+    confusing/repetitive with the other visuals already on the page (the
+    hero shot + the three how-it-works stills below it). The real
+    walkthrough now is the live, no-signup public sandbox at ``/meso/demo/``
+    (issue #389) — a cold visitor can drive the actual product instead of
+    watching a recording of it.
+
+    Nothing about the section or its ``{% if demo_video_url %}`` gate
+    changed — only the *default* of ``MESO_DEMO_VIDEO_URL`` /
+    ``MESO_DEMO_VIDEO_POSTER_URL`` flipped from a live S3 URL to ``""``, so
+    re-enabling a future, better recording is still zero code: `just
+    record-demo && just publish-demo-video`, then set the env var. The tests
+    below split accordingly: the plain, no-override request must show
+    nothing; an explicit override (the re-enable path) must still render the
+    full player, poster, and the `preload="none"` page-weight guard.
+    """
+
+    def test_video_section_hidden_by_default(self, client):
+        """No override => no section, no heading, no trace of the old asset."""
+        resp = client.get(reverse("meso:roster"))
+        body = resp.content.decode()
+        assert "<video" not in body
+        assert "See it in action" not in body
+        assert "meso-walkthrough" not in body  # the S3 object's filename
+
+    @override_settings(
+        MESO_DEMO_VIDEO_URL="https://example.test/meso/demo.mp4",
+        MESO_DEMO_VIDEO_POSTER_URL="https://example.test/meso/poster.webp",
+    )
     def test_video_section_renders_with_settings_url(self, client):
-        """The <video> section renders from settings, not a hardcoded URL."""
+        """Re-enabled (a URL set), the <video> section renders from settings."""
         resp = client.get(reverse("meso:roster"))
         body = resp.content.decode()
         assert "<video" in body
         assert f'<source src="{settings.MESO_DEMO_VIDEO_URL}"' in body
         assert 'type="video/mp4"' in body
 
+    @override_settings(
+        MESO_DEMO_VIDEO_URL="https://example.test/meso/demo.mp4",
+        MESO_DEMO_VIDEO_POSTER_URL="https://example.test/meso/poster.webp",
+    )
     def test_poster_renders_from_settings(self, client):
         resp = client.get(reverse("meso:roster"))
         body = resp.content.decode()
         assert f'poster="{settings.MESO_DEMO_VIDEO_POSTER_URL}"' in body
 
+    @override_settings(
+        MESO_DEMO_VIDEO_URL="https://example.test/meso/demo.mp4",
+        MESO_DEMO_VIDEO_POSTER_URL="https://example.test/meso/poster.webp",
+    )
     def test_preload_none_guards_page_weight(self, client):
-        """The page-weight guarantee.
+        """The page-weight guarantee, still true once re-enabled.
 
         An anonymous visit must not fetch the video unless the visitor
         presses play — the only thing that should load unconditionally is
@@ -186,17 +227,6 @@ class TestLandingDemoVideo:
         """
         resp = client.get(reverse("meso:roster"))
         assert 'preload="none"' in resp.content.decode()
-
-    @override_settings(MESO_DEMO_VIDEO_URL="")
-    def test_hidden_when_url_is_blank(self, client):
-        """An empty override hides the section, not a broken/empty player.
-
-        E.g. mid-refresh, before a first upload.
-        """
-        resp = client.get(reverse("meso:roster"))
-        body = resp.content.decode()
-        assert "<video" not in body
-        assert "See it in action" not in body
 
 
 # ---------------------------------------------------------------------------

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -335,9 +335,11 @@ class RosterView(TemplateView):
                     # so the price can't drift out of sync with the landing page.
                     "price_summary": presenters.PRICE_SUMMARY,
                     # The hosted walkthrough video (issue #415 follow-up to
-                    # #388) — settings-driven so `just record-demo && just
-                    # publish-demo-video` is the entire refresh story; an empty
-                    # override hides the section (template checks
+                    # #388) — hidden by default (issue #454; blank is the
+                    # default in settings). Still settings-driven so setting
+                    # a URL is the entire re-enable story: `just record-demo
+                    # && just publish-demo-video`, then set
+                    # MESO_DEMO_VIDEO_URL (template checks
                     # `{% if demo_video_url %}`).
                     "demo_video_url": settings.MESO_DEMO_VIDEO_URL,
                     "demo_video_poster_url": settings.MESO_DEMO_VIDEO_POSTER_URL,

--- a/app/store_project/templates/meso/landing.html
+++ b/app/store_project/templates/meso/landing.html
@@ -99,20 +99,29 @@ visitor — demo/trial lead, athlete login is a compact strip, not a card.
     </div>
 
     {% comment %}
-      Hosted walkthrough video (issue #415 follow-up to #388) — the real coach
-      flow (roster -> athlete -> designer -> agent proposal -> review ->
-      deliver), captured by `just record-demo` and hosted on S3 by
-      `just publish-demo-video` (scripts/publish_demo_video.py). Both write to
-      fixed keys, so refreshing after a UI change is just re-running those two
-      commands — nothing here or in settings needs to change.
+      Hosted walkthrough video (issue #415 follow-up to #388) — HIDDEN BY
+      DEFAULT (issue #454). The recording's quality wasn't good enough and it
+      was confusing/repetitive with the other visuals already on this page
+      (the hero shot + the how-it-works stills below); the live, no-signup
+      public sandbox at /meso/demo/ (issue #389) is the walkthrough now, so
+      `demo_video_url` defaults to "" in settings and this section renders
+      nothing.
+
+      The section itself is untouched, so re-enabling a future, better
+      recording is still just: `just record-demo` (captures the real coach
+      flow: roster -> athlete -> designer -> agent proposal -> review ->
+      deliver) then `just publish-demo-video`
+      (scripts/publish_demo_video.py) to host it on S3 at a fixed key, then
+      set MESO_DEMO_VIDEO_URL — nothing here or in the view needs to change.
 
       `preload="none"` + this `{% if %}` guard are the page-weight guarantee:
       an anonymous visit that never presses play costs nothing beyond the
       ~50KB poster image, and the whole section (including that image) simply
-      isn't in the page when the setting is blanked (e.g. mid-refresh, before
-      a first upload). Framed with `.meso-hero-shot` (meso.css) — the same
-      card chrome as the hero screenshot above, so the two product visuals on
-      this page read as one system.
+      isn't in the page when the setting is blank (the default, or
+      mid-refresh before a first upload). Framed with `.meso-hero-shot`
+      (meso.css) — the same card chrome as the hero screenshot above, so the
+      two product visuals on this page would read as one system if
+      re-enabled.
     {% endcomment %}
     {% if demo_video_url %}
       <div class="meso-card meso-card--pad" style="text-align:center;margin-bottom:18px;">

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -1,5 +1,13 @@
 # Meso walkthrough demo video
 
+**As of issue [#454](https://github.com/lancegoyke/fitness-store/issues/454),
+the landing page does not show this video by default** — the recording's
+quality wasn't good enough and it repeated visuals already on the page, and
+the live, no-signup public sandbox at `/meso/demo/` (issue #389) is the
+walkthrough now. The recorder below still works; publishing a new recording
+and setting `MESO_DEMO_VIDEO_URL` (see `.env.example`) is what puts a video
+back on the page.
+
 `just record-demo` regenerates a short screen recording of the real Meso
 product — no manual steps, no editing. It's the "level 1" demo for issue
 [#388](https://github.com/lancegoyke/fitness-store/issues/388): plan at

--- a/docs/meso/demo-walkthrough-video-plan.md
+++ b/docs/meso/demo-walkthrough-video-plan.md
@@ -2,6 +2,8 @@
 
 Status: **SHIPPED** — issue [#388](https://github.com/lancegoyke/fitness-store/issues/388) is done. `just record-demo` (`scripts/record_demo.py`) seeds deterministic demo data, drives the full storyboard below in headless Chromium via Playwright, and writes `docs/demo/out/meso-walkthrough.mp4` — zero manual steps, re-recordable after any UI change. See `docs/demo/README.md` for prerequisites, the enumerated `data-testid`s, and the storyboard-step editing model.
 
+**Not currently on the landing page**, though: issue [#454](https://github.com/lancegoyke/fitness-store/issues/454) turned the embed off (the recording was confusing and repeated the page's other visuals) — the live, no-signup sandbox at `/meso/demo/` (issue #389) is the walkthrough cold visitors get now. The recorder and publisher still work; re-enabling is `just record-demo && just publish-demo-video`, then setting `MESO_DEMO_VIDEO_URL`.
+
 ## Why
 
 A new, non-subscriber visitor currently cannot see Meso in action without

--- a/scripts/publish_demo_video.py
+++ b/scripts/publish_demo_video.py
@@ -17,6 +17,14 @@ timestamp/hash) — the landing page's URL never changes, so re-running this
 after a UI change is the entire "update the video" story; nothing in
 settings or the template needs touching.
 
+Publishing alone no longer puts the video *on* the page, though: issue #454
+turned the landing embed off by default (the recording was confusing and
+repeated the page's other visuals; the live sandbox at ``/meso/demo/`` is the
+walkthrough now), so ``MESO_DEMO_VIDEO_URL`` defaults to ``""``. To put a new,
+better recording back on the page, publish it with this script and *then* set
+``MESO_DEMO_VIDEO_URL`` (and optionally ``MESO_DEMO_VIDEO_POSTER_URL``) in the
+environment to the keys below.
+
 Uploaded objects (``ACL: public-read``, matching every other object this app
 puts in the bucket — see ``AWS_S3_OBJECT_PARAMETERS`` in
 ``config/settings/production.py``):


### PR DESCRIPTION
Closes #454.

## Why

The recorded coach-flow video wasn't earning its place on the Meso landing page: the quality wasn't good enough, it was confusing, and its visuals just repeated what the page already shows (the hero shot and the three how-it-works stills). We also have a better answer for a cold visitor now — the live, no-signup public sandbox at `/meso/demo/` (#389) lets them drive the real product instead of watching a recording of it.

## What

The `<video>` section was already fully settings-gated (`{% if demo_video_url %}` in `landing.html`, fed by `MESO_DEMO_VIDEO_URL` / `MESO_DEMO_VIDEO_POSTER_URL`), so this is a **default flip, not a removal**: both settings now default to `""` instead of the live S3 URLs, and the section renders nothing in every environment. Prod does not pin either variable in its `.env`, so the flip actually takes effect on deploy.

The recording and publishing tooling is deliberately untouched (`just record-demo`, `just publish-demo-video`, `scripts/`, `docs/demo/`). Putting a future, better recording back on the page stays zero-code: record, publish, then set `MESO_DEMO_VIDEO_URL`.

- `app/config/settings/base.py` — defaults flipped to `""`, comment rewritten with the why and the re-enable path.
- `app/store_project/meso/tests/test_landing.py` — `TestLandingDemoVideo` inverted: the plain request must show no player, no "See it in action", and no trace of the S3 asset; the **re-enable path** (an explicit URL override) still covers the player, the poster, and the `preload="none"` page-weight guard, so that contract doesn't rot while the video is off.
- `app/store_project/meso/views.py`, `app/store_project/templates/meso/landing.html` — stale comments corrected (blank is now the default, a URL is the opt-in).
- `.env.example`, `docs/demo/README.md`, `docs/meso/demo-walkthrough-video-plan.md`, `scripts/publish_demo_video.py` docstring — documented that publishing alone no longer puts the video on the page; you must also set the env var. (Without this, a future re-enabler publishes and wonders why the page is unchanged.)

No migrations.

## Verification

- Red→green: `test_video_section_hidden_by_default` failed against the old live-S3 default, passes after the flip.
- `uv run pytest` — **2310 passed**. `just lint` clean.
- Codex review loop — **CLEAN** on the first pass (0 blocking, 0 nits).
- Driven in a real browser against the dev server: `/meso/` returns 200 with zero video markers in the HTML, and the page flows from the demo/coach cards straight into the how-it-works stills — no empty gap where the card was, no leaked template comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)