### PR TITLE
feat(meso): is_current auto-advance — the athlete's week follows their logging (#456)

### DIFF
--- a/app/store_project/meso/models.py
+++ b/app/store_project/meso/models.py
@@ -2622,7 +2622,19 @@ class GroupMembership(models.Model):
         athlete's own progress, and blindly mirroring onto a brand-new week
         could produce two ``True`` rows at once (nothing in the schema forbids
         that; ``presenters._single_current_week`` treats it as a defensive
-        fallback case, not the expected shape).
+        fallback case, not the expected shape). One narrow exception (#456 nit
+        1): ``Week.soft_delete`` never clears ``is_current``, so a week dropped
+        from the block while it happened to be the member's current one keeps
+        that stale flag on its now-dead row. If the source week later returns
+        (the coach undoes the drop, or re-adds it), REVIVING that row verbatim
+        would resurrect the stale ``True`` alongside wherever the member's own
+        logging/coach override has since moved them. So a revival (the row
+        existed and was soft-deleted before this sync) whose stale flag is
+        ``True`` checks whether the member plan already has another live
+        current week: if so, that week wins and the revived row's flag is
+        dropped; if the member has NO other live current week at all (they
+        never advanced past the dropped week), the flag is preserved instead —
+        the coach's temporary removal shouldn't strand the member positionless.
 
         Syncing in place this way preserves any ``SessionLog`` the athlete
         already wrote against an unchanged slot while propagating the coach's
@@ -2662,6 +2674,21 @@ class GroupMembership(models.Model):
             order=src_meso.order,
             defaults={"name": src_meso.name, "week_count": src_meso.week_count},
         )
+        # Snapshot each existing member week's soft-delete + pointer state
+        # BEFORE this sync mutates anything (#456 nit 1) — used below to detect
+        # a week being REVIVED (dropped from the block, now returning) so a
+        # stale ``is_current`` (``Week.soft_delete`` leaves the flag set on the
+        # dead row) can't resurrect a second live current week. Only needed for
+        # a non-first sync — a first sync (``plan_created``) creates every row
+        # fresh, so nothing here can have a prior soft-deleted state.
+        prior_week_state = (
+            {}
+            if plan_created
+            else {
+                w.index: (w.pk, w.deleted_at, w.is_current)
+                for w in member_meso.weeks.all()
+            }
+        )
         # Mirror every live source week onto the member's block (matched by
         # ``index``); ``deleted_at: None`` revives a member week whose source
         # week was dropped then returned. ``week_pairs`` keeps each source week
@@ -2693,6 +2720,33 @@ class GroupMembership(models.Model):
             # (``week_set_current``) are the only things that move it from here.
             if plan_created:
                 week_defaults["is_current"] = src_week.is_current
+            else:
+                # A REVIVAL (#456 nit 1): this member week existed and was
+                # soft-deleted before this sync, and its dead row's flag is
+                # still ``True`` (``Week.soft_delete`` never clears it). Reviving
+                # it verbatim could resurrect a second live current week
+                # alongside wherever the member's own logging/coach override has
+                # since moved them. If the member has another live current week,
+                # that one wins and this row's flag is dropped; if they have
+                # NONE (they never moved past the dropped week), preserve it —
+                # the coach's temporary removal shouldn't strand the member
+                # positionless. Rows that aren't a stale-current revival are
+                # left out of ``week_defaults`` entirely, so ``update_or_create``
+                # doesn't touch their ``is_current`` — unchanged behavior.
+                prior = prior_week_state.get(src_week.index)
+                if prior is not None:
+                    prior_pk, prior_deleted_at, prior_is_current = prior
+                    if prior_deleted_at is not None and prior_is_current:
+                        has_other_current = (
+                            Week.objects.filter(
+                                mesocycle__plan=member_plan,
+                                is_current=True,
+                                deleted_at__isnull=True,
+                            )
+                            .exclude(pk=prior_pk)
+                            .exists()
+                        )
+                        week_defaults["is_current"] = not has_other_current
             member_week, _ = Week.objects.update_or_create(
                 mesocycle=member_meso,
                 index=src_week.index,

--- a/app/store_project/meso/models.py
+++ b/app/store_project/meso/models.py
@@ -2582,9 +2582,18 @@ class GroupMembership(models.Model):
         slot on that week — a swap override becomes the cell's ``swap_name``
         (block identity stays the shared slot's); load/sets/reps/note overrides
         become the cell's numbers. Each member week's ``is_current`` MIRRORS its
-        source week's (post-P3 ``is_current`` = the week the athlete is on), so
-        the athlete's home anchors on the same week the coach points to — never a
-        block that flags every week current.
+        source week's pointer, but **only on this member's very first
+        materialization** (issue #456) — the moment their plan is created, so
+        the athlete's home opens on the same week the coach was pointing at
+        when the block first reached them. Every sync after that leaves
+        ``is_current`` alone entirely, on every week, new or existing: once the
+        athlete starts logging, their own position (``Week.advance_current_week``)
+        or the coach's manual override (``week_set_current``) is what moves it —
+        a re-delivery snapping it back to the coach's pointer would undo the
+        athlete's own progress, and blindly mirroring onto a brand-new week
+        could produce two ``True`` rows at once (nothing in the schema forbids
+        that; ``presenters._single_current_week`` treats it as a defensive
+        fallback case, not the expected shape).
 
         Syncing in place this way preserves any ``SessionLog`` the athlete
         already wrote against an unchanged slot while propagating the coach's
@@ -2600,7 +2609,7 @@ class GroupMembership(models.Model):
         from .serializers import resolve_prescription
 
         shared_plan = src_meso.plan
-        member_plan, _ = Plan.objects.get_or_create(
+        member_plan, plan_created = Plan.objects.get_or_create(
             relationship=self.relationship,
             source_group=self.group,
             defaults={
@@ -2635,18 +2644,30 @@ class GroupMembership(models.Model):
         member_weeks = []
         week_pairs = []
         for src_week in src_weeks:
+            week_defaults = {
+                "phase": src_week.phase,
+                "volume": src_week.volume,
+                "intensity": src_week.intensity,
+                "is_deload": src_week.is_deload,
+                "deleted_at": None,
+            }
+            # Mirror the source pointer ONLY on this member's very first
+            # materialization (#456) — gated on the PLAN-level created flag, not
+            # a per-week one: a week created by a *later* sync (the coach grows
+            # the block after the member has already started logging) must
+            # default to ``is_current=False`` even if it happens to be the
+            # source's current week, or it would materialize alongside the
+            # member's own already-advanced week — nothing in the schema
+            # prevents two ``True`` rows. After first sync, this method never
+            # touches ``is_current`` again; the athlete's own logging
+            # (``Week.advance_current_week``) and the coach's manual override
+            # (``week_set_current``) are the only things that move it from here.
+            if plan_created:
+                week_defaults["is_current"] = src_week.is_current
             member_week, _ = Week.objects.update_or_create(
                 mesocycle=member_meso,
                 index=src_week.index,
-                defaults={
-                    "phase": src_week.phase,
-                    "volume": src_week.volume,
-                    "intensity": src_week.intensity,
-                    "is_deload": src_week.is_deload,
-                    # Mirror the source pointer — do NOT hardcode ``True`` (P3).
-                    "is_current": src_week.is_current,
-                    "deleted_at": None,
-                },
+                defaults=week_defaults,
             )
             member_weeks.append(member_week)
             week_pairs.append((src_week, member_week))

--- a/app/store_project/meso/models.py
+++ b/app/store_project/meso/models.py
@@ -1689,6 +1689,16 @@ class Week(models.Model):
         (``_athlete_session_or_404`` only ever serves a live session), and a
         soft-deleted week must never be treated as, or clobbered into, current.
 
+        Re-resolves THIS week from the post-lock ``live_weeks`` read (by pk)
+        rather than trusting the caller's pre-lock ``self`` (Finding 2): a
+        concurrent writer (another log write, or the coach's
+        ``week_set_current``) can commit between the caller loading ``self``
+        and this method acquiring the lock, and both the forward/no-op
+        comparison and the eventual save use that freshly-read row so they're
+        never split across two different snapshots of the same week. A week
+        concurrently soft-deleted out from under ``self`` between load and
+        lock is never resurrected — this returns ``False`` instead.
+
         Returns ``True`` when the pointer moved — including a plan with zero
         current weeks self-healing onto this one — ``False`` for a no-op. A
         caller that cares about ``Plan.modified`` staleness should bump it
@@ -1703,18 +1713,37 @@ class Week(models.Model):
                 .select_related("mesocycle")
                 .order_by("mesocycle__order", "index")
             )
+            # Re-resolve THIS week from the just-locked, fresh read instead of
+            # trusting the pre-lock ``self`` (issue #456 Finding 2): a concurrent
+            # writer (another log write, or the coach's ``week_set_current``) can
+            # commit between the caller loading ``self`` and this method
+            # acquiring the lock, leaving ``self.is_current`` stale. Comparing
+            # and saving against ``fresh`` instead means the flag this method
+            # tests and the row it saves are always the same, current-as-of-the
+            # -lock instance — the stale ``self`` was letting a concurrent
+            # "coach moves the pointer earlier, then we advance past it" race
+            # skip the save (stale ``True``) and leave the plan with ZERO
+            # current weeks.
+            fresh = next((w for w in live_weeks if w.pk == self.pk), None)
+            if fresh is None:
+                # Concurrently soft-deleted between ``self`` loading and this
+                # lock — never resurrect a dead week as current.
+                return False
             current = next((w for w in live_weeks if w.is_current), None)
             if current is not None:
                 current_key = (current.mesocycle.order, current.index)
-                logged_key = (self.mesocycle.order, self.index)
+                logged_key = (fresh.mesocycle.order, fresh.index)
                 if logged_key <= current_key:
                     return False
             Week.objects.filter(
                 mesocycle__plan_id=plan_id, deleted_at__isnull=True
-            ).exclude(pk=self.pk).update(is_current=False)
-            if not self.is_current:
-                self.is_current = True
-                self.save(update_fields=["is_current"])
+            ).exclude(pk=fresh.pk).update(is_current=False)
+            if not fresh.is_current:
+                fresh.is_current = True
+                fresh.save(update_fields=["is_current"])
+            # Keep the caller's (possibly stale) instance coherent with what we
+            # just persisted, in case they read ``self.is_current`` afterward.
+            self.is_current = True
             return True
 
 

--- a/app/store_project/meso/models.py
+++ b/app/store_project/meso/models.py
@@ -2697,6 +2697,10 @@ class GroupMembership(models.Model):
         src_weeks = list(
             src_meso.weeks.filter(deleted_at__isnull=True).order_by("index")
         )
+        # One list, two consumers: the revival check below only counts a
+        # "surviving" current week (one this sync isn't about to drop), and the
+        # drop loop at the bottom soft-deletes everything outside it.
+        src_indexes = [w.index for w in src_weeks]
         member_weeks = []
         week_pairs = []
         for src_week in src_weeks:
@@ -2737,6 +2741,13 @@ class GroupMembership(models.Model):
                 if prior is not None:
                     prior_pk, prior_deleted_at, prior_is_current = prior
                     if prior_deleted_at is not None and prior_is_current:
+                        # Only a current week that SURVIVES this sync counts as
+                        # "the member's real position": a week of this block
+                        # whose source is gone is soft-deleted at the bottom of
+                        # this very method, so counting it here would clear the
+                        # revived flag and then kill the counted week — zero
+                        # live currents. Weeks in other mesocycles always
+                        # survive (this sync never touches them).
                         has_other_current = (
                             Week.objects.filter(
                                 mesocycle__plan=member_plan,
@@ -2744,6 +2755,12 @@ class GroupMembership(models.Model):
                                 deleted_at__isnull=True,
                             )
                             .exclude(pk=prior_pk)
+                            .exclude(
+                                mesocycle=member_meso,
+                                index__in=[
+                                    i for i in prior_week_state if i not in src_indexes
+                                ],
+                            )
                             .exists()
                         )
                         week_defaults["is_current"] = not has_other_current
@@ -2856,7 +2873,6 @@ class GroupMembership(models.Model):
         # Soft-delete member weeks whose source week is no longer live — a whole
         # column the coach removed from the shared block disappears from the
         # member's copy too (``Week.soft_delete`` cascades to its sessions).
-        src_indexes = [w.index for w in src_weeks]
         for dropped_week in member_meso.weeks.exclude(index__in=src_indexes).filter(
             deleted_at__isnull=True
         ):

--- a/app/store_project/meso/models.py
+++ b/app/store_project/meso/models.py
@@ -17,6 +17,7 @@ from datetime import timedelta
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.db import transaction
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
@@ -1656,6 +1657,65 @@ class Week(models.Model):
         self.save(update_fields=["deleted_at"])
         self.sessions.filter(deleted_at__isnull=True).update(deleted_at=now)
         return self
+
+    def advance_current_week(self):
+        """Move the plan's ``is_current`` pointer forward onto this week (#456).
+
+        Locked product rule: when an athlete logs a session belonging to a week
+        LATER than the plan's current week, the pointer follows them — "they
+        started the next week." Forward-only: logging an earlier-or-equal week
+        is a no-op. Advances on ANY successful log write, ``pending`` ("Save
+        progress") just as much as ``done`` ("Log session") — the rule is about
+        which week the athlete is *on*, not whether they finished it, so this
+        deliberately does NOT gate on completion.
+
+        "Later" is PLAN-wide, not per-block: compared as the tuple
+        ``(mesocycle.order, week.index)`` — the same ordering ``current_week()``
+        (serializers.py) walks — since ``is_current`` is unique per plan and
+        spans mesocycles, while a block's own week ``index`` resets to 1 each
+        time.
+
+        Locks the plan first (mirrors ``week_set_current``/``session_add`` et
+        al. in views.py) so two concurrent log writes can't both read a stale
+        current week and race past each other.
+
+        Never calls ``record_plan_action``: the athlete moving their own
+        position is not a coach designer edit and must not enter the coach's
+        undo stack — ``week_set_current`` stays the coach's manual, undoable
+        override, in any direction.
+
+        Only ever compares against / clears *live* weeks (``deleted_at``
+        ``isnull``) — the logged week is live by construction
+        (``_athlete_session_or_404`` only ever serves a live session), and a
+        soft-deleted week must never be treated as, or clobbered into, current.
+
+        Returns ``True`` when the pointer moved — including a plan with zero
+        current weeks self-healing onto this one — ``False`` for a no-op. A
+        caller that cares about ``Plan.modified`` staleness should bump it
+        itself when this returns ``True`` (mirrors views.py's ``_touch_plan``;
+        kept out of this model-layer helper to avoid a models→views dependency).
+        """
+        plan_id = self.mesocycle.plan_id
+        with transaction.atomic():
+            Plan.objects.select_for_update().filter(pk=plan_id).first()
+            live_weeks = list(
+                Week.objects.filter(mesocycle__plan_id=plan_id, deleted_at__isnull=True)
+                .select_related("mesocycle")
+                .order_by("mesocycle__order", "index")
+            )
+            current = next((w for w in live_weeks if w.is_current), None)
+            if current is not None:
+                current_key = (current.mesocycle.order, current.index)
+                logged_key = (self.mesocycle.order, self.index)
+                if logged_key <= current_key:
+                    return False
+            Week.objects.filter(
+                mesocycle__plan_id=plan_id, deleted_at__isnull=True
+            ).exclude(pk=self.pk).update(is_current=False)
+            if not self.is_current:
+                self.is_current = True
+                self.save(update_fields=["is_current"])
+            return True
 
 
 class Session(models.Model):

--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -36,6 +36,7 @@ from .one_rm import one_rm_values
 from .serializers import _fmt_num
 from .serializers import _num
 from .serializers import _phase_states
+from .serializers import _week_label
 from .serializers import current_week
 from .serializers import diff_week_snapshots
 from .serializers import initials
@@ -1094,7 +1095,7 @@ def _single_current_week(plan):
     )
 
 
-def athlete_home(user):
+def athlete_home(user, focus_week_id=None):
     """The athlete's active programs, each as its whole delivered block.
 
     One card per non-archived plan across the athlete's *active* coaches (D-a).
@@ -1103,7 +1104,24 @@ def athlete_home(user):
     else the latest delivered week) — that focus week's sessions are the tappable
     log rows — and carries a read-only multi-week table (``grid``) of the whole
     delivered block so the athlete can see the weeks around them (P3).
+
+    ``focus_week_id`` is a **display-only** override (issue #456): when it names
+    a live, delivered week belonging to one of the athlete's own cards, that
+    week — and therefore its block — becomes the anchor for THAT plan's card
+    only; every other card renders normally. It never touches ``is_current``;
+    the pointer only moves via the athlete's own logging (auto-advance) or the
+    coach's "Make current". An invalid/foreign/undelivered/deleted id is
+    silently ignored, rendering exactly as a bare request would.
     """
+    requested_week = None
+    if focus_week_id is not None:
+        requested_week = (
+            Week.objects.filter(
+                pk=focus_week_id, deleted_at__isnull=True, delivered_at__isnull=False
+            )
+            .select_related("mesocycle")
+            .first()
+        )
     plans = (
         Plan.objects.for_athlete(user)
         .exclude(status=Plan.Status.ARCHIVED)
@@ -1142,15 +1160,23 @@ def athlete_home(user):
         # When it doesn't hold (or the flagged week is undelivered — a current
         # week the coach is still building), fall back to the latest delivered
         # week, whose ordering already tracks the newest delivery.
-        current = current_week(plan)
-        if (
-            current is not None
-            and current.delivered_at is not None
-            and _single_current_week(plan)
-        ):
-            anchor = current
+        #
+        # ``requested_week`` (the ``?week=`` override) wins over both when it
+        # names a live delivered week of THIS plan — matched by ``plan_id``
+        # rather than a second per-card query. A foreign/other-plan week never
+        # matches here, so it's a no-op for every other card.
+        if requested_week is not None and requested_week.mesocycle.plan_id == plan.pk:
+            anchor = requested_week
         else:
-            anchor = latest
+            current = current_week(plan)
+            if (
+                current is not None
+                and current.delivered_at is not None
+                and _single_current_week(plan)
+            ):
+                anchor = current
+            else:
+                anchor = latest
         block = anchor.mesocycle
         focus = anchor
         # The table columns: only DELIVERED live weeks of this block — a week the
@@ -1172,6 +1198,36 @@ def athlete_home(user):
         done = _done_session_ids([s.pk for s in session_objs], user)
         sessions = [_athlete_session_row(s, done=s.pk in done) for s in session_objs]
 
+        # Week chips (issue #456): the navigation affordance onto any delivered
+        # week of the block, not just the focus one — a partially-skipped week
+        # still has a tappable way forward. ``current`` reads the week's own
+        # ``is_current`` (the real pointer); ``focused`` is merely which column
+        # this card is showing right now (the ``?week=`` override, or the
+        # anchor's default). They usually coincide but must not be conflated —
+        # ``_athlete_block_grid``'s own ``current`` flag means "focused column",
+        # a separate, older field kept as-is for its existing consumers.
+        week_chips = [
+            {
+                "id": w.pk,
+                "index": w.index,
+                "label": _week_label(w),
+                "current": w.is_current,
+                "focused": w.pk == focus.pk,
+            }
+            for w in delivered_weeks
+        ]
+        next_week_obj = next(
+            (w for w in delivered_weeks if w.index > focus.index), None
+        )
+        next_week = (
+            {"id": next_week_obj.pk, "index": next_week_obj.index}
+            if next_week_obj is not None
+            else None
+        )
+        # Vacuously false with no sessions — "start next week" would be a
+        # non-sequitur nudge on an empty focus week.
+        focus_done = bool(session_objs) and all(s.pk in done for s in session_objs)
+
         cards.append(
             {
                 "id": plan.pk,
@@ -1183,6 +1239,9 @@ def athlete_home(user):
                 "delivered_at": focus.delivered_at,
                 "sessions": sessions,
                 "grid": _athlete_block_grid(block, delivered_ids, focus.pk, plan.unit),
+                "week_chips": week_chips,
+                "next_week": next_week,
+                "focus_done": focus_done,
                 "awaiting": False,
             }
         )

--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -1076,11 +1076,15 @@ def _athlete_block_grid(block, delivered_week_ids, focus_week_id, unit):
 def _single_current_week(plan):
     """True when ``plan`` has exactly one live ``is_current`` week.
 
-    An individual plan keeps a single current pointer (``week_set_current``
-    clears the others), so its current week is trustworthy as "the week the
-    athlete is on." A group-materialized snapshot instead flags EVERY delivered
-    week ``is_current`` (``sync_delivered_plan``), so there ``current_week`` is
-    ambiguous — this is how ``athlete_home`` tells the two apart.
+    Both an individual plan (``week_set_current``) and a group-materialized
+    member plan (``sync_delivered_plan``, which now only ever mirrors the
+    source's pointer on the member's *first* materialization — issue #456)
+    keep a single current pointer, so ``current_week`` is normally trustworthy
+    as "the week the athlete is on." Nothing in the schema enforces that,
+    though — no DB constraint bars two live ``True`` rows on the same plan —
+    so this stays defensive hardening rather than an assumption: ``athlete_home``
+    falls back to the latest delivered week whenever this doesn't hold, instead
+    of trusting an ambiguous pointer.
     """
     return (
         Week.objects.filter(
@@ -1129,11 +1133,15 @@ def athlete_home(user):
         # Anchor the card (both the block shown and the focus week) on the week
         # the athlete is on. For an individual plan that's its single ``is_current``
         # week, so a coach's "Make current" is honored even when it moves the
-        # athlete back to an earlier delivered block. A group-materialized snapshot
-        # flags every delivered week ``is_current``, so there ``current_week`` is
-        # ambiguous (it returns the earliest) — fall back to the latest delivered
-        # week, whose ordering already tracks the newest delivery. A current week
-        # the coach is still building (undelivered) also falls back to latest.
+        # athlete back to an earlier delivered block. A group-materialized member
+        # plan carries that same single pointer post-#456 (mirrored once, at the
+        # member's first materialization; from there the athlete's own logging or
+        # a coach override is what moves it) — ``_single_current_week`` is
+        # defensive hardening against the schema not actually enforcing "exactly
+        # one," not an expectation that a group plan is shaped any differently.
+        # When it doesn't hold (or the flagged week is undelivered — a current
+        # week the coach is still building), fall back to the latest delivered
+        # week, whose ordering already tracks the newest delivery.
         current = current_week(plan)
         if (
             current is not None

--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -1112,6 +1112,13 @@ def athlete_home(user, focus_week_id=None):
     the pointer only moves via the athlete's own logging (auto-advance) or the
     coach's "Make current". An invalid/foreign/undelivered/deleted id is
     silently ignored, rendering exactly as a bare request would.
+
+    The chip strip and "start next week" nudge span every delivered week of
+    the whole PLAN, not just the anchored block (Finding 1, issue #456): a
+    coach delivering a new block never moves the pointer, so a chip strip
+    scoped to only the anchored block would strand the athlete on the old one
+    forever. ``grid``/``sessions`` stay block-scoped — they follow the anchor
+    (the focus week's mesocycle) alone.
     """
     requested_week = None
     if focus_week_id is not None:
@@ -1198,32 +1205,30 @@ def athlete_home(user, focus_week_id=None):
         done = _done_session_ids([s.pk for s in session_objs], user)
         sessions = [_athlete_session_row(s, done=s.pk in done) for s in session_objs]
 
-        # Week chips (issue #456): the navigation affordance onto any delivered
-        # week of the block, not just the focus one — a partially-skipped week
-        # still has a tappable way forward. ``current`` reads the week's own
-        # ``is_current`` (the real pointer); ``focused`` is merely which column
-        # this card is showing right now (the ``?week=`` override, or the
-        # anchor's default). They usually coincide but must not be conflated —
-        # ``_athlete_block_grid``'s own ``current`` flag means "focused column",
-        # a separate, older field kept as-is for its existing consumers.
-        week_chips = [
-            {
-                "id": w.pk,
-                "index": w.index,
-                "label": _week_label(w),
-                "current": w.is_current,
-                "focused": w.pk == focus.pk,
-            }
-            for w in delivered_weeks
-        ]
-        next_week_obj = next(
-            (w for w in delivered_weeks if w.index > focus.index), None
+        # Week chips + the "start next week" nudge (issue #456 Finding 1) span the
+        # WHOLE PLAN, not just the anchored block: delivery never moves
+        # ``is_current`` (by design — see ``Week.advance_current_week`` /
+        # ``GroupMembership.sync_delivered_plan``), so a coach delivering a NEW
+        # block never touches the athlete's (or a group member's, post-first-
+        # materialization) pointer. Restricting navigation to the anchored
+        # block's own delivered weeks would make that new block invisible and
+        # permanently unreachable — the athlete could never tap into it, and
+        # auto-advance could never carry them there either, since it only fires
+        # from a session the athlete has already reached. Ordered plan-wide by
+        # ``(mesocycle.order, index)`` — the same tuple order
+        # ``advance_current_week`` compares — since a block's own week
+        # ``index`` restarts at 1 each mesocycle.
+        plan_delivered_weeks = list(
+            Week.objects.filter(
+                mesocycle__plan_id=plan.pk,
+                deleted_at__isnull=True,
+                delivered_at__isnull=False,
+            )
+            .select_related("mesocycle")
+            .order_by("mesocycle__order", "index")
         )
-        next_week = (
-            {"id": next_week_obj.pk, "index": next_week_obj.index}
-            if next_week_obj is not None
-            else None
-        )
+        week_chip_groups = _week_chip_groups(plan_delivered_weeks, focus)
+        next_week = _next_delivered_week(plan_delivered_weeks, focus)
         # Vacuously false with no sessions — "start next week" would be a
         # non-sequitur nudge on an empty focus week.
         focus_done = bool(session_objs) and all(s.pk in done for s in session_objs)
@@ -1239,13 +1244,74 @@ def athlete_home(user, focus_week_id=None):
                 "delivered_at": focus.delivered_at,
                 "sessions": sessions,
                 "grid": _athlete_block_grid(block, delivered_ids, focus.pk, plan.unit),
-                "week_chips": week_chips,
+                "week_chip_groups": week_chip_groups,
+                "chip_count": len(plan_delivered_weeks),
                 "next_week": next_week,
                 "focus_done": focus_done,
                 "awaiting": False,
             }
         )
     return cards
+
+
+def _week_chip_groups(plan_delivered_weeks, focus):
+    """Navigation chips for every delivered week of the PLAN, grouped by block.
+
+    Issue #456 Finding 1: the chip strip must span every live mesocycle, not
+    just the anchored one, or a newly delivered block is permanently
+    unreachable. Grouping is by mesocycle (order preserved from
+    ``plan_delivered_weeks``, already plan-wide ordered); a plan with more
+    than one delivered block gets each group labeled with its block's name
+    (``mesocycle.name`` — the same string the card header shows as
+    ``plan.block``) so the jump is legible, while a single-block plan gets one
+    unlabeled group — today's flat "Wk N" row, unchanged. ``current`` reads
+    the week's own ``is_current`` (the real pointer); ``focused`` is merely
+    which column this card is showing right now (the ``?week=`` override, or
+    the anchor's default) — they usually coincide but must not be conflated.
+    """
+    multi_block = len({w.mesocycle_id for w in plan_delivered_weeks}) > 1
+    groups = []
+    current_meso_id = None
+    group = None
+    for w in plan_delivered_weeks:
+        if w.mesocycle_id != current_meso_id:
+            group = {"label": w.mesocycle.name if multi_block else "", "chips": []}
+            groups.append(group)
+            current_meso_id = w.mesocycle_id
+        group["chips"].append(
+            {
+                "id": w.pk,
+                "index": w.index,
+                "label": _week_label(w),
+                "current": w.is_current,
+                "focused": w.pk == focus.pk,
+            }
+        )
+    return groups
+
+
+def _next_delivered_week(plan_delivered_weeks, focus):
+    """The next delivered week after ``focus``, plan-wide — or ``None``.
+
+    Issue #456 Finding 1: crosses block boundaries, so the "start next week"
+    nudge can point into a newly delivered block, not just the anchored one.
+    ``cross_block`` flags when the next week belongs to a different mesocycle
+    than the focus week, so the template can phrase the nudge with the
+    destination block's name instead of a same-block "start Week N".
+    """
+    focus_pos = next(
+        (i for i, w in enumerate(plan_delivered_weeks) if w.pk == focus.pk), None
+    )
+    if focus_pos is None or focus_pos + 1 >= len(plan_delivered_weeks):
+        return None
+    nxt = plan_delivered_weeks[focus_pos + 1]
+    cross_block = nxt.mesocycle_id != focus.mesocycle_id
+    return {
+        "id": nxt.pk,
+        "index": nxt.index,
+        "cross_block": cross_block,
+        "block_label": nxt.mesocycle.name if cross_block else "",
+    }
 
 
 def _prescribed_set_count(sets_text):

--- a/app/store_project/meso/tests/test_athlete_logging.py
+++ b/app/store_project/meso/tests/test_athlete_logging.py
@@ -27,12 +27,17 @@ from django.utils import timezone
 from store_project.meso.agent import service
 from store_project.meso.factories import CoachAthleteFactory
 from store_project.meso.factories import MesocycleFactory
+from store_project.meso.factories import MesoGroupFactory
 from store_project.meso.factories import PlanFactory
 from store_project.meso.factories import WeekFactory
 from store_project.meso.models import CoachAthlete
+from store_project.meso.models import ExerciseSlot
 from store_project.meso.models import LoggedSet
 from store_project.meso.models import Plan
+from store_project.meso.models import PlanAction
 from store_project.meso.models import SessionLog
+from store_project.meso.models import SessionSlot
+from store_project.meso.models import Week
 from store_project.meso.serializers import serialize_recent_logs
 from store_project.meso.tests._helpers import day
 from store_project.meso.tests._helpers import presc
@@ -626,3 +631,188 @@ class TestLogFeedsBack:
         # And through the agent's context builder.
         context = service.build_context(s.plan)
         assert context["recent_logs"][0]["sets"][0]["load"] == "105"
+
+
+# -- issue #456: logging auto-advances the plan's is_current pointer -------
+
+
+class TestLogAdvancesCurrentWeek:
+    """A log write moves ``Week.is_current`` forward to the week it belongs to.
+
+    Locked rule: logging (pending OR done) a session in a week LATER than the
+    plan's current week advances the pointer there — forward-only, tuple
+    compared on ``(mesocycle.order, week.index)`` since ``is_current`` is
+    plan-wide (see ``Week.advance_current_week``). The coach's manual
+    ``week_set_current`` override is untouched by this behavior.
+    """
+
+    def _two_week_plan(
+        self,
+        *,
+        coach=None,
+        athlete=None,
+        current_index=1,
+        other_index=2,
+        delivered=True,
+    ):
+        """One mesocycle, two weeks sharing a day/row, each independently loggable."""
+        coach = coach or UserFactory()
+        athlete = athlete or UserFactory()
+        rel = CoachAthleteFactory(
+            coach=coach, athlete=athlete, status=CoachAthlete.Status.ACTIVE
+        )
+        plan = PlanFactory(
+            relationship=rel, title="Hypertrophy Block", status=Plan.Status.ACTIVE
+        )
+        meso = MesocycleFactory(plan=plan, name="Hypertrophy", order=0)
+        now = timezone.now()
+        slot = SessionSlot.objects.create(
+            mesocycle=meso, day_number=1, name="Lower", bias="Quad", order=0
+        )
+        ex = ExerciseSlot.objects.create(session_slot=slot, name="Box Squat", order=0)
+        week_a = WeekFactory(
+            mesocycle=meso,
+            index=current_index,
+            is_current=True,
+            delivered_at=now if delivered else None,
+        )
+        week_b = WeekFactory(
+            mesocycle=meso,
+            index=other_index,
+            is_current=False,
+            delivered_at=now if delivered else None,
+        )
+        session_a = day(week_a, session_slot=slot)
+        session_b = day(week_b, session_slot=slot)
+        presc(exercise_slot=ex, week=week_a, sets="3", reps="6", load="70", rpe="7")
+        presc(exercise_slot=ex, week=week_b, sets="3", reps="6", load="75", rpe="7")
+        return SimpleNamespace(
+            coach=coach,
+            athlete=athlete,
+            rel=rel,
+            plan=plan,
+            meso=meso,
+            week_a=week_a,
+            week_b=week_b,
+            session_a=session_a,
+            session_b=session_b,
+        )
+
+    def test_logging_a_later_week_done_advances_and_clears_the_old_one(self, client):
+        s = self._two_week_plan()  # week_a (idx 1) current, week_b (idx 2) later
+        client.force_login(s.athlete)
+        resp = post(client, s.session_b, {"sets": []})
+        assert resp.status_code == 200
+        s.week_a.refresh_from_db()
+        s.week_b.refresh_from_db()
+        assert s.week_b.is_current is True
+        assert s.week_a.is_current is False
+        assert Week.objects.filter(mesocycle__plan=s.plan, is_current=True).count() == 1
+
+    def test_logging_a_later_week_pending_also_advances(self, client):
+        s = self._two_week_plan()
+        client.force_login(s.athlete)
+        resp = post(client, s.session_b, {"status": "pending", "sets": []})
+        assert resp.status_code == 200
+        s.week_a.refresh_from_db()
+        s.week_b.refresh_from_db()
+        assert s.week_b.is_current is True
+        assert s.week_a.is_current is False
+
+    def test_logging_the_current_week_is_a_noop(self, client):
+        s = self._two_week_plan()
+        client.force_login(s.athlete)
+        resp = post(client, s.session_a, {"sets": []})
+        assert resp.status_code == 200
+        s.week_a.refresh_from_db()
+        s.week_b.refresh_from_db()
+        assert s.week_a.is_current is True
+        assert s.week_b.is_current is False
+
+    def test_logging_an_earlier_week_is_a_noop(self, client):
+        # week_a (idx 2) is current; week_b (idx 1) is earlier.
+        s = self._two_week_plan(current_index=2, other_index=1)
+        client.force_login(s.athlete)
+        resp = post(client, s.session_b, {"sets": []})
+        assert resp.status_code == 200
+        s.week_a.refresh_from_db()
+        s.week_b.refresh_from_db()
+        assert s.week_a.is_current is True
+        assert s.week_b.is_current is False
+
+    def test_cross_mesocycle_advance_uses_tuple_order_not_bare_index(self, client):
+        # week1 lives in mesocycle order=0 at index 2 (current); week2 lives in a
+        # LATER mesocycle (order=1) at index 1 — a lower bare index, but later in
+        # plan-wide (mesocycle.order, index) tuple order.
+        coach = UserFactory()
+        athlete = UserFactory()
+        rel = CoachAthleteFactory(
+            coach=coach, athlete=athlete, status=CoachAthlete.Status.ACTIVE
+        )
+        plan = PlanFactory(relationship=rel, status=Plan.Status.ACTIVE)
+        meso1 = MesocycleFactory(plan=plan, order=0)
+        meso2 = MesocycleFactory(plan=plan, order=1)
+        now = timezone.now()
+        week1 = WeekFactory(mesocycle=meso1, index=2, is_current=True, delivered_at=now)
+        week2 = WeekFactory(
+            mesocycle=meso2, index=1, is_current=False, delivered_at=now
+        )
+        session2 = day(week2, day_number=1, name="Lower")
+        presc(session2, name="Squat")
+        client.force_login(athlete)
+        resp = post(client, session2, {"sets": []})
+        assert resp.status_code == 200
+        week1.refresh_from_db()
+        week2.refresh_from_db()
+        assert week2.is_current is True
+        assert week1.is_current is False
+
+    def test_self_heals_when_plan_has_no_current_week(self, client):
+        s = self._two_week_plan()
+        s.week_a.is_current = False
+        s.week_a.save(update_fields=["is_current"])
+        client.force_login(s.athlete)
+        resp = post(client, s.session_b, {"sets": []})
+        assert resp.status_code == 200
+        s.week_a.refresh_from_db()
+        s.week_b.refresh_from_db()
+        assert s.week_b.is_current is True
+        assert s.week_a.is_current is False
+
+    def test_advances_a_group_materialized_member_plan_not_the_shared_pointer(
+        self, client
+    ):
+        coach = UserFactory()
+        group = MesoGroupFactory(coach=coach)
+        athlete = UserFactory()
+        CoachAthleteFactory(
+            coach=coach, athlete=athlete, status=CoachAthlete.Status.ACTIVE
+        )
+        group.add_athlete(athlete)
+        shared_plan = group.create_shared_plan()
+        shared_meso = shared_plan.mesocycles.get()
+        shared_meso.append_week()  # a second live week; week 1 stays current
+
+        _, delivered = group.deliver_block(shared_plan)
+        member_plan, member_weeks = delivered[0]
+        member_week1, member_week2 = member_weeks  # index order
+
+        client.force_login(athlete)
+        session2 = member_week2.sessions.first()
+        resp = post(client, session2, {"sets": []})
+        assert resp.status_code == 200
+
+        member_week1.refresh_from_db()
+        member_week2.refresh_from_db()
+        assert member_week2.is_current is True
+        assert member_week1.is_current is False
+
+        # The group's own shared pointer is untouched by a member's log.
+        shared_week1 = shared_meso.weeks.get(index=1)
+        assert shared_week1.is_current is True
+
+    def test_advance_does_not_append_to_the_undo_stack(self, client):
+        s = self._two_week_plan()
+        client.force_login(s.athlete)
+        post(client, s.session_b, {"sets": []})
+        assert PlanAction.objects.filter(plan=s.plan).count() == 0

--- a/app/store_project/meso/tests/test_athlete_logging.py
+++ b/app/store_project/meso/tests/test_athlete_logging.py
@@ -816,3 +816,60 @@ class TestLogAdvancesCurrentWeek:
         client.force_login(s.athlete)
         post(client, s.session_b, {"sets": []})
         assert PlanAction.objects.filter(plan=s.plan).count() == 0
+
+    # -- issue #456 Finding 2: stale `self` under a concurrent pointer move --
+
+    def test_stale_self_survives_a_concurrent_earlier_pointer_move(self):
+        """The compare/save must use a lock-fresh row, not the pre-lock `self`.
+
+        Race: an athlete's Week instance is loaded (``is_current`` True) before
+        a concurrent write; the coach's "Make current" then moves the pointer
+        to an EARLIER week and commits, clearing our week's flag in the DB out
+        from under the in-memory instance — without touching the in-memory
+        ``self.is_current``, which is still stale ``True``. Calling that STALE
+        instance's ``advance_current_week`` must still land on exactly one
+        current week — itself — not zero. (Pre-fix: ``live_weeks`` decided to
+        proceed off a fresh read, but the final ``if not self.is_current``
+        check and the eventual save used the stale ``self`` — its stale
+        ``True`` short-circuited the save entirely, after the bulk-clear had
+        already wiped the earlier week's flag, leaving the plan with zero
+        current weeks.)
+        """
+        s = self._two_week_plan(current_index=2, other_index=1)
+        # week_a (index 2, "w2") starts current; week_b (index 1, "w1") is earlier.
+        stale = Week.objects.get(pk=s.week_a.pk)
+        assert stale.is_current is True
+
+        # A concurrent coach "Make current" moves the pointer back to the
+        # EARLIER week and commits — mimicking a write that lands between our
+        # instance loading and its (later) ``advance_current_week`` call.
+        Week.objects.filter(pk=s.week_a.pk).update(is_current=False)
+        Week.objects.filter(pk=s.week_b.pk).update(is_current=True)
+
+        assert stale.advance_current_week() is True
+
+        live_current = Week.objects.filter(
+            mesocycle__plan=s.plan, is_current=True, deleted_at__isnull=True
+        )
+        assert live_current.count() == 1
+        assert live_current.get().pk == stale.pk
+        assert stale.is_current is True  # the caller's instance stays coherent
+
+    def test_stale_self_concurrently_soft_deleted_is_a_noop(self):
+        s = self._two_week_plan()  # week_a (idx 1) current; week_b (idx 2) later
+        stale = Week.objects.get(pk=s.week_b.pk)
+
+        # The week the caller loaded is concurrently soft-deleted before the
+        # lock is acquired (e.g. the coach deleted its day/row build mid-race).
+        Week.objects.filter(pk=s.week_b.pk).update(deleted_at=timezone.now())
+
+        assert stale.advance_current_week() is False
+
+        s.week_a.refresh_from_db()
+        assert s.week_a.is_current is True  # the pointer is untouched
+        assert (
+            Week.objects.filter(
+                mesocycle__plan=s.plan, is_current=True, deleted_at__isnull=True
+            ).count()
+            == 1
+        )

--- a/app/store_project/meso/tests/test_athlete_surface.py
+++ b/app/store_project/meso/tests/test_athlete_surface.py
@@ -15,6 +15,7 @@ weeks, and never another athlete's data. Delivery — not plan status — is the
 publish gate; an undelivered week is invisible even to its own athlete.
 """
 
+import json
 from datetime import timedelta
 from types import SimpleNamespace
 
@@ -33,6 +34,7 @@ from store_project.meso.models import ExerciseSlot
 from store_project.meso.models import Plan
 from store_project.meso.models import SessionLog
 from store_project.meso.models import SessionSlot
+from store_project.meso.models import Week
 from store_project.meso.tests._helpers import day
 from store_project.meso.tests._helpers import presc as make_presc
 from store_project.users.factories import UserFactory
@@ -412,6 +414,214 @@ class TestAthleteHome:
         assert "Read-only multi-week" not in body
         assert "server-rendered" not in body
         assert "#}" not in body
+
+
+# -- issue #456: ?week= display-only focus override + the chip/nudge UI ---
+
+
+def log_url(session):
+    return reverse("meso:athlete_log_session", kwargs={"pk": session.pk})
+
+
+def post_log(client, session, payload):
+    return client.post(
+        log_url(session),
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+
+
+class TestWeekFocusOverride:
+    """``?week=<id>`` opens a card onto a different delivered week — display only.
+
+    Never moves ``is_current``: that pointer only ever advances via the
+    athlete's own logging (auto-advance, #456) or the coach's "Make current".
+    """
+
+    def test_valid_later_week_switches_focus_without_moving_is_current(self, client):
+        b = seed_block(third_delivered=True)  # w2 is_current; w1 & w3 delivered too
+        client.force_login(b.athlete)
+        resp = client.get(HOME, {"week": b.w3.pk})
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert session_url(b.s3) in body  # focus switched to week 3
+        assert session_url(b.s2) not in body
+        b.w2.refresh_from_db()
+        b.w3.refresh_from_db()
+        assert b.w2.is_current is True  # the GET never moved the pointer
+        assert b.w3.is_current is False
+        assert Week.objects.filter(mesocycle__plan=b.plan, is_current=True).count() == 1
+
+    def test_valid_earlier_week_switches_focus_too(self, client):
+        b = seed_block(third_delivered=True)  # w2 is_current; w1 is earlier
+        client.force_login(b.athlete)
+        resp = client.get(HOME, {"week": b.w1.pk})
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert session_url(b.s1) in body
+        assert session_url(b.s2) not in body
+        b.w2.refresh_from_db()
+        assert b.w2.is_current is True  # review direction is still a no-op on write
+
+    def test_nonexistent_week_id_is_ignored(self, client):
+        b = seed_block()
+        client.force_login(b.athlete)
+        resp = client.get(HOME, {"week": 999999})
+        assert resp.status_code == 200
+        assert session_url(b.s2) in resp.content.decode()  # bare default focus
+
+    def test_non_numeric_week_param_is_ignored(self, client):
+        b = seed_block()
+        client.force_login(b.athlete)
+        resp = client.get(HOME, {"week": "not-an-id"})
+        assert resp.status_code == 200
+        assert session_url(b.s2) in resp.content.decode()
+
+    def test_another_athletes_week_is_ignored(self, client):
+        mine = seed_block()
+        theirs = seed_block()
+        client.force_login(mine.athlete)
+        resp = client.get(HOME, {"week": theirs.w1.pk})
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert session_url(mine.s2) in body  # my own card renders as normal
+        assert session_url(theirs.s1) not in body
+        assert session_url(theirs.s2) not in body
+
+    def test_undelivered_week_is_ignored(self, client):
+        b = seed_block()  # week 3 left undelivered by default
+        client.force_login(b.athlete)
+        resp = client.get(HOME, {"week": b.w3.pk})
+        assert resp.status_code == 200
+        assert session_url(b.s2) in resp.content.decode()
+
+    def test_soft_deleted_week_is_ignored(self, client):
+        b = seed_block(third_delivered=True)
+        b.w3.deleted_at = timezone.now()
+        b.w3.save(update_fields=["deleted_at"])
+        client.force_login(b.athlete)
+        resp = client.get(HOME, {"week": b.w3.pk})
+        assert resp.status_code == 200
+        assert session_url(b.s2) in resp.content.decode()
+
+    def test_override_is_scoped_to_its_own_plans_card(self, client):
+        """Plan A's ``?week=`` override never disturbs plan B's card."""
+        athlete = UserFactory()
+        a = seed_block(athlete=athlete, third_delivered=True)
+        b = seed_block(athlete=athlete, third_delivered=True)
+        client.force_login(athlete)
+        body = client.get(HOME, {"week": a.w3.pk}).content.decode()
+        assert session_url(a.s3) in body  # plan A switched to week 3
+        assert session_url(a.s2) not in body
+        assert session_url(b.s2) in body  # plan B is untouched — still its own current
+        assert session_url(b.s3) not in body
+
+
+class TestWeekChips:
+    """The tappable chip row above the session list — the universal navigation path."""
+
+    def test_rendered_with_current_and_focused_marked(self, client):
+        b = seed_block()  # w1, w2 delivered; w2 is_current + focus
+        client.force_login(b.athlete)
+        body = client.get(HOME).content.decode()
+        assert "Wk 1" in body
+        assert "Wk 2" in body
+        assert f"?week={b.w1.pk}" in body  # the non-current chip carries the param
+        assert f"?week={b.w2.pk}" not in body  # the current chip links to the bare URL
+
+    def test_focused_week_distinguished_from_current(self, client):
+        b = seed_block(third_delivered=True)  # w2 current; view w1 instead
+        client.force_login(b.athlete)
+        body = client.get(HOME, {"week": b.w1.pk}).content.decode()
+        # The current week's chip still points at the bare URL...
+        assert f"?week={b.w2.pk}" not in body
+        # ...while the now-focused week's chip links back to itself.
+        assert f"?week={b.w1.pk}" in body
+
+    def test_not_rendered_for_a_single_delivered_week(self, client):
+        s = seed()  # only one delivered week
+        client.force_login(s.athlete)
+        body = client.get(HOME).content.decode()
+        assert "?week=" not in body
+
+    def test_undelivered_week_never_appears_as_a_chip(self, client):
+        b = seed_block()  # week 3 left undelivered
+        client.force_login(b.athlete)
+        body = client.get(HOME).content.decode()
+        assert "Wk 3" not in body
+        assert f"?week={b.w3.pk}" not in body
+
+    def test_soft_deleted_delivered_week_never_appears_as_a_chip(self, client):
+        b = seed_block(third_delivered=True)
+        b.w3.deleted_at = timezone.now()
+        b.w3.save(update_fields=["deleted_at"])
+        client.force_login(b.athlete)
+        body = client.get(HOME).content.decode()
+        assert "Wk 3" not in body
+        assert f"?week={b.w3.pk}" not in body
+
+    def test_chip_comment_does_not_leak_onto_the_page(self, client):
+        b = seed_block()
+        client.force_login(b.athlete)
+        body = client.get(HOME).content.decode()
+        assert "tappable path onto any delivered" not in body
+        assert "#}" not in body
+
+
+class TestStartNextWeekNudge:
+    """The "start next week" link appears only once the focus week is fully logged."""
+
+    def test_absent_when_not_all_focus_sessions_done(self, client):
+        b = seed_block(third_delivered=True)  # w2 focus, nothing logged
+        client.force_login(b.athlete)
+        body = client.get(HOME).content.decode()
+        assert "start Week" not in body
+
+    def test_absent_when_focus_is_the_last_delivered_week(self, client):
+        b = seed_block()  # w2 is focus + the LAST delivered week (w3 undelivered)
+        SessionLogFactory(
+            session=b.s2, athlete=b.athlete, status=SessionLog.Status.DONE
+        )
+        client.force_login(b.athlete)
+        body = client.get(HOME).content.decode()
+        assert "start Week" not in body
+
+    def test_appears_when_focus_done_and_a_later_week_exists(self, client):
+        b = seed_block(third_delivered=True)  # w2 focus; w3 delivered + later
+        SessionLogFactory(
+            session=b.s2, athlete=b.athlete, status=SessionLog.Status.DONE
+        )
+        client.force_login(b.athlete)
+        body = client.get(HOME).content.decode()
+        assert "start Week 3" in body
+        assert f"?week={b.w3.pk}" in body
+
+
+class TestWeekFocusIntegrationLoop:
+    """Tap a later week's chip, log a session there, and auto-advance closes the loop."""
+
+    def test_visiting_via_week_param_then_logging_advances_is_current(self, client):
+        b = seed_block(third_delivered=True)  # w2 is_current; w3 later, delivered
+        client.force_login(b.athlete)
+
+        # The athlete taps the Wk 3 chip...
+        body = client.get(HOME, {"week": b.w3.pk}).content.decode()
+        assert session_url(b.s3) in body
+
+        # ...and logs its session (already-shipped auto-advance, #456).
+        resp = post_log(client, b.s3, {"sets": []})
+        assert resp.status_code == 200
+
+        b.w2.refresh_from_db()
+        b.w3.refresh_from_db()
+        assert b.w3.is_current is True
+        assert b.w2.is_current is False
+        assert Week.objects.filter(mesocycle__plan=b.plan, is_current=True).count() == 1
+
+        # Their next bare visit naturally focuses week 3.
+        body = client.get(HOME).content.decode()
+        assert session_url(b.s3) in body
+        assert session_url(b.s2) not in body
 
 
 # -- athlete session detail ------------------------------------------------

--- a/app/store_project/meso/tests/test_athlete_surface.py
+++ b/app/store_project/meso/tests/test_athlete_surface.py
@@ -159,6 +159,63 @@ def seed_block(
     )
 
 
+def seed_two_block(*, coach=None, athlete=None):
+    """A two-mesocycle plan (issue #456 Finding 1): both blocks delivered.
+
+    Block A ("Base", order 0) carries two delivered weeks, week 2 of which is
+    the athlete's ``is_current`` week — the athlete is mid-block-A. Block B
+    ("Peak", order 1) carries one delivered week, index 1, ``is_current``
+    False — a coach delivering a brand-new mesocycle never moves the pointer
+    (by design), so block B starts out reachable only via plan-wide
+    navigation, never the anchored block A alone.
+    """
+    coach = coach or UserFactory()
+    athlete = athlete or UserFactory()
+    rel = CoachAthleteFactory(
+        coach=coach, athlete=athlete, status=CoachAthlete.Status.ACTIVE
+    )
+    plan = PlanFactory(
+        relationship=rel, title="Two-Block Plan", status=Plan.Status.ACTIVE
+    )
+    now = timezone.now()
+
+    meso_a = MesocycleFactory(plan=plan, name="Base", order=0)
+    slot_a = SessionSlot.objects.create(
+        mesocycle=meso_a, day_number=1, name="Squat Day", bias="Quad", order=0
+    )
+    ex_a = ExerciseSlot.objects.create(session_slot=slot_a, name="Back Squat", order=0)
+    a1 = WeekFactory(mesocycle=meso_a, index=1, is_current=False, delivered_at=now)
+    a2 = WeekFactory(mesocycle=meso_a, index=2, is_current=True, delivered_at=now)
+    sa1 = day(a1, session_slot=slot_a)
+    sa2 = day(a2, session_slot=slot_a)
+    make_presc(exercise_slot=ex_a, week=a1, sets="5", reps="5", load="90", rpe="8")
+    make_presc(exercise_slot=ex_a, week=a2, sets="5", reps="5", load="100", rpe="8")
+
+    meso_b = MesocycleFactory(plan=plan, name="Peak", order=1)
+    slot_b = SessionSlot.objects.create(
+        mesocycle=meso_b, day_number=1, name="Bench Day", bias="Push", order=0
+    )
+    ex_b = ExerciseSlot.objects.create(session_slot=slot_b, name="Bench Press", order=0)
+    b1 = WeekFactory(mesocycle=meso_b, index=1, is_current=False, delivered_at=now)
+    sb1 = day(b1, session_slot=slot_b)
+    make_presc(exercise_slot=ex_b, week=b1, sets="3", reps="5", load="80", rpe="8")
+
+    return SimpleNamespace(
+        coach=coach,
+        athlete=athlete,
+        rel=rel,
+        plan=plan,
+        meso_a=meso_a,
+        meso_b=meso_b,
+        a1=a1,
+        a2=a2,
+        b1=b1,
+        sa1=sa1,
+        sa2=sa2,
+        sb1=sb1,
+    )
+
+
 HOME = reverse("meso:athlete_home")
 
 
@@ -331,7 +388,10 @@ class TestAthleteHome:
         ``latest_delivered_week`` points at the newest block, but when the coach
         moves the (single) ``is_current`` pointer to a week in an earlier
         delivered block, the individual athlete's home must open to THAT block and
-        week — not the most recent delivery.
+        week — not the most recent delivery. The newer block is still reachable
+        (issue #456 Finding 1: the chip strip spans the whole plan), just not the
+        anchor — its session is not a tappable log row until the athlete taps
+        into it.
         """
         coach = UserFactory()
         athlete = UserFactory()
@@ -375,8 +435,8 @@ class TestAthleteHome:
         assert "Base" in body  # anchored on block A (the current pointer)
         assert "Back Squat" in body
         assert session_url(s_a) in body  # its week is the tappable log row
-        assert "Peak" not in body  # the newer block is not shown
-        assert session_url(s_b) not in body
+        assert "Peak" in body  # the newer block is reachable via the chip strip
+        assert session_url(s_b) not in body  # but not a tappable row (not the anchor)
 
     def test_future_only_add_this_week_row_is_not_leaked(self, client):
         """An exercise added only to an undelivered future week must not surface.
@@ -622,6 +682,163 @@ class TestWeekFocusIntegrationLoop:
         body = client.get(HOME).content.decode()
         assert session_url(b.s3) in body
         assert session_url(b.s2) not in body
+
+
+# -- issue #456 Finding 1: navigation spans the whole PLAN, not just the ----
+# -- anchored block (a newly delivered block never moves is_current) -------
+
+
+class TestPlanWideChips:
+    """The chip strip spans every delivered week of the plan, grouped by block."""
+
+    def test_chips_span_both_blocks_with_block_labels(self, client):
+        b = seed_two_block()  # a2 (block A) is_current; block B has one more
+        client.force_login(b.athlete)
+        body = client.get(HOME).content.decode()
+        assert "Base" in body
+        assert "Peak" in body
+        assert f"?week={b.a1.pk}" in body  # block A's earlier week
+        assert f"?week={b.b1.pk}" in body  # block B's week is reachable too
+        assert "Wk 1" in body
+        assert "Wk 2" in body
+
+    def test_override_into_a_different_block_renders_that_blocks_grid_and_sessions(
+        self, client
+    ):
+        b = seed_two_block()
+        client.force_login(b.athlete)
+        resp = client.get(HOME, {"week": b.b1.pk})
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert session_url(b.sb1) in body  # block B's session is now tappable
+        assert session_url(b.sa2) not in body
+        assert "Bench Press" in body  # block B's grid
+        assert "Back Squat" not in body  # block A's grid is not also shown
+        # The GET never moved the pointer.
+        b.a2.refresh_from_db()
+        b.b1.refresh_from_db()
+        assert b.a2.is_current is True
+        assert b.b1.is_current is False
+        assert Week.objects.filter(mesocycle__plan=b.plan, is_current=True).count() == 1
+
+
+class TestPlanWideNudge:
+    """The "start next week" nudge crosses block boundaries too."""
+
+    def test_nudge_crosses_into_the_next_delivered_block(self, client):
+        b = seed_two_block()  # a2 = last delivered week of block A, is_current
+        SessionLogFactory(
+            session=b.sa2, athlete=b.athlete, status=SessionLog.Status.DONE
+        )
+        client.force_login(b.athlete)
+        body = client.get(HOME).content.decode()
+        assert "start Peak · Week 1" in body  # block-aware copy
+        assert f"?week={b.b1.pk}" in body
+
+
+class TestPlanWideIntegrationLoop:
+    """Tapping into a later BLOCK, logging there, and auto-advance crossing it."""
+
+    def test_full_http_loop_logs_into_block_two_and_advances_across_blocks(
+        self, client
+    ):
+        b = seed_two_block()
+        client.force_login(b.athlete)
+
+        # The athlete taps into block B via the override...
+        body = client.get(HOME, {"week": b.b1.pk}).content.decode()
+        assert session_url(b.sb1) in body
+
+        # ...and logs its session — auto-advance follows them across the block.
+        resp = post_log(client, b.sb1, {"sets": []})
+        assert resp.status_code == 200
+
+        b.a2.refresh_from_db()
+        b.b1.refresh_from_db()
+        assert b.b1.is_current is True
+        assert b.a2.is_current is False
+        assert Week.objects.filter(mesocycle__plan=b.plan, is_current=True).count() == 1
+
+        # Their next bare visit naturally focuses block B.
+        body = client.get(HOME).content.decode()
+        assert session_url(b.sb1) in body
+        assert session_url(b.sa2) not in body
+        assert "Peak" in body
+
+
+class TestPlanWideGroupMember:
+    """A group member's materialized plan gets the same plan-wide navigation."""
+
+    def test_second_delivered_block_reachable_and_advances_the_members_own_pointer(
+        self, client
+    ):
+        from store_project.meso.tests.test_group_deliver import seed_group
+        from store_project.meso.tests.test_group_deliver import shared_meso
+
+        group, plan, [m] = seed_group(member_count=1)
+        meso1 = shared_meso(plan)
+        group.deliver_block()  # first materialization mirrors is_current onto block 1
+        athlete = m.relationship.athlete
+
+        member_plan = Plan.objects.get(relationship=m.relationship, source_group=group)
+        member_week1 = member_plan.mesocycles.get(order=meso1.order).weeks.get(
+            is_current=True
+        )
+
+        # The coach ships a brand-new mesocycle (block 2) and delivers it.
+        meso2 = MesocycleFactory(plan=plan, name="Peak", order=1)
+        slot2 = SessionSlot.objects.create(
+            mesocycle=meso2, day_number=1, name="Bench Day", bias="Push", order=0
+        )
+        ex2 = ExerciseSlot.objects.create(
+            session_slot=slot2, name="Bench Press", order=0
+        )
+        src_week2 = WeekFactory(
+            mesocycle=meso2, index=1, is_current=False, delivered_at=timezone.now()
+        )
+        day(src_week2, session_slot=slot2)
+        make_presc(
+            exercise_slot=ex2, week=src_week2, sets="3", reps="5", load="80", rpe="8"
+        )
+
+        # Second materialization: is_current is NOT re-mirrored (post-first-sync rule).
+        _, member_weeks2 = m.sync_delivered_plan(meso2)
+        member_week2 = member_weeks2[0]
+        member_week2.delivered_at = timezone.now()
+        member_week2.save(update_fields=["delivered_at"])
+
+        member_week1.refresh_from_db()
+        member_week2.refresh_from_db()
+        assert member_week1.is_current is True
+        assert member_week2.is_current is False
+
+        client.force_login(athlete)
+        body = client.get(HOME).content.decode()
+        assert "Peak" in body  # block 2's chip group is reachable
+        assert f"?week={member_week2.pk}" in body
+
+        resp = client.get(HOME, {"week": member_week2.pk})
+        assert resp.status_code == 200
+        assert "Bench Press" in resp.content.decode()
+
+        session2 = member_week2.sessions.first()
+        resp = post_log(client, session2, {"sets": []})
+        assert resp.status_code == 200
+
+        member_week1.refresh_from_db()
+        member_week2.refresh_from_db()
+        assert member_week2.is_current is True
+        assert member_week1.is_current is False
+        assert (
+            Week.objects.filter(
+                mesocycle__plan=member_plan, is_current=True, deleted_at__isnull=True
+            ).count()
+            == 1
+        )
+
+        # The shared plan's own pointer is untouched by the member's log.
+        shared_week1 = meso1.weeks.get(index=1)
+        assert shared_week1.is_current is True
 
 
 # -- athlete session detail ------------------------------------------------

--- a/app/store_project/meso/tests/test_athlete_surface.py
+++ b/app/store_project/meso/tests/test_athlete_surface.py
@@ -475,6 +475,38 @@ class TestAthleteHome:
         assert "server-rendered" not in body
         assert "#}" not in body
 
+    # -- nit #456 P2: an empty focused week must not hide navigation --------
+
+    def test_focused_week_with_no_live_sessions_still_shows_chips_and_grid(
+        self, client
+    ):
+        """A focused week with zero live sessions keeps plan-wide navigation.
+
+        When the focused/current week's sessions are all soft-deleted but the
+        plan still has another delivered week, the card must keep the chip
+        strip and the block grid — hiding them (the old all-or-nothing
+        ``{% if plan.sessions %}`` gate) would strand the athlete on the empty
+        week with no way to reach the rest of the block.
+        """
+        b = seed_block()  # w1 & w2 delivered, w2 is_current
+        b.s2.deleted_at = timezone.now()
+        b.s2.save(update_fields=["deleted_at"])
+        client.force_login(b.athlete)
+        body = client.get(HOME).content.decode()
+        assert "No sessions this week." in body
+        assert "Nothing delivered yet" not in body
+        # The chip strip (2 delivered weeks) survives — week 1 is reachable.
+        assert f"?week={b.w1.pk}" in body
+        # The block grid survives too.
+        assert "Your block" in body
+
+    def test_nothing_delivered_still_shows_awaiting_copy(self, client):
+        """The truly-nothing-delivered state keeps its own distinct copy."""
+        s = seed(delivered=False)
+        client.force_login(s.athlete)
+        body = client.get(HOME).content.decode()
+        assert "Nothing delivered yet — your coach is still building this week." in body
+
 
 # -- issue #456: ?week= display-only focus override + the chip/nudge UI ---
 
@@ -946,13 +978,20 @@ class TestSoftDeletedRowsHidden:
         )
 
     def test_home_hides_soft_deleted_session(self, client):
+        # The tappable "log today" row/link for a soft-deleted Session must be
+        # gone. This does NOT assert the day's name disappears from the page
+        # entirely: since nit #456 P2, the read-only block-wide grid renders
+        # independent of the focus week's live ``Session`` rows (it's driven by
+        # the block-level ``SessionSlot``/``ExerciseSlot``/``Prescription``,
+        # none of which this test touches), so the day can legitimately still
+        # appear there even though its per-week log affordance is hidden.
         s = seed(session_name="Lower")
         s.session.deleted_at = timezone.now()
         s.session.save(update_fields=["deleted_at"])
         client.force_login(s.athlete)
         body = client.get(HOME).content.decode()
         assert session_url(s.session) not in body
-        assert "Lower" not in body
+        assert "No sessions this week." in body
 
     def test_session_page_404s_when_session_soft_deleted(self, client):
         s = seed()

--- a/app/store_project/meso/tests/test_designer_exceptions.py
+++ b/app/store_project/meso/tests/test_designer_exceptions.py
@@ -4,7 +4,7 @@ Model fields (``Prescription.skipped``/``.swap_exercise``/``.swap_name``)
 already exist from P0; the grid serializer already emits them read-only; the
 undo snapshot already captures/restores them. P2 adds the coach WRITE UX for
 one-week exceptions — four backend endpoints, no migrations, no serializer
-changes (see ``docs/meso/fixed-selection-plan.md`` + the P2 contract):
+changes (see ``docs/archive/meso/fixed-selection-plan.md`` + the P2 contract):
 
 - ``session_add_exercise`` extended with an optional ``week_id`` body key
   (add-this-week — the new row lands trained only on that week, skipped on

--- a/app/store_project/meso/tests/test_group_deliver.py
+++ b/app/store_project/meso/tests/test_group_deliver.py
@@ -8,8 +8,11 @@ surface (`/meso/me/` + the session logger) and get a single "your block is ready
 email/push — one per member, not one per week.
 
 This is the group peer of the P3 individual whole-block delivery: both release
-the whole mesocycle at once, and both mirror the source's ``is_current`` pointer
-(the week the athlete is on) rather than flagging every delivered week current.
+the whole mesocycle at once. A member's very first materialization mirrors the
+source's ``is_current`` pointer (the week the athlete is on) rather than
+flagging every delivered week current; every sync after that leaves it alone —
+the athlete's own logging (issue #456) or the coach's manual override is what
+moves it from there, so a re-delivery can never snap an advanced member back.
 
 The modeling: a materialized plan is rooted at the member's `CoachAthlete`
 relationship (an ordinary individual plan to the athlete surface) and tagged
@@ -352,6 +355,79 @@ class TestSyncDeliveredPlan:
         dropped = member_meso.weeks.get(index=2)
         assert dropped.deleted_at is not None
         assert member_meso.weeks.filter(deleted_at__isnull=True).count() == 1
+
+    def test_member_advance_is_preserved_across_redelivery(self):
+        # Issue #456: post-first-sync, a re-delivery must never snap an
+        # athlete's own advanced pointer back to the coach's.
+        group, plan, [m] = seed_group(member_count=1)
+        append_shared_week(plan)
+        meso = shared_meso(plan)
+
+        # First sync materializes + mirrors the source's current pointer (week 1).
+        _, member_weeks = m.sync_delivered_plan(meso)
+        by_index = {w.index: w for w in member_weeks}
+        assert by_index[1].is_current is True
+        assert by_index[2].is_current is False
+
+        # The member advances to week 2 on their own (e.g. by logging it).
+        by_index[1].is_current = False
+        by_index[1].save(update_fields=["is_current"])
+        by_index[2].is_current = True
+        by_index[2].save(update_fields=["is_current"])
+
+        # The coach re-delivers (e.g. tweaks a load) — must NOT snap them back.
+        m.sync_delivered_plan(meso)
+
+        by_index[1].refresh_from_db()
+        by_index[2].refresh_from_db()
+        assert by_index[2].is_current is True
+        assert by_index[1].is_current is False
+
+    def test_source_pointer_move_does_not_move_an_already_materialized_member(self):
+        # Post-first-sync, a re-sync never touches ``is_current`` — even when
+        # the coach moves the shared pointer.
+        group, plan, [m] = seed_group(member_count=1)
+        week2 = append_shared_week(plan)
+        meso = shared_meso(plan)
+        week1 = meso.weeks.get(index=1)
+
+        m.sync_delivered_plan(meso)  # first sync mirrors week 1
+
+        week1.is_current = False
+        week1.save(update_fields=["is_current"])
+        week2.is_current = True
+        week2.save(update_fields=["is_current"])
+
+        _, member_weeks = m.sync_delivered_plan(meso)  # re-sync
+
+        by_index = {w.index: w for w in member_weeks}
+        assert by_index[1].is_current is True
+        assert by_index[2].is_current is False
+
+    def test_new_week_added_after_first_sync_materializes_not_current(self):
+        # A week the member never had before must not materialize current just
+        # because it happens to be the source's current pointer — otherwise a
+        # member who already advanced past first sync would end up with two
+        # ``is_current`` weeks (nothing in the DB prevents that).
+        group, plan, [m] = seed_group(member_count=1)
+        meso = shared_meso(plan)
+        week1 = meso.weeks.get(index=1)
+
+        _, member_weeks = m.sync_delivered_plan(meso)  # first sync: week 1 only
+        assert [w.index for w in member_weeks] == [1]
+
+        week2 = append_shared_week(plan)
+        week1.is_current = False
+        week1.save(update_fields=["is_current"])
+        week2.is_current = True
+        week2.save(update_fields=["is_current"])
+
+        _, member_weeks = m.sync_delivered_plan(meso)
+
+        by_index = {w.index: w for w in member_weeks}
+        assert by_index[2].is_current is False
+        # The member's own already-materialized pointer stays untouched too.
+        assert by_index[1].is_current is True
 
 
 # -- model: deliver_block (the whole-block fan-out) --------------------------

--- a/app/store_project/meso/tests/test_group_deliver.py
+++ b/app/store_project/meso/tests/test_group_deliver.py
@@ -43,6 +43,7 @@ from store_project.meso.models import Plan
 from store_project.meso.models import Prescription
 from store_project.meso.models import Session
 from store_project.meso.models import SessionLog
+from store_project.meso.models import Week
 from store_project.meso.models import WeekDelivery
 from store_project.users.factories import UserFactory
 
@@ -428,6 +429,99 @@ class TestSyncDeliveredPlan:
         assert by_index[2].is_current is False
         # The member's own already-materialized pointer stays untouched too.
         assert by_index[1].is_current is True
+
+    def test_revived_week_drops_stale_current_when_member_has_moved_on(self):
+        # Issue #456 nit 1: ``Week.soft_delete`` never clears ``is_current``, so
+        # a week dropped from the block while it was the member's current one
+        # keeps that stale ``True`` on its dead row. Real ``advance_current_week``
+        # only clears LIVE weeks' pointer (``.filter(deleted_at__isnull=True)``),
+        # so it never touches the dead week's stale flag either — it just
+        # quietly survives. If the coach later brings the week back, reviving
+        # it verbatim would resurrect a second live current week alongside
+        # wherever the member has since moved on — the member's real position
+        # must win instead.
+        group, plan, [m] = seed_group(member_count=1)
+        append_shared_week(plan)
+        append_shared_week(plan)
+        meso = shared_meso(plan)
+        week1 = meso.weeks.get(index=1)
+
+        m.sync_delivered_plan(meso)  # first sync mirrors week 1 as current
+        member_plan = Plan.objects.get(relationship=m.relationship, source_group=group)
+        member_meso = member_plan.mesocycles.get()
+        assert member_meso.weeks.get(index=1).is_current is True
+
+        # The coach drops week 1 from the shared block — the member's copy is
+        # soft-deleted, but its stale ``is_current`` survives the drop.
+        week1.soft_delete()
+        m.sync_delivered_plan(meso)
+        member_week1 = member_meso.weeks.get(index=1)
+        assert member_week1.deleted_at is not None
+        assert member_week1.is_current is True
+
+        # The member's own logging moves their pointer to week 3 — mirroring
+        # ``Week.advance_current_week``, which only clears live weeks, so it
+        # never touches the dead week 1's stale flag.
+        member_week3 = member_meso.weeks.get(index=3)
+        member_week3.is_current = True
+        member_week3.save(update_fields=["is_current"])
+
+        # The coach re-adds week 1 and re-delivers.
+        week1.deleted_at = None
+        week1.save(update_fields=["deleted_at"])
+        m.sync_delivered_plan(meso)
+
+        member_week1.refresh_from_db()
+        member_week3.refresh_from_db()
+        assert member_week1.deleted_at is None  # revived
+        assert member_week1.is_current is False  # stale flag dropped
+        assert member_week3.is_current is True  # member's real position wins
+        assert (
+            Week.objects.filter(
+                mesocycle__plan=member_plan, is_current=True, deleted_at__isnull=True
+            ).count()
+            == 1
+        )
+
+    def test_revived_week_keeps_stale_current_when_member_has_no_other_current(self):
+        # Issue #456 nit 1, the flip side: when the member never moved past the
+        # dropped week (so they have NO other live current week once it's
+        # dead), reviving it should restore their position rather than
+        # stranding them positionless.
+        group, plan, [m] = seed_group(member_count=1)
+        append_shared_week(plan)
+        meso = shared_meso(plan)
+        week1 = meso.weeks.get(index=1)
+
+        m.sync_delivered_plan(meso)  # first sync: week 1 current
+        member_plan = Plan.objects.get(relationship=m.relationship, source_group=group)
+        member_meso = member_plan.mesocycles.get()
+        assert member_meso.weeks.get(index=1).is_current is True
+
+        week1.soft_delete()
+        m.sync_delivered_plan(meso)
+        member_week1 = member_meso.weeks.get(index=1)
+        assert member_week1.deleted_at is not None
+        assert member_week1.is_current is True  # stale flag survives the drop
+        # The member now has zero LIVE current weeks — their only current week
+        # is dead.
+        assert not Week.objects.filter(
+            mesocycle__plan=member_plan, is_current=True, deleted_at__isnull=True
+        ).exists()
+
+        week1.deleted_at = None
+        week1.save(update_fields=["deleted_at"])
+        m.sync_delivered_plan(meso)
+
+        member_week1.refresh_from_db()
+        assert member_week1.deleted_at is None  # revived
+        assert member_week1.is_current is True  # position restored
+        assert (
+            Week.objects.filter(
+                mesocycle__plan=member_plan, is_current=True, deleted_at__isnull=True
+            ).count()
+            == 1
+        )
 
 
 # -- model: deliver_block (the whole-block fan-out) --------------------------

--- a/app/store_project/meso/tests/test_group_deliver.py
+++ b/app/store_project/meso/tests/test_group_deliver.py
@@ -523,6 +523,57 @@ class TestSyncDeliveredPlan:
             == 1
         )
 
+    def test_revival_ignores_a_current_week_the_same_sync_drops(self):
+        # Issue #456 nit follow-up: ONE sync can both revive the member's old
+        # stale-current week AND drop the week they had advanced to. The
+        # revival's "does the member have another live current week?" check
+        # must not count a week this very sync is about to soft-delete —
+        # otherwise it clears the revived flag, then the drop loop kills the
+        # counted week, and the member plan ends with ZERO live current weeks.
+        group, plan, [m] = seed_group(member_count=1)
+        append_shared_week(plan)
+        append_shared_week(plan)
+        meso = shared_meso(plan)
+        week1 = meso.weeks.get(index=1)
+        week3 = meso.weeks.get(index=3)
+
+        m.sync_delivered_plan(meso)  # first sync mirrors week 1 as current
+        member_plan = Plan.objects.get(relationship=m.relationship, source_group=group)
+        member_meso = member_plan.mesocycles.get()
+
+        # Coach drops week 1; the member's dead copy keeps its stale flag.
+        week1.soft_delete()
+        m.sync_delivered_plan(meso)
+        member_week1 = member_meso.weeks.get(index=1)
+        assert member_week1.deleted_at is not None
+        assert member_week1.is_current is True
+
+        # The member advances to week 3 (their real position).
+        member_week3 = member_meso.weeks.get(index=3)
+        member_week3.is_current = True
+        member_week3.save(update_fields=["is_current"])
+
+        # In ONE shared-block edit the coach brings week 1 back and removes
+        # week 3, then re-delivers.
+        week1.deleted_at = None
+        week1.save(update_fields=["deleted_at"])
+        week3.soft_delete()
+        m.sync_delivered_plan(meso)
+
+        member_week1.refresh_from_db()
+        member_week3.refresh_from_db()
+        assert member_week1.deleted_at is None  # revived
+        assert member_week3.deleted_at is not None  # dropped with its source
+        # The doomed week 3 must not have counted as the member's position:
+        # the revived week keeps the pointer, leaving exactly one live current.
+        assert member_week1.is_current is True
+        assert (
+            Week.objects.filter(
+                mesocycle__plan=member_plan, is_current=True, deleted_at__isnull=True
+            ).count()
+            == 1
+        )
+
 
 # -- model: deliver_block (the whole-block fan-out) --------------------------
 

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -1510,6 +1510,12 @@ def athlete_log_session(request, pk):
             list(session.trainable_cells()),
             session.week.mesocycle.plan.unit,
         )
+        # #456: any successful log write — pending or done alike, forward-only —
+        # advances the plan's ``is_current`` pointer onto this week (the athlete
+        # started it). Covers both individual and group-materialized member
+        # plans, since both flow through this one view.
+        if session.week.advance_current_week():
+            _touch_plan(session.week.mesocycle.plan)
     # #441 P3-5: the results step auto-advances once the coach *completes* one of
     # their own self-link sessions. Gated on the step's own predicate so a
     # ``pending`` "save progress" — or a done log the coach makes as an athlete

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -1352,14 +1352,29 @@ def _athlete_session_or_404(user, pk):
 
 
 class AthleteHomeView(LoginRequiredMixin, TemplateView):
-    """The athlete's training home: their delivered programs, this week."""
+    """The athlete's training home: their delivered programs, this week.
+
+    ``?week=<id>`` is a display-only focus override (issue #456): it opens a
+    card onto a different delivered week of its block (e.g. tapping a week
+    chip, or the "start next week" nudge after finishing the focus week)
+    without moving anything — ``is_current`` only ever advances via the
+    athlete's own logging (``athlete_log_session``) or the coach's "Make
+    current". A missing/invalid id is just ``None``, which renders exactly
+    like a bare request.
+    """
 
     template_name = "meso/athlete_home.html"
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         ctx["active"] = "training"
-        ctx["plans"] = presenters.athlete_home(self.request.user)
+        try:
+            focus_week_id = int(self.request.GET.get("week", ""))
+        except (TypeError, ValueError):
+            focus_week_id = None
+        ctx["plans"] = presenters.athlete_home(
+            self.request.user, focus_week_id=focus_week_id
+        )
         # Pending coach links (N4 Phase 2): invites awaiting my reply + requests
         # I've sent + the request-a-coach form all live on this surface.
         ctx["pending"] = presenters.athlete_pending(self.request.user)

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -2917,9 +2917,13 @@ def week_set_current(request, plan_id, week_id):
     it next time. Post-P3 this pointer also means "the week the athlete is on":
     the athlete home (``presenters.athlete_home``) opens its block card onto the
     current week (when it's delivered) and takes "today's session" from it — the
-    coach marks which week the athlete is on by setting it current here. (Setting
-    it stays manual; auto-advance is out of scope.) Exactly one week is current —
-    the others in the plan are cleared.
+    coach marks which week the athlete is on by setting it current here. Since
+    #456, the athlete's own logging auto-advances the pointer forward too
+    (``Week.advance_current_week``, forward-only, off any successful log write)
+    — this endpoint is the coach's *manual* override: unlike the athlete's
+    logging, it can move the pointer in either direction (back to an earlier
+    week included). Exactly one week is current — the others in the plan are
+    cleared.
     Scoped + edit-gated (403 foreign, 402 over-limit); a foreign week is a 404.
     Row-locks the plan so concurrent set-currents serialize, and re-reads the
     week's liveness under that lock — a concurrent ``week_delete`` (which

--- a/app/store_project/templates/meso/athlete_home.html
+++ b/app/store_project/templates/meso/athlete_home.html
@@ -132,19 +132,30 @@
         <p class="meso-row-meta" style="margin-bottom:12px;">Coach {{ plan.coach }}{% if plan.goal %} · {{ plan.goal }}{% endif %}</p>
 
         {% if plan.sessions %}
-          {% if plan.week_chips|length > 1 %}
+          {% if plan.chip_count > 1 %}
             {% comment %}
               Week chips (issue #456) — the tappable path onto any delivered
-              week of this block, not just the focus one, so an athlete who
-              partially skipped a week is never stranded on it. Pure
-              server-rendered links; the CURRENT (is_current) chip is filled,
-              the FOCUSED (viewed) chip gets an accent outline, and the two
-              can differ (viewing an earlier week for review doesn't move
-              is_current). Only shown for a multi-delivered-week block.
+              week of this PLAN, not just the anchored block's (Finding 1: a
+              coach delivering a new block never moves is_current, so scoping
+              this to the anchored block would strand the athlete on the old
+              one forever). Pure server-rendered links; the CURRENT
+              (is_current) chip is filled, the FOCUSED (viewed) chip gets an
+              accent outline, and the two can differ (viewing an earlier week
+              for review doesn't move is_current). Grouped by block: a group
+              only gets a visible label once the plan has more than one
+              delivered block, otherwise it's today's flat "Wk N" row. Only
+              shown at all once the plan has more than one delivered week.
             {% endcomment %}
-            <div style="display:flex;flex-wrap:wrap;gap:7px;margin-bottom:12px;">
-              {% for w in plan.week_chips %}
-                <a href="{% if w.current %}{% url 'meso:athlete_home' %}{% else %}{% url 'meso:athlete_home' %}?week={{ w.id }}{% endif %}" class="meso-mono" style="display:inline-flex;align-items:center;padding:7px 13px;border-radius:999px;font-size:12px;font-weight:700;text-decoration:none;{% if w.current %}background:var(--accent-deep);color:var(--accent-ink);border:1px solid var(--accent-deep);{% else %}background:var(--surface);color:var(--ink);border:1px solid var(--line);{% endif %}{% if w.focused and not w.current %}box-shadow:inset 0 0 0 1.5px var(--accent-deep);color:var(--accent-deep);{% endif %}">{{ w.label }}</a>
+            <div style="margin-bottom:12px;">
+              {% for group in plan.week_chip_groups %}
+                <div style="{% if not forloop.first %}margin-top:8px;{% endif %}">
+                  {% if group.label %}<p class="meso-eyebrow" style="margin-bottom:5px;">{{ group.label }}</p>{% endif %}
+                  <div style="display:flex;flex-wrap:wrap;gap:7px;">
+                    {% for w in group.chips %}
+                      <a href="{% if w.current %}{% url 'meso:athlete_home' %}{% else %}{% url 'meso:athlete_home' %}?week={{ w.id }}{% endif %}" class="meso-mono" style="display:inline-flex;align-items:center;padding:7px 13px;border-radius:999px;font-size:12px;font-weight:700;text-decoration:none;{% if w.current %}background:var(--accent-deep);color:var(--accent-ink);border:1px solid var(--accent-deep);{% else %}background:var(--surface);color:var(--ink);border:1px solid var(--line);{% endif %}{% if w.focused and not w.current %}box-shadow:inset 0 0 0 1.5px var(--accent-deep);color:var(--accent-deep);{% endif %}">{{ w.label }}</a>
+                    {% endfor %}
+                  </div>
+                </div>
               {% endfor %}
             </div>
           {% endif %}
@@ -168,8 +179,8 @@
           </div>
 
           {% if plan.focus_done and plan.next_week %}
-            {# "Start next week" nudge (#456) — discoverability sugar; the chips above are the universal path. #}
-            <a class="meso-btn meso-btn--primary" href="{% url 'meso:athlete_home' %}?week={{ plan.next_week.id }}" style="width:100%;justify-content:center;margin-top:10px;padding:11px 14px;font-size:13.5px;">Week {{ plan.focus_index }} done — start Week {{ plan.next_week.index }} &rarr;</a>
+            {# "Start next week" nudge (#456) — discoverability sugar; the chips above are the universal path. Crosses blocks (Finding 1): when the next delivered week lives in a different mesocycle, the copy names the destination block so the jump makes sense. #}
+            <a class="meso-btn meso-btn--primary" href="{% url 'meso:athlete_home' %}?week={{ plan.next_week.id }}" style="width:100%;justify-content:center;margin-top:10px;padding:11px 14px;font-size:13.5px;">{% if plan.next_week.cross_block %}Week {{ plan.focus_index }} done — start {{ plan.next_week.block_label }} · Week {{ plan.next_week.index }} &rarr;{% else %}Week {{ plan.focus_index }} done — start Week {{ plan.next_week.index }} &rarr;{% endif %}</a>
           {% endif %}
 
           {% if plan.grid.days %}

--- a/app/store_project/templates/meso/athlete_home.html
+++ b/app/store_project/templates/meso/athlete_home.html
@@ -132,7 +132,24 @@
         <p class="meso-row-meta" style="margin-bottom:12px;">Coach {{ plan.coach }}{% if plan.goal %} · {{ plan.goal }}{% endif %}</p>
 
         {% if plan.sessions %}
-          {# The focus (current) week's sessions — the "log today" affordance. #}
+          {% if plan.week_chips|length > 1 %}
+            {% comment %}
+              Week chips (issue #456) — the tappable path onto any delivered
+              week of this block, not just the focus one, so an athlete who
+              partially skipped a week is never stranded on it. Pure
+              server-rendered links; the CURRENT (is_current) chip is filled,
+              the FOCUSED (viewed) chip gets an accent outline, and the two
+              can differ (viewing an earlier week for review doesn't move
+              is_current). Only shown for a multi-delivered-week block.
+            {% endcomment %}
+            <div style="display:flex;flex-wrap:wrap;gap:7px;margin-bottom:12px;">
+              {% for w in plan.week_chips %}
+                <a href="{% if w.current %}{% url 'meso:athlete_home' %}{% else %}{% url 'meso:athlete_home' %}?week={{ w.id }}{% endif %}" class="meso-mono" style="display:inline-flex;align-items:center;padding:7px 13px;border-radius:999px;font-size:12px;font-weight:700;text-decoration:none;{% if w.current %}background:var(--accent-deep);color:var(--accent-ink);border:1px solid var(--accent-deep);{% else %}background:var(--surface);color:var(--ink);border:1px solid var(--line);{% endif %}{% if w.focused and not w.current %}box-shadow:inset 0 0 0 1.5px var(--accent-deep);color:var(--accent-deep);{% endif %}">{{ w.label }}</a>
+              {% endfor %}
+            </div>
+          {% endif %}
+
+          {# The focus week's sessions — the "log today" affordance. #}
           <div class="meso-flex" style="flex-direction:column;gap:8px;">
             {% for s in plan.sessions %}
               <a class="meso-row" href="{{ s.url }}" style="display:flex;align-items:center;gap:12px;padding:12px 14px;border:1px solid var(--line);border-radius:11px;text-decoration:none;color:inherit;">
@@ -149,6 +166,11 @@
               </a>
             {% endfor %}
           </div>
+
+          {% if plan.focus_done and plan.next_week %}
+            {# "Start next week" nudge (#456) — discoverability sugar; the chips above are the universal path. #}
+            <a class="meso-btn meso-btn--primary" href="{% url 'meso:athlete_home' %}?week={{ plan.next_week.id }}" style="width:100%;justify-content:center;margin-top:10px;padding:11px 14px;font-size:13.5px;">Week {{ plan.focus_index }} done — start Week {{ plan.next_week.index }} &rarr;</a>
+          {% endif %}
 
           {% if plan.grid.days %}
             {% comment %}

--- a/app/store_project/templates/meso/athlete_home.html
+++ b/app/store_project/templates/meso/athlete_home.html
@@ -131,7 +131,9 @@
         </div>
         <p class="meso-row-meta" style="margin-bottom:12px;">Coach {{ plan.coach }}{% if plan.goal %} · {{ plan.goal }}{% endif %}</p>
 
-        {% if plan.sessions %}
+        {% if plan.awaiting %}
+          <p class="meso-row-meta">Nothing delivered yet — your coach is still building this week.</p>
+        {% else %}
           {% if plan.chip_count > 1 %}
             {% comment %}
               Week chips (issue #456) — the tappable path onto any delivered
@@ -145,6 +147,9 @@
               only gets a visible label once the plan has more than one
               delivered block, otherwise it's today's flat "Wk N" row. Only
               shown at all once the plan has more than one delivered week.
+              Rendered independent of plan.sessions (nit #456 P2): a focused
+              week whose sessions were all soft-deleted must not hide the only
+              plan-wide navigation off it.
             {% endcomment %}
             <div style="margin-bottom:12px;">
               {% for group in plan.week_chip_groups %}
@@ -160,23 +165,33 @@
             </div>
           {% endif %}
 
-          {# The focus week's sessions — the "log today" affordance. #}
-          <div class="meso-flex" style="flex-direction:column;gap:8px;">
-            {% for s in plan.sessions %}
-              <a class="meso-row" href="{{ s.url }}" style="display:flex;align-items:center;gap:12px;padding:12px 14px;border:1px solid var(--line);border-radius:11px;text-decoration:none;color:inherit;">
-                <div class="meso-mono" style="font-size:12px;font-weight:700;color:var(--dim);">D{{ s.n }}</div>
-                <div style="flex:1;min-width:0;">
-                  <div style="font-size:14px;font-weight:700;letter-spacing:-0.01em;">{{ s.name }}{% if s.bias %} · {{ s.bias }}{% endif %}</div>
-                  <div class="meso-row-meta">{{ s.exercise_count }} exercise{{ s.exercise_count|pluralize }}</div>
-                </div>
-                {% if s.status == 'done' %}
-                  <span class="meso-badge meso-badge--ok">{{ s.status_label }}</span>
-                {% else %}
-                  <span class="meso-badge">{{ s.status_label }}</span>
-                {% endif %}
-              </a>
-            {% endfor %}
-          </div>
+          {% if plan.sessions %}
+            {# The focus week's sessions — the "log today" affordance. #}
+            <div class="meso-flex" style="flex-direction:column;gap:8px;">
+              {% for s in plan.sessions %}
+                <a class="meso-row" href="{{ s.url }}" style="display:flex;align-items:center;gap:12px;padding:12px 14px;border:1px solid var(--line);border-radius:11px;text-decoration:none;color:inherit;">
+                  <div class="meso-mono" style="font-size:12px;font-weight:700;color:var(--dim);">D{{ s.n }}</div>
+                  <div style="flex:1;min-width:0;">
+                    <div style="font-size:14px;font-weight:700;letter-spacing:-0.01em;">{{ s.name }}{% if s.bias %} · {{ s.bias }}{% endif %}</div>
+                    <div class="meso-row-meta">{{ s.exercise_count }} exercise{{ s.exercise_count|pluralize }}</div>
+                  </div>
+                  {% if s.status == 'done' %}
+                    <span class="meso-badge meso-badge--ok">{{ s.status_label }}</span>
+                  {% else %}
+                    <span class="meso-badge">{{ s.status_label }}</span>
+                  {% endif %}
+                </a>
+              {% endfor %}
+            </div>
+          {% else %}
+            {# This card's plan HAS delivered weeks — this focused week just has
+               no live sessions right now (e.g. the coach removed them all after
+               delivering it, or after a group-member re-sync). Distinct from
+               the truly-nothing-delivered "awaiting" state above (nit #456
+               P2): the plan-wide chips/grid above still stand, so this is
+               deliberately a light inline note, not the "still building" copy. #}
+            <p class="meso-row-meta">No sessions this week.</p>
+          {% endif %}
 
           {% if plan.focus_done and plan.next_week %}
             {# "Start next week" nudge (#456) — discoverability sugar; the chips above are the universal path. Crosses blocks (Finding 1): when the next delivered week lives in a different mesocycle, the copy names the destination block so the jump makes sense. #}
@@ -191,7 +206,9 @@
               phone screen never scrolls the whole page sideways. Pure
               server-rendered — no JS. (A multi-line {# #} comment is NOT
               stripped by Django — its tokenizer is single-line — so it would
-              leak onto the athlete's screen; use {% comment %} here.)
+              leak onto the athlete's screen; use {% comment %} here.) Rendered
+              independent of plan.sessions (nit #456 P2) — see the chips
+              comment above.
             {% endcomment %}
             <div style="margin-top:14px;">
               <p class="meso-eyebrow" style="margin-bottom:8px;">Your block</p>
@@ -226,8 +243,6 @@
               {% endfor %}
             </div>
           {% endif %}
-        {% else %}
-          <p class="meso-row-meta">Nothing delivered yet — your coach is still building this week.</p>
         {% endif %}
       </div>
     {% empty %}


### PR DESCRIPTION
## Summary

Closes #456. The athlete's `is_current` pointer now follows their own logging instead of waiting on the coach's manual "Make current".

**Advance rule (server):** `Week.advance_current_week()` — on ANY successful log write (pending or done alike; "they started the next week", no completion accounting), a session in a LATER week moves the plan's pointer there. Forward-only; plan-wide tuple compare on `(mesocycle.order, week.index)` (week indexes reset per block); plan-locked (`select_for_update`, re-resolving the logged week under the lock to survive concurrent coach moves); self-heals a zero-current plan; deliberately no `record_plan_action` (an athlete's position isn't a coach designer edit). Wired into `athlete_log_session` — the single choke point both individual and group-member plans flow through. `week_set_current` stays as the coach's manual override, any direction.

**Groups (member independence):** `sync_delivered_plan` mirrors the source pointer only on FIRST materialization (plan-level `created` flag — a per-week flag could mint two currents). After that, syncs never touch member pointers: a member on Wk3 no longer snaps back on re-delivery. Reviving a dropped-then-restored week reconciles its stale flag (`Week.soft_delete` never clears `is_current`): another surviving live current wins; a member who never moved gets their position restored; a current the same sync is about to drop doesn't count.

**Athlete navigation (the piece that makes the rule reachable):** the athlete home previously linked ONLY the focus week's sessions — an athlete finishing week 1 had no path to week 2, which would have left auto-advance inert. Now, pure server-rendered (no JS):
- **Week chips** across ALL delivered weeks of the plan (grouped/labeled per block when the plan spans blocks — so a newly delivered second block is always reachable), current week filled, viewed week outlined.
- **`?week=<id>` display-only focus override** (validated live+delivered+owned; invalid ignored; a GET never moves the pointer).
- **"Week N done — start Week N+1 →" nudge** when the focus week's sessions are all logged and a later delivered week exists (cross-block aware).
- Chips/grid render independent of the focus week's sessions; an emptied week shows "No sessions this week." instead of swallowing navigation.

**Docs debt:** `_single_current_week` / `athlete_home` / `sync_delivered_plan` / `week_set_current` docstrings reconciled (the pre-P5 "group snapshot flags EVERY delivered week current" story is gone; multiple-current handling reframed as defensive hardening). Stale plan-doc path in `test_designer_exceptions.py` updated to the #457 archive location.

## Review + verification
- Codex review loop converged: 1 P1 (new blocks unreachable for existing members) + 1 P2 race + 3 P2 nits — all fixed with regression tests, none declined.
- Full meso suite **2097 passed** (+30 new tests); `ruff` clean; `makemigrations --check` clean — **NO migrations**.
- Browser-verified end-to-end on local dev as a real athlete: chips render (current vs viewed distinct), `?week=` swaps focus without moving the pointer, logging the Week-2 session advanced `is_current` (DB-confirmed), bare home re-anchored on Week 2, the "start Week 3" nudge appeared and navigates.

https://claude.ai/code/session_01GpaxgUSRbupnkecSo9Pmx4