### PR TITLE
feat(meso): A1 — keyboard grid navigation in the multi-week table (#455)

### DIFF
--- a/frontend/designer/src/components/MesoTable.test.tsx
+++ b/frontend/designer/src/components/MesoTable.test.tsx
@@ -4,9 +4,10 @@
 // forward ExerciseRow's dirtySinceFocus semantics (only actually-typed
 // fields persist). Deload marker/skipped em-dash/swap badge are display-only
 // in P1 — no write UX for swap/skip.
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MesoTable } from "./MesoTable";
+import { tableCellDomKey, tableCellAriaLabel } from "../hooks/useTableNav";
 import type { GridCell, GridDay, GridRow, GridWeek, GroupIdentity, MesoGrid } from "../lib/api";
 
 function week(overrides: Partial<GridWeek> = {}): GridWeek {
@@ -585,5 +586,275 @@ describe("group per-athlete adjust badge", () => {
       expect.objectContaining({ exercise_slot_id: 9 }),
       expect.objectContaining({ prescription_id: 100 }),
     );
+  });
+});
+
+// --- Issue #455 phase A1: keyboard grid navigation ------------------------
+// useTableNav (../hooks/useTableNav) is instantiated ONCE inside MesoTable —
+// GridCellEditor/RowNameEditor are module-private, so there's no externally
+// injectable gridNav prop and no INERT fallback to test; every spec here
+// renders the real table and drives real keyboard events through RTL,
+// mirroring WeekGrid.test.tsx's "Phase 3" block (the one-week precedent).
+//
+// Fixture: day 1 (session_slot_id 1) has row 9 "Box Squat" (cells 900/901)
+// and row 10 "RDL" (cells 1000/1001); day 2 (session_slot_id 2) has row 11
+// "Bench" (cells 1100/1101). Two weeks (id 1 "Wk 1", id 2 "Wk 2") so
+// ArrowRight/Left week-crossing is exercisable directly.
+const NAV_GRID: MesoGrid = grid({
+  weeks: [week({ id: 1, label: "Wk 1", current: true }), week({ id: 2, label: "Wk 2", current: false })],
+  days: [
+    day({
+      session_slot_id: 1,
+      name: "Lower",
+      rows: [
+        row({
+          exercise_slot_id: 9,
+          name: "Box Squat",
+          cells: { "1": cell({ prescription_id: 900 }), "2": cell({ prescription_id: 901 }) },
+        }),
+        row({
+          exercise_slot_id: 10,
+          name: "RDL",
+          cells: { "1": cell({ prescription_id: 1000 }), "2": cell({ prescription_id: 1001 }) },
+        }),
+      ],
+    }),
+    day({
+      session_slot_id: 2,
+      name: "Upper",
+      rows: [
+        row({
+          exercise_slot_id: 11,
+          name: "Bench",
+          cells: { "1": cell({ prescription_id: 1100 }), "2": cell({ prescription_id: 1101 }) },
+        }),
+      ],
+    }),
+  ],
+});
+
+describe("keyboard grid navigation", () => {
+  describe("data-grid-cell + aria-label", () => {
+    it("stamps data-grid-cell on every field input and the row-name input, keyed by (rowId, weekId, field)", () => {
+      render(<MesoTable {...baseProps({ grid: NAV_GRID })} />);
+      expect(screen.getByTestId("row-name-9")).toHaveAttribute("data-grid-cell", tableCellDomKey(9, null, "name"));
+      expect(screen.getByTestId("cell-sets-900")).toHaveAttribute("data-grid-cell", tableCellDomKey(9, 1, "sets"));
+      expect(screen.getByTestId("cell-reps-900")).toHaveAttribute("data-grid-cell", tableCellDomKey(9, 1, "reps"));
+      expect(screen.getByTestId("cell-load-900")).toHaveAttribute("data-grid-cell", tableCellDomKey(9, 1, "load"));
+      expect(screen.getByTestId("cell-rpe-900")).toHaveAttribute("data-grid-cell", tableCellDomKey(9, 1, "rpe"));
+      expect(screen.getByTestId("cell-rest-900")).toHaveAttribute("data-grid-cell", tableCellDomKey(9, 1, "rest"));
+      expect(screen.getByTestId("cell-note-900")).toHaveAttribute("data-grid-cell", tableCellDomKey(9, 1, "note"));
+      expect(screen.getByTestId("cell-sets-901")).toHaveAttribute("data-grid-cell", tableCellDomKey(9, 2, "sets"));
+    });
+
+    it("gives every field input an aria-label reflecting row/week/field, and the name input its own", () => {
+      render(<MesoTable {...baseProps({ grid: NAV_GRID })} />);
+      expect(screen.getByTestId("cell-sets-900")).toHaveAttribute("aria-label", tableCellAriaLabel("Box Squat", "Wk 1", "sets"));
+      expect(screen.getByTestId("cell-rpe-900")).toHaveAttribute("aria-label", tableCellAriaLabel("Box Squat", "Wk 1", "rpe"));
+      expect(screen.getByTestId("cell-sets-901")).toHaveAttribute("aria-label", tableCellAriaLabel("Box Squat", "Wk 2", "sets"));
+      expect(screen.getByTestId("row-name-9")).toHaveAttribute("aria-label", tableCellAriaLabel("Box Squat", null, "name"));
+    });
+  });
+
+  describe("roving tabindex", () => {
+    it("exactly one cell (the table's first: row-name) is tabbable on initial render", () => {
+      render(<MesoTable {...baseProps({ grid: NAV_GRID })} />);
+      expect(screen.getByTestId("row-name-9")).toHaveAttribute("tabindex", "0");
+      expect(screen.getByTestId("cell-sets-900")).toHaveAttribute("tabindex", "-1");
+      expect(screen.getByTestId("row-name-10")).toHaveAttribute("tabindex", "-1");
+      expect(screen.getByTestId("row-name-11")).toHaveAttribute("tabindex", "-1");
+    });
+
+    it("focusing another cell moves the roving tabIndex to it", async () => {
+      const user = userEvent.setup();
+      render(<MesoTable {...baseProps({ grid: NAV_GRID })} />);
+      await user.click(screen.getByTestId("cell-rpe-1000"));
+      expect(screen.getByTestId("cell-rpe-1000")).toHaveAttribute("tabindex", "0");
+      expect(screen.getByTestId("row-name-9")).toHaveAttribute("tabindex", "-1");
+    });
+
+    it("roving tabIndex spans multiple day-tables as ONE grid", async () => {
+      const user = userEvent.setup();
+      render(<MesoTable {...baseProps({ grid: NAV_GRID })} />);
+      await user.click(screen.getByTestId("cell-load-1000")); // day 1's last row
+      await user.keyboard("{ArrowDown}");
+      expect(screen.getByTestId("cell-load-1100")).toHaveFocus(); // day 2's row
+      expect(screen.getByTestId("cell-load-1100")).toHaveAttribute("tabindex", "0");
+    });
+  });
+
+  describe("ArrowDown / ArrowUp navigate rows across day-table boundaries", () => {
+    it("ArrowDown moves focus to the same field on the next row within a day", async () => {
+      const user = userEvent.setup();
+      render(<MesoTable {...baseProps({ grid: NAV_GRID })} />);
+      await user.click(screen.getByTestId("cell-sets-900"));
+      await user.keyboard("{ArrowDown}");
+      expect(screen.getByTestId("cell-sets-1000")).toHaveFocus();
+    });
+
+    it("ArrowDown crosses a day-table boundary (last row of day 1 -> first row of day 2)", async () => {
+      const user = userEvent.setup();
+      render(<MesoTable {...baseProps({ grid: NAV_GRID })} />);
+      await user.click(screen.getByTestId("cell-load-1000"));
+      await user.keyboard("{ArrowDown}");
+      expect(screen.getByTestId("cell-load-1100")).toHaveFocus();
+    });
+
+    it("ArrowUp mirrors ArrowDown, crossing day boundaries upward", async () => {
+      const user = userEvent.setup();
+      render(<MesoTable {...baseProps({ grid: NAV_GRID })} />);
+      await user.click(screen.getByTestId("cell-rpe-1100"));
+      await user.keyboard("{ArrowUp}");
+      expect(screen.getByTestId("cell-rpe-1000")).toHaveFocus();
+    });
+  });
+
+  describe("ArrowRight / ArrowLeft move fields only at caret extremes, crossing weeks and the name column", () => {
+    it("ArrowRight at the end of the text moves to the next field within the same week", () => {
+      render(<MesoTable {...baseProps({ grid: NAV_GRID })} />);
+      const setsInput = screen.getByTestId("cell-sets-900") as HTMLInputElement;
+      setsInput.focus();
+      setsInput.setSelectionRange(setsInput.value.length, setsInput.value.length);
+      fireEvent.keyDown(setsInput, { key: "ArrowRight" });
+      expect(screen.getByTestId("cell-reps-900")).toHaveFocus();
+    });
+
+    it("ArrowLeft at the start of the text moves to the previous field within the same week", () => {
+      render(<MesoTable {...baseProps({ grid: NAV_GRID })} />);
+      const repsInput = screen.getByTestId("cell-reps-900") as HTMLInputElement;
+      repsInput.focus();
+      repsInput.setSelectionRange(0, 0);
+      fireEvent.keyDown(repsInput, { key: "ArrowLeft" });
+      expect(screen.getByTestId("cell-sets-900")).toHaveFocus();
+    });
+
+    it("ArrowRight at the last field of week 1 crosses into week 2's first field", () => {
+      render(<MesoTable {...baseProps({ grid: NAV_GRID })} />);
+      const noteInput = screen.getByTestId("cell-note-900") as HTMLInputElement;
+      noteInput.focus();
+      noteInput.setSelectionRange(noteInput.value.length, noteInput.value.length);
+      fireEvent.keyDown(noteInput, { key: "ArrowRight" });
+      expect(screen.getByTestId("cell-sets-901")).toHaveFocus();
+    });
+
+    it("ArrowRight at the end of the name column moves into week 1's sets field", () => {
+      render(<MesoTable {...baseProps({ grid: NAV_GRID })} />);
+      const nameInput = screen.getByTestId("row-name-9") as HTMLInputElement;
+      nameInput.focus();
+      nameInput.setSelectionRange(nameInput.value.length, nameInput.value.length);
+      fireEvent.keyDown(nameInput, { key: "ArrowRight" });
+      expect(screen.getByTestId("cell-sets-900")).toHaveFocus();
+    });
+
+    it("ArrowLeft at the start of week 1's sets field moves back to the name column", () => {
+      render(<MesoTable {...baseProps({ grid: NAV_GRID })} />);
+      const setsInput = screen.getByTestId("cell-sets-900") as HTMLInputElement;
+      setsInput.focus();
+      setsInput.setSelectionRange(0, 0);
+      fireEvent.keyDown(setsInput, { key: "ArrowLeft" });
+      expect(screen.getByTestId("row-name-9")).toHaveFocus();
+    });
+  });
+
+  describe("Enter commits / Escape reverts (integrated)", () => {
+    it("Enter commits only when the cell is dirty, and keeps focus in place", async () => {
+      const user = userEvent.setup();
+      const onPatchCell = vi.fn();
+      render(<MesoTable {...baseProps({ grid: NAV_GRID, onPatchCell })} />);
+      const loadInput = screen.getByTestId("cell-load-900");
+      await user.click(loadInput);
+      await user.keyboard("{Enter}"); // clean cell: no-op (existing dirty gate)
+      expect(onPatchCell).not.toHaveBeenCalled();
+      await user.clear(loadInput);
+      await user.type(loadInput, "150");
+      await user.keyboard("{Enter}");
+      expect(onPatchCell).toHaveBeenCalledWith(900, { load: "150" });
+      expect(onPatchCell).toHaveBeenCalledTimes(1);
+      expect(loadInput).toHaveFocus();
+    });
+
+    it("Escape reverts only the focused field's draft, leaving a second dirty field on the same cell untouched", () => {
+      // A per-cell dirty Set (not a per-row boolean) needs per-field removal
+      // — revertField (MesoTable.tsx) is the new code under test here.
+      // fireEvent.change without a prior real .focus() dirties "load"
+      // without giving it real DOM focus, so focusing "sets" next doesn't
+      // trigger a real blur-commit of "load" and contaminate the assertion.
+      const onPatchCell = vi.fn();
+      render(<MesoTable {...baseProps({ grid: NAV_GRID, onPatchCell })} />);
+      const setsInput = screen.getByTestId("cell-sets-900") as HTMLInputElement;
+      const loadInput = screen.getByTestId("cell-load-900") as HTMLInputElement;
+
+      fireEvent.change(loadInput, { target: { value: "150" } });
+
+      setsInput.focus();
+      fireEvent.change(setsInput, { target: { value: "9" } });
+      fireEvent.keyDown(setsInput, { key: "Escape" });
+
+      expect(setsInput).toHaveValue("3"); // reverted to the original cell value
+      expect(loadInput).toHaveValue("150"); // untouched dirty draft survives
+
+      fireEvent.blur(setsInput); // commits whatever's still dirty on this cell
+      expect(onPatchCell).toHaveBeenCalledWith(900, { load: "150" });
+      expect(onPatchCell).not.toHaveBeenCalledWith(900, expect.objectContaining({ sets: expect.anything() }));
+    });
+
+    it("Escape keeps focus on the field and suppresses its next blur-commit", () => {
+      const onPatchCell = vi.fn();
+      render(<MesoTable {...baseProps({ grid: NAV_GRID, onPatchCell })} />);
+      const setsInput = screen.getByTestId("cell-sets-900") as HTMLInputElement;
+      setsInput.focus();
+      fireEvent.change(setsInput, { target: { value: "9" } });
+      fireEvent.keyDown(setsInput, { key: "Escape" });
+      expect(setsInput).toHaveValue("3");
+      expect(setsInput).toHaveFocus();
+      fireEvent.blur(setsInput);
+      expect(onPatchCell).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("data-grid-restore integration", () => {
+    it("refocuses the replacement cell after a fresh grid identity from a data-grid-restore control (Undo)", () => {
+      const { rerender } = render(
+        <MesoTable
+          {...baseProps({
+            grid: NAV_GRID,
+            history: { can_undo: true, can_redo: false, undo_label: "Edited", redo_label: "" },
+          })}
+        />,
+      );
+      const setsInput = screen.getByTestId("cell-sets-900") as HTMLInputElement;
+      setsInput.focus();
+
+      // Simulates the coach clicking Undo — real DOM focus moves to the
+      // (data-grid-restore-marked) button before the refetch resolves.
+      const undoButton = screen.getByTestId("grid-undo") as HTMLButtonElement;
+      undoButton.focus();
+
+      const NEXT_GRID = grid({ weeks: NAV_GRID.weeks, days: NAV_GRID.days });
+      rerender(
+        <MesoTable
+          {...baseProps({
+            grid: NEXT_GRID,
+            history: { can_undo: false, can_redo: true, undo_label: "", redo_label: "Edited" },
+          })}
+        />,
+      );
+
+      expect(screen.getByTestId("cell-sets-900")).toHaveFocus();
+    });
+
+    it("clicking the unmarked load-type toggle across a grid identity change does NOT steal focus", () => {
+      const { rerender } = render(<MesoTable {...baseProps({ grid: NAV_GRID })} />);
+      const setsInput = screen.getByTestId("cell-sets-900") as HTMLInputElement;
+      setsInput.focus();
+
+      const toggle = screen.getByTestId("cell-loadtype-900") as HTMLButtonElement;
+      toggle.focus(); // the load-type toggle is intentionally NOT data-grid-restore
+
+      const NEXT_GRID = grid({ weeks: NAV_GRID.weeks, days: NAV_GRID.days });
+      rerender(<MesoTable {...baseProps({ grid: NEXT_GRID })} />);
+
+      expect(toggle).toHaveFocus();
+    });
   });
 });

--- a/frontend/designer/src/components/MesoTable.test.tsx
+++ b/frontend/designer/src/components/MesoTable.test.tsx
@@ -858,3 +858,53 @@ describe("keyboard grid navigation", () => {
     });
   });
 });
+
+// Issue #455 review nit: arrow moves must skid past holes/skipped cells
+// (no `data-grid-cell` node) to the next RENDERED cell rather than
+// committing the anchor to a coordinate nothing renders — see
+// useTableNav.test.tsx's "hole-skidding" describe for the hook-level specs.
+// This is the one integration check that drives it through the real
+// MesoTable render (a skipped cell is display-only real-app coverage the
+// hook's own unit tests, mounting bare DOM nodes, can't provide).
+describe("keyboard grid navigation: skidding over a skipped cell (issue #455 review nit)", () => {
+  it("ArrowRight from the prior week's note field skips an entire skipped-week cell and lands on the following week's sets input", () => {
+    const SKIP_GRID = grid({
+      weeks: [
+        week({ id: 1, label: "Wk 1", current: true }),
+        week({ id: 2, label: "Wk 2", current: false }),
+        week({ id: 3, label: "Wk 3", current: false }),
+      ],
+      days: [
+        day({
+          session_slot_id: 1,
+          name: "Lower",
+          rows: [
+            row({
+              exercise_slot_id: 9,
+              name: "Box Squat",
+              cells: {
+                "1": cell({ prescription_id: 900 }),
+                "2": cell({ prescription_id: 901, skipped: true }),
+                "3": cell({ prescription_id: 902 }),
+              },
+            }),
+          ],
+        }),
+      ],
+    });
+    render(<MesoTable {...baseProps({ grid: SKIP_GRID })} />);
+
+    // Sanity: week 2 really is the skipped em-dash display, not an input.
+    expect(screen.getByTestId("cell-skipped-901")).toHaveTextContent("—");
+    expect(screen.queryByTestId("cell-sets-901")).not.toBeInTheDocument();
+
+    const noteInput = screen.getByTestId("cell-note-900") as HTMLInputElement;
+    noteInput.focus();
+    noteInput.setSelectionRange(noteInput.value.length, noteInput.value.length);
+    fireEvent.keyDown(noteInput, { key: "ArrowRight" });
+
+    expect(screen.getByTestId("cell-sets-902")).toHaveFocus();
+    expect(screen.getByTestId("cell-sets-902")).toHaveAttribute("tabindex", "0");
+    expect(screen.getByTestId("cell-note-900")).toHaveAttribute("tabindex", "-1");
+  });
+});

--- a/frontend/designer/src/components/MesoTable.tsx
+++ b/frontend/designer/src/components/MesoTable.tsx
@@ -12,13 +12,21 @@
 // toggle is the one exception: like ExerciseRow's toggleLoadType, it commits
 // immediately on click (an atomic flip, not a per-keystroke draft).
 //
-// P1: deferred (see docs/meso/fixed-selection-plan.md) — dnd-kit drag
-// reordering, keyboard grid-nav (useGridNav), in-cell group override editor /
-// one-rm editor, agent-chat wiring, coachmarks. Swap/skip/add-this-week
-// WRITE UX is P2 — this file only ever DISPLAYS swap_name/skipped.
+// Keyboard grid navigation (issue #455 A1) is owned by useTableNav
+// (../hooks/useTableNav), a sibling of the one-week path's useGridNav —
+// instantiated ONCE here, below, and threaded into GridCellEditor/
+// RowNameEditor as a required prop (they're module-private, so there's no
+// INERT-fallback case to support).
+//
+// P1: deferred (see docs/archive/meso/fixed-selection-plan.md) — dnd-kit
+// drag reordering, in-cell group override editor / one-rm editor,
+// agent-chat wiring, coachmarks. Swap/skip/add-this-week WRITE UX is P2 —
+// this file only ever DISPLAYS swap_name/skipped.
 import { useEffect, useRef, useState } from "react";
 import type { GridCell, GridDay, GridHistory, GridRow, GridWeek, GroupIdentity, MesoGrid } from "../lib/api";
 import type { GridCellPatch, Id } from "../hooks/useGrid";
+import { useTableNav, tableCellDomKey, tableCellAriaLabel } from "../hooks/useTableNav";
+import type { EditableField, UseTableNavResult } from "../hooks/useTableNav";
 
 export interface MesoTableProps {
   grid: MesoGrid | null;
@@ -57,9 +65,6 @@ export interface MesoTableProps {
 type ArmedKind = "exercise" | "day" | "week";
 type Armed = { type: ArmedKind; id: Id } | null;
 
-const EDITABLE_FIELDS = ["sets", "reps", "load", "rpe", "rest", "note"] as const;
-type EditableField = (typeof EDITABLE_FIELDS)[number];
-
 function draftFrom(cell: GridCell): Record<EditableField, string> {
   return { sets: cell.sets, reps: cell.reps, load: cell.load, rpe: cell.rpe, rest: cell.rest, note: cell.note };
 }
@@ -67,10 +72,13 @@ function draftFrom(cell: GridCell): Record<EditableField, string> {
 interface GridCellEditorProps {
   cell: GridCell;
   unit: string;
+  row: GridRow;
+  week: GridWeek;
+  tableNav: UseTableNavResult;
   onPatchCell(cellId: Id, patch: GridCellPatch): void;
 }
 
-function GridCellEditor({ cell, unit, onPatchCell }: GridCellEditorProps) {
+function GridCellEditor({ cell, unit, row, week, tableNav, onPatchCell }: GridCellEditorProps) {
   const [draft, setDraft] = useState<Record<EditableField, string>>(() => draftFrom(cell));
   // Per-cell (not per-field) dirty set: on commit, only the fields the coach
   // actually typed into are sent — an unconditional blur commit would
@@ -103,15 +111,25 @@ function GridCellEditor({ cell, unit, onPatchCell }: GridCellEditorProps) {
     onPatchCell(cell.prescription_id, patch);
   }
 
-  function onKeyDownField(e: React.KeyboardEvent<HTMLInputElement>) {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      commitIfDirty();
-    }
+  // Escape reverts ONLY the focused field's draft — a per-cell dirty Set
+  // needs per-field removal (unlike ExerciseRow's per-row dirtySinceFocus
+  // boolean), so a second, still-dirty field on the same cell survives an
+  // Escape on its sibling untouched.
+  function revertField(field: EditableField, value: string) {
+    dirtyRef.current.delete(field);
+    setDraft((prev) => ({ ...prev, [field]: value }));
   }
 
   function toggleLoadType() {
     onPatchCell(cell.prescription_id, { load_type: cell.load_type === "pct" ? "abs" : "pct" });
+  }
+
+  // Every field's useTableNav wiring: same callback shape, keyed by field.
+  function fieldNavProps(field: EditableField) {
+    return tableNav.cellProps(row.exercise_slot_id, week.id, field, {
+      onCommit: commitIfDirty,
+      onRevert: (value) => revertField(field, value),
+    });
   }
 
   const cellId = cell.prescription_id;
@@ -122,32 +140,35 @@ function GridCellEditor({ cell, unit, onPatchCell }: GridCellEditorProps) {
         <input
           className="meso-cell meso-num-input"
           data-testid={`cell-sets-${cellId}`}
-          aria-label="sets"
+          data-grid-cell={tableCellDomKey(row.exercise_slot_id, week.id, "sets")}
+          aria-label={tableCellAriaLabel(row.name, week.label, "sets")}
           value={draft.sets}
           onChange={(e) => changed("sets", e.target.value)}
           onBlur={commitIfDirty}
-          onKeyDown={onKeyDownField}
+          {...fieldNavProps("sets")}
         />
         <span className="meso-x-sep">×</span>
         <input
           className="meso-cell meso-num-input"
           data-testid={`cell-reps-${cellId}`}
-          aria-label="reps"
+          data-grid-cell={tableCellDomKey(row.exercise_slot_id, week.id, "reps")}
+          aria-label={tableCellAriaLabel(row.name, week.label, "reps")}
           value={draft.reps}
           onChange={(e) => changed("reps", e.target.value)}
           onBlur={commitIfDirty}
-          onKeyDown={onKeyDownField}
+          {...fieldNavProps("reps")}
         />
       </div>
       <div className="meso-table-cell-load">
         <input
           className="meso-cell meso-num-input"
           data-testid={`cell-load-${cellId}`}
-          aria-label="load"
+          data-grid-cell={tableCellDomKey(row.exercise_slot_id, week.id, "load")}
+          aria-label={tableCellAriaLabel(row.name, week.label, "load")}
           value={draft.load}
           onChange={(e) => changed("load", e.target.value)}
           onBlur={commitIfDirty}
-          onKeyDown={onKeyDownField}
+          {...fieldNavProps("load")}
         />
         <button
           type="button"
@@ -163,30 +184,33 @@ function GridCellEditor({ cell, unit, onPatchCell }: GridCellEditorProps) {
       <input
         className="meso-cell meso-num-input"
         data-testid={`cell-rpe-${cellId}`}
-        aria-label="RPE"
+        data-grid-cell={tableCellDomKey(row.exercise_slot_id, week.id, "rpe")}
+        aria-label={tableCellAriaLabel(row.name, week.label, "rpe")}
         value={draft.rpe}
         onChange={(e) => changed("rpe", e.target.value)}
         onBlur={commitIfDirty}
-        onKeyDown={onKeyDownField}
+        {...fieldNavProps("rpe")}
       />
       <input
         className="meso-cell meso-num-input"
         data-testid={`cell-rest-${cellId}`}
-        aria-label="rest"
+        data-grid-cell={tableCellDomKey(row.exercise_slot_id, week.id, "rest")}
+        aria-label={tableCellAriaLabel(row.name, week.label, "rest")}
         value={draft.rest}
         onChange={(e) => changed("rest", e.target.value)}
         onBlur={commitIfDirty}
-        onKeyDown={onKeyDownField}
+        {...fieldNavProps("rest")}
       />
       <input
         className="meso-note"
         data-testid={`cell-note-${cellId}`}
-        aria-label="note"
+        data-grid-cell={tableCellDomKey(row.exercise_slot_id, week.id, "note")}
+        aria-label={tableCellAriaLabel(row.name, week.label, "note")}
         placeholder="—"
         value={draft.note}
         onChange={(e) => changed("note", e.target.value)}
         onBlur={commitIfDirty}
-        onKeyDown={onKeyDownField}
+        {...fieldNavProps("note")}
       />
     </div>
   );
@@ -323,10 +347,11 @@ function CellActions({ cell, busy, onSkipCell, onSwapCell, onFillAcrossWeeks }: 
 
 interface RowNameEditorProps {
   row: GridRow;
+  tableNav: UseTableNavResult;
   onRename(exerciseSlotId: Id, name: string): void;
 }
 
-function RowNameEditor({ row, onRename }: RowNameEditorProps) {
+function RowNameEditor({ row, tableNav, onRename }: RowNameEditorProps) {
   const [value, setValue] = useState(row.name);
   const dirtyRef = useRef(false);
 
@@ -341,23 +366,33 @@ function RowNameEditor({ row, onRename }: RowNameEditorProps) {
     onRename(row.exercise_slot_id, value);
   }
 
+  // Mirrors GridCellEditor's revertField/ExerciseRow's revert: writes the
+  // focus-time value directly (bypassing the dirtying onChange path) and
+  // clears the dirty flag so a subsequent blur doesn't re-commit the draft
+  // the coach just backed out of.
+  function revert(newValue: string) {
+    dirtyRef.current = false;
+    setValue(newValue);
+  }
+
+  const navProps = tableNav.cellProps(row.exercise_slot_id, null, "name", {
+    onCommit: commitIfDirty,
+    onRevert: revert,
+  });
+
   return (
     <input
       className="meso-cell meso-ex-name-input"
       data-testid={`row-name-${row.exercise_slot_id}`}
-      aria-label="exercise name"
+      data-grid-cell={tableCellDomKey(row.exercise_slot_id, null, "name")}
+      aria-label={tableCellAriaLabel(row.name, null, "name")}
       value={value}
       onChange={(e) => {
         dirtyRef.current = true;
         setValue(e.target.value);
       }}
       onBlur={commitIfDirty}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") {
-          e.preventDefault();
-          commitIfDirty();
-        }
-      }}
+      {...navProps}
     />
   );
 }
@@ -446,6 +481,11 @@ export function MesoTable(props: MesoTableProps) {
   // members — an individual plan carries no `group`, so no cell ever shows it.
   const showAdjust = !!(group && group.members.length);
 
+  // Rules of Hooks: called unconditionally, before the `!grid` early return
+  // below — useTableNav tolerates a null grid the same way (anchor stays
+  // null, no throw).
+  const tableNav = useTableNav({ grid });
+
   if (!grid) return null;
 
   return (
@@ -455,6 +495,7 @@ export function MesoTable(props: MesoTableProps) {
           type="button"
           data-testid="grid-undo"
           data-hover="rail"
+          data-grid-restore=""
           className="meso-week-strip-btn"
           disabled={busy || !history.can_undo}
           aria-label="Undo"
@@ -467,6 +508,7 @@ export function MesoTable(props: MesoTableProps) {
           type="button"
           data-testid="grid-redo"
           data-hover="rail"
+          data-grid-restore=""
           className="meso-week-strip-btn"
           disabled={busy || !history.can_redo}
           aria-label="Redo"
@@ -480,6 +522,7 @@ export function MesoTable(props: MesoTableProps) {
           type="button"
           data-testid="add-week"
           data-hover="add"
+          data-grid-restore=""
           className="meso-week-strip-btn meso-week-strip-btn--dashed"
           disabled={busy}
           onClick={onAddWeek}
@@ -563,7 +606,7 @@ export function MesoTable(props: MesoTableProps) {
                     return (
                       <tr key={row.exercise_slot_id} data-testid={`meso-row-${row.exercise_slot_id}`}>
                         <td className="meso-table-row-name-col">
-                          <RowNameEditor row={row} onRename={onRenameExercise} />
+                          <RowNameEditor row={row} tableNav={tableNav} onRename={onRenameExercise} />
                           {!rowArmed && (
                             <button
                               type="button"
@@ -630,7 +673,7 @@ export function MesoTable(props: MesoTableProps) {
                                 </>
                               ) : (
                                 <>
-                                  <GridCellEditor cell={cell} unit={unit} onPatchCell={onPatchCell} />
+                                  <GridCellEditor cell={cell} unit={unit} row={row} week={week} tableNav={tableNav} onPatchCell={onPatchCell} />
                                   {cell.swap_display && (
                                     <span
                                       className="meso-table-swap-badge"
@@ -752,6 +795,7 @@ function WeekColumnHeader({ week, armed, busy, onArm, onDisarm, onSetCurrentWeek
           <button
             type="button"
             data-testid={`make-current-${week.id}`}
+            data-grid-restore=""
             className="meso-week-strip-btn meso-week-strip-btn--accent"
             disabled={busy}
             title="Make this the live week — delivery will send it"
@@ -763,6 +807,7 @@ function WeekColumnHeader({ week, armed, busy, onArm, onDisarm, onSetCurrentWeek
             <button
               type="button"
               data-testid={`remove-week-${week.id}`}
+              data-grid-restore=""
               className="meso-week-strip-btn"
               disabled={busy}
               aria-label="Remove this week"
@@ -777,6 +822,7 @@ function WeekColumnHeader({ week, armed, busy, onArm, onDisarm, onSetCurrentWeek
               <button
                 type="button"
                 data-testid={`confirm-remove-week-${week.id}`}
+                data-grid-restore=""
                 className="meso-week-strip-btn meso-week-strip-btn--confirm"
                 disabled={busy}
                 aria-label="Confirm remove week"
@@ -790,6 +836,7 @@ function WeekColumnHeader({ week, armed, busy, onArm, onDisarm, onSetCurrentWeek
               <button
                 type="button"
                 data-testid={`cancel-remove-week-${week.id}`}
+                data-grid-restore=""
                 className="meso-week-strip-btn"
                 disabled={busy}
                 aria-label="Cancel remove week"

--- a/frontend/designer/src/hooks/useTableNav.test.tsx
+++ b/frontend/designer/src/hooks/useTableNav.test.tsx
@@ -128,6 +128,42 @@ function resyncCells(g: MesoGrid) {
   return mountCells(g);
 }
 
+/** Like mountCells, but a row's OWN `cells` map decides what actually
+ * mounts: a week id missing from `row.cells` gets no `data-grid-cell` node
+ * for any of its fields — the same "no rendered input at all" shape
+ * MesoTable produces for a hole (an add-this-week row's bare `<td/>`, no
+ * GridCellEditor) or a skipped cell (em-dash + Unskip button, no
+ * GridCellEditor). Fixtures express holes just by leaving a weekId out of
+ * `row(id, weekIds)`. The row-name column always mounts — MesoTable renders
+ * RowNameEditor unconditionally, independent of any week's holes. */
+function mountCellsWithHoles(g: MesoGrid) {
+  const nodes: Record<string, HTMLInputElement> = {};
+  for (const d of g.days) {
+    for (const r of d.rows) {
+      const nameInput = document.createElement("input");
+      nameInput.type = "text";
+      nameInput.value = r.name;
+      nameInput.setAttribute("data-grid-cell", tableCellDomKey(r.exercise_slot_id, null, "name"));
+      document.body.appendChild(nameInput);
+      nodes[tableCellDomKey(r.exercise_slot_id, null, "name")] = nameInput;
+
+      for (const w of g.weeks) {
+        const c = r.cells[String(w.id)];
+        if (!c) continue; // hole: no cell for this row this week, no inputs at all.
+        for (const field of TABLE_FIELDS) {
+          const input = document.createElement("input");
+          input.type = "text";
+          input.value = String((c as unknown as Record<string, unknown>)[field] ?? "");
+          input.setAttribute("data-grid-cell", tableCellDomKey(r.exercise_slot_id, w.id, field));
+          document.body.appendChild(input);
+          nodes[tableCellDomKey(r.exercise_slot_id, w.id, field)] = input;
+        }
+      }
+    }
+  }
+  return nodes;
+}
+
 function keyEvent(
   key: string,
   target: HTMLInputElement,
@@ -742,5 +778,134 @@ describe("holes (missing DOM cells)", () => {
       });
     }).not.toThrow();
     expect(document.activeElement).toBe(noteInput);
+  });
+});
+
+// Issue #455 review nit: arrow handlers used to commit the anchor to the
+// adjacent COORDINATE before checking whether it actually renders — landing
+// on a hole left the old input with real DOM focus but tabIndex -1, and no
+// cell anywhere holding tabIndex 0 (the grid drops out of the tab order).
+// The fix scans past holes, at keydown time, to the first coordinate that
+// DOES render — using mountCellsWithHoles so a fixture's holes are just a
+// row's own `cells` map, exactly like MesoTable's `!cell` bare <td/> case.
+describe("hole-skidding: arrows land on the next RENDERED cell, never a phantom coordinate", () => {
+  it("(1) ArrowRight over a hole in the middle of a row skips the entire missing week and lands on the next rendered cell", () => {
+    // Row 9 has cells for weeks 1 and 3 only — week 2 is a total hole.
+    const HOLE_GRID = grid({
+      weeks: [week({ id: 1, label: "Wk 1" }), week({ id: 2, label: "Wk 2", current: false }), week({ id: 3, label: "Wk 3", current: false })],
+      days: [day(1, [row(9, [1, 3])])],
+    });
+    const cells = mountCellsWithHoles(HOLE_GRID);
+    const { result } = renderHook(() => useTableNav({ grid: HOLE_GRID }));
+    const noteInput = cells[tableCellDomKey(9, 1, "note")]!;
+    noteInput.setSelectionRange(0, 0);
+    const event = keyEvent("ArrowRight", noteInput);
+    act(() => {
+      result.current.cellProps(9, 1, "note", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(9, 3, "sets")]);
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 3, field: "sets" });
+    expect(event.preventDefault).toHaveBeenCalled();
+    // (5) invariant: the anchor addresses a real node holding tabIndex 0.
+    expect(result.current.cellProps(9, 3, "sets", NOOP_CALLBACKS).tabIndex).toBe(0);
+    expect(result.current.cellProps(9, 1, "note", NOOP_CALLBACKS).tabIndex).toBe(-1);
+  });
+
+  it("(2) ArrowRight when everything to the right is holes leaves the anchor/focus unchanged, but still preventDefaults", () => {
+    // Row 9 has a cell for week 1 only — week 2 (the only thing to its
+    // right) is a total hole all the way to the table's edge.
+    const HOLE_GRID = grid({
+      weeks: [week({ id: 1, label: "Wk 1" }), week({ id: 2, label: "Wk 2", current: false })],
+      days: [day(1, [row(9, [1])])],
+    });
+    const cells = mountCellsWithHoles(HOLE_GRID);
+    const { result } = renderHook(() => useTableNav({ grid: HOLE_GRID }));
+    const noteInput = cells[tableCellDomKey(9, 1, "note")]!;
+    noteInput.focus();
+    noteInput.setSelectionRange(0, 0);
+    const event = keyEvent("ArrowRight", noteInput);
+    act(() => {
+      result.current.cellProps(9, 1, "note", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(noteInput);
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 1, field: "note" });
+    expect(event.preventDefault).toHaveBeenCalled();
+    // (5) invariant: the anchor still addresses the real node it started at.
+    expect(result.current.cellProps(9, 1, "note", NOOP_CALLBACKS).tabIndex).toBe(0);
+  });
+
+  it("(3) ArrowLeft mirrors (1): skips the entire missing week backwards, landing on the previous rendered cell", () => {
+    const HOLE_GRID = grid({
+      weeks: [week({ id: 1, label: "Wk 1" }), week({ id: 2, label: "Wk 2", current: false }), week({ id: 3, label: "Wk 3", current: false })],
+      days: [day(1, [row(9, [1, 3])])],
+    });
+    const cells = mountCellsWithHoles(HOLE_GRID);
+    const { result } = renderHook(() => useTableNav({ grid: HOLE_GRID }));
+    const setsInput = cells[tableCellDomKey(9, 3, "sets")]!;
+    setsInput.setSelectionRange(0, 0);
+    const event = keyEvent("ArrowLeft", setsInput);
+    act(() => {
+      result.current.cellProps(9, 3, "sets", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(9, 1, "note")]);
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 1, field: "note" });
+    expect(event.preventDefault).toHaveBeenCalled();
+    // (5) invariant.
+    expect(result.current.cellProps(9, 1, "note", NOOP_CALLBACKS).tabIndex).toBe(0);
+    expect(result.current.cellProps(9, 3, "sets", NOOP_CALLBACKS).tabIndex).toBe(-1);
+  });
+
+  it("(4) ArrowDown skips a row whose cell at (weekId, field) is unrendered, landing on the next row that has it", () => {
+    // Row 10 (between 9 and 11) has no week-1 cell at all.
+    const HOLE_GRID = grid({
+      weeks: [week({ id: 1, label: "Wk 1" }), week({ id: 2, label: "Wk 2", current: false })],
+      days: [day(1, [row(9, [1, 2]), row(10, [2]), row(11, [1, 2])])],
+    });
+    const cells = mountCellsWithHoles(HOLE_GRID);
+    const { result } = renderHook(() => useTableNav({ grid: HOLE_GRID }));
+    const event = keyEvent("ArrowDown", cells[tableCellDomKey(9, 1, "sets")]!);
+    act(() => {
+      result.current.cellProps(9, 1, "sets", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(11, 1, "sets")]);
+    expect(result.current.anchor).toEqual({ rowId: 11, weekId: 1, field: "sets" });
+    expect(event.preventDefault).toHaveBeenCalled();
+    // (5) invariant: row 10 (skipped over, never had this cell) never became
+    // the anchor; row 11 (the real landing) holds the roving tabIndex 0.
+    expect(result.current.cellProps(11, 1, "sets", NOOP_CALLBACKS).tabIndex).toBe(0);
+    expect(result.current.cellProps(9, 1, "sets", NOOP_CALLBACKS).tabIndex).toBe(-1);
+  });
+
+  it("(5) invariant holds across a repeated skid in both horizontal directions: the anchor always addresses an existing, tabIndex-0 node", () => {
+    const HOLE_GRID = grid({
+      weeks: [week({ id: 1, label: "Wk 1" }), week({ id: 2, label: "Wk 2", current: false }), week({ id: 3, label: "Wk 3", current: false })],
+      days: [day(1, [row(9, [1, 3])])],
+    });
+    const cells = mountCellsWithHoles(HOLE_GRID);
+    const { result } = renderHook(() => useTableNav({ grid: HOLE_GRID }));
+
+    function assertAnchorIsReal() {
+      const a = result.current.anchor;
+      expect(a).not.toBeNull();
+      if (!a) return;
+      expect(document.querySelector(`[data-grid-cell="${tableCellDomKey(a.rowId, a.weekId, a.field)}"]`)).not.toBeNull();
+      expect(result.current.cellProps(a.rowId, a.weekId, a.field, NOOP_CALLBACKS).tabIndex).toBe(0);
+    }
+
+    const noteInput = cells[tableCellDomKey(9, 1, "note")]!;
+    noteInput.setSelectionRange(0, 0);
+    act(() => {
+      result.current.cellProps(9, 1, "note", NOOP_CALLBACKS).onKeyDown(keyEvent("ArrowRight", noteInput));
+    });
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 3, field: "sets" });
+    assertAnchorIsReal();
+
+    const setsInput = cells[tableCellDomKey(9, 3, "sets")]!;
+    setsInput.setSelectionRange(0, 0);
+    act(() => {
+      result.current.cellProps(9, 3, "sets", NOOP_CALLBACKS).onKeyDown(keyEvent("ArrowLeft", setsInput));
+    });
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 1, field: "note" });
+    assertAnchorIsReal();
   });
 });

--- a/frontend/designer/src/hooks/useTableNav.test.tsx
+++ b/frontend/designer/src/hooks/useTableNav.test.tsx
@@ -652,6 +652,50 @@ describe("focus restoration across a grid swap", () => {
     expect(result.current.anchor).toEqual({ rowId: 9, weekId: 1, field: "sets" });
   });
 
+  it("post-tier guard: skids forward off a surviving-but-hollow coordinate (skip on the focused cell)", () => {
+    // Skipping the FOCUSED cell hollows out its coordinate on the refetch:
+    // row 9 and week 1 both survive, but row 9 renders nothing at week 1
+    // anymore. Tier 1 alone would strand the anchor there — no rendered
+    // cell would hold tabIndex=0 and the table would drop out of the tab
+    // order. The guard skids to the nearest rendered column of the row
+    // (forward first: week 2's sets).
+    let cells = mountCells(GRID);
+    const { result, rerender } = renderHook(({ grid: g }) => useTableNav({ grid: g }), {
+      initialProps: { grid: GRID },
+    });
+    focus(result.current, cells, 9, 1, "sets");
+
+    const NEXT = grid({ days: [day(1, [row(9, [2]), row(10, [1, 2])]), day(2, [row(11, [1, 2])])] });
+    document.querySelectorAll("[data-grid-cell]").forEach((n) => n.remove());
+    cells = mountCellsWithHoles(NEXT);
+    act(() => rerender({ grid: NEXT }));
+
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 2, field: "sets" });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(9, 2, "sets")]);
+    expect(result.current.cellProps(9, 2, "sets", NOOP_CALLBACKS).tabIndex).toBe(0);
+    expect(result.current.cellProps(9, 1, "sets", NOOP_CALLBACKS).tabIndex).toBe(-1);
+  });
+
+  it("post-tier guard: skids backward when everything after the hollow coordinate is holes too", () => {
+    let cells = mountCells(GRID);
+    const { result, rerender } = renderHook(({ grid: g }) => useTableNav({ grid: g }), {
+      initialProps: { grid: GRID },
+    });
+    focus(result.current, cells, 9, 2, "sets");
+
+    // Row 9 keeps only week 1 — the focused week-2 coordinate and every
+    // column after it are gone, so the guard scans backward and lands on
+    // week 1's trailing note field (the nearest rendered column).
+    const NEXT = grid({ days: [day(1, [row(9, [1]), row(10, [1, 2])]), day(2, [row(11, [1, 2])])] });
+    document.querySelectorAll("[data-grid-cell]").forEach((n) => n.remove());
+    cells = mountCellsWithHoles(NEXT);
+    act(() => rerender({ grid: NEXT }));
+
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 1, field: "note" });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(9, 1, "note")]);
+    expect(result.current.cellProps(9, 1, "note", NOOP_CALLBACKS).tabIndex).toBe(0);
+  });
+
   it("tier 3: falls back to the table's first cell when the day itself is gone", () => {
     let cells = mountCells(GRID);
     const { result, rerender } = renderHook(({ grid: g }) => useTableNav({ grid: g }), {

--- a/frontend/designer/src/hooks/useTableNav.test.tsx
+++ b/frontend/designer/src/hooks/useTableNav.test.tsx
@@ -1,0 +1,746 @@
+// Specs for useTableNav (issue #455 phase A1) — the P1 multi-week table's
+// roving-tabindex + keyboard-nav + focus-restoration hook. Mirrors
+// useGridNav.test.tsx's structure/coverage, generalized from a 1D
+// (prescriptionId, column) identity to a 2D (rowId, weekId, field) identity
+// over a variable-width week axis (see useTableNav.ts's header for the
+// sibling-not-shared rationale).
+//
+// Fixture: day 1 (session_slot_id 1) has rows 9, 10; day 2 (session_slot_id
+// 2) has row 11 — flattened row order (day-major/row-minor): (9), (10),
+// (11). Two weeks (id 1 "Wk 1", id 2 "Wk 2") so ArrowRight/Left week-
+// crossing and tier 2b (a week removed, row survives) are exercisable
+// without a second fixture.
+import { act, renderHook } from "@testing-library/react";
+import type { FocusEvent, KeyboardEvent } from "react";
+import { useTableNav, tableCellDomKey, tableCellAriaLabel, TABLE_FIELDS } from "./useTableNav";
+import type { TableColumn, UseTableNavResult } from "./useTableNav";
+import type { GridCell, GridDay, GridRow, GridWeek, MesoGrid } from "../lib/api";
+
+function week(overrides: Partial<GridWeek> = {}): GridWeek {
+  return {
+    id: 1,
+    index: 0,
+    label: "Wk 1",
+    phase: "Accum",
+    deload: false,
+    current: true,
+    delivered_at: null,
+    ...overrides,
+  };
+}
+
+function cell(overrides: Partial<GridCell> = {}): GridCell {
+  return {
+    prescription_id: 100,
+    sets: "3",
+    reps: "5",
+    load: "100",
+    load_type: "abs",
+    rpe: "8",
+    rest: "90",
+    note: "",
+    skipped: false,
+    swap_name: "",
+    swap_exercise_id: null,
+    swap_display: "",
+    ...overrides,
+  };
+}
+
+function row(id: number, weekIds: number[], overrides: Partial<GridRow> = {}): GridRow {
+  const cells: Record<string, GridCell> = {};
+  weekIds.forEach((wid, i) => {
+    cells[String(wid)] = cell({ prescription_id: id * 100 + i });
+  });
+  return {
+    exercise_slot_id: id,
+    name: `Ex ${id}`,
+    exercise_id: id + 1000,
+    order: 0,
+    tags: [],
+    cells,
+    ...overrides,
+  };
+}
+
+function day(id: number, rows: GridRow[], overrides: Partial<GridDay> = {}): GridDay {
+  return {
+    session_slot_id: id,
+    session_id: id + 10,
+    day_number: id,
+    name: `Day ${id}`,
+    bias: "",
+    order: 0,
+    rows,
+    ...overrides,
+  };
+}
+
+function grid(overrides: Partial<MesoGrid> = {}): MesoGrid {
+  return {
+    mesocycle: { id: 1, plan_id: 1, name: "Block", week_count: 2 },
+    weeks: [week({ id: 1, label: "Wk 1" }), week({ id: 2, label: "Wk 2", current: false })],
+    days: [day(1, [row(9, [1, 2]), row(10, [1, 2])]), day(2, [row(11, [1, 2])])],
+    history: { can_undo: false, can_redo: false, undo_label: "", redo_label: "" },
+    ...overrides,
+  };
+}
+
+const GRID: MesoGrid = grid();
+
+const NOOP_CALLBACKS = { onCommit: vi.fn(), onRevert: vi.fn() };
+
+/** Mounts one real `<input>` per (rowId, weekId, field) in `g`, so the
+ * hook's `document.querySelector`-based focus moves have somewhere real to
+ * land — mirrors what GridCellEditor/RowNameEditor would render, without
+ * needing a full React render of the table tree. */
+function mountCells(g: MesoGrid) {
+  const nodes: Record<string, HTMLInputElement> = {};
+  for (const d of g.days) {
+    for (const r of d.rows) {
+      const nameInput = document.createElement("input");
+      nameInput.type = "text";
+      nameInput.value = r.name;
+      nameInput.setAttribute("data-grid-cell", tableCellDomKey(r.exercise_slot_id, null, "name"));
+      document.body.appendChild(nameInput);
+      nodes[tableCellDomKey(r.exercise_slot_id, null, "name")] = nameInput;
+
+      for (const w of g.weeks) {
+        const c = r.cells[String(w.id)];
+        for (const field of TABLE_FIELDS) {
+          const input = document.createElement("input");
+          input.type = "text";
+          input.value = c ? String((c as unknown as Record<string, unknown>)[field] ?? "") : "";
+          input.setAttribute("data-grid-cell", tableCellDomKey(r.exercise_slot_id, w.id, field));
+          document.body.appendChild(input);
+          nodes[tableCellDomKey(r.exercise_slot_id, w.id, field)] = input;
+        }
+      }
+    }
+  }
+  return nodes;
+}
+
+/** Simulates the DOM swap a real refetchGrid-driven re-render performs: tear
+ * down every existing grid cell and mount fresh ones for the new grid. */
+function resyncCells(g: MesoGrid) {
+  document.querySelectorAll("[data-grid-cell]").forEach((n) => n.remove());
+  return mountCells(g);
+}
+
+function keyEvent(
+  key: string,
+  target: HTMLInputElement,
+  extra: Partial<{ ctrlKey: boolean; metaKey: boolean; shiftKey: boolean }> = {},
+): KeyboardEvent<HTMLInputElement> {
+  return {
+    key,
+    currentTarget: target,
+    target,
+    preventDefault: vi.fn(),
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    ...extra,
+  } as unknown as KeyboardEvent<HTMLInputElement>;
+}
+
+function focusEvent(target: HTMLInputElement): FocusEvent<HTMLInputElement> {
+  return { currentTarget: target, target } as unknown as FocusEvent<HTMLInputElement>;
+}
+
+function focus(
+  result: UseTableNavResult,
+  cells: Record<string, HTMLInputElement>,
+  rowId: number,
+  weekId: number | null,
+  field: TableColumn,
+) {
+  act(() => {
+    result.cellProps(rowId, weekId, field, NOOP_CALLBACKS).onFocus(focusEvent(cells[tableCellDomKey(rowId, weekId, field)]!));
+  });
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("pure helpers", () => {
+  describe("tableCellDomKey", () => {
+    it("joins rowId, weekId, and field with colons", () => {
+      expect(tableCellDomKey(9, 2, "sets")).toBe("9:2:sets");
+    });
+
+    it("uses the 'row' sentinel for a null weekId (the name column)", () => {
+      expect(tableCellDomKey(9, null, "name")).toBe("9:row:name");
+    });
+  });
+
+  describe("tableCellAriaLabel", () => {
+    it("builds '<name> — <week label> — <field label>' for a week field", () => {
+      expect(tableCellAriaLabel("Box Squat", "Wk 2", "sets")).toBe("Box Squat — Wk 2 — sets");
+      expect(tableCellAriaLabel("Box Squat", "Wk 2", "rpe")).toBe("Box Squat — Wk 2 — RPE");
+    });
+
+    it("labels the name column as '<name> — exercise name' regardless of weekLabel", () => {
+      expect(tableCellAriaLabel("Box Squat", null, "name")).toBe("Box Squat — exercise name");
+    });
+
+    it("falls back to 'exercise' when the row has no name yet", () => {
+      expect(tableCellAriaLabel("", "Wk 1", "sets")).toBe("exercise — Wk 1 — sets");
+    });
+  });
+});
+
+describe("anchor + roving tabindex", () => {
+  it("starts anchored on the first row's name column", () => {
+    mountCells(GRID);
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: null, field: "name" });
+  });
+
+  it("exactly one cell is tabbable (0) initially — every other cell is -1", () => {
+    mountCells(GRID);
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    expect(result.current.cellProps(9, null, "name", NOOP_CALLBACKS).tabIndex).toBe(0);
+    expect(result.current.cellProps(9, 1, "sets", NOOP_CALLBACKS).tabIndex).toBe(-1);
+    expect(result.current.cellProps(10, null, "name", NOOP_CALLBACKS).tabIndex).toBe(-1);
+    expect(result.current.cellProps(11, 2, "note", NOOP_CALLBACKS).tabIndex).toBe(-1);
+  });
+
+  it("focusing another cell moves the roving 0 to it", () => {
+    const cells = mountCells(GRID);
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    act(() => {
+      result.current.cellProps(10, 2, "load", NOOP_CALLBACKS).onFocus(focusEvent(cells[tableCellDomKey(10, 2, "load")]!));
+    });
+    expect(result.current.anchor).toEqual({ rowId: 10, weekId: 2, field: "load" });
+    expect(result.current.cellProps(10, 2, "load", NOOP_CALLBACKS).tabIndex).toBe(0);
+    expect(result.current.cellProps(9, null, "name", NOOP_CALLBACKS).tabIndex).toBe(-1);
+  });
+
+  it("cell identity is (rowId, weekId, field), never an index — the same field on a different row/week is a different cell", () => {
+    mountCells(GRID);
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    expect(result.current.cellProps(9, 1, "sets", NOOP_CALLBACKS).tabIndex).toBe(-1);
+    expect(result.current.cellProps(9, 2, "sets", NOOP_CALLBACKS).tabIndex).toBe(-1);
+    expect(result.current.cellProps(10, 1, "sets", NOOP_CALLBACKS).tabIndex).toBe(-1);
+  });
+});
+
+describe("ArrowDown / ArrowUp", () => {
+  it("ArrowDown moves focus to the same (weekId, field) on the next row within a day", () => {
+    const cells = mountCells(GRID);
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const event = keyEvent("ArrowDown", cells[tableCellDomKey(9, 1, "sets")]!);
+    act(() => {
+      result.current.cellProps(9, 1, "sets", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(10, 1, "sets")]);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(result.current.anchor).toEqual({ rowId: 10, weekId: 1, field: "sets" });
+  });
+
+  it("ArrowDown crosses a day-table boundary (last row of day 1 -> first row of day 2)", () => {
+    const cells = mountCells(GRID);
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const event = keyEvent("ArrowDown", cells[tableCellDomKey(10, 2, "load")]!);
+    act(() => {
+      result.current.cellProps(10, 2, "load", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(11, 2, "load")]);
+  });
+
+  it("ArrowDown at the very last row is a no-op but still preventDefault", () => {
+    const cells = mountCells(GRID);
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const event = keyEvent("ArrowDown", cells[tableCellDomKey(11, 2, "note")]!);
+    act(() => {
+      result.current.cellProps(11, 2, "note", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(result.current.anchor).toEqual({ rowId: 11, weekId: 2, field: "note" });
+  });
+
+  it("ArrowUp mirrors ArrowDown, crossing day boundaries upward", () => {
+    const cells = mountCells(GRID);
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const event = keyEvent("ArrowUp", cells[tableCellDomKey(11, 1, "rpe")]!);
+    act(() => {
+      result.current.cellProps(11, 1, "rpe", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(10, 1, "rpe")]);
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it("ArrowUp at the very first row is a no-op but still preventDefault", () => {
+    const cells = mountCells(GRID);
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const event = keyEvent("ArrowUp", cells[tableCellDomKey(9, null, "name")]!);
+    act(() => {
+      result.current.cellProps(9, null, "name", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it("the name column moves vertically too, keeping weekId null", () => {
+    const cells = mountCells(GRID);
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const event = keyEvent("ArrowDown", cells[tableCellDomKey(9, null, "name")]!);
+    act(() => {
+      result.current.cellProps(9, null, "name", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(10, null, "name")]);
+    expect(result.current.anchor).toEqual({ rowId: 10, weekId: null, field: "name" });
+  });
+});
+
+describe("ArrowRight / ArrowLeft (caret-conditional)", () => {
+  it("ArrowRight at the end of the text moves to the next field within the same week", () => {
+    const cells = mountCells(GRID);
+    const setsInput = cells[tableCellDomKey(9, 1, "sets")]!;
+    setsInput.value = "42";
+    setsInput.setSelectionRange(2, 2); // caret at end (value.length === 2)
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const event = keyEvent("ArrowRight", setsInput);
+    act(() => {
+      result.current.cellProps(9, 1, "sets", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(9, 1, "reps")]);
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it("ArrowLeft at the start of the text moves to the previous field within the same week", () => {
+    const cells = mountCells(GRID);
+    const repsInput = cells[tableCellDomKey(9, 1, "reps")]!;
+    repsInput.value = "5";
+    repsInput.setSelectionRange(0, 0); // caret at start
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const event = keyEvent("ArrowLeft", repsInput);
+    act(() => {
+      result.current.cellProps(9, 1, "reps", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(9, 1, "sets")]);
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it("ArrowRight at the last field of week 1 crosses into week 2's first field (no special-case)", () => {
+    const cells = mountCells(GRID);
+    const noteInput = cells[tableCellDomKey(9, 1, "note")]!;
+    noteInput.value = "";
+    noteInput.setSelectionRange(0, 0);
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const event = keyEvent("ArrowRight", noteInput);
+    act(() => {
+      result.current.cellProps(9, 1, "note", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(9, 2, "sets")]);
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 2, field: "sets" });
+  });
+
+  it("ArrowLeft at the first field of week 2 crosses back into week 1's last field", () => {
+    const cells = mountCells(GRID);
+    const setsInput = cells[tableCellDomKey(9, 2, "sets")]!;
+    setsInput.value = "3";
+    setsInput.setSelectionRange(0, 0);
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const event = keyEvent("ArrowLeft", setsInput);
+    act(() => {
+      result.current.cellProps(9, 2, "sets", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(9, 1, "note")]);
+  });
+
+  it("ArrowRight at the end of the name column moves to week 1's sets field", () => {
+    const cells = mountCells(GRID);
+    const nameInput = cells[tableCellDomKey(9, null, "name")]!;
+    nameInput.value = "Ex 9";
+    nameInput.setSelectionRange(4, 4);
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const event = keyEvent("ArrowRight", nameInput);
+    act(() => {
+      result.current.cellProps(9, null, "name", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(9, 1, "sets")]);
+  });
+
+  it("ArrowLeft at the start of week 1's sets field moves back to the name column", () => {
+    const cells = mountCells(GRID);
+    const setsInput = cells[tableCellDomKey(9, 1, "sets")]!;
+    setsInput.value = "3";
+    setsInput.setSelectionRange(0, 0);
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const event = keyEvent("ArrowLeft", setsInput);
+    act(() => {
+      result.current.cellProps(9, 1, "sets", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(9, null, "name")]);
+  });
+
+  it("ArrowRight mid-text does NOT move focus or preventDefault (native caret move wins)", () => {
+    const cells = mountCells(GRID);
+    const setsInput = cells[tableCellDomKey(9, 1, "sets")]!;
+    setsInput.value = "4200";
+    setsInput.setSelectionRange(2, 2); // caret in the middle
+    setsInput.focus();
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const event = keyEvent("ArrowRight", setsInput);
+    act(() => {
+      result.current.cellProps(9, 1, "sets", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(setsInput);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("ArrowLeft with a non-collapsed selection does NOT move focus", () => {
+    const cells = mountCells(GRID);
+    const repsInput = cells[tableCellDomKey(9, 1, "reps")]!;
+    repsInput.value = "5";
+    repsInput.setSelectionRange(0, 1); // a selection, not a collapsed caret
+    repsInput.focus();
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const event = keyEvent("ArrowLeft", repsInput);
+    act(() => {
+      result.current.cellProps(9, 1, "reps", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(repsInput);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("no wrap at an absolute extreme: ArrowLeft at the start of the very first column (name, row 9) is a pure no-op", () => {
+    const cells = mountCells(GRID);
+    const nameInput = cells[tableCellDomKey(9, null, "name")]!;
+    nameInput.setSelectionRange(0, 0);
+    nameInput.focus();
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const event = keyEvent("ArrowLeft", nameInput);
+    act(() => {
+      result.current.cellProps(9, null, "name", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(nameInput);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("no wrap at an absolute extreme: ArrowRight at the end of the very last column (note, week 2, row 9) is a pure no-op", () => {
+    const cells = mountCells(GRID);
+    const noteInput = cells[tableCellDomKey(9, 2, "note")]!;
+    noteInput.value = "";
+    noteInput.setSelectionRange(0, 0);
+    noteInput.focus();
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const event = keyEvent("ArrowRight", noteInput);
+    act(() => {
+      result.current.cellProps(9, 2, "note", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(noteInput);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+});
+
+describe("Enter (commit) / Escape (revert)", () => {
+  it("Enter calls the cell's onCommit, preventDefaults, and does not move focus", () => {
+    const cells = mountCells(GRID);
+    cells[tableCellDomKey(9, 1, "load")]!.focus();
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const onCommit = vi.fn();
+    const event = keyEvent("Enter", cells[tableCellDomKey(9, 1, "load")]!);
+    act(() => {
+      result.current.cellProps(9, 1, "load", { ...NOOP_CALLBACKS, onCommit }).onKeyDown(event);
+    });
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(document.activeElement).toBe(cells[tableCellDomKey(9, 1, "load")]);
+  });
+
+  it("Escape reverts to the focus-time value via onRevert, preventDefaults, and keeps focus", () => {
+    const cells = mountCells(GRID);
+    const loadInput = cells[tableCellDomKey(9, 1, "load")]!;
+    loadInput.value = "100";
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const onRevert = vi.fn();
+    const callbacks = { ...NOOP_CALLBACKS, onRevert };
+    loadInput.focus();
+    act(() => {
+      result.current.cellProps(9, 1, "load", callbacks).onFocus(focusEvent(loadInput));
+    });
+    loadInput.value = "999";
+    const event = keyEvent("Escape", loadInput);
+    act(() => {
+      result.current.cellProps(9, 1, "load", callbacks).onKeyDown(event);
+    });
+    expect(onRevert).toHaveBeenCalledWith("100");
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(document.activeElement).toBe(loadInput);
+  });
+
+  it("Escape without a prior focus call reverts to the DOM value at keydown time", () => {
+    const cells = mountCells(GRID);
+    const rpeInput = cells[tableCellDomKey(9, 1, "rpe")]!;
+    rpeInput.value = "8";
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const onRevert = vi.fn();
+    const event = keyEvent("Escape", rpeInput);
+    act(() => {
+      result.current.cellProps(9, 1, "rpe", { ...NOOP_CALLBACKS, onRevert }).onKeyDown(event);
+    });
+    expect(onRevert).toHaveBeenCalledWith("8");
+  });
+
+  it("Enter resets the Escape baseline to the committed value", () => {
+    const cells = mountCells(GRID);
+    const loadInput = cells[tableCellDomKey(9, 1, "load")]!;
+    loadInput.value = "100";
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const onCommit = vi.fn();
+    const onRevert = vi.fn();
+    const callbacks = { ...NOOP_CALLBACKS, onCommit, onRevert };
+    loadInput.focus();
+    act(() => {
+      result.current.cellProps(9, 1, "load", callbacks).onFocus(focusEvent(loadInput));
+    });
+    loadInput.value = "150";
+    act(() => {
+      result.current.cellProps(9, 1, "load", callbacks).onKeyDown(keyEvent("Enter", loadInput));
+    });
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    loadInput.value = "175";
+    act(() => {
+      result.current.cellProps(9, 1, "load", callbacks).onKeyDown(keyEvent("Escape", loadInput));
+    });
+    expect(onRevert).toHaveBeenCalledWith("150");
+  });
+});
+
+describe("undo/redo bypass + native keys", () => {
+  it("Ctrl+Z / Cmd+Z / Shift+Ctrl+Z on a cell are NOT intercepted", () => {
+    const cells = mountCells(GRID);
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    for (const extra of [{ ctrlKey: true }, { metaKey: true }, { ctrlKey: true, shiftKey: true }]) {
+      const event = keyEvent("z", cells[tableCellDomKey(9, null, "name")]!, extra);
+      act(() => {
+        result.current.cellProps(9, null, "name", NOOP_CALLBACKS).onKeyDown(event);
+      });
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    }
+    expect(NOOP_CALLBACKS.onCommit).not.toHaveBeenCalled();
+    expect(NOOP_CALLBACKS.onRevert).not.toHaveBeenCalled();
+  });
+
+  it.each(["Home", "End", "PageUp", "PageDown", "a", "Tab"])("%s is not preventDefault'd", (key) => {
+    const cells = mountCells(GRID);
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const event = keyEvent(key, cells[tableCellDomKey(9, 1, "sets")]!);
+    act(() => {
+      result.current.cellProps(9, 1, "sets", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("Shift+ArrowDown is not intercepted", () => {
+    const cells = mountCells(GRID);
+    cells[tableCellDomKey(9, 1, "sets")]!.focus();
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const event = keyEvent("ArrowDown", cells[tableCellDomKey(9, 1, "sets")]!, { shiftKey: true });
+    act(() => {
+      result.current.cellProps(9, 1, "sets", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(cells[tableCellDomKey(9, 1, "sets")]);
+  });
+
+  it("Ctrl+ArrowLeft at the caret boundary is not intercepted", () => {
+    const cells = mountCells(GRID);
+    const input = cells[tableCellDomKey(9, 1, "sets")]!;
+    input.value = "3";
+    input.focus();
+    input.setSelectionRange(0, 0);
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const event = keyEvent("ArrowLeft", input, { ctrlKey: true });
+    act(() => {
+      result.current.cellProps(9, 1, "sets", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(input);
+  });
+});
+
+describe("focus restoration across a grid swap", () => {
+  it("tier 1: re-focuses the same (rowId, weekId, field) when it survives the swap", () => {
+    let cells = mountCells(GRID);
+    const { result, rerender } = renderHook(({ grid: g }) => useTableNav({ grid: g }), {
+      initialProps: { grid: GRID },
+    });
+    focus(result.current, cells, 9, 1, "sets");
+
+    const NEXT = grid({ days: [day(1, [row(9, [1, 2], { name: "Box Squat" }), row(10, [1, 2])]), day(2, [row(11, [1, 2])])] });
+    cells = resyncCells(NEXT);
+    act(() => rerender({ grid: NEXT }));
+
+    expect(document.activeElement).toBe(cells[tableCellDomKey(9, 1, "sets")]);
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 1, field: "sets" });
+  });
+
+  it("tier 2a: falls back to the first row of the same day (name column) when the row is gone but the day survives", () => {
+    let cells = mountCells(GRID);
+    const { result, rerender } = renderHook(({ grid: g }) => useTableNav({ grid: g }), {
+      initialProps: { grid: GRID },
+    });
+    focus(result.current, cells, 9, 1, "sets");
+
+    // Day 1 survives (id 1) but row 9 is gone; row 10 remains.
+    const NEXT = grid({ days: [day(1, [row(10, [1, 2])]), day(2, [row(11, [1, 2])])] });
+    cells = resyncCells(NEXT);
+    act(() => rerender({ grid: NEXT }));
+
+    expect(document.activeElement).toBe(cells[tableCellDomKey(10, null, "name")]);
+    expect(result.current.anchor).toEqual({ rowId: 10, weekId: null, field: "name" });
+  });
+
+  it("tier 2b: keeps the row+field but snaps to the first remaining week when the focused week is removed", () => {
+    let cells = mountCells(GRID);
+    const { result, rerender } = renderHook(({ grid: g }) => useTableNav({ grid: g }), {
+      initialProps: { grid: GRID },
+    });
+    focus(result.current, cells, 9, 2, "sets");
+
+    // Week 2 is removed; both rows survive on week 1 only.
+    const NEXT = grid({ weeks: [week({ id: 1, label: "Wk 1" })], days: [day(1, [row(9, [1]), row(10, [1])]), day(2, [row(11, [1])])] });
+    cells = resyncCells(NEXT);
+    act(() => rerender({ grid: NEXT }));
+
+    expect(document.activeElement).toBe(cells[tableCellDomKey(9, 1, "sets")]);
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 1, field: "sets" });
+  });
+
+  it("tier 3: falls back to the table's first cell when the day itself is gone", () => {
+    let cells = mountCells(GRID);
+    const { result, rerender } = renderHook(({ grid: g }) => useTableNav({ grid: g }), {
+      initialProps: { grid: GRID },
+    });
+    focus(result.current, cells, 11, 1, "sets"); // day 2's row
+
+    // Day 2 (id 2) is gone entirely; only day 1 remains.
+    const NEXT = grid({ days: [day(1, [row(9, [1, 2]), row(10, [1, 2])])] });
+    cells = resyncCells(NEXT);
+    act(() => rerender({ grid: NEXT }));
+
+    expect(document.activeElement).toBe(cells[tableCellDomKey(9, null, "name")]);
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: null, field: "name" });
+  });
+
+  it("tier 4: does nothing (no throw, no focus) when the whole table is emptied", () => {
+    const cells = mountCells(GRID);
+    const { result, rerender } = renderHook(({ grid: g }) => useTableNav({ grid: g }), {
+      initialProps: { grid: GRID },
+    });
+    focus(result.current, cells, 9, null, "name");
+
+    const NEXT = grid({ days: [] });
+    resyncCells(NEXT);
+    expect(() => act(() => rerender({ grid: NEXT }))).not.toThrow();
+
+    expect(result.current.anchor).toBe(null);
+  });
+
+  it("tier 4: a null grid behaves the same as an empty table (no throw, anchor null)", () => {
+    mountCells(GRID);
+    expect(() => renderHook(() => useTableNav({ grid: null }))).not.toThrow();
+    const { result } = renderHook(() => useTableNav({ grid: null }));
+    expect(result.current.anchor).toBe(null);
+  });
+
+  it("does NOT steal focus on a grid swap when the table was never focused", () => {
+    let cells = mountCells(GRID);
+    const { rerender } = renderHook(({ grid: g }) => useTableNav({ grid: g }), {
+      initialProps: { grid: GRID },
+    });
+    const NEXT = grid({ days: [day(1, [row(9, [1, 2]), row(10, [1, 2])]), day(2, [row(11, [1, 2])])] });
+    cells = resyncCells(NEXT);
+    act(() => rerender({ grid: NEXT }));
+
+    expect(document.activeElement).toBe(document.body);
+    expect(cells[tableCellDomKey(9, null, "name")]).not.toBe(document.activeElement);
+  });
+
+  it("restoration never steals focus from a non-grid form field (e.g. the chat composer)", () => {
+    let cells = mountCells(GRID);
+    const composer = document.createElement("input");
+    document.body.appendChild(composer);
+    const { result, rerender } = renderHook(({ grid: g }) => useTableNav({ grid: g }), {
+      initialProps: { grid: GRID },
+    });
+    focus(result.current, cells, 9, 1, "sets");
+    composer.focus();
+
+    const NEXT = grid({ days: [day(1, [row(10, [1, 2])]), day(2, [row(11, [1, 2])])] });
+    cells = resyncCells(NEXT);
+    act(() => rerender({ grid: NEXT }));
+
+    expect(document.activeElement).toBe(composer);
+  });
+
+  it("an unmarked control keeps focus across a grid identity change", () => {
+    let cells = mountCells(GRID);
+    const toggle = document.createElement("button");
+    document.body.appendChild(toggle);
+    const { result, rerender } = renderHook(({ grid: g }) => useTableNav({ grid: g }), {
+      initialProps: { grid: GRID },
+    });
+    focus(result.current, cells, 9, 1, "sets");
+    toggle.focus();
+
+    const NEXT = grid({ days: [day(1, [row(9, [1, 2], { name: "Box Squat" }), row(10, [1, 2])]), day(2, [row(11, [1, 2])])] });
+    cells = resyncCells(NEXT);
+    act(() => rerender({ grid: NEXT }));
+
+    expect(document.activeElement).toBe(toggle);
+  });
+
+  it("a data-grid-restore control still hands focus back to the table", () => {
+    let cells = mountCells(GRID);
+    const undoButton = document.createElement("button");
+    undoButton.setAttribute("data-grid-restore", "");
+    document.body.appendChild(undoButton);
+    const { result, rerender } = renderHook(({ grid: g }) => useTableNav({ grid: g }), {
+      initialProps: { grid: GRID },
+    });
+    focus(result.current, cells, 9, 1, "sets");
+    undoButton.focus();
+
+    const NEXT = grid({ days: [day(1, [row(10, [1, 2])]), day(2, [row(11, [1, 2])])] });
+    cells = resyncCells(NEXT);
+    act(() => rerender({ grid: NEXT }));
+
+    expect(document.activeElement).toBe(cells[tableCellDomKey(10, null, "name")]);
+  });
+});
+
+describe("holes (missing DOM cells)", () => {
+  it("arrowing onto a hole doesn't throw and doesn't move activeElement", () => {
+    // Mount only row 9's name + week 1 cells — week 2 is a total hole (as
+    // add-this-week rows and skipped-cell display leave gaps in the real
+    // app; MesoTable's own <td/> with no GridCellEditor is the same shape).
+    const nameInput = document.createElement("input");
+    nameInput.setAttribute("data-grid-cell", tableCellDomKey(9, null, "name"));
+    document.body.appendChild(nameInput);
+    const noteInput = document.createElement("input");
+    noteInput.value = "";
+    noteInput.setAttribute("data-grid-cell", tableCellDomKey(9, 1, "note"));
+    document.body.appendChild(noteInput);
+    // Week 2's "sets" cell is intentionally never mounted.
+
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    noteInput.focus();
+    const event = keyEvent("ArrowRight", noteInput);
+    expect(() => {
+      act(() => {
+        result.current.cellProps(9, 1, "note", NOOP_CALLBACKS).onKeyDown(event);
+      });
+    }).not.toThrow();
+    expect(document.activeElement).toBe(noteInput);
+  });
+});

--- a/frontend/designer/src/hooks/useTableNav.ts
+++ b/frontend/designer/src/hooks/useTableNav.ts
@@ -1,0 +1,314 @@
+// useTableNav — grid keyboard navigation + cell a11y for the P1 multi-week
+// table (MesoTable). Sibling of useGridNav (the one-week WeekGrid/DayCard/
+// ExerciseRow hook), NOT a shared/generalized abstraction: A5 deletes the
+// entire one-week stack (WeekStrip/WeekGrid/DayCard/ExerciseRow +
+// useGridNav + its test) in one clean `rm`, and MesoTable's own header
+// comment already duplicates ExerciseRow's dirtySinceFocus pattern rather
+// than sharing it for the same reason — the shapes genuinely differ (a
+// per-row boolean vs a per-cell dirty Set; a 1D (prescriptionId, column)
+// identity vs a 2D (rowId, weekId, field) identity over a variable-width
+// week axis). Duplication here is small and a proven algorithm re-derived
+// over a 2D coordinate, not new design.
+//
+// Instantiated ONCE inside MesoTable (the hook-owning level, analog of
+// WeekGrid) — GridCellEditor/RowNameEditor are module-private and receive
+// the result as a required prop; no INERT fallback is needed since they
+// never render outside MesoTable.
+//
+// Cell identity is (rowId, weekId, field) — NEVER an index, and NEVER
+// prescription_id: the row-name column and "holes" (a week with no cell for
+// a row — add-this-week rows; see MesoTable.tsx's bare <td/> case) have no
+// prescription_id. exercise_slot_id/session_slot_id/week.id are fixed-
+// lineup block structures (P0) that survive an in-place cell edit, unlike
+// prescription_id-keyed identity which would be fine too but isn't
+// universally available. DOM lookups go through `document.querySelector`
+// against a `data-grid-cell` attribute (see `tableCellDomKey`), exactly
+// like useGridNav, so arrow-key moves and focus restoration work
+// identically for a hook-only unit test and the real mounted app.
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { FocusEvent, KeyboardEvent } from "react";
+import type { MesoGrid } from "../lib/api";
+
+export type TableColumn = "name" | "sets" | "reps" | "load" | "rpe" | "rest" | "note";
+
+/** Editable per-cell fields, visual order (excludes "name" — that's the
+ * leading row-identity column, not a per-week field). */
+export const TABLE_FIELDS = ["sets", "reps", "load", "rpe", "rest", "note"] as const;
+export type EditableField = (typeof TABLE_FIELDS)[number];
+
+export const TABLE_FIELD_LABELS: Record<TableColumn, string> = {
+  name: "exercise name",
+  sets: "sets",
+  reps: "reps",
+  load: "load",
+  rpe: "RPE",
+  rest: "rest",
+  note: "note",
+};
+
+export interface TableCellId {
+  /** GridRow.exercise_slot_id — vertical identity, never an index. */
+  rowId: number;
+  /** GridWeek.id, or null for the row-name column. */
+  weekId: number | null;
+  field: TableColumn;
+}
+
+// No onChange here — verified dead surface in useGridNav's GridCellCallbacks
+// (never invoked; ExerciseRow's own `changed()` wrapper handles dirtying
+// directly, same as MesoTable's GridCellEditor).
+export interface TableCellCallbacks {
+  onCommit(): void;
+  onRevert(value: string): void;
+}
+
+export interface TableCellBindings {
+  tabIndex: 0 | -1;
+  onFocus(event: FocusEvent<HTMLInputElement>): void;
+  onKeyDown(event: KeyboardEvent<HTMLInputElement>): void;
+}
+
+export interface UseTableNavResult {
+  anchor: TableCellId | null;
+  cellProps(
+    rowId: number,
+    weekId: number | null,
+    field: TableColumn,
+    callbacks: TableCellCallbacks,
+  ): TableCellBindings;
+}
+
+export interface UseTableNavOptions {
+  grid: MesoGrid | null;
+}
+
+/** DOM identity for a cell's `data-grid-cell` attribute / querySelector key.
+ * `weekId ?? "row"` sentinel means this can never collide with a real week
+ * id (a number), e.g. "9:2:sets", "9:row:name". */
+export function tableCellDomKey(rowId: number, weekId: number | null, field: TableColumn): string {
+  return `${rowId}:${weekId ?? "row"}:${field}`;
+}
+
+/** "<row name or 'exercise'> — <week label> — <field label>", or
+ * "<name> — exercise name" for the row-name column (no week context). */
+export function tableCellAriaLabel(rowName: string, weekLabel: string | null, field: TableColumn): string {
+  const name = rowName || "exercise";
+  if (field === "name") return `${name} — exercise name`;
+  return `${name} — ${weekLabel} — ${TABLE_FIELD_LABELS[field]}`;
+}
+
+/** One entry of the horizontal (within-row) axis: the leading name column,
+ * then every week's fields in visual order. Identical for every row, so
+ * it's derived once from `grid.weeks` — walking it with `.findIndex` drives
+ * ArrowRight/Left, including the "no special-case" week-to-week crossing
+ * (last field of week N sits immediately before week N+1's first field). */
+interface TableColumnPos {
+  weekId: number | null;
+  field: TableColumn;
+}
+
+function buildColumns(grid: MesoGrid | null): TableColumnPos[] {
+  const columns: TableColumnPos[] = [{ weekId: null, field: "name" }];
+  if (!grid) return columns;
+  for (const week of grid.weeks) {
+    for (const field of TABLE_FIELDS) {
+      columns.push({ weekId: week.id, field });
+    }
+  }
+  return columns;
+}
+
+interface FlatTable {
+  /** Every row id, day-major/row-minor (server-ordered). */
+  rowOrder: number[];
+  /** Every week id, index-ordered (server-ordered). */
+  weekOrder: number[];
+  dayIdByRow: Map<number, number>;
+  firstRowByDay: Map<number, number>;
+}
+
+function flattenGrid(grid: MesoGrid | null): FlatTable {
+  const rowOrder: number[] = [];
+  const dayIdByRow = new Map<number, number>();
+  const firstRowByDay = new Map<number, number>();
+  if (!grid) return { rowOrder, weekOrder: [], dayIdByRow, firstRowByDay };
+  for (const day of grid.days) {
+    for (const row of day.rows) {
+      rowOrder.push(row.exercise_slot_id);
+      dayIdByRow.set(row.exercise_slot_id, day.session_slot_id);
+      if (!firstRowByDay.has(day.session_slot_id)) firstRowByDay.set(day.session_slot_id, row.exercise_slot_id);
+    }
+  }
+  const weekOrder = grid.weeks.map((w) => w.id);
+  return { rowOrder, weekOrder, dayIdByRow, firstRowByDay };
+}
+
+function firstCellOf(flat: FlatTable): TableCellId | null {
+  const id = flat.rowOrder[0];
+  return id === undefined ? null : { rowId: id, weekId: null, field: "name" };
+}
+
+function focusCell(rowId: number, weekId: number | null, field: TableColumn) {
+  const selector = `[data-grid-cell="${tableCellDomKey(rowId, weekId, field)}"]`;
+  document.querySelector<HTMLElement>(selector)?.focus();
+}
+
+const HANDLED_KEYS = new Set(["ArrowDown", "ArrowUp", "ArrowLeft", "ArrowRight", "Enter", "Escape"]);
+
+export function useTableNav(options: UseTableNavOptions): UseTableNavResult {
+  const { grid } = options;
+  const columns = useMemo(() => buildColumns(grid), [grid]);
+  const flat = useMemo(() => flattenGrid(grid), [grid]);
+
+  const [anchor, setAnchor] = useState<TableCellId | null>(() => firstCellOf(flat));
+  const anchorRef = useRef<TableCellId | null>(anchor);
+  const lastDayIdRef = useRef<number | null>(anchor ? (flat.dayIdByRow.get(anchor.rowId) ?? null) : null);
+  // Flips true the first time any cell actually receives focus — gates
+  // whether restoration is allowed to steal DOM focus, mirrors useGridNav.
+  const focusedOnceRef = useRef(false);
+  // Cell key -> value captured at focus time, for Escape's revert target.
+  const focusValuesRef = useRef<Record<string, string>>({});
+
+  function commitAnchor(next: TableCellId | null, flatForLookup: FlatTable, shouldFocus: boolean) {
+    anchorRef.current = next;
+    lastDayIdRef.current = next ? (flatForLookup.dayIdByRow.get(next.rowId) ?? null) : null;
+    setAnchor(next);
+    if (next && shouldFocus) focusCell(next.rowId, next.weekId, next.field);
+  }
+
+  // Restoration: recompute the anchor on EVERY grid identity change so
+  // tabIndex stays valid even when the table never had focus, but only call
+  // .focus() when it did. Both rowId and weekId can independently disappear
+  // (remove-exercise/day vs remove-week), so tier 2 splits in two — see
+  // brief §4 for the four-tier rationale (mirrors useGridNav's tiers 1/3/4).
+  useEffect(() => {
+    const prev = anchorRef.current;
+    if (prev === null) {
+      commitAnchor(firstCellOf(flat), flat, false);
+      return;
+    }
+
+    const rowSurvives = flat.rowOrder.includes(prev.rowId);
+    const weekSurvives = prev.weekId === null || flat.weekOrder.includes(prev.weekId);
+
+    let next: TableCellId | null;
+    if (rowSurvives && weekSurvives) {
+      // Tier 1: same (rowId, weekId, field) survives.
+      next = { rowId: prev.rowId, weekId: prev.weekId, field: prev.field };
+    } else if (rowSurvives) {
+      // Tier 2b: the week is gone (remove-week) but the row survives — keep
+      // the row+field, snap to the first remaining week (simplest rule
+      // consistent with tier 2's "first of ..." precedent, not "nearest").
+      const firstWeek = flat.weekOrder[0];
+      next =
+        firstWeek !== undefined
+          ? { rowId: prev.rowId, weekId: firstWeek, field: prev.field }
+          : { rowId: prev.rowId, weekId: null, field: "name" };
+    } else {
+      // Row gone (remove-exercise, or its whole day removed).
+      const dayId = lastDayIdRef.current;
+      const firstOfDay = dayId == null ? undefined : flat.firstRowByDay.get(dayId);
+      // Tier 2a: first row of the same day, else Tier 3: table's first cell
+      // (firstCellOf returns null for Tier 4 — the whole table is empty).
+      next = firstOfDay !== undefined ? { rowId: firstOfDay, weekId: null, field: "name" } : firstCellOf(flat);
+    }
+
+    // Restoration may move focus ONLY when it won't steal it: the active
+    // element is a grid cell, focus was orphaned by the swap (fell to
+    // body), or the coach is on a control explicitly marked
+    // data-grid-restore (undo/redo, add-week, make-current, remove-week —
+    // swap initiators whose result should return them to the table).
+    // Anything else — the chat composer, the load-type toggle re-rendering
+    // under focus on a cell patch — keeps focus.
+    const active = document.activeElement as HTMLElement | null;
+    const allowFocusMove =
+      !active ||
+      active === document.body ||
+      active.hasAttribute("data-grid-cell") ||
+      active.closest("[data-grid-restore]") !== null;
+    commitAnchor(next, flat, focusedOnceRef.current && allowFocusMove);
+    // grid is the only externally-driven trigger for restoration; flat/
+    // columns are derived from it in lockstep, and the anchor/ref reads are
+    // intentionally "current value at effect time", not reactive deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [grid]);
+
+  function cellProps(
+    rowId: number,
+    weekId: number | null,
+    field: TableColumn,
+    callbacks: TableCellCallbacks,
+  ): TableCellBindings {
+    const tabIndex: 0 | -1 =
+      anchor && anchor.rowId === rowId && anchor.weekId === weekId && anchor.field === field ? 0 : -1;
+
+    const onFocus = (event: FocusEvent<HTMLInputElement>) => {
+      focusedOnceRef.current = true;
+      focusValuesRef.current[tableCellDomKey(rowId, weekId, field)] = event.currentTarget.value;
+      commitAnchor({ rowId, weekId, field }, flat, false);
+    };
+
+    const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "z") return; // undo/redo: untouched.
+      if (!HANDLED_KEYS.has(event.key)) return;
+      // Modified keys are native text editing (Shift+Arrow selection,
+      // Ctrl/Alt/Cmd+Arrow word- and line-navigation) — never grid moves.
+      if (event.shiftKey || event.ctrlKey || event.metaKey || event.altKey) return;
+
+      // Any handled keydown implies this cell currently holds focus — keep
+      // the anchor synced even if no onFocus round-trip preceded it.
+      commitAnchor({ rowId, weekId, field }, flat, false);
+
+      switch (event.key) {
+        case "ArrowDown":
+        case "ArrowUp": {
+          event.preventDefault();
+          const idx = flat.rowOrder.indexOf(rowId);
+          if (idx === -1) return;
+          const nextIdx = idx + (event.key === "ArrowDown" ? 1 : -1);
+          const targetRowId = flat.rowOrder[nextIdx];
+          if (targetRowId === undefined) return; // extreme: no-op, preventDefault already fired.
+          commitAnchor({ rowId: targetRowId, weekId, field }, flat, true);
+          return;
+        }
+        case "ArrowRight":
+        case "ArrowLeft": {
+          const el = event.currentTarget;
+          const collapsed = el.selectionStart === el.selectionEnd;
+          const atBoundary =
+            event.key === "ArrowRight" ? el.selectionStart === el.value.length : el.selectionStart === 0;
+          if (!collapsed || !atBoundary) return; // let the caret move natively.
+          const colIdx = columns.findIndex((c) => c.weekId === weekId && c.field === field);
+          const nextColIdx = colIdx + (event.key === "ArrowRight" ? 1 : -1);
+          const nextCol = columns[nextColIdx];
+          if (nextCol === undefined) return; // row extreme: nothing to prevent either.
+          event.preventDefault();
+          commitAnchor({ rowId, weekId: nextCol.weekId, field: nextCol.field }, flat, true);
+          return;
+        }
+        case "Enter": {
+          event.preventDefault();
+          callbacks.onCommit();
+          // The committed value is the new Escape baseline — without this, a
+          // fresh draft + Escape would roll the UI back PAST the commit,
+          // desyncing it from the server.
+          focusValuesRef.current[tableCellDomKey(rowId, weekId, field)] = event.currentTarget.value;
+          return;
+        }
+        case "Escape": {
+          event.preventDefault();
+          const key = tableCellDomKey(rowId, weekId, field);
+          const value = focusValuesRef.current[key] ?? event.currentTarget.value;
+          callbacks.onRevert(value);
+          return;
+        }
+        default:
+          return;
+      }
+    };
+
+    return { tabIndex, onFocus, onKeyDown };
+  }
+
+  return { anchor, cellProps };
+}

--- a/frontend/designer/src/hooks/useTableNav.ts
+++ b/frontend/designer/src/hooks/useTableNav.ts
@@ -25,6 +25,25 @@
 // against a `data-grid-cell` attribute (see `tableCellDomKey`), exactly
 // like useGridNav, so arrow-key moves and focus restoration work
 // identically for a hook-only unit test and the real mounted app.
+//
+// Arrow moves SKID over holes rather than landing on them: useGridNav's
+// one-week grid has no gaps (every ExerciseRow field always renders), so its
+// "extreme: no-op, preventDefault already fired" precedent only ever had to
+// handle running off the end of the row/column. A 2D table isn't that
+// simple — a hole (an add-this-week row's missing week) or a skipped cell
+// (em-dash + Unskip, no GridCellEditor) can sit in the MIDDLE of a row or
+// column, with no `data-grid-cell` node at all. Committing the anchor to
+// that coordinate would drop the whole grid out of the tab order (no
+// rendered cell left holding tabIndex 0) and leave the anchor pointing at
+// nothing. So every arrow move re-checks `cellExists` at keydown time and
+// keeps stepping in the same direction, past any hole, to the first
+// coordinate that actually renders. If none exists all the way to the edge,
+// the anchor is left exactly where it was — vertical moves still
+// preventDefault regardless (matching ArrowDown/Up's original unconditional
+// behavior), while a horizontal move only preventDefaults once it has
+// confirmed at least one adjacent column POSITION exists to attempt (a true
+// row-extreme with zero columns left, holes or otherwise, is still a pure
+// no-op, exactly as before).
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { FocusEvent, KeyboardEvent } from "react";
 import type { MesoGrid } from "../lib/api";
@@ -148,9 +167,22 @@ function firstCellOf(flat: FlatTable): TableCellId | null {
   return id === undefined ? null : { rowId: id, weekId: null, field: "name" };
 }
 
+function cellSelector(rowId: number, weekId: number | null, field: TableColumn): string {
+  return `[data-grid-cell="${tableCellDomKey(rowId, weekId, field)}"]`;
+}
+
 function focusCell(rowId: number, weekId: number | null, field: TableColumn) {
-  const selector = `[data-grid-cell="${tableCellDomKey(rowId, weekId, field)}"]`;
-  document.querySelector<HTMLElement>(selector)?.focus();
+  document.querySelector<HTMLElement>(cellSelector(rowId, weekId, field))?.focus();
+}
+
+/** Whether a cell actually has a rendered `data-grid-cell` node right now.
+ * Checked fresh at keydown time (never precomputed/cached) — cells appear
+ * and disappear with skip/unskip and add-this-week, so the DOM is the only
+ * source of truth for "is this coordinate landable". Arrow moves use this
+ * to skid over holes (see the header comment) instead of committing the
+ * anchor to a coordinate nothing renders. */
+function cellExists(rowId: number, weekId: number | null, field: TableColumn): boolean {
+  return document.querySelector(cellSelector(rowId, weekId, field)) !== null;
 }
 
 const HANDLED_KEYS = new Set(["ArrowDown", "ArrowUp", "ArrowLeft", "ArrowRight", "Enter", "Escape"]);
@@ -193,7 +225,20 @@ export function useTableNav(options: UseTableNavOptions): UseTableNavResult {
 
     let next: TableCellId | null;
     if (rowSurvives && weekSurvives) {
-      // Tier 1: same (rowId, weekId, field) survives.
+      // Tier 1: same (rowId, weekId, field) survives. This checks row/week
+      // EXISTENCE (is the id still anywhere in the grid), not whether THIS
+      // row still renders a cell at THIS week — a skip or a this-week-only
+      // add/remove can hollow out just one coordinate while its row and
+      // week both live on elsewhere. Unlike the arrow-key scan above (this
+      // PR's #455 review-nit fix), Tier 1 doesn't re-verify against
+      // cellExists: doing so would mean deciding what to fall back to
+      // (Tier 2b's "first remaining week" isn't guaranteed to exist for
+      // this row either), which is restoration-tier redesign, not an
+      // arrow-key fix. Tiers 2a/2b/3 land on the name column or the
+      // table's first cell, which — row-name always renders regardless of
+      // per-week holes — always exist. Left as-is deliberately: revisit
+      // with a failing restoration test if Tier 1 is ever observed to
+      // strand the anchor in practice.
       next = { rowId: prev.rowId, weekId: prev.weekId, field: prev.field };
     } else if (rowSurvives) {
       // Tier 2b: the week is gone (remove-week) but the row survives — keep
@@ -265,9 +310,21 @@ export function useTableNav(options: UseTableNavOptions): UseTableNavResult {
           event.preventDefault();
           const idx = flat.rowOrder.indexOf(rowId);
           if (idx === -1) return;
-          const nextIdx = idx + (event.key === "ArrowDown" ? 1 : -1);
-          const targetRowId = flat.rowOrder[nextIdx];
-          if (targetRowId === undefined) return; // extreme: no-op, preventDefault already fired.
+          const step = event.key === "ArrowDown" ? 1 : -1;
+          // Skid past any row that has no rendered cell at this (weekId,
+          // field) — a row's holes are independent of its neighbors' (a
+          // missing week or a skipped cell), so the next INDEX isn't
+          // necessarily the next LANDABLE row. Stop at the first row that
+          // actually renders this column, or fall off the end: either way
+          // the key was handled (preventDefault already fired above).
+          let nextIdx = idx + step;
+          let candidateRowId = flat.rowOrder[nextIdx];
+          while (candidateRowId !== undefined && !cellExists(candidateRowId, weekId, field)) {
+            nextIdx += step;
+            candidateRowId = flat.rowOrder[nextIdx];
+          }
+          const targetRowId = candidateRowId;
+          if (targetRowId === undefined) return; // no rendered cell to the edge: stay put.
           commitAnchor({ rowId: targetRowId, weekId, field }, flat, true);
           return;
         }
@@ -279,10 +336,27 @@ export function useTableNav(options: UseTableNavOptions): UseTableNavResult {
             event.key === "ArrowRight" ? el.selectionStart === el.value.length : el.selectionStart === 0;
           if (!collapsed || !atBoundary) return; // let the caret move natively.
           const colIdx = columns.findIndex((c) => c.weekId === weekId && c.field === field);
-          const nextColIdx = colIdx + (event.key === "ArrowRight" ? 1 : -1);
-          const nextCol = columns[nextColIdx];
-          if (nextCol === undefined) return; // row extreme: nothing to prevent either.
+          const step = event.key === "ArrowRight" ? 1 : -1;
+          let nextColIdx = colIdx + step;
+          let candidateCol = columns[nextColIdx];
+          if (candidateCol === undefined) return; // absolute row extreme: no adjacent column at all, nothing to prevent.
+          // There IS an adjacent column position, so this key is being
+          // handled from here on — preventDefault even if every remaining
+          // position turns out to be a hole (below) and the anchor doesn't
+          // actually move.
           event.preventDefault();
+          // Skid past any column with no rendered cell for THIS row — a
+          // hole (an add-this-week row's missing week) or a skipped cell
+          // (em-dash + Unskip, no GridCellEditor) both leave no
+          // `data-grid-cell` node, so arrowing across one jumps straight to
+          // the next editable cell instead of stranding the anchor on a
+          // coordinate nothing renders.
+          while (candidateCol !== undefined && !cellExists(rowId, candidateCol.weekId, candidateCol.field)) {
+            nextColIdx += step;
+            candidateCol = columns[nextColIdx];
+          }
+          const nextCol = candidateCol;
+          if (nextCol === undefined) return; // ran out of columns while skidding past holes: stay put, key already handled.
           commitAnchor({ rowId, weekId: nextCol.weekId, field: nextCol.field }, flat, true);
           return;
         }

--- a/frontend/designer/src/hooks/useTableNav.ts
+++ b/frontend/designer/src/hooks/useTableNav.ts
@@ -185,6 +185,25 @@ function cellExists(rowId: number, weekId: number | null, field: TableColumn): b
   return document.querySelector(cellSelector(rowId, weekId, field)) !== null;
 }
 
+/** The nearest rendered column of `cell`'s own row — forward first, then
+ * backward. Restoration's post-tier guard uses this when a surviving
+ * (row, week) coordinate turns out to be hollow (see the effect below);
+ * the leading name column always renders for a live row, so the backward
+ * scan terminates there at worst. */
+function nearestRenderedInRow(cell: TableCellId, columns: TableColumnPos[]): TableCellId | null {
+  const at = columns.findIndex((c) => c.weekId === cell.weekId && c.field === cell.field);
+  if (at === -1) return null;
+  for (let i = at + 1; i < columns.length; i++) {
+    const col = columns[i];
+    if (col && cellExists(cell.rowId, col.weekId, col.field)) return { rowId: cell.rowId, weekId: col.weekId, field: col.field };
+  }
+  for (let i = at - 1; i >= 0; i--) {
+    const col = columns[i];
+    if (col && cellExists(cell.rowId, col.weekId, col.field)) return { rowId: cell.rowId, weekId: col.weekId, field: col.field };
+  }
+  return null;
+}
+
 const HANDLED_KEYS = new Set(["ArrowDown", "ArrowUp", "ArrowLeft", "ArrowRight", "Enter", "Escape"]);
 
 export function useTableNav(options: UseTableNavOptions): UseTableNavResult {
@@ -225,20 +244,10 @@ export function useTableNav(options: UseTableNavOptions): UseTableNavResult {
 
     let next: TableCellId | null;
     if (rowSurvives && weekSurvives) {
-      // Tier 1: same (rowId, weekId, field) survives. This checks row/week
-      // EXISTENCE (is the id still anywhere in the grid), not whether THIS
-      // row still renders a cell at THIS week — a skip or a this-week-only
-      // add/remove can hollow out just one coordinate while its row and
-      // week both live on elsewhere. Unlike the arrow-key scan above (this
-      // PR's #455 review-nit fix), Tier 1 doesn't re-verify against
-      // cellExists: doing so would mean deciding what to fall back to
-      // (Tier 2b's "first remaining week" isn't guaranteed to exist for
-      // this row either), which is restoration-tier redesign, not an
-      // arrow-key fix. Tiers 2a/2b/3 land on the name column or the
-      // table's first cell, which — row-name always renders regardless of
-      // per-week holes — always exist. Left as-is deliberately: revisit
-      // with a failing restoration test if Tier 1 is ever observed to
-      // strand the anchor in practice.
+      // Tier 1: same (rowId, weekId, field) survives — row/week EXISTENCE
+      // only; whether the coordinate still RENDERS is the post-tier guard
+      // below's job (a skip can hollow out one coordinate while its row and
+      // week both live on).
       next = { rowId: prev.rowId, weekId: prev.weekId, field: prev.field };
     } else if (rowSurvives) {
       // Tier 2b: the week is gone (remove-week) but the row survives — keep
@@ -256,6 +265,19 @@ export function useTableNav(options: UseTableNavOptions): UseTableNavResult {
       // Tier 2a: first row of the same day, else Tier 3: table's first cell
       // (firstCellOf returns null for Tier 4 — the whole table is empty).
       next = firstOfDay !== undefined ? { rowId: firstOfDay, weekId: null, field: "name" } : firstCellOf(flat);
+    }
+
+    // Post-tier guard (#455 review): a SURVIVING coordinate can still be
+    // hollow — skipping the focused cell (or dropping an add-this-week
+    // cell) refetches the grid with that input gone while its row and week
+    // both live on. Committing the anchor there would zero the whole table
+    // out of the tab order (every rendered cell gets tabIndex=-1 and
+    // focusCell no-ops). This effect runs after React committed the new
+    // DOM, so cellExists sees the post-refetch truth: skid to the nearest
+    // rendered column of the same row (the name column always renders for
+    // a live row), else the table's first cell.
+    if (next && !cellExists(next.rowId, next.weekId, next.field)) {
+      next = nearestRenderedInRow(next, columns) ?? firstCellOf(flat);
     }
 
     // Restoration may move focus ONLY when it won't steal it: the active


### PR DESCRIPTION
## Summary

Phase A1 of #455 (MesoTable parity): arrow-key cell navigation for the multi-week designer table, closing the first of the four one-week-only capability gaps.

- **New `useTableNav` hook** (`frontend/designer/src/hooks/useTableNav.ts`) — a deliberate sibling of `useGridNav`, not a shared abstraction: the one-week stack is scheduled for deletion in A5, and the nav identity genuinely differs (2D `(rowId, weekId, field)` with a variable-width week axis vs the one-week `(prescriptionId, column)`). Roving tabindex (one tab stop for the whole grid, spanning every per-day table), ArrowUp/Down across rows (day-major), ArrowLeft/Right walks fields within a cell and **crosses week boundaries** at caret edge with a collapsed selection, Enter commits (and re-baselines Escape), Escape reverts only the focused field's draft (per-cell dirty-Set semantics), Cmd/Ctrl+Z left to undo/redo.
- **Hole semantics:** skipped cells and add-this-week holes render no input — arrow moves **skid** past them to the next rendered cell (both axes), and the focus-restoration guard re-anchors when a refetch hollows out the focused coordinate (e.g. Skip on the focused cell), so the grid never drops out of the page's tab order. Both were Codex review findings; both carry regression tests.
- **Focus restoration across grid refetches** generalizes the one-week tiers to two independently-removable axes (row gone vs week gone), with the same never-steal-focus guard (`data-grid-restore` ported with the exact one-week marker split).
- **A11y:** the table's inputs gain real aria-labels ("Box Squat — Wk 1 — sets") replacing the static field-name labels.
- Header-comment sweep: stale plan-doc path → `docs/archive/meso/fixed-selection-plan.md` (#457 follow-through).

Frontend-only — no backend, no migrations, `serialize_plan`/one-week view untouched.

## Review + verification
- Codex review loop converged CLEAN (iter 3: 0/0; two P2 findings across iters 1–2 — hole-stranded anchor on arrows, hollowed Tier-1 restoration — both fixed red-green).
- Vitest **657 passed** (+75 vs baseline: 49-spec `useTableNav` suite + MesoTable integration block), strict `tsc` clean, `vite build` clean.
- **Browser-verified in real Chrome** on the live designer (3-week plan): ArrowDown/Up rows, ArrowRight/Left field-walk + week-boundary crossing, Escape revert (no network call), Enter commit (exactly one autosave POST; value persisted across reload), and skid over a real skipped week in both directions.

Refs #455 (A1)

https://claude.ai/code/session_01GpaxgUSRbupnkecSo9Pmx4