### PR TITLE
feat(meso): A2 — drag reordering in the multi-week table (#455)

### DIFF
--- a/app/store_project/meso/serializers.py
+++ b/app/store_project/meso/serializers.py
@@ -1090,6 +1090,19 @@ def serialize_mesocycle_grid(mesocycle):
                 "session_id": _pick_session_id(
                     slot.pk, sessions_by_slot, current_week_id, weeks
                 ),
+                # Per-week session pks for this day (Codex #455 A2 review
+                # finding 2) — reuses ``sessions_by_slot`` (already loaded
+                # above for ``_pick_session_id``, no extra query), keyed by
+                # ``str(week_id)`` so a day-reorder client can look up its
+                # OWN current-week session id instead of trusting
+                # ``session_id`` above, which can silently be a FALLBACK to
+                # a different (non-current) week's session when the current
+                # week's was independently soft-deleted. A week missing a
+                # live session for this slot has no entry.
+                "session_ids": {
+                    str(week_id): session_pk
+                    for week_id, session_pk in sessions_by_slot.get(slot.pk, {}).items()
+                },
                 "day_number": slot.day_number,
                 "name": slot.name,
                 "bias": slot.bias,

--- a/app/store_project/meso/tests/test_serializers.py
+++ b/app/store_project/meso/tests/test_serializers.py
@@ -751,6 +751,40 @@ class TestSerializeMesocycleGrid:
         day1_data = result["days"][0]
         assert day1_data["session_id"] == f.day1_wk2.pk
 
+    def test_session_ids_maps_every_live_week_to_its_own_session_pk(self):
+        # Codex #455 A2 review finding 2: a day-reorder client must be able
+        # to look up ITS OWN current-week session id rather than trusting
+        # the (possibly-fallback) ``session_id`` field.
+        f = _build_grid_meso()
+        result = serialize_mesocycle_grid(f.meso)
+        day1_data = result["days"][0]
+        assert day1_data["session_ids"] == {
+            str(f.week1.pk): f.day1.pk,
+            str(f.week2.pk): f.day1_wk2.pk,
+        }
+        day2_data = result["days"][1]
+        assert day2_data["session_ids"] == {
+            str(f.week1.pk): f.day2.pk,
+            str(f.week2.pk): f.day2_wk2.pk,
+        }
+
+    def test_session_ids_omits_a_week_missing_a_live_session_even_though_session_id_falls_back(
+        self,
+    ):
+        f = _build_grid_meso()
+        # Same soft-delete as the session_id fallback test above: day1's
+        # CURRENT week (week1) session is gone, so session_id falls back to
+        # week2's — but session_ids must show NO entry for week1 at all
+        # (never substitute the fallback), only the live week2 entry.
+        Session.objects.filter(pk=f.day1.pk).update(deleted_at=timezone.now())
+        result = serialize_mesocycle_grid(f.meso)
+        day1_data = result["days"][0]
+        assert (
+            day1_data["session_id"] == f.day1_wk2.pk
+        )  # display-only fallback, unaffected
+        assert str(f.week1.pk) not in day1_data["session_ids"]
+        assert day1_data["session_ids"] == {str(f.week2.pk): f.day1_wk2.pk}
+
     def test_individual_grid_cells_carry_no_adj_overlay(self):
         # The per-athlete ``adj`` overlay is a GROUP-only concern; an individual
         # plan's grid cells never carry ``adj``/``adjusts``.

--- a/frontend/designer/src/DesignerRoot.test.tsx
+++ b/frontend/designer/src/DesignerRoot.test.tsx
@@ -134,6 +134,7 @@ function gridPayload(overrides: Record<string, unknown> = {}) {
       {
         session_slot_id: 1,
         session_id: 11,
+        session_ids: { "1": 11 },
         day_number: 1,
         name: "Lower",
         bias: "Quad bias",

--- a/frontend/designer/src/DesignerRoot.tsx
+++ b/frontend/designer/src/DesignerRoot.tsx
@@ -26,6 +26,7 @@ import { useOverrideEditor } from "./hooks/useOverrideEditor";
 import { useOneRmEditor } from "./hooks/useOneRmEditor";
 import { useReorder } from "./hooks/useReorder";
 import { useGrid } from "./hooks/useGrid";
+import { useTableReorder } from "./hooks/useTableReorder";
 import { useAgentChat } from "./hooks/useAgentChat";
 import type { ChatMessage } from "./hooks/useAgentChat";
 import { useCoachmarks } from "./hooks/useCoachmarks";
@@ -310,6 +311,15 @@ export function DesignerRoot() {
     setProgram: planData.setProgram,
     applyPlanData: planData.applyPlanData,
   });
+  // Issue #455 phase A2 (drag reordering): the table's own pure drag-event
+  // translator, a sibling of `reorder` above — wired to gridState's two new
+  // structural verbs (reorderExercises/reorderDays), not planData's. See
+  // useTableReorder.ts's header for why this hook owns no state of its own.
+  const tableReorder = useTableReorder({
+    grid: gridState.grid,
+    reorderRow: gridState.reorderExercises,
+    reorderDay: gridState.reorderDays,
+  });
   const agentChat = useAgentChat({
     planId,
     csrf,
@@ -448,6 +458,7 @@ export function DesignerRoot() {
                 onSwapCell={gridState.swapCell}
                 onFillAcrossWeeks={gridState.fillAcrossWeeks}
                 onAddExerciseThisWeek={gridState.addExerciseThisWeek}
+                onDragEnd={tableReorder.onDragEnd}
               />
             )}
 

--- a/frontend/designer/src/components/MesoTable.test.tsx
+++ b/frontend/designer/src/components/MesoTable.test.tsx
@@ -1016,6 +1016,45 @@ describe("tableCollisionDetection (day drags collide only with day containers)",
     expect(collisions.every((c: { id: unknown }) => String(c.id).startsWith("day-"))).toBe(true);
     expect(String(collisions[0]!.id)).toBe("day-1");
   });
+
+  it("returns NO collision when a row is dropped nowhere near its own day's candidates (no phantom same-day reorder)", async () => {
+    // closestCenter would have snapped this far-away drop to the nearest
+    // same-day row and committed an unintended reorder; intersection-based
+    // collision leaves `over` null so the drop no-ops (Codex #455 A2 review).
+    const { tableCollisionDetection } = await import("./MesoTable");
+    const rect = (top: number, height = 40) => ({ top, bottom: top + height, left: 0, right: 800, width: 800, height });
+    const containers = [
+      { id: "row-1-9", rect: { current: rect(0) }, data: { current: {} }, disabled: false },
+      { id: "row-1-10", rect: { current: rect(40) }, data: { current: {} }, disabled: false },
+      { id: "row-2-11", rect: { current: rect(400) }, data: { current: {} }, disabled: false },
+    ];
+    const collisions = tableCollisionDetection({
+      active: { id: "row-1-9", rect: { current: { initial: rect(0), translated: rect(400) } }, data: { current: {} } },
+      collisionRect: rect(400), // dropped over day 2's territory — no same-day candidate there
+      droppableRects: new Map(containers.map((c) => [c.id, c.rect.current])),
+      droppableContainers: containers,
+      pointerCoordinates: { x: 100, y: 420 },
+    } as never);
+    expect(collisions).toEqual([]);
+  });
+
+  it("returns the same-day row under the pointer for an in-day row drag", async () => {
+    const { tableCollisionDetection } = await import("./MesoTable");
+    const rect = (top: number, height = 40) => ({ top, bottom: top + height, left: 0, right: 800, width: 800, height });
+    const containers = [
+      { id: "row-1-9", rect: { current: rect(0) }, data: { current: {} }, disabled: false },
+      { id: "row-1-10", rect: { current: rect(40) }, data: { current: {} }, disabled: false },
+    ];
+    const collisions = tableCollisionDetection({
+      active: { id: "row-1-10", rect: { current: { initial: rect(40), translated: rect(10) } }, data: { current: {} } },
+      collisionRect: rect(10),
+      droppableRects: new Map(containers.map((c) => [c.id, c.rect.current])),
+      droppableContainers: containers,
+      pointerCoordinates: { x: 100, y: 20 },
+    } as never);
+    expect(collisions.length).toBeGreaterThan(0);
+    expect(String(collisions[0]!.id)).toBe("row-1-9");
+  });
 });
 
 describe("tableKeyboardCoordinates delegates to the real droppable map", () => {

--- a/frontend/designer/src/components/MesoTable.test.tsx
+++ b/frontend/designer/src/components/MesoTable.test.tsx
@@ -908,3 +908,160 @@ describe("keyboard grid navigation: skidding over a skipped cell (issue #455 rev
     expect(screen.getByTestId("cell-note-900")).toHaveAttribute("tabindex", "-1");
   });
 });
+
+// --- Issue #455 phase A2: drag reordering (row + day) -----------------------
+// Real pointer/keyboard dnd-kit drags are browser-only-verifiable (see
+// useTableReorder.ts's header + the WeekGrid/DayCard precedent, which never
+// simulates an actual drag through RTL either) — these specs pin the seams
+// MesoTable itself owns: the handles' rendering/a11y, and the three pure
+// functions its DndContext wires its sensors to (mirrors WeekGrid.test.tsx's
+// "keyboard drag candidate filtering" / "typedCollisionDetection" /
+// "typedKeyboardCoordinates" suites). onDragEnd's own translation logic is
+// covered by useTableReorder.test.ts.
+describe("drag handles", () => {
+  it("renders a row drag handle with testid/type/aria-label, first in the name cell", () => {
+    render(<MesoTable {...baseProps()} />);
+    const handle = screen.getByTestId("row-drag-9");
+    expect(handle).toHaveAttribute("type", "button");
+    expect(handle).toHaveAttribute("aria-label", "Reorder Squat");
+  });
+
+  it("falls back to a generic row handle label for a blank exercise name", () => {
+    render(<MesoTable {...baseProps({ grid: grid({ days: [day({ rows: [row({ name: "" })] })] }) })} />);
+    expect(screen.getByTestId("row-drag-9")).toHaveAttribute("aria-label", "Reorder exercise");
+  });
+
+  it("the row handle carries no data-grid-restore (Undo/etc. must not steal-refocus it)", () => {
+    render(<MesoTable {...baseProps()} />);
+    expect(screen.getByTestId("row-drag-9")).not.toHaveAttribute("data-grid-restore");
+  });
+
+  it("the row handle carries no data-grid-cell (outside useTableNav's grid entirely)", () => {
+    render(<MesoTable {...baseProps()} />);
+    expect(screen.getByTestId("row-drag-9")).not.toHaveAttribute("data-grid-cell");
+  });
+
+  it("disables the row handle while busy", () => {
+    render(<MesoTable {...baseProps({ busy: true })} />);
+    expect(screen.getByTestId("row-drag-9")).toBeDisabled();
+  });
+
+  it("renders a day drag handle with testid/type/aria-label, first in the day header", () => {
+    render(<MesoTable {...baseProps()} />);
+    const handle = screen.getByTestId("day-drag-1");
+    expect(handle).toHaveAttribute("type", "button");
+    expect(handle).toHaveAttribute("aria-label", "Reorder Lower");
+  });
+
+  it("falls back to 'Reorder Day <n>' for a blank day name", () => {
+    render(<MesoTable {...baseProps({ grid: grid({ days: [day({ name: "", day_number: 2 })] }) })} />);
+    expect(screen.getByTestId("day-drag-1")).toHaveAttribute("aria-label", "Reorder Day 2");
+  });
+
+  it("the day handle carries no data-grid-restore", () => {
+    render(<MesoTable {...baseProps()} />);
+    expect(screen.getByTestId("day-drag-1")).not.toHaveAttribute("data-grid-restore");
+  });
+
+  it("disables the day handle while busy", () => {
+    render(<MesoTable {...baseProps({ busy: true })} />);
+    expect(screen.getByTestId("day-drag-1")).toBeDisabled();
+  });
+});
+
+describe("filterTableDragCandidates (row drags stay within their own day; day drags target only days)", () => {
+  it("keeps only day containers for a day-active drag", async () => {
+    const { filterTableDragCandidates } = await import("./MesoTable");
+    const containers = [{ id: "day-1" }, { id: "row-1-9" }, { id: "row-2-11" }, { id: "day-2" }] as never[];
+    expect(filterTableDragCandidates("day-1", containers).map((c: { id: string }) => c.id)).toEqual([
+      "day-1",
+      "day-2",
+    ]);
+  });
+
+  it("keeps only SAME-DAY row containers for a row-active drag (cross-day is OUT of A2 scope)", async () => {
+    const { filterTableDragCandidates } = await import("./MesoTable");
+    const containers = [
+      { id: "day-1" },
+      { id: "row-1-9" },
+      { id: "row-1-10" },
+      { id: "row-2-11" },
+      { id: "day-2" },
+    ] as never[];
+    expect(filterTableDragCandidates("row-1-9", containers).map((c: { id: string }) => c.id)).toEqual([
+      "row-1-9",
+      "row-1-10",
+    ]);
+  });
+});
+
+describe("tableCollisionDetection (day drags collide only with day containers)", () => {
+  it("returns only day collisions for a day drag", async () => {
+    const { tableCollisionDetection } = await import("./MesoTable");
+    const rect = (top: number) => ({ top, bottom: top + 200, left: 0, right: 800, width: 800, height: 200 });
+    const containers = [
+      { id: "day-1", rect: { current: rect(0) }, data: { current: {} }, disabled: false },
+      { id: "row-1-9", rect: { current: rect(40) }, data: { current: {} }, disabled: false },
+      { id: "day-2", rect: { current: rect(220) }, data: { current: {} }, disabled: false },
+    ];
+    const collisions = tableCollisionDetection({
+      active: { id: "day-2", rect: { current: { initial: rect(220), translated: rect(10) } }, data: { current: {} } },
+      collisionRect: rect(10),
+      droppableRects: new Map(containers.map((c) => [c.id, c.rect.current])),
+      droppableContainers: containers,
+      pointerCoordinates: null,
+    } as never);
+    expect(collisions.length).toBeGreaterThan(0);
+    expect(collisions.every((c: { id: unknown }) => String(c.id).startsWith("day-"))).toBe(true);
+    expect(String(collisions[0]!.id)).toBe("day-1");
+  });
+});
+
+describe("tableKeyboardCoordinates delegates to the real droppable map", () => {
+  // dnd-kit's DroppableContainersMap is a real Map subclass; a spread/assign
+  // clone borrows its prototype without Map internal slots, so .get() throws
+  // "called on incompatible receiver" and keyboard reordering dies silently
+  // (see WeekGrid.tsx's typedKeyboardCoordinates, ported verbatim-adapted).
+  it("returns coordinates for a day drag without throwing on Map methods", async () => {
+    const { tableKeyboardCoordinates } = await import("./MesoTable");
+    class FakeContainers extends Map<string, unknown> {
+      getEnabled() {
+        return [...this.values()];
+      }
+    }
+    const mk = (id: string, top: number) => {
+      const node = document.createElement("div");
+      document.body.appendChild(node);
+      return {
+        id,
+        disabled: false,
+        node: { current: node },
+        data: { current: { sortable: { containerId: "table", index: 0, items: [] } } },
+        rect: { current: { top, bottom: top + 100, left: 0, right: 800, width: 800, height: 100 } },
+      };
+    };
+    const containers = new FakeContainers();
+    for (const c of [mk("day-1", 0), mk("row-1-9", 30), mk("day-2", 200)]) containers.set(c.id, c);
+    const rects = new Map(
+      [...containers.values()].map((c) => {
+        const e = c as { id: string; rect: { current: unknown } };
+        return [e.id, e.rect.current] as const;
+      }),
+    );
+    const event = new KeyboardEvent("keydown", { code: "ArrowDown", key: "ArrowDown" });
+    const coords = tableKeyboardCoordinates(event, {
+      currentCoordinates: { x: 0, y: 0 },
+      context: {
+        active: { id: "day-1" },
+        over: null,
+        collisionRect: { top: 0, bottom: 100, left: 0, right: 800, width: 800, height: 100 },
+        droppableRects: rects,
+        droppableContainers: containers,
+        scrollableAncestors: [],
+      },
+    } as never);
+    expect(coords).toBeTruthy();
+    // Proposed target must be day-2 (top 200), never row-1-9 (top 30).
+    expect(coords!.y).toBeGreaterThanOrEqual(150);
+  });
+});

--- a/frontend/designer/src/components/MesoTable.test.tsx
+++ b/frontend/designer/src/components/MesoTable.test.tsx
@@ -57,6 +57,7 @@ function day(overrides: Partial<GridDay> = {}): GridDay {
   return {
     session_slot_id: 1,
     session_id: 11,
+    session_ids: { "1": 11 },
     day_number: 1,
     name: "Lower",
     bias: "Quad bias",

--- a/frontend/designer/src/components/MesoTable.tsx
+++ b/frontend/designer/src/components/MesoTable.tsx
@@ -54,6 +54,7 @@ import type { GridCellPatch, Id } from "../hooks/useGrid";
 import { useTableNav, tableCellDomKey, tableCellAriaLabel } from "../hooks/useTableNav";
 import type { EditableField, UseTableNavResult } from "../hooks/useTableNav";
 import type { TableDragData, TableDragEndEvent } from "../hooks/useTableReorder";
+import { TABLE_DAY_DRAG_PREFIX, tableDayDragId, tableRowDragId, tableRowDragPrefix } from "../lib/tableDragIds";
 
 export interface MesoTableProps {
   grid: MesoGrid | null;
@@ -99,20 +100,23 @@ type Armed = { type: ArmedKind; id: Id } | null;
 
 // Issue #455 phase A2: sortable ids are "day-<sessionSlotId>" and
 // "row-<daySlotId>-<exerciseSlotId>" (id-string encoded, mirroring
-// WeekGrid.tsx's "day-"/"ex-" prefix convention). A day drag targets only
-// day containers; a row drag targets only ROW containers of its OWN day —
-// cross-day row moves are OUT of scope for A2 (decisions 5/7), enforced
-// here at the collision-filter layer (and independently again inside
-// useTableReorder's onDragEnd). Unlike WeekGrid's exercise-active filter
-// (which keeps day containers too, for the one-week grid's exercise-over-
-// day append path), the table has no cross-type drop target at all in A2.
+// WeekGrid.tsx's "day-"/"ex-" prefix convention) — built EXCLUSIVELY via
+// tableDayDragId/tableRowDragId (../lib/tableDragIds), the single source of
+// truth for this encoding (Codex #455 A2 review finding 1). A day drag
+// targets only day containers; a row drag targets only ROW containers of
+// its OWN day — cross-day row moves are OUT of scope for A2 (decisions
+// 5/7), enforced here at the collision-filter layer (and independently
+// again inside useTableReorder's onDragEnd, off TableDragData — never off
+// these strings). Unlike WeekGrid's exercise-active filter (which keeps day
+// containers too, for the one-week grid's exercise-over-day append path),
+// the table has no cross-type drop target at all in A2.
 export function filterTableDragCandidates<T extends { id: unknown }>(activeId: unknown, containers: T[]): T[] {
   const activeIdStr = String(activeId);
-  if (activeIdStr.startsWith("day-")) {
-    return containers.filter((c) => String(c.id).startsWith("day-"));
+  if (activeIdStr.startsWith(TABLE_DAY_DRAG_PREFIX)) {
+    return containers.filter((c) => String(c.id).startsWith(TABLE_DAY_DRAG_PREFIX));
   }
-  const daySlotId = activeIdStr.split("-")[1];
-  return containers.filter((c) => String(c.id).startsWith(`row-${daySlotId}-`));
+  const daySlotId = activeIdStr.split("-")[1] ?? "";
+  return containers.filter((c) => String(c.id).startsWith(tableRowDragPrefix(daySlotId)));
 }
 
 // Same type/scope filtering at the collision layer as
@@ -581,7 +585,7 @@ function TableRow({
     exerciseSlotId: row.exercise_slot_id,
   };
   const { attributes, listeners, setNodeRef, setActivatorNodeRef, isDragging } = useSortable({
-    id: `row-${day.session_slot_id}-${row.exercise_slot_id}`,
+    id: tableRowDragId(day.session_slot_id, row.exercise_slot_id),
     data: dragData,
     disabled: busy,
   });
@@ -776,7 +780,7 @@ function TableDayBlock({
   const dayArmed = isArmed("day", day.session_slot_id);
   const dragData: TableDragData = { type: "day", sessionSlotId: day.session_slot_id };
   const { attributes, listeners, setNodeRef, setActivatorNodeRef, isDragging } = useSortable({
-    id: `day-${day.session_slot_id}`,
+    id: tableDayDragId(day.session_slot_id),
     data: dragData,
     disabled: busy,
   });
@@ -863,7 +867,7 @@ function TableDayBlock({
           </thead>
           <tbody>
             <SortableContext
-              items={day.rows.map((r) => `row-${day.session_slot_id}-${r.exercise_slot_id}`)}
+              items={day.rows.map((r) => tableRowDragId(day.session_slot_id, r.exercise_slot_id))}
               strategy={verticalListSortingStrategy}
             >
               {day.rows.map((row) => (
@@ -1045,7 +1049,7 @@ export function MesoTable(props: MesoTableProps) {
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
       >
-        <SortableContext items={grid.days.map((d) => `day-${d.session_slot_id}`)} strategy={verticalListSortingStrategy}>
+        <SortableContext items={grid.days.map((d) => tableDayDragId(d.session_slot_id))} strategy={verticalListSortingStrategy}>
           {grid.days.map((day) => (
             <TableDayBlock
               key={day.session_slot_id}

--- a/frontend/designer/src/components/MesoTable.tsx
+++ b/frontend/designer/src/components/MesoTable.tsx
@@ -43,7 +43,8 @@ import {
   DragOverlay,
   KeyboardSensor,
   PointerSensor,
-  closestCenter,
+  pointerWithin,
+  rectIntersection,
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
@@ -120,14 +121,21 @@ export function filterTableDragCandidates<T extends { id: unknown }>(activeId: u
 }
 
 // Same type/scope filtering at the collision layer as
-// filterTableDragCandidates above — a lifted day block's center can stay
-// closest to its OWN slot (blocks are tall), so `over` never reaches the
-// neighbor even when the keyboard getter proposes its coordinates.
-export const tableCollisionDetection: CollisionDetection = (args) =>
-  closestCenter({
-    ...args,
-    droppableContainers: filterTableDragCandidates(args.active.id, args.droppableContainers),
-  });
+// filterTableDragCandidates above. INTERSECTION-based on purpose, with NO
+// closest-center fallback: closestCenter always returns the nearest
+// candidate even when the drop lands nowhere near it, which would turn an
+// unsupported cross-day drop (candidates are same-day only) into a phantom
+// same-day reorder against whichever row happened to be nearest (Codex
+// #455 A2 review). Outside every candidate → no collision → `over` stays
+// null → the drop no-ops. pointerWithin first (precise for real pointer
+// drags), rectIntersection as the fallback (keyboard drags move the overlay
+// rect with no pointer coordinates).
+export const tableCollisionDetection: CollisionDetection = (args) => {
+  const droppableContainers = filterTableDragCandidates(args.active.id, args.droppableContainers);
+  const within = pointerWithin({ ...args, droppableContainers });
+  if (within.length > 0) return within;
+  return rectIntersection({ ...args, droppableContainers });
+};
 
 // Ported verbatim-adapted from WeekGrid.tsx's typedKeyboardCoordinates:
 // DroppableContainersMap is a real Map subclass — a spread/assign clone

--- a/frontend/designer/src/components/MesoTable.tsx
+++ b/frontend/designer/src/components/MesoTable.tsx
@@ -18,15 +18,42 @@
 // RowNameEditor as a required prop (they're module-private, so there's no
 // INERT-fallback case to support).
 //
-// P1: deferred (see docs/archive/meso/fixed-selection-plan.md) — dnd-kit
-// drag reordering, in-cell group override editor / one-rm editor,
-// agent-chat wiring, coachmarks. Swap/skip/add-this-week WRITE UX is P2 —
-// this file only ever DISPLAYS swap_name/skipped.
+// Drag reordering (issue #455 A2) — row + day — is owned by useTableReorder
+// (a sibling of DesignerRoot's instantiation, NOT this file): MesoTable only
+// wires up dnd-kit's DndContext/sensors/DragOverlay and the two drag
+// handles, translating dnd-kit's real DragEndEvent into the pure
+// TableDragEndEvent shape and forwarding it to the optional `onDragEnd`
+// prop, mirroring WeekGrid.tsx's onDragEnd/handleDragEnd split exactly.
+// Cross-day row moves are OUT of scope for this phase (see
+// useTableReorder.ts's header) — enforced at the collision-filter layer
+// below (filterTableDragCandidates) so a row drag never even collides with
+// another day's rows. No live CSS.Transform on a <tr> or a day block (a
+// transformed row inside border-collapse + a sticky first column, or a
+// transformed block inside .meso-table-scroll's overflow-x:auto, are both
+// known cross-browser glitches, unverifiable in jsdom) — a DragOverlay ghost
+// plus `.is-dragging` opacity only.
+//
+// P1: deferred (see docs/archive/meso/fixed-selection-plan.md) — in-cell
+// group override editor / one-rm editor, agent-chat wiring, coachmarks.
+// Swap/skip/add-this-week WRITE UX is P2 — this file only ever DISPLAYS
+// swap_name/skipped.
 import { useEffect, useRef, useState } from "react";
+import {
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import type { CollisionDetection, DragEndEvent, DragStartEvent, KeyboardCoordinateGetter } from "@dnd-kit/core";
+import { SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import type { GridCell, GridDay, GridHistory, GridRow, GridWeek, GroupIdentity, MesoGrid } from "../lib/api";
 import type { GridCellPatch, Id } from "../hooks/useGrid";
 import { useTableNav, tableCellDomKey, tableCellAriaLabel } from "../hooks/useTableNav";
 import type { EditableField, UseTableNavResult } from "../hooks/useTableNav";
+import type { TableDragData, TableDragEndEvent } from "../hooks/useTableReorder";
 
 export interface MesoTableProps {
   grid: MesoGrid | null;
@@ -57,6 +84,11 @@ export interface MesoTableProps {
   onSwapCell(cellId: number, swapName: string): void;
   onFillAcrossWeeks(cellId: number): void;
   onAddExerciseThisWeek(day: GridDay, weekId: number): void;
+  // Issue #455 phase A2 (drag reordering): optional, with a no-op fallback
+  // in handleDragEnd below — mirrors WeekGrid.tsx's onDragEnd prop, so
+  // MesoTable.test.tsx's existing baseProps() (which never sets it) keeps
+  // passing untouched.
+  onDragEnd?(event: TableDragEndEvent): void;
 }
 
 /** The single arm/confirm slot — mirrors usePlanData's PendingDelete
@@ -64,6 +96,56 @@ export interface MesoTableProps {
  * remove verbs fire the mutation directly with no confirm step of their own. */
 type ArmedKind = "exercise" | "day" | "week";
 type Armed = { type: ArmedKind; id: Id } | null;
+
+// Issue #455 phase A2: sortable ids are "day-<sessionSlotId>" and
+// "row-<daySlotId>-<exerciseSlotId>" (id-string encoded, mirroring
+// WeekGrid.tsx's "day-"/"ex-" prefix convention). A day drag targets only
+// day containers; a row drag targets only ROW containers of its OWN day —
+// cross-day row moves are OUT of scope for A2 (decisions 5/7), enforced
+// here at the collision-filter layer (and independently again inside
+// useTableReorder's onDragEnd). Unlike WeekGrid's exercise-active filter
+// (which keeps day containers too, for the one-week grid's exercise-over-
+// day append path), the table has no cross-type drop target at all in A2.
+export function filterTableDragCandidates<T extends { id: unknown }>(activeId: unknown, containers: T[]): T[] {
+  const activeIdStr = String(activeId);
+  if (activeIdStr.startsWith("day-")) {
+    return containers.filter((c) => String(c.id).startsWith("day-"));
+  }
+  const daySlotId = activeIdStr.split("-")[1];
+  return containers.filter((c) => String(c.id).startsWith(`row-${daySlotId}-`));
+}
+
+// Same type/scope filtering at the collision layer as
+// filterTableDragCandidates above — a lifted day block's center can stay
+// closest to its OWN slot (blocks are tall), so `over` never reaches the
+// neighbor even when the keyboard getter proposes its coordinates.
+export const tableCollisionDetection: CollisionDetection = (args) =>
+  closestCenter({
+    ...args,
+    droppableContainers: filterTableDragCandidates(args.active.id, args.droppableContainers),
+  });
+
+// Ported verbatim-adapted from WeekGrid.tsx's typedKeyboardCoordinates:
+// DroppableContainersMap is a real Map subclass — a spread/assign clone
+// borrows its prototype WITHOUT Map internal slots, and .get() then throws
+// "called on incompatible receiver". Delegate every member to the original
+// map (methods bound to it), overriding only getEnabled with the filter.
+export const tableKeyboardCoordinates: KeyboardCoordinateGetter = (event, args) => {
+  const containers = args.context.droppableContainers;
+  const filtered = new Proxy(containers, {
+    get(target, prop) {
+      if (prop === "getEnabled") {
+        return () => filterTableDragCandidates(args.context.active?.id ?? "", target.getEnabled());
+      }
+      const value = Reflect.get(target, prop, target);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+  return sortableKeyboardCoordinates(event, {
+    ...args,
+    context: { ...args.context, droppableContainers: filtered },
+  });
+};
 
 function draftFrom(cell: GridCell): Record<EditableField, string> {
   return { sets: cell.sets, reps: cell.reps, load: cell.load, rpe: cell.rpe, rest: cell.rest, note: cell.note };
@@ -448,6 +530,389 @@ function AddThisWeekControl({ day, weeks, busy, onAddExerciseThisWeek }: AddThis
   );
 }
 
+interface TableRowProps {
+  row: GridRow;
+  day: GridDay;
+  weeks: GridWeek[];
+  busy: boolean;
+  unit: string;
+  showAdjust: boolean;
+  tableNav: UseTableNavResult;
+  rowArmed: boolean;
+  onArmRow(): void;
+  onConfirmRemoveRow(): void;
+  onCancelRemoveRow(): void;
+  onOpenOverride(row: GridRow, cell: GridCell): void;
+  onPatchCell(cellId: Id, patch: GridCellPatch): void;
+  onRenameExercise(exerciseSlotId: Id, name: string): void;
+  onSkipCell(cellId: number, skipped: boolean): void;
+  onSwapCell(cellId: number, swapName: string): void;
+  onFillAcrossWeeks(cellId: number): void;
+}
+
+/** Issue #455 phase A2: one exercise row — now a dnd-kit sortable item
+ * within its day's own row SortableContext. Drag LISTENERS are bound only
+ * to the handle button (dnd-kit's documented "drag handle" pattern, mirrors
+ * ExerciseRow.tsx) — a click/drag anywhere else in the row (a cell input, a
+ * badge) never starts a drag. No live CSS.Transform on the <tr> (see this
+ * file's header) — only the `.is-dragging` opacity class. */
+function TableRow({
+  row,
+  day,
+  weeks,
+  busy,
+  unit,
+  showAdjust,
+  tableNav,
+  rowArmed,
+  onArmRow,
+  onConfirmRemoveRow,
+  onCancelRemoveRow,
+  onOpenOverride,
+  onPatchCell,
+  onRenameExercise,
+  onSkipCell,
+  onSwapCell,
+  onFillAcrossWeeks,
+}: TableRowProps) {
+  const dragData: TableDragData = {
+    type: "row",
+    daySlotId: day.session_slot_id,
+    exerciseSlotId: row.exercise_slot_id,
+  };
+  const { attributes, listeners, setNodeRef, setActivatorNodeRef, isDragging } = useSortable({
+    id: `row-${day.session_slot_id}-${row.exercise_slot_id}`,
+    data: dragData,
+    disabled: busy,
+  });
+
+  return (
+    <tr
+      ref={setNodeRef}
+      className={isDragging ? "is-dragging" : undefined}
+      data-testid={`meso-row-${row.exercise_slot_id}`}
+    >
+      <td className="meso-table-row-name-col">
+        <button
+          type="button"
+          ref={setActivatorNodeRef}
+          data-testid={`row-drag-${row.exercise_slot_id}`}
+          className="meso-drag-handle"
+          aria-label={`Reorder ${row.name || "exercise"}`}
+          disabled={busy}
+          {...attributes}
+          {...listeners}
+        >
+          ⠿
+        </button>
+        <RowNameEditor row={row} tableNav={tableNav} onRename={onRenameExercise} />
+        {!rowArmed && (
+          <button
+            type="button"
+            data-testid={`remove-exercise-${row.exercise_slot_id}`}
+            className="meso-remove-x meso-remove-x--sm"
+            disabled={busy}
+            aria-label="Remove exercise"
+            title="Remove exercise"
+            onClick={onArmRow}
+          >
+            ×
+          </button>
+        )}
+        {rowArmed && (
+          <span className="meso-confirm-pair">
+            <button
+              type="button"
+              data-testid={`confirm-remove-exercise-${row.exercise_slot_id}`}
+              className="meso-confirm-btn"
+              disabled={busy}
+              aria-label="Confirm remove exercise"
+              onClick={onConfirmRemoveRow}
+            >
+              Confirm?
+            </button>
+            <button
+              type="button"
+              data-testid={`cancel-remove-exercise-${row.exercise_slot_id}`}
+              className="meso-cancel-btn"
+              disabled={busy}
+              aria-label="Cancel remove exercise"
+              onClick={onCancelRemoveRow}
+            >
+              Cancel
+            </button>
+          </span>
+        )}
+      </td>
+      {weeks.map((week) => {
+        const cell = row.cells[String(week.id)];
+        const testId = `cell-${row.exercise_slot_id}-${week.id}`;
+        if (!cell) return <td key={week.id} data-testid={testId} />;
+        return (
+          <td key={week.id} data-testid={testId} className="meso-table-cell">
+            {cell.skipped ? (
+              <>
+                <span className="meso-table-skipped" data-testid={`cell-skipped-${cell.prescription_id}`}>
+                  —
+                </span>
+                <button
+                  type="button"
+                  data-testid={`cell-unskip-${cell.prescription_id}`}
+                  className="meso-cell-action-btn"
+                  disabled={busy}
+                  aria-label="Unskip this week"
+                  title="Unskip this week"
+                  onClick={() => onSkipCell(cell.prescription_id, false)}
+                >
+                  Unskip
+                </button>
+              </>
+            ) : (
+              <>
+                <GridCellEditor cell={cell} unit={unit} row={row} week={week} tableNav={tableNav} onPatchCell={onPatchCell} />
+                {cell.swap_display && (
+                  <span
+                    className="meso-table-swap-badge"
+                    data-testid={`cell-swap-${cell.prescription_id}`}
+                    title={"Swapped for " + cell.swap_display + " this week"}
+                  >
+                    {cell.swap_display}
+                    <button
+                      type="button"
+                      data-testid={`cell-swap-clear-${cell.prescription_id}`}
+                      className="meso-swap-badge-clear"
+                      disabled={busy}
+                      aria-label="Clear swap"
+                      title="Clear swap"
+                      onClick={() => onSwapCell(cell.prescription_id, "")}
+                    >
+                      ×
+                    </button>
+                  </span>
+                )}
+                {showAdjust && (
+                  <button
+                    type="button"
+                    data-testid={`cell-override-badge-${cell.prescription_id}`}
+                    data-hover="brighten"
+                    className="meso-adjust-badge"
+                    onClick={() => onOpenOverride(row, cell)}
+                    title={
+                      cell.adj
+                        ? (cell.adjusts || []).map((a) => (a.name || "") + ": " + (a.label || "")).join("\n")
+                        : "Set a per-athlete adjust"
+                    }
+                  >
+                    {cell.adj ? cell.adj : <span className="meso-adjust-empty">+ adjust</span>}
+                  </button>
+                )}
+                <CellActions
+                  cell={cell}
+                  busy={busy}
+                  onSkipCell={onSkipCell}
+                  onSwapCell={onSwapCell}
+                  onFillAcrossWeeks={onFillAcrossWeeks}
+                />
+              </>
+            )}
+          </td>
+        );
+      })}
+    </tr>
+  );
+}
+
+interface TableDayBlockProps {
+  day: GridDay;
+  weeks: GridWeek[];
+  busy: boolean;
+  unit: string;
+  showAdjust: boolean;
+  tableNav: UseTableNavResult;
+  isArmed(type: ArmedKind, id: Id): boolean;
+  arm(type: ArmedKind, id: Id): void;
+  disarm(): void;
+  onOpenOverride(row: GridRow, cell: GridCell): void;
+  onPatchCell(cellId: Id, patch: GridCellPatch): void;
+  onRenameExercise(exerciseSlotId: Id, name: string): void;
+  onAddExercise(day: GridDay): void;
+  onRemoveExercise(exerciseSlotId: Id): void;
+  onRemoveDay(day: GridDay): void;
+  onSetCurrentWeek(weekId: Id): void;
+  onRemoveWeek(weekId: Id): void;
+  onSkipCell(cellId: number, skipped: boolean): void;
+  onSwapCell(cellId: number, swapName: string): void;
+  onFillAcrossWeeks(cellId: number): void;
+  onAddExerciseThisWeek(day: GridDay, weekId: number): void;
+}
+
+/** Issue #455 phase A2: one training day's table — now also a dnd-kit
+ * sortable item within the block's own day-strip SortableContext (mirrors
+ * DayCard.tsx). Same no-live-transform rule as TableRow above — only
+ * `.is-dragging` opacity, no CSS.Transform on the block itself. */
+function TableDayBlock({
+  day,
+  weeks,
+  busy,
+  unit,
+  showAdjust,
+  tableNav,
+  isArmed,
+  arm,
+  disarm,
+  onOpenOverride,
+  onPatchCell,
+  onRenameExercise,
+  onAddExercise,
+  onRemoveExercise,
+  onRemoveDay,
+  onSetCurrentWeek,
+  onRemoveWeek,
+  onSkipCell,
+  onSwapCell,
+  onFillAcrossWeeks,
+  onAddExerciseThisWeek,
+}: TableDayBlockProps) {
+  const dayArmed = isArmed("day", day.session_slot_id);
+  const dragData: TableDragData = { type: "day", sessionSlotId: day.session_slot_id };
+  const { attributes, listeners, setNodeRef, setActivatorNodeRef, isDragging } = useSortable({
+    id: `day-${day.session_slot_id}`,
+    data: dragData,
+    disabled: busy,
+  });
+  const dayHandleLabel = `Reorder ${day.name || `Day ${day.day_number}`}`;
+
+  return (
+    <div className={`meso-table-day${isDragging ? " is-dragging" : ""}`} ref={setNodeRef}>
+      <div className="meso-table-day-header">
+        <button
+          type="button"
+          ref={setActivatorNodeRef}
+          data-testid={`day-drag-${day.session_slot_id}`}
+          className="meso-drag-handle"
+          aria-label={dayHandleLabel}
+          disabled={busy}
+          {...attributes}
+          {...listeners}
+        >
+          ⠿
+        </button>
+        <div className="meso-day-name">{day.name}</div>
+        {day.bias && <div className="meso-day-bias">{day.bias}</div>}
+        <div className="meso-flex-spacer" />
+        {!dayArmed && (
+          <button
+            type="button"
+            data-testid={`remove-day-${day.session_slot_id}`}
+            className="meso-remove-x"
+            disabled={busy}
+            aria-label="Remove this day"
+            title="Remove this day"
+            onClick={() => arm("day", day.session_slot_id)}
+          >
+            ×
+          </button>
+        )}
+        {dayArmed && (
+          <span className="meso-confirm-pair">
+            <button
+              type="button"
+              data-testid={`confirm-remove-day-${day.session_slot_id}`}
+              className="meso-confirm-btn"
+              disabled={busy}
+              aria-label="Confirm remove day"
+              onClick={() => {
+                onRemoveDay(day);
+                disarm();
+              }}
+            >
+              Confirm?
+            </button>
+            <button
+              type="button"
+              data-testid={`cancel-remove-day-${day.session_slot_id}`}
+              className="meso-cancel-btn"
+              disabled={busy}
+              aria-label="Cancel remove day"
+              onClick={disarm}
+            >
+              Cancel
+            </button>
+          </span>
+        )}
+      </div>
+
+      <div className="meso-table-scroll">
+        <table className="meso-table" data-testid={`meso-day-table-${day.session_slot_id}`}>
+          <thead>
+            <tr>
+              <th className="meso-table-exercise-col">Exercise</th>
+              {weeks.map((week) => (
+                <WeekColumnHeader
+                  key={week.id}
+                  week={week}
+                  armed={isArmed("week", week.id)}
+                  busy={busy}
+                  onArm={() => arm("week", week.id)}
+                  onDisarm={disarm}
+                  onSetCurrentWeek={onSetCurrentWeek}
+                  onRemoveWeek={onRemoveWeek}
+                />
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            <SortableContext
+              items={day.rows.map((r) => `row-${day.session_slot_id}-${r.exercise_slot_id}`)}
+              strategy={verticalListSortingStrategy}
+            >
+              {day.rows.map((row) => (
+                <TableRow
+                  key={row.exercise_slot_id}
+                  row={row}
+                  day={day}
+                  weeks={weeks}
+                  busy={busy}
+                  unit={unit}
+                  showAdjust={showAdjust}
+                  tableNav={tableNav}
+                  rowArmed={isArmed("exercise", row.exercise_slot_id)}
+                  onArmRow={() => arm("exercise", row.exercise_slot_id)}
+                  onConfirmRemoveRow={() => {
+                    onRemoveExercise(row.exercise_slot_id);
+                    disarm();
+                  }}
+                  onCancelRemoveRow={disarm}
+                  onOpenOverride={onOpenOverride}
+                  onPatchCell={onPatchCell}
+                  onRenameExercise={onRenameExercise}
+                  onSkipCell={onSkipCell}
+                  onSwapCell={onSwapCell}
+                  onFillAcrossWeeks={onFillAcrossWeeks}
+                />
+              ))}
+            </SortableContext>
+          </tbody>
+        </table>
+      </div>
+
+      <div className="meso-table-add-row-group">
+        <button
+          type="button"
+          data-hover="add"
+          className="meso-add-row"
+          data-testid={`add-exercise-${day.session_slot_id}`}
+          disabled={busy}
+          onClick={() => onAddExercise(day)}
+        >
+          + Add exercise
+        </button>
+        <AddThisWeekControl day={day} weeks={weeks} busy={busy} onAddExerciseThisWeek={onAddExerciseThisWeek} />
+      </div>
+    </div>
+  );
+}
+
 export function MesoTable(props: MesoTableProps) {
   const {
     grid,
@@ -471,10 +936,12 @@ export function MesoTable(props: MesoTableProps) {
     onSwapCell,
     onFillAcrossWeeks,
     onAddExerciseThisWeek,
+    onDragEnd,
   } = props;
 
   const [armed, setArmed] = useState<Armed>(null);
   const isArmed = (type: ArmedKind, id: Id) => !!armed && armed.type === type && armed.id === id;
+  const arm = (type: ArmedKind, id: Id) => setArmed({ type, id });
   const disarm = () => setArmed(null);
 
   // P5 group: the per-cell adjust badge only exists on a GROUP plan with
@@ -485,6 +952,47 @@ export function MesoTable(props: MesoTableProps) {
   // below — useTableNav tolerates a null grid the same way (anchor stays
   // null, no throw).
   const tableNav = useTableNav({ grid });
+
+  // Issue #455 phase A2 (drag reordering): PointerSensor gets a small
+  // activation distance so a plain click into a cell input doesn't start a
+  // drag; KeyboardSensor rides the handle buttons' tab-order focus
+  // (Space/Enter lifts, arrows move, Space/Enter drops, Escape cancels) —
+  // mirrors WeekGrid.tsx's sensors exactly, pointed at this file's own
+  // tableKeyboardCoordinates.
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: tableKeyboardCoordinates }),
+  );
+
+  // DragOverlay ghost label — set from the lifted item's own data on drag
+  // start, cleared on drop. No live sibling reflow: rows/days snap to their
+  // new position only once refetchGrid resolves, matching every other
+  // structural verb's UX (skip/add-exercise etc.).
+  const [activeDragLabel, setActiveDragLabel] = useState<string | null>(null);
+
+  function handleDragStart(event: DragStartEvent) {
+    if (!grid) return;
+    const data = event.active.data.current as TableDragData | undefined;
+    if (!data) return;
+    if (data.type === "row") {
+      const activeDay = grid.days.find((d) => d.session_slot_id === data.daySlotId);
+      const activeRow = activeDay?.rows.find((r) => r.exercise_slot_id === data.exerciseSlotId);
+      setActiveDragLabel(activeRow?.name || "exercise");
+    } else {
+      const activeDay = grid.days.find((d) => d.session_slot_id === data.sessionSlotId);
+      setActiveDragLabel(activeDay ? activeDay.name || `Day ${activeDay.day_number}` : "day");
+    }
+  }
+
+  function handleDragEnd(event: DragEndEvent) {
+    setActiveDragLabel(null);
+    if (!onDragEnd) return;
+    const { active, over } = event;
+    onDragEnd({
+      active: { id: active.id, data: { current: active.data.current as TableDragData } },
+      over: over ? { id: over.id, data: { current: over.data.current as TableDragData } } : null,
+    });
+  }
 
   if (!grid) return null;
 
@@ -531,225 +1039,44 @@ export function MesoTable(props: MesoTableProps) {
         </button>
       </div>
 
-      {grid.days.map((day) => {
-        const dayArmed = isArmed("day", day.session_slot_id);
-        return (
-          <div className="meso-table-day" key={day.session_slot_id}>
-            <div className="meso-table-day-header">
-              <div className="meso-day-name">{day.name}</div>
-              {day.bias && <div className="meso-day-bias">{day.bias}</div>}
-              <div className="meso-flex-spacer" />
-              {!dayArmed && (
-                <button
-                  type="button"
-                  data-testid={`remove-day-${day.session_slot_id}`}
-                  className="meso-remove-x"
-                  disabled={busy}
-                  aria-label="Remove this day"
-                  title="Remove this day"
-                  onClick={() => setArmed({ type: "day", id: day.session_slot_id })}
-                >
-                  ×
-                </button>
-              )}
-              {dayArmed && (
-                <span className="meso-confirm-pair">
-                  <button
-                    type="button"
-                    data-testid={`confirm-remove-day-${day.session_slot_id}`}
-                    className="meso-confirm-btn"
-                    disabled={busy}
-                    aria-label="Confirm remove day"
-                    onClick={() => {
-                      onRemoveDay(day);
-                      disarm();
-                    }}
-                  >
-                    Confirm?
-                  </button>
-                  <button
-                    type="button"
-                    data-testid={`cancel-remove-day-${day.session_slot_id}`}
-                    className="meso-cancel-btn"
-                    disabled={busy}
-                    aria-label="Cancel remove day"
-                    onClick={disarm}
-                  >
-                    Cancel
-                  </button>
-                </span>
-              )}
-            </div>
-
-            <div className="meso-table-scroll">
-              <table className="meso-table" data-testid={`meso-day-table-${day.session_slot_id}`}>
-                <thead>
-                  <tr>
-                    <th className="meso-table-exercise-col">Exercise</th>
-                    {grid.weeks.map((week) => (
-                      <WeekColumnHeader
-                        key={week.id}
-                        week={week}
-                        armed={isArmed("week", week.id)}
-                        busy={busy}
-                        onArm={() => setArmed({ type: "week", id: week.id })}
-                        onDisarm={disarm}
-                        onSetCurrentWeek={onSetCurrentWeek}
-                        onRemoveWeek={onRemoveWeek}
-                      />
-                    ))}
-                  </tr>
-                </thead>
-                <tbody>
-                  {day.rows.map((row) => {
-                    const rowArmed = isArmed("exercise", row.exercise_slot_id);
-                    return (
-                      <tr key={row.exercise_slot_id} data-testid={`meso-row-${row.exercise_slot_id}`}>
-                        <td className="meso-table-row-name-col">
-                          <RowNameEditor row={row} tableNav={tableNav} onRename={onRenameExercise} />
-                          {!rowArmed && (
-                            <button
-                              type="button"
-                              data-testid={`remove-exercise-${row.exercise_slot_id}`}
-                              className="meso-remove-x meso-remove-x--sm"
-                              disabled={busy}
-                              aria-label="Remove exercise"
-                              title="Remove exercise"
-                              onClick={() => setArmed({ type: "exercise", id: row.exercise_slot_id })}
-                            >
-                              ×
-                            </button>
-                          )}
-                          {rowArmed && (
-                            <span className="meso-confirm-pair">
-                              <button
-                                type="button"
-                                data-testid={`confirm-remove-exercise-${row.exercise_slot_id}`}
-                                className="meso-confirm-btn"
-                                disabled={busy}
-                                aria-label="Confirm remove exercise"
-                                onClick={() => {
-                                  onRemoveExercise(row.exercise_slot_id);
-                                  disarm();
-                                }}
-                              >
-                                Confirm?
-                              </button>
-                              <button
-                                type="button"
-                                data-testid={`cancel-remove-exercise-${row.exercise_slot_id}`}
-                                className="meso-cancel-btn"
-                                disabled={busy}
-                                aria-label="Cancel remove exercise"
-                                onClick={disarm}
-                              >
-                                Cancel
-                              </button>
-                            </span>
-                          )}
-                        </td>
-                        {grid.weeks.map((week) => {
-                          const cell = row.cells[String(week.id)];
-                          const testId = `cell-${row.exercise_slot_id}-${week.id}`;
-                          if (!cell) return <td key={week.id} data-testid={testId} />;
-                          return (
-                            <td key={week.id} data-testid={testId} className="meso-table-cell">
-                              {cell.skipped ? (
-                                <>
-                                  <span className="meso-table-skipped" data-testid={`cell-skipped-${cell.prescription_id}`}>
-                                    —
-                                  </span>
-                                  <button
-                                    type="button"
-                                    data-testid={`cell-unskip-${cell.prescription_id}`}
-                                    className="meso-cell-action-btn"
-                                    disabled={busy}
-                                    aria-label="Unskip this week"
-                                    title="Unskip this week"
-                                    onClick={() => onSkipCell(cell.prescription_id, false)}
-                                  >
-                                    Unskip
-                                  </button>
-                                </>
-                              ) : (
-                                <>
-                                  <GridCellEditor cell={cell} unit={unit} row={row} week={week} tableNav={tableNav} onPatchCell={onPatchCell} />
-                                  {cell.swap_display && (
-                                    <span
-                                      className="meso-table-swap-badge"
-                                      data-testid={`cell-swap-${cell.prescription_id}`}
-                                      title={"Swapped for " + cell.swap_display + " this week"}
-                                    >
-                                      {cell.swap_display}
-                                      <button
-                                        type="button"
-                                        data-testid={`cell-swap-clear-${cell.prescription_id}`}
-                                        className="meso-swap-badge-clear"
-                                        disabled={busy}
-                                        aria-label="Clear swap"
-                                        title="Clear swap"
-                                        onClick={() => onSwapCell(cell.prescription_id, "")}
-                                      >
-                                        ×
-                                      </button>
-                                    </span>
-                                  )}
-                                  {showAdjust && (
-                                    <button
-                                      type="button"
-                                      data-testid={`cell-override-badge-${cell.prescription_id}`}
-                                      data-hover="brighten"
-                                      className="meso-adjust-badge"
-                                      onClick={() => onOpenOverride(row, cell)}
-                                      title={
-                                        cell.adj
-                                          ? (cell.adjusts || []).map((a) => (a.name || "") + ": " + (a.label || "")).join("\n")
-                                          : "Set a per-athlete adjust"
-                                      }
-                                    >
-                                      {cell.adj ? cell.adj : <span className="meso-adjust-empty">+ adjust</span>}
-                                    </button>
-                                  )}
-                                  <CellActions
-                                    cell={cell}
-                                    busy={busy}
-                                    onSkipCell={onSkipCell}
-                                    onSwapCell={onSwapCell}
-                                    onFillAcrossWeeks={onFillAcrossWeeks}
-                                  />
-                                </>
-                              )}
-                            </td>
-                          );
-                        })}
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
-
-            <div className="meso-table-add-row-group">
-              <button
-                type="button"
-                data-hover="add"
-                className="meso-add-row"
-                data-testid={`add-exercise-${day.session_slot_id}`}
-                disabled={busy}
-                onClick={() => onAddExercise(day)}
-              >
-                + Add exercise
-              </button>
-              <AddThisWeekControl
-                day={day}
-                weeks={grid.weeks}
-                busy={busy}
-                onAddExerciseThisWeek={onAddExerciseThisWeek}
-              />
-            </div>
-          </div>
-        );
-      })}
+      <DndContext
+        sensors={sensors}
+        collisionDetection={tableCollisionDetection}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext items={grid.days.map((d) => `day-${d.session_slot_id}`)} strategy={verticalListSortingStrategy}>
+          {grid.days.map((day) => (
+            <TableDayBlock
+              key={day.session_slot_id}
+              day={day}
+              weeks={grid.weeks}
+              busy={busy}
+              unit={unit}
+              showAdjust={showAdjust}
+              tableNav={tableNav}
+              isArmed={isArmed}
+              arm={arm}
+              disarm={disarm}
+              onOpenOverride={onOpenOverride}
+              onPatchCell={onPatchCell}
+              onRenameExercise={onRenameExercise}
+              onAddExercise={onAddExercise}
+              onRemoveExercise={onRemoveExercise}
+              onRemoveDay={onRemoveDay}
+              onSetCurrentWeek={onSetCurrentWeek}
+              onRemoveWeek={onRemoveWeek}
+              onSkipCell={onSkipCell}
+              onSwapCell={onSwapCell}
+              onFillAcrossWeeks={onFillAcrossWeeks}
+              onAddExerciseThisWeek={onAddExerciseThisWeek}
+            />
+          ))}
+        </SortableContext>
+        <DragOverlay>
+          {activeDragLabel ? <div className="meso-table-drag-ghost">{activeDragLabel}</div> : null}
+        </DragOverlay>
+      </DndContext>
 
       <button
         type="button"

--- a/frontend/designer/src/hooks/useGrid.test.ts
+++ b/frontend/designer/src/hooks/useGrid.test.ts
@@ -485,6 +485,47 @@ describe("concurrency guard on structural ops", () => {
   });
 });
 
+describe("reorder -> undo integration (issue #455 phase A2)", () => {
+  it("a reorder POST's fresh undo_label flows through to a subsequent undo, in the right fetch sequence", async () => {
+    const { result } = setup();
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(res({ ok: true })) // POST reorder
+      .mockResolvedValueOnce(
+        res({
+          ok: true,
+          ...grid({ history: { can_undo: true, can_redo: false, undo_label: "Reordered exercises", redo_label: "" } }),
+        }),
+      ) // GET grid (post-reorder)
+      .mockResolvedValueOnce(res({ ok: true, program: [], weeks: [], phases: [], viewing: null })) // POST undo (its own single-week envelope, ignored)
+      .mockResolvedValueOnce(
+        res({
+          ok: true,
+          ...grid({ history: { can_undo: false, can_redo: true, undo_label: "", redo_label: "Reordered exercises" } }),
+        }),
+      ) as unknown as typeof fetch; // GET grid (post-undo)
+
+    await act(async () => {
+      await result.current.reorderExercises(11, [101, 100]);
+    });
+    expect(result.current.history.undo_label).toBe("Reordered exercises");
+
+    await act(async () => {
+      await result.current.undo();
+    });
+
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls.map((c) => c[0])).toEqual([
+      "/meso/api/plan/7/session/11/reorder/",
+      "/meso/api/plan/7/grid/",
+      "/meso/api/plan/7/undo/",
+      "/meso/api/plan/7/grid/",
+    ]);
+    expect(result.current.history.can_undo).toBe(false);
+    expect(result.current.history.redo_label).toBe("Reordered exercises");
+  });
+});
+
 describe("refetchGrid", () => {
   it("GETs the grid endpoint (no options) and adopts the reply", async () => {
     const { result } = setup();
@@ -512,6 +553,65 @@ describe("refetchGrid", () => {
 
     expect(console.error).toHaveBeenCalled();
     expect(result.current.grid?.mesocycle.name).toBe("Block 1");
+  });
+});
+
+// --- Issue #455 phase A2: drag reordering ---------------------------------
+// reorderExercises/reorderDays are STRUCTURAL, same shape as every verb
+// above: await the POST, then refetch the whole grid, sharing busyRef.
+// useTableReorder (the pure drag-event translator) is the caller; these
+// specs only cover the verbs' own POST/refetch contract.
+
+describe("reorderExercises", () => {
+  it("POSTs {order} to session/{sessionId}/reorder/, then refetches the grid", async () => {
+    const { result } = setup();
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(res({ ok: true }))
+      .mockResolvedValueOnce(res({ ok: true, ...grid() })) as unknown as typeof fetch;
+
+    await act(async () => {
+      await result.current.reorderExercises(11, [201, 202]);
+    });
+
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0]![0]).toBe("/meso/api/plan/7/session/11/reorder/");
+    expect(calls[0]![1].method).toBe("POST");
+    expect(sentBody()).toEqual({ order: [201, 202] });
+    expect(calls[1]![0]).toBe("/meso/api/plan/7/grid/");
+  });
+
+  it("console.errors and does not refetch on POST failure", async () => {
+    const { result } = setup();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("boom")) as unknown as typeof fetch;
+
+    await act(async () => {
+      await result.current.reorderExercises(11, [201, 202]);
+    });
+
+    expect(console.error).toHaveBeenCalled();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1); // no refetch after a failed POST
+  });
+});
+
+describe("reorderDays", () => {
+  it("POSTs {order} to week/{weekId}/reorder/, then refetches the grid", async () => {
+    const { result } = setup();
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(res({ ok: true }))
+      .mockResolvedValueOnce(res({ ok: true, ...grid() })) as unknown as typeof fetch;
+
+    await act(async () => {
+      await result.current.reorderDays(1, [10, 11]);
+    });
+
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0]![0]).toBe("/meso/api/plan/7/week/1/reorder/");
+    expect(calls[0]![1].method).toBe("POST");
+    expect(sentBody()).toEqual({ order: [10, 11] });
+    expect(calls[1]![0]).toBe("/meso/api/plan/7/grid/");
   });
 });
 
@@ -713,6 +813,40 @@ describe("concurrency guard covers the new P2 verbs", () => {
     act(() => {
       first = result.current.skipCell(100, true);
       second = result.current.swapCell(100, "Leg Press");
+    });
+
+    expect(result.current.busy).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // the second call bailed before POSTing
+
+    fetchMock.mockResolvedValueOnce(res({ ok: true, ...grid() })); // the refetch GET
+
+    await act(async () => {
+      resolvePost(res({ ok: true }));
+      await first;
+      await second;
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2); // POST + GET only — no third/fourth call
+    expect(result.current.busy).toBe(false);
+  });
+
+  it("reorderExercises (issue #455 phase A2) also shares the busyRef guard", async () => {
+    const { result } = setup();
+    let resolvePost!: (v: unknown) => void;
+    const fetchMock = vi.fn();
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolvePost = resolve;
+        }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    let first!: Promise<void>;
+    let second!: Promise<void>;
+    act(() => {
+      first = result.current.reorderExercises(11, [100]);
+      second = result.current.addWeek();
     });
 
     expect(result.current.busy).toBe(true);

--- a/frontend/designer/src/hooks/useGrid.test.ts
+++ b/frontend/designer/src/hooks/useGrid.test.ts
@@ -56,6 +56,7 @@ function day(overrides: Partial<GridDay> = {}): GridDay {
   return {
     session_slot_id: 1,
     session_id: 11,
+    session_ids: { "1": 11 },
     day_number: 1,
     name: "Lower",
     bias: "",

--- a/frontend/designer/src/hooks/useGrid.ts
+++ b/frontend/designer/src/hooks/useGrid.ts
@@ -331,6 +331,44 @@ export function useGrid(options: UseGridOptions) {
     [planId, csrf, runStructural, refetchGrid],
   );
 
+  // Issue #455 phase A2 (drag reordering): same STRUCTURAL shape as every
+  // verb above — the server owns the authoritative order (block-wide P0
+  // ExerciseSlot/SessionSlot.order), so these await their POST then
+  // refetch the whole grid, sharing busyRef. useTableReorder (the pure
+  // drag-event translator) builds `order` from the CURRENT week's live
+  // cell/session ids and calls these two verbs — see its own header for the
+  // payload contract (mirrors views.py session_reorder/week_reorder_sessions
+  // exactly: `order` must be EXACTLY the live id set for the target session/
+  // week, in the new order).
+
+  const reorderExercises = useCallback(
+    (sessionId: Id, order: number[]) =>
+      runStructural(async () => {
+        try {
+          await apiPost(`/meso/api/plan/${planId}/session/${sessionId}/reorder/`, { order }, csrf);
+        } catch (err) {
+          console.error("Reorder exercises failed", err);
+          return;
+        }
+        await refetchGrid();
+      }),
+    [planId, csrf, runStructural, refetchGrid],
+  );
+
+  const reorderDays = useCallback(
+    (weekId: Id, order: number[]) =>
+      runStructural(async () => {
+        try {
+          await apiPost(`/meso/api/plan/${planId}/week/${weekId}/reorder/`, { order }, csrf);
+        } catch (err) {
+          console.error("Reorder days failed", err);
+          return;
+        }
+        await refetchGrid();
+      }),
+    [planId, csrf, runStructural, refetchGrid],
+  );
+
   // --- P2 exceptions: skip / swap / fill / add-this-week -----------------
   // Same STRUCTURAL shape as add/removeExercise|Day|Week above — the grid
   // (not just one cell) can change shape/content in ways only the server
@@ -445,6 +483,8 @@ export function useGrid(options: UseGridOptions) {
     addWeek,
     removeWeek,
     setCurrentWeek,
+    reorderExercises,
+    reorderDays,
     skipCell,
     swapCell,
     fillAcrossWeeks,

--- a/frontend/designer/src/hooks/useTableNav.test.tsx
+++ b/frontend/designer/src/hooks/useTableNav.test.tsx
@@ -67,6 +67,7 @@ function day(id: number, rows: GridRow[], overrides: Partial<GridDay> = {}): Gri
   return {
     session_slot_id: id,
     session_id: id + 10,
+    session_ids: { "1": id + 10, "2": id + 10 },
     day_number: id,
     name: `Day ${id}`,
     bias: "",

--- a/frontend/designer/src/hooks/useTableReorder.test.ts
+++ b/frontend/designer/src/hooks/useTableReorder.test.ts
@@ -1,0 +1,281 @@
+// Specs for useTableReorder (issue #455 phase A2) — a pure, stateless
+// drag-event -> verb-call translator for MesoTable's row/day reordering.
+// Unlike useReorder (WeekGrid's Phase-4 hook), this hook owns NO state and
+// makes NO fetch of its own: onDragEnd's ONLY job is to read `grid` (passed
+// in whole, mirroring useReorder's `program`) and the hand-built dnd-kit-
+// shaped drop event, then call one of the two injected verbs
+// (`reorderRow`/`reorderDay`, which DesignerRoot wires to useGrid's own
+// `reorderExercises`/`reorderDays` — already awaiting their POST behind
+// useGrid's shared busyRef guard) with the new id order. No fetch mocking
+// needed here — see useGrid.test.ts for the verbs' own POST/refetch specs.
+//
+// === Contract this file pins ===
+// - Drag identity = exercise_slot_id / session_slot_id (P0 block-wide
+//   identity), never prescription_id — a cell's *content* identity is
+//   always resolved fresh from `grid` at drop time (never carried on the
+//   event), mirroring useReorder's dayId/prescriptionId split.
+// - Row order payload = the CURRENT week's (`grid.weeks.find(w =>
+//   w.current)`) live row cells' prescription_ids, in the new order — a row
+//   with no cell for that week (an add-this-week-only hole) is excluded,
+//   mirroring the server's own `session.cells()` query for that week
+//   (views.py `session_reorder`).
+// - Day order payload = the CURRENT week's live Session pks (GridDay.
+//   session_id), in the new order (views.py `week_reorder_sessions`) — a
+//   defensive no-op if ANY live day's session_id is null.
+// - Cross-day row moves are OUT of scope for A2 (own follow-up) — enforced
+//   here as a second, independent guard even though MesoTable's own
+//   collision filter (filterTableDragCandidates) should already keep a row
+//   drag from colliding with another day's rows in the first place.
+import { renderHook } from "@testing-library/react";
+import { useTableReorder } from "./useTableReorder";
+import type { TableDragEndEvent } from "./useTableReorder";
+import type { GridCell, GridDay, GridRow, GridWeek, MesoGrid } from "../lib/api";
+import type { Id } from "./useGrid";
+
+function week(overrides: Partial<GridWeek> = {}): GridWeek {
+  return {
+    id: 1,
+    index: 0,
+    label: "Wk 1",
+    phase: "Accum",
+    deload: false,
+    current: true,
+    delivered_at: null,
+    ...overrides,
+  };
+}
+
+function cell(overrides: Partial<GridCell> = {}): GridCell {
+  return {
+    prescription_id: 100,
+    sets: "3",
+    reps: "5",
+    load: "100",
+    load_type: "abs",
+    rpe: "8",
+    rest: "90",
+    note: "",
+    skipped: false,
+    swap_name: "",
+    swap_exercise_id: null,
+    swap_display: "",
+    ...overrides,
+  };
+}
+
+function row(overrides: Partial<GridRow> = {}): GridRow {
+  return {
+    exercise_slot_id: 9,
+    name: "Squat",
+    exercise_id: 55,
+    order: 0,
+    tags: [],
+    cells: { "1": cell() },
+    ...overrides,
+  };
+}
+
+function day(overrides: Partial<GridDay> = {}): GridDay {
+  return {
+    session_slot_id: 1,
+    session_id: 11,
+    day_number: 1,
+    name: "Lower",
+    bias: "",
+    order: 0,
+    rows: [row()],
+    ...overrides,
+  };
+}
+
+function grid(overrides: Partial<MesoGrid> = {}): MesoGrid {
+  return {
+    mesocycle: { id: 1, plan_id: 7, name: "Block 1", week_count: 1 },
+    weeks: [week()],
+    days: [day()],
+    history: { can_undo: false, can_redo: false, undo_label: "", redo_label: "" },
+    ...overrides,
+  };
+}
+
+/** Builds a dnd-kit-shaped row drag event — see useTableReorder.ts's
+ * `TableDragData` union. `overDaySlotId` defaults to the active row's own
+ * day (the common within-day case); pass a different one to build a
+ * cross-day drop for the scope-guard spec. */
+function rowDragEvent(
+  activeExerciseSlotId: Id,
+  activeDaySlotId: Id,
+  overExerciseSlotId: Id | null,
+  overDaySlotId: Id = activeDaySlotId,
+): TableDragEndEvent {
+  return {
+    active: {
+      id: activeExerciseSlotId,
+      data: { current: { type: "row", daySlotId: activeDaySlotId, exerciseSlotId: activeExerciseSlotId } },
+    },
+    over:
+      overExerciseSlotId == null
+        ? null
+        : {
+            id: overExerciseSlotId,
+            data: { current: { type: "row", daySlotId: overDaySlotId, exerciseSlotId: overExerciseSlotId } },
+          },
+  };
+}
+
+/** Builds a dnd-kit-shaped day-strip drag event. */
+function dayDragEvent(activeSessionSlotId: Id, overSessionSlotId: Id | null): TableDragEndEvent {
+  return {
+    active: { id: activeSessionSlotId, data: { current: { type: "day", sessionSlotId: activeSessionSlotId } } },
+    over:
+      overSessionSlotId == null
+        ? null
+        : { id: overSessionSlotId, data: { current: { type: "day", sessionSlotId: overSessionSlotId } } },
+  };
+}
+
+function setup(g: MesoGrid | null) {
+  const reorderRow = vi.fn();
+  const reorderDay = vi.fn();
+  const { result } = renderHook(() => useTableReorder({ grid: g, reorderRow, reorderDay }));
+  return { onDragEnd: result.current.onDragEnd, reorderRow, reorderDay };
+}
+
+describe("within-day row reorder", () => {
+  it("calls reorderRow with the day's session_id and the current week's cell ids in the new order", () => {
+    const g = grid({
+      days: [
+        day({
+          session_slot_id: 1,
+          session_id: 11,
+          rows: [
+            row({ exercise_slot_id: 9, cells: { "1": cell({ prescription_id: 900 }) } }),
+            row({ exercise_slot_id: 10, cells: { "1": cell({ prescription_id: 1000 }) } }),
+          ],
+        }),
+      ],
+    });
+    const { onDragEnd, reorderRow } = setup(g);
+    onDragEnd(rowDragEvent(9, 1, 10));
+    expect(reorderRow).toHaveBeenCalledWith(11, [1000, 900]);
+  });
+
+  it("arrayMove semantics: a 3-row day, moving row1 past row2, orders as [row2, row1, row3]", () => {
+    const g = grid({
+      days: [
+        day({
+          session_slot_id: 1,
+          session_id: 11,
+          rows: [
+            row({ exercise_slot_id: 9, cells: { "1": cell({ prescription_id: 900 }) } }),
+            row({ exercise_slot_id: 10, cells: { "1": cell({ prescription_id: 1000 }) } }),
+            row({ exercise_slot_id: 12, cells: { "1": cell({ prescription_id: 1200 }) } }),
+          ],
+        }),
+      ],
+    });
+    const { onDragEnd, reorderRow } = setup(g);
+    onDragEnd(rowDragEvent(9, 1, 10));
+    expect(reorderRow).toHaveBeenCalledWith(11, [1000, 900, 1200]);
+  });
+
+  it("excludes a hole row (no cell for the current week) from the posted order array", () => {
+    const g = grid({
+      days: [
+        day({
+          session_slot_id: 1,
+          session_id: 11,
+          rows: [
+            row({ exercise_slot_id: 9, cells: { "1": cell({ prescription_id: 900 }) } }),
+            row({ exercise_slot_id: 10, cells: {} }), // add-this-week-only hole: no cell for week 1
+            row({ exercise_slot_id: 12, cells: { "1": cell({ prescription_id: 1200 }) } }),
+          ],
+        }),
+      ],
+    });
+    const { onDragEnd, reorderRow } = setup(g);
+    onDragEnd(rowDragEvent(9, 1, 12));
+    expect(reorderRow).toHaveBeenCalledWith(11, [1200, 900]);
+  });
+});
+
+describe("day reorder", () => {
+  it("calls reorderDay with the current week's id and the block's session ids in the new order", () => {
+    const g = grid({
+      weeks: [week({ id: 1, current: true })],
+      days: [day({ session_slot_id: 1, session_id: 11 }), day({ session_slot_id: 2, session_id: 22 })],
+    });
+    const { onDragEnd, reorderDay } = setup(g);
+    onDragEnd(dayDragEvent(1, 2));
+    expect(reorderDay).toHaveBeenCalledWith(1, [22, 11]);
+  });
+
+  it("no-ops when any live day's session_id is null", () => {
+    const g = grid({
+      days: [day({ session_slot_id: 1, session_id: 11 }), day({ session_slot_id: 2, session_id: null })],
+    });
+    const { onDragEnd, reorderDay } = setup(g);
+    onDragEnd(dayDragEvent(1, 2));
+    expect(reorderDay).not.toHaveBeenCalled();
+  });
+});
+
+describe("cross-day scope guard", () => {
+  it("no-ops a row dropped over a row belonging to a DIFFERENT day (A2 defers cross-day moves)", () => {
+    const g = grid({
+      days: [
+        day({ session_slot_id: 1, session_id: 11, rows: [row({ exercise_slot_id: 9 })] }),
+        day({
+          session_slot_id: 2,
+          session_id: 22,
+          rows: [row({ exercise_slot_id: 20, cells: { "1": cell({ prescription_id: 2000 }) } })],
+        }),
+      ],
+    });
+    const { onDragEnd, reorderRow } = setup(g);
+    onDragEnd(rowDragEvent(9, 1, 20, 2));
+    expect(reorderRow).not.toHaveBeenCalled();
+  });
+});
+
+describe("no-op drops", () => {
+  it("does nothing when over is null", () => {
+    const { onDragEnd, reorderRow, reorderDay } = setup(grid());
+    onDragEnd(rowDragEvent(9, 1, null));
+    expect(reorderRow).not.toHaveBeenCalled();
+    expect(reorderDay).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when active and over are the same item", () => {
+    const { onDragEnd, reorderRow } = setup(grid());
+    onDragEnd(rowDragEvent(9, 1, 9));
+    expect(reorderRow).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when there is no current week", () => {
+    const g = grid({
+      weeks: [week({ id: 1, current: false })],
+      days: [
+        day({
+          session_slot_id: 1,
+          session_id: 11,
+          rows: [
+            row({ exercise_slot_id: 9, cells: { "1": cell({ prescription_id: 900 }) } }),
+            row({ exercise_slot_id: 10, cells: { "1": cell({ prescription_id: 1000 }) } }),
+          ],
+        }),
+      ],
+    });
+    const { onDragEnd, reorderRow } = setup(g);
+    onDragEnd(rowDragEvent(9, 1, 10));
+    expect(reorderRow).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when grid is null", () => {
+    const { onDragEnd, reorderRow, reorderDay } = setup(null);
+    onDragEnd(rowDragEvent(9, 1, 10));
+    onDragEnd(dayDragEvent(1, 2));
+    expect(reorderRow).not.toHaveBeenCalled();
+    expect(reorderDay).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/designer/src/hooks/useTableReorder.test.ts
+++ b/frontend/designer/src/hooks/useTableReorder.test.ts
@@ -19,18 +19,34 @@
 //   with no cell for that week (an add-this-week-only hole) is excluded,
 //   mirroring the server's own `session.cells()` query for that week
 //   (views.py `session_reorder`).
-// - Day order payload = the CURRENT week's live Session pks (GridDay.
-//   session_id), in the new order (views.py `week_reorder_sessions`) — a
-//   defensive no-op if ANY live day's session_id is null.
+// - Day order payload = the CURRENT week's live Session pks, read from EACH
+//   day's OWN `GridDay.session_ids[String(currentWeekId)]` (views.py
+//   `week_reorder_sessions`) — never the display-only `GridDay.session_id`,
+//   which can silently fall back to a DIFFERENT week's session
+//   (`_pick_session_id`, serializers.py) and would 400 server-side if
+//   posted. Defensive no-op if ANY live day lacks a `session_ids` entry for
+//   the current week.
 // - Cross-day row moves are OUT of scope for A2 (own follow-up) — enforced
 //   here as a second, independent guard even though MesoTable's own
 //   collision filter (filterTableDragCandidates) should already keep a row
 //   drag from colliding with another day's rows in the first place.
+//
+// === Fixture truthfulness (Codex #455 A2 review finding 1) ===
+// Every event's top-level `id` below is built with `tableRowDragId`/
+// `tableDayDragId` — the SAME exported builders the real MesoTable.tsx uses
+// at its useSortable/SortableContext call sites (../lib/tableDragIds) — NOT
+// bare numeric slot ids. The old fixtures here used bare numeric ids, which
+// made every spec pass against a hook that read `active.id`/`over.id`
+// directly as if they WERE the numeric slot ids; the real MesoTable never
+// emits an id shaped that way (it's always the encoded string), so every
+// real drop silently no-op'd. Building ids the real way here is what
+// catches that class of bug.
 import { renderHook } from "@testing-library/react";
 import { useTableReorder } from "./useTableReorder";
 import type { TableDragEndEvent } from "./useTableReorder";
 import type { GridCell, GridDay, GridRow, GridWeek, MesoGrid } from "../lib/api";
 import type { Id } from "./useGrid";
+import { tableDayDragId, tableRowDragId } from "../lib/tableDragIds";
 
 function week(overrides: Partial<GridWeek> = {}): GridWeek {
   return {
@@ -79,6 +95,7 @@ function day(overrides: Partial<GridDay> = {}): GridDay {
   return {
     session_slot_id: 1,
     session_id: 11,
+    session_ids: { "1": 11 },
     day_number: 1,
     name: "Lower",
     bias: "",
@@ -99,9 +116,13 @@ function grid(overrides: Partial<MesoGrid> = {}): MesoGrid {
 }
 
 /** Builds a dnd-kit-shaped row drag event — see useTableReorder.ts's
- * `TableDragData` union. `overDaySlotId` defaults to the active row's own
- * day (the common within-day case); pass a different one to build a
- * cross-day drop for the scope-guard spec. */
+ * `TableDragData` union. The top-level `id`s are built with
+ * `tableRowDragId`, the SAME builder MesoTable.tsx uses at its
+ * useSortable/SortableContext call sites — an ENCODED string
+ * ("row-<daySlotId>-<exerciseSlotId>"), never the bare numeric slot id (see
+ * this file's header). `overDaySlotId` defaults to the active row's own day
+ * (the common within-day case); pass a different one to build a cross-day
+ * drop for the scope-guard spec. */
 function rowDragEvent(
   activeExerciseSlotId: Id,
   activeDaySlotId: Id,
@@ -110,27 +131,29 @@ function rowDragEvent(
 ): TableDragEndEvent {
   return {
     active: {
-      id: activeExerciseSlotId,
+      id: tableRowDragId(activeDaySlotId, activeExerciseSlotId),
       data: { current: { type: "row", daySlotId: activeDaySlotId, exerciseSlotId: activeExerciseSlotId } },
     },
     over:
       overExerciseSlotId == null
         ? null
         : {
-            id: overExerciseSlotId,
+            id: tableRowDragId(overDaySlotId, overExerciseSlotId),
             data: { current: { type: "row", daySlotId: overDaySlotId, exerciseSlotId: overExerciseSlotId } },
           },
   };
 }
 
-/** Builds a dnd-kit-shaped day-strip drag event. */
+/** Builds a dnd-kit-shaped day-strip drag event — `id`s built with
+ * `tableDayDragId`, mirroring `rowDragEvent` above (see this file's
+ * header). */
 function dayDragEvent(activeSessionSlotId: Id, overSessionSlotId: Id | null): TableDragEndEvent {
   return {
-    active: { id: activeSessionSlotId, data: { current: { type: "day", sessionSlotId: activeSessionSlotId } } },
+    active: { id: tableDayDragId(activeSessionSlotId), data: { current: { type: "day", sessionSlotId: activeSessionSlotId } } },
     over:
       overSessionSlotId == null
         ? null
-        : { id: overSessionSlotId, data: { current: { type: "day", sessionSlotId: overSessionSlotId } } },
+        : { id: tableDayDragId(overSessionSlotId), data: { current: { type: "day", sessionSlotId: overSessionSlotId } } },
   };
 }
 
@@ -140,6 +163,59 @@ function setup(g: MesoGrid | null) {
   const { result } = renderHook(() => useTableReorder({ grid: g, reorderRow, reorderDay }));
   return { onDragEnd: result.current.onDragEnd, reorderRow, reorderDay };
 }
+
+// Regression (Codex #455 A2 review finding 1): the real MesoTable never
+// emits a bare numeric slot id as a dnd-kit sortable id — every id is
+// ENCODED (`tableRowDragId`/`tableDayDragId`). A hook that resolved
+// identity off `active.id`/`over.id` directly (comparing an encoded string
+// against a numeric `exercise_slot_id`/`session_slot_id`) would find
+// `oldIndex === -1` on every real drop and silently no-op. These specs
+// build the exact event shape MesoTable emits and assert the verb still
+// fires — proving identity comes from `TableDragData`, not the id string.
+describe("regression: encoded dnd ids (as the real MesoTable emits) resolve correctly", () => {
+  it("a row event with encoded string ids still calls reorderRow with the right payload", () => {
+    const g = grid({
+      days: [
+        day({
+          session_slot_id: 1,
+          session_id: 11,
+          session_ids: { "1": 11 },
+          rows: [
+            row({ exercise_slot_id: 9, cells: { "1": cell({ prescription_id: 900 }) } }),
+            row({ exercise_slot_id: 10, cells: { "1": cell({ prescription_id: 1000 }) } }),
+          ],
+        }),
+      ],
+    });
+    const event = rowDragEvent(9, 1, 10);
+    // Sanity: the ids really are encoded strings, not the bare numeric slot
+    // ids — this is the exact shape the old (buggy) numeric-lookup hook
+    // would silently no-op on.
+    expect(event.active.id).toBe("row-1-9");
+    expect(event.over?.id).toBe("row-1-10");
+    expect(event.active.id).not.toBe(9);
+    const { onDragEnd, reorderRow } = setup(g);
+    onDragEnd(event);
+    expect(reorderRow).toHaveBeenCalledWith(11, [1000, 900]);
+  });
+
+  it("a day event with encoded string ids still calls reorderDay with the right payload", () => {
+    const g = grid({
+      weeks: [week({ id: 1, current: true })],
+      days: [
+        day({ session_slot_id: 1, session_id: 11, session_ids: { "1": 11 } }),
+        day({ session_slot_id: 2, session_id: 22, session_ids: { "1": 22 } }),
+      ],
+    });
+    const event = dayDragEvent(1, 2);
+    expect(event.active.id).toBe("day-1");
+    expect(event.over?.id).toBe("day-2");
+    expect(event.active.id).not.toBe(1);
+    const { onDragEnd, reorderDay } = setup(g);
+    onDragEnd(event);
+    expect(reorderDay).toHaveBeenCalledWith(1, [22, 11]);
+  });
+});
 
 describe("within-day row reorder", () => {
   it("calls reorderRow with the day's session_id and the current week's cell ids in the new order", () => {
@@ -203,20 +279,66 @@ describe("day reorder", () => {
   it("calls reorderDay with the current week's id and the block's session ids in the new order", () => {
     const g = grid({
       weeks: [week({ id: 1, current: true })],
-      days: [day({ session_slot_id: 1, session_id: 11 }), day({ session_slot_id: 2, session_id: 22 })],
+      days: [
+        day({ session_slot_id: 1, session_id: 11, session_ids: { "1": 11 } }),
+        day({ session_slot_id: 2, session_id: 22, session_ids: { "1": 22 } }),
+      ],
     });
     const { onDragEnd, reorderDay } = setup(g);
     onDragEnd(dayDragEvent(1, 2));
     expect(reorderDay).toHaveBeenCalledWith(1, [22, 11]);
   });
 
-  it("no-ops when any live day's session_id is null", () => {
+  it("no-ops when any live day lacks a session_ids entry for the current week", () => {
     const g = grid({
-      days: [day({ session_slot_id: 1, session_id: 11 }), day({ session_slot_id: 2, session_id: null })],
+      days: [
+        day({ session_slot_id: 1, session_id: 11, session_ids: { "1": 11 } }),
+        day({ session_slot_id: 2, session_id: 22, session_ids: {} }),
+      ],
     });
     const { onDragEnd, reorderDay } = setup(g);
     onDragEnd(dayDragEvent(1, 2));
     expect(reorderDay).not.toHaveBeenCalled();
+  });
+
+  // Regression (Codex #455 A2 review finding 2): `session_id` is a
+  // DISPLAY-ONLY field that can fall back to a different, non-current
+  // week's session pk (`_pick_session_id`, serializers.py) when the current
+  // week's own session was independently deleted (see the per-week
+  // exceptions system's `session_delete` endpoint). Day reorder must read
+  // `session_ids[currentWeekKey]` — never let the fallback `session_id`
+  // substitute — or the client posts another week's session pk to
+  // `week_reorder_sessions`, which 400s (it requires EXACTLY the current
+  // week's live session ids).
+  it("does not substitute the fallback session_id when the current week's own session_ids entry is missing", () => {
+    const g = grid({
+      weeks: [week({ id: 1, current: true })],
+      days: [
+        day({ session_slot_id: 1, session_id: 11, session_ids: { "1": 11 } }),
+        // day 2's current week (week 1) session was independently deleted —
+        // session_id falls back to some OTHER week's session (pk 999), but
+        // session_ids carries no "1" entry.
+        day({ session_slot_id: 2, session_id: 999, session_ids: {} }),
+      ],
+    });
+    const { onDragEnd, reorderDay } = setup(g);
+    onDragEnd(dayDragEvent(1, 2));
+    expect(reorderDay).not.toHaveBeenCalled();
+  });
+
+  it("builds the order from each day's CURRENT-WEEK session_ids entry, not the (possibly-fallback) session_id field", () => {
+    const g = grid({
+      weeks: [week({ id: 5, current: true })],
+      days: [
+        // session_id (999) intentionally mismatches session_ids["5"] (11) —
+        // if the hook ever read session_id again, this assertion would catch it.
+        day({ session_slot_id: 1, session_id: 999, session_ids: { "5": 11 } }),
+        day({ session_slot_id: 2, session_id: 22, session_ids: { "5": 22 } }),
+      ],
+    });
+    const { onDragEnd, reorderDay } = setup(g);
+    onDragEnd(dayDragEvent(1, 2));
+    expect(reorderDay).toHaveBeenCalledWith(5, [22, 11]);
   });
 });
 

--- a/frontend/designer/src/hooks/useTableReorder.test.ts
+++ b/frontend/designer/src/hooks/useTableReorder.test.ts
@@ -236,6 +236,48 @@ describe("within-day row reorder", () => {
     expect(reorderRow).toHaveBeenCalledWith(11, [1000, 900]);
   });
 
+  it("no-ops a row drop when the day's session_ids lacks a current-week entry (fallback session_id must not substitute)", () => {
+    // The current week's session was independently soft-deleted:
+    // `session_id` silently falls back to ANOTHER week's session
+    // (`_pick_session_id`), so posting current-week cell ids to it would
+    // 400 server-side — same guard the day path already has.
+    const g = grid({
+      days: [
+        day({
+          session_slot_id: 1,
+          session_id: 99, // fallback: another week's session
+          session_ids: { "2": 99 }, // no entry for current week "1"
+          rows: [
+            row({ exercise_slot_id: 9, cells: { "1": cell({ prescription_id: 900 }) } }),
+            row({ exercise_slot_id: 10, cells: { "1": cell({ prescription_id: 1000 }) } }),
+          ],
+        }),
+      ],
+    });
+    const { onDragEnd, reorderRow } = setup(g);
+    onDragEnd(rowDragEvent(9, 1, 10));
+    expect(reorderRow).not.toHaveBeenCalled();
+  });
+
+  it("posts a row reorder to the CURRENT week's session_ids entry, not the (possibly-fallback) session_id field", () => {
+    const g = grid({
+      days: [
+        day({
+          session_slot_id: 1,
+          session_id: 99, // display fallback pointing elsewhere
+          session_ids: { "1": 11 }, // the current week's real session
+          rows: [
+            row({ exercise_slot_id: 9, cells: { "1": cell({ prescription_id: 900 }) } }),
+            row({ exercise_slot_id: 10, cells: { "1": cell({ prescription_id: 1000 }) } }),
+          ],
+        }),
+      ],
+    });
+    const { onDragEnd, reorderRow } = setup(g);
+    onDragEnd(rowDragEvent(9, 1, 10));
+    expect(reorderRow).toHaveBeenCalledWith(11, [1000, 900]);
+  });
+
   it("arrayMove semantics: a 3-row day, moving row1 past row2, orders as [row2, row1, row3]", () => {
     const g = grid({
       days: [

--- a/frontend/designer/src/hooks/useTableReorder.ts
+++ b/frontend/designer/src/hooks/useTableReorder.ts
@@ -69,10 +69,17 @@ export function useTableReorder(options: UseTableReorderOptions) {
   const { grid, reorderRow, reorderDay } = options;
 
   function rowReorder(day: GridDay, activeExerciseSlotId: Id, overExerciseSlotId: Id) {
-    if (!grid || day.session_id == null) return;
+    if (!grid) return;
     const weekId = currentWeekId(grid);
     if (weekId == null) return;
     const weekKey = String(weekId);
+    // The endpoint is the CURRENT week's session — resolved via
+    // `session_ids[weekKey]`, never `session_id`, which can silently be a
+    // FALLBACK to a different week when the current week's session was
+    // independently soft-deleted; posting current-week cell ids to a
+    // fallback session 400s server-side (same guard as dayReorder below).
+    const sessionId = day.session_ids[weekKey];
+    if (sessionId == null) return;
     // Only rows with a live cell for the CURRENT week can appear in the
     // order array — session_reorder's contract is EXACTLY session.cells()
     // for the viewed (current) week. A row that exists only on some OTHER
@@ -84,7 +91,7 @@ export function useTableReorder(options: UseTableReorderOptions) {
     if (oldIndex === -1 || newIndex === -1) return;
     const reordered = arrayMove(liveRows, oldIndex, newIndex);
     const order = reordered.map((r) => r.cells[weekKey]?.prescription_id).filter((id): id is number => id != null);
-    reorderRow(day.session_id, order);
+    reorderRow(sessionId, order);
   }
 
   function dayReorder(activeSessionSlotId: Id, overSessionSlotId: Id) {

--- a/frontend/designer/src/hooks/useTableReorder.ts
+++ b/frontend/designer/src/hooks/useTableReorder.ts
@@ -20,12 +20,22 @@
 //    live row cells' `prescription_id`s, in the new order — a row with no
 //    cell for that week (an add-this-week-only hole) is excluded, mirroring
 //    the server's own `session.cells()` query for that week.
-//  - Day order = the CURRENT week's live Session pks (`GridDay.session_id`),
-//    in the new order. Defensive no-op if ANY live day's `session_id` is
-//    null — `_pick_session_id` (serializers.py:954) can fall back to an
-//    earlier week's session for a slot when the current week's was
-//    independently soft-deleted, which would desync the posted order from
-//    the current week's actual live session set and 400 server-side.
+//  - Day order = the CURRENT week's live Session pks, in the new order —
+//    read from EACH day's own `GridDay.session_ids[String(currentWeekId)]`,
+//    never `GridDay.session_id` (display-only, and `_pick_session_id`
+//    (serializers.py:954) can fall back to an earlier live week's session
+//    for a slot when the current week's was independently soft-deleted; the
+//    fallback pk belongs to the WRONG week and would 400 server-side if
+//    posted as part of the current week's order — Codex #455 A2 review
+//    finding 2). Defensive no-op if ANY live day lacks a `session_ids` entry
+//    for the current week.
+//
+// IMPORTANT (Codex #455 A2 review finding 1): identity for both verbs comes
+// EXCLUSIVELY from the `TableDragData` carried on `active.data.current`/
+// `over.data.current` — `active.id`/`over.id` are dnd-kit's own opaque
+// sortable ids (in the real MesoTable wiring, ENCODED strings like
+// "row-<daySlotId>-<exerciseSlotId>" — see ../lib/tableDragIds), never
+// parsed or compared here as if they were the numeric slot ids themselves.
 import { arrayMove } from "@dnd-kit/sortable";
 import type { GridDay, MesoGrid } from "../lib/api";
 import type { Id } from "./useGrid";
@@ -81,15 +91,17 @@ export function useTableReorder(options: UseTableReorderOptions) {
     if (!grid) return;
     const weekId = currentWeekId(grid);
     if (weekId == null) return;
-    // Defensive no-op: every live day must resolve a session for the
-    // CURRENT week (see this file's header) — reordering against a
-    // mismatched week's session set would 400 server-side.
-    if (grid.days.some((d) => d.session_id == null)) return;
+    const weekKey = String(weekId);
+    // Defensive no-op: every live day must resolve its OWN current-week
+    // session id via `session_ids[weekKey]` (see this file's header) —
+    // `session_id` can silently be a FALLBACK to a different week and must
+    // never substitute here, or the posted order 400s server-side.
+    if (grid.days.some((d) => d.session_ids[weekKey] == null)) return;
     const oldIndex = grid.days.findIndex((d) => d.session_slot_id === activeSessionSlotId);
     const newIndex = grid.days.findIndex((d) => d.session_slot_id === overSessionSlotId);
     if (oldIndex === -1 || newIndex === -1) return;
     const reordered = arrayMove(grid.days, oldIndex, newIndex);
-    const order = reordered.map((d) => d.session_id).filter((id): id is number => id != null);
+    const order = reordered.map((d) => d.session_ids[weekKey]).filter((id): id is number => id != null);
     reorderDay(weekId, order);
   }
 
@@ -103,12 +115,15 @@ export function useTableReorder(options: UseTableReorderOptions) {
       if (activeData.daySlotId !== overData.daySlotId) return; // cross-day: OUT of A2 scope
       const day = grid.days.find((d) => d.session_slot_id === activeData.daySlotId);
       if (!day) return;
-      rowReorder(day, active.id, over.id);
+      // Identity is the TableDragData payload, NEVER active.id/over.id (the
+      // real MesoTable emits ENCODED string ids there — Codex #455 A2
+      // review finding 1).
+      rowReorder(day, activeData.exerciseSlotId, overData.exerciseSlotId);
       return;
     }
 
     if (activeData.type === "day" && overData.type === "day") {
-      dayReorder(active.id, over.id);
+      dayReorder(activeData.sessionSlotId, overData.sessionSlotId);
     }
     // Any other type combination (row-over-day-header etc.) is unreachable
     // through the real UI (separate row/day SortableContexts +

--- a/frontend/designer/src/hooks/useTableReorder.ts
+++ b/frontend/designer/src/hooks/useTableReorder.ts
@@ -1,0 +1,119 @@
+// useTableReorder (issue #455 phase A2 — drag reordering in the multi-week
+// table) — a pure, stateless drag-event -> verb-call translator. Unlike
+// useReorder (WeekGrid's Phase-4 hook), this hook owns NO optimistic state
+// and makes NO fetch of its own: `grid` is read fresh at drop time (never
+// carried on the event, mirroring useReorder's `program`) and every
+// mutation routes through the two injected verbs — DesignerRoot wires them
+// to useGrid's own `reorderExercises`/`reorderDays`, which already await
+// their POST behind useGrid's shared `busyRef` guard (see useGrid.ts's
+// header) — so there is no concurrency guard to duplicate here.
+//
+// Cross-day row moves are explicitly OUT of scope for A2 (own follow-up;
+// the backend's `prescription_move` needs zero changes for it later) —
+// enforced here as a second, independent guard even though MesoTable's own
+// collision filter (`filterTableDragCandidates`) already keeps a row drag
+// from colliding with another day's rows in the first place.
+//
+// Payload construction mirrors the two endpoints' exact contracts
+// (app/store_project/meso/views.py `session_reorder`/`week_reorder_sessions`):
+//  - Row order = the CURRENT week's (`grid.weeks.find(w => w.current)`)
+//    live row cells' `prescription_id`s, in the new order — a row with no
+//    cell for that week (an add-this-week-only hole) is excluded, mirroring
+//    the server's own `session.cells()` query for that week.
+//  - Day order = the CURRENT week's live Session pks (`GridDay.session_id`),
+//    in the new order. Defensive no-op if ANY live day's `session_id` is
+//    null — `_pick_session_id` (serializers.py:954) can fall back to an
+//    earlier week's session for a slot when the current week's was
+//    independently soft-deleted, which would desync the posted order from
+//    the current week's actual live session set and 400 server-side.
+import { arrayMove } from "@dnd-kit/sortable";
+import type { GridDay, MesoGrid } from "../lib/api";
+import type { Id } from "./useGrid";
+
+/** Carried by every sortable item via dnd-kit's `useSortable({ id, data })`
+ * — decision 2 (brief): drag identity is exercise_slot_id/session_slot_id
+ * (P0 block-wide identity), never prescription_id. */
+export type TableDragData =
+  | { type: "row"; daySlotId: Id; exerciseSlotId: Id }
+  | { type: "day"; sessionSlotId: Id };
+
+/** Modeled on dnd-kit's real `DragEndEvent` — MesoTable's `onDragEnd` adapts
+ * the real event into this shape before calling the hook's handler (mirrors
+ * WeekGrid's `ReorderDragEndEvent` / handleDragEnd). */
+export interface TableDragEndEvent {
+  active: { id: Id; data: { current: TableDragData } };
+  over: { id: Id; data: { current: TableDragData } } | null;
+}
+
+export interface UseTableReorderOptions {
+  grid: MesoGrid | null;
+  reorderRow(sessionId: Id, order: number[]): void;
+  reorderDay(weekId: Id, order: number[]): void;
+}
+
+function currentWeekId(grid: MesoGrid): Id | undefined {
+  return grid.weeks.find((w) => w.current)?.id;
+}
+
+export function useTableReorder(options: UseTableReorderOptions) {
+  const { grid, reorderRow, reorderDay } = options;
+
+  function rowReorder(day: GridDay, activeExerciseSlotId: Id, overExerciseSlotId: Id) {
+    if (!grid || day.session_id == null) return;
+    const weekId = currentWeekId(grid);
+    if (weekId == null) return;
+    const weekKey = String(weekId);
+    // Only rows with a live cell for the CURRENT week can appear in the
+    // order array — session_reorder's contract is EXACTLY session.cells()
+    // for the viewed (current) week. A row that exists only on some OTHER
+    // week (an add-this-week-only hole) is invisible here, same as the
+    // server's own query.
+    const liveRows = day.rows.filter((r) => r.cells[weekKey]);
+    const oldIndex = liveRows.findIndex((r) => r.exercise_slot_id === activeExerciseSlotId);
+    const newIndex = liveRows.findIndex((r) => r.exercise_slot_id === overExerciseSlotId);
+    if (oldIndex === -1 || newIndex === -1) return;
+    const reordered = arrayMove(liveRows, oldIndex, newIndex);
+    const order = reordered.map((r) => r.cells[weekKey]?.prescription_id).filter((id): id is number => id != null);
+    reorderRow(day.session_id, order);
+  }
+
+  function dayReorder(activeSessionSlotId: Id, overSessionSlotId: Id) {
+    if (!grid) return;
+    const weekId = currentWeekId(grid);
+    if (weekId == null) return;
+    // Defensive no-op: every live day must resolve a session for the
+    // CURRENT week (see this file's header) — reordering against a
+    // mismatched week's session set would 400 server-side.
+    if (grid.days.some((d) => d.session_id == null)) return;
+    const oldIndex = grid.days.findIndex((d) => d.session_slot_id === activeSessionSlotId);
+    const newIndex = grid.days.findIndex((d) => d.session_slot_id === overSessionSlotId);
+    if (oldIndex === -1 || newIndex === -1) return;
+    const reordered = arrayMove(grid.days, oldIndex, newIndex);
+    const order = reordered.map((d) => d.session_id).filter((id): id is number => id != null);
+    reorderDay(weekId, order);
+  }
+
+  function onDragEnd(event: TableDragEndEvent): void {
+    if (!grid || !event.over || event.active.id === event.over.id) return;
+    const { active, over } = event;
+    const activeData = active.data.current;
+    const overData = over.data.current;
+
+    if (activeData.type === "row" && overData.type === "row") {
+      if (activeData.daySlotId !== overData.daySlotId) return; // cross-day: OUT of A2 scope
+      const day = grid.days.find((d) => d.session_slot_id === activeData.daySlotId);
+      if (!day) return;
+      rowReorder(day, active.id, over.id);
+      return;
+    }
+
+    if (activeData.type === "day" && overData.type === "day") {
+      dayReorder(active.id, over.id);
+    }
+    // Any other type combination (row-over-day-header etc.) is unreachable
+    // through the real UI (separate row/day SortableContexts +
+    // filterTableDragCandidates) — a silent no-op here.
+  }
+
+  return { onDragEnd };
+}

--- a/frontend/designer/src/lib/api.ts
+++ b/frontend/designer/src/lib/api.ts
@@ -201,7 +201,19 @@ export interface GridRow {
 
 export interface GridDay {
   session_slot_id: number;
+  /** The session pk the P1 table DISPLAYS for this day column — prefers the
+   * current week, but FALLS BACK to an earlier live week's session
+   * (`_pick_session_id`, serializers.py) when the current week's was
+   * independently soft-deleted. Display-only: never use this for a day
+   * REORDER post (see `session_ids` below and useTableReorder.ts's header —
+   * Codex #455 A2 review finding 2). */
   session_id: number | null;
+  /** Per-week session pks for this day, keyed by `String(week.id)` —
+   * covers only the live weeks that have a LIVE session for this day (a
+   * week missing one has no entry). The source of truth for day-reorder
+   * payloads: always read `session_ids[String(currentWeekId)]`, never the
+   * (possibly-fallback) `session_id` above. */
+  session_ids: Record<string, number>;
   day_number: number;
   name: string;
   bias: string;

--- a/frontend/designer/src/lib/tableDragIds.ts
+++ b/frontend/designer/src/lib/tableDragIds.ts
@@ -1,0 +1,34 @@
+// Shared dnd-kit id encoding for MesoTable's drag reordering (issue #455
+// A2) — the SINGLE SOURCE OF TRUTH for the two sortable id string formats.
+// Every site that builds or parses one of these ids goes through here:
+// MesoTable.tsx's useSortable({id}) calls, its SortableContext `items`
+// arrays, and its collision-filter prefix tests (filterTableDragCandidates)
+// — plus useTableReorder.test.ts's hand-built drag events, so the hook's
+// specs construct ids the SAME way the real MesoTable does.
+//
+// useTableReorder.ts itself must NEVER import from here / parse these
+// strings — a sortable id is opaque transport for dnd-kit; real identity for
+// the hook always comes from the TableDragData payload carried as `data`
+// (see that file's header). This module exists only for the places that
+// legitimately need the encoded string: dnd-kit's own id prop, and the
+// collision filter, which dnd-kit calls with only a raw id (no data) to
+// decide.
+import type { Id } from "../hooks/useGrid";
+
+export const TABLE_DAY_DRAG_PREFIX = "day-";
+export const TABLE_ROW_DRAG_PREFIX = "row-";
+
+export function tableDayDragId(sessionSlotId: Id): string {
+  return `${TABLE_DAY_DRAG_PREFIX}${sessionSlotId}`;
+}
+
+export function tableRowDragId(daySlotId: Id, exerciseSlotId: Id): string {
+  return `${TABLE_ROW_DRAG_PREFIX}${daySlotId}-${exerciseSlotId}`;
+}
+
+/** The id prefix shared by every row belonging to one day — lets the
+ * collision filter scope a lifted row to its own day's row containers
+ * without decoding a full row id. */
+export function tableRowDragPrefix(daySlotId: Id): string {
+  return `${TABLE_ROW_DRAG_PREFIX}${daySlotId}-`;
+}

--- a/frontend/designer/src/styles/designer-mesotable.css
+++ b/frontend/designer/src/styles/designer-mesotable.css
@@ -222,3 +222,34 @@
   gap: 5px;
   padding: 4px 15px 8px;
 }
+
+/* Issue #455 phase A2 (drag reordering): the day block / table row being
+   actively dragged. No live CSS transform (a transformed <tr> inside
+   border-collapse + a sticky first column, or a transformed day block
+   inside .meso-table-scroll's overflow-x:auto, both have known cross-
+   browser glitches, unverifiable in jsdom) — opacity + shadow only,
+   mirroring designer-grid.css's .meso-day-card.is-dragging /
+   .meso-ex-row.is-dragging. The drag handle itself (`.meso-drag-handle`)
+   and `--day` variant are reused verbatim from designer-grid.css. The
+   visible drag affordance is the DragOverlay ghost below instead of a
+   live-transformed original element. */
+.meso-table-day.is-dragging {
+  opacity: 0.85;
+  box-shadow: 0 6px 18px rgba(16, 18, 22, 0.16);
+  position: relative;
+  z-index: 1;
+}
+.meso-table tbody tr.is-dragging {
+  opacity: 0.6;
+  background: var(--soft);
+}
+.meso-table-drag-ghost {
+  font-size: 12.5px;
+  font-weight: 650;
+  color: var(--ink);
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: 0 8px 24px rgba(16, 18, 22, 0.2);
+  padding: 6px 12px;
+}


### PR DESCRIPTION
## Summary

Phase A2 of #455 (MesoTable parity): drag-and-drop reordering of exercise rows and training days in the multi-week designer table. A row drag moves the **`ExerciseSlot` block-wide** and a day drag the **`SessionSlot` block-wide** — the P0 fixed-lineup semantics; the server endpoints (`session_reorder`, `week_reorder_sessions`) already write block-wide, so this is front-end wiring plus one additive serializer field.

- **New `useTableReorder` hook** — a pure drag-event → verb translator (no state/fetch of its own); persistence goes through two new `useGrid` structural verbs (`reorderExercises`, `reorderDays`) that reuse the house await-POST-then-`refetchGrid` pattern behind the shared in-flight guard. Reorders are server-undoable ("Undo: Reordered exercises/days") with zero new undo code.
- **Drag surfaces:** a ⠿ handle per row (in the sticky name column) and per day header, `DndContext` + `DragOverlay` ghost — deliberately **no live CSS transform on `<tr>`** (an `overflow-x:auto` ancestor clips transformed rows, and sticky-column + `border-collapse` inside a transformed row is cross-browser-glitchy). dnd-kit ids are built by a single-source `tableDragIds` module shared by components, filters, and test fixtures.
- **Scope guard, enforced twice:** cross-day row moves are out of A2 (tracked as a follow-up; the one-week view keeps the capability until then) — excluded at the collision-filter layer and re-checked in `onDragEnd` off `TableDragData`.
- **Collision is intersection-based (`pointerWithin` → `rectIntersection`), no closest-center**: a drop nowhere near a same-day candidate leaves `over` null and no-ops instead of phantom-reordering against the nearest row (Codex finding, regression-tested).
- **Current-week payload correctness:** `serialize_mesocycle_grid` gains an additive per-day `session_ids` map (week → session pk, no extra queries); both row and day reorders resolve their endpoint/order ids from the **current week's** entries and no-op when absent — `GridDay.session_id` can silently be another week's fallback (`_pick_session_id`) and must never be posted (two Codex findings, both regression-tested).
- Keyboard nav (A1) and drag coexist structurally: dnd-kit listeners bind only to the handle buttons, `useTableNav` only to inputs; the `typedKeyboardCoordinates` Proxy trick is ported for keyboard drags.

No migrations; the only backend change is the additive serializer field + tests.

## Review + verification
- Codex review loop: 3 iterations — 1 P1 (encoded dnd ids treated as numeric slot ids → every real drop silently no-oped; the hook's original fixtures had pinned the wrong seam) + 3 P2s (fallback-session payloads ×2, phantom cross-day reorder), all fixed red-green with truthful fixtures; final findings all addressed.
- Vitest **693 passed** (+36), strict tsc clean, build clean; Django **2099 passed** (+2 serializer tests); `makemigrations --check` clean.
- **Browser-verified on the live designer**: row drag persists block-wide to the DB (`ExerciseSlot.order` flipped, "Undo: Reordered exercises"), day drag reorders the day tables ("Undo: Reordered days"), the DragOverlay ghost + dimmed source render correctly, and a drop far outside the day no-ops with no phantom reorder. The P1 was first caught live (drop never fired a request) before Codex independently flagged it.

Refs #455 (A2)

https://claude.ai/code/session_01GpaxgUSRbupnkecSo9Pmx4