### PR TITLE
feat(meso): A3 — %1RM editor in the multi-week table (#455)

### DIFF
--- a/app/store_project/meso/serializers.py
+++ b/app/store_project/meso/serializers.py
@@ -1017,12 +1017,16 @@ def serialize_mesocycle_grid(mesocycle):
     # One query for every live cell in the block, grouped by (slot, week) so
     # each row's dense ``cells`` map is built without a per-row lookup.
     # ``select_related("swap_exercise")`` lets swap_display resolve a
-    # catalog-only swap's name below without a per-cell query.
+    # catalog-only swap's name below without a per-cell query;
+    # ``select_related("exercise_slot")`` does the same for ``one_rm_values``
+    # below — it reads each cell's RESOLVING ``.exercise_id``/``.name``
+    # properties (models.py), which fall back to ``self.exercise_slot`` for an
+    # unswapped cell and would otherwise be an N+1 (one query per cell).
     cells_by_key = {
         (cell.exercise_slot_id, cell.week_id): cell
         for cell in models.Prescription.objects.filter(
             exercise_slot_id__in=exercise_slot_ids, week_id__in=week_ids
-        ).select_related("swap_exercise")
+        ).select_related("swap_exercise", "exercise_slot")
     }
 
     # A GROUP plan carries the per-athlete adjust overlay on each cell (P5): the
@@ -1031,6 +1035,21 @@ def serialize_mesocycle_grid(mesocycle):
     # block's cells, keyed by prescription pk. An individual plan has no members,
     # so its cells get no ``adj`` keys.
     adj_map = group_adjustments(plan, cells_by_key.values()) if plan.is_group else {}
+
+    # The athlete's persisted %1RM estimate (issue #455 phase A3) — mirrors
+    # ``serialize_plan``'s single-week attach exactly (local import: ``one_rm``
+    # imports this module). Attached to EVERY live cell regardless of
+    # ``load_type`` — the pct gate is a frontend concern (MesoTable.tsx /
+    # ExerciseRow.tsx), and ``Prescription.exercise_id``/``.name`` are
+    # swap-resolving properties, so a swapped cell's own identity is read
+    # automatically. A group plan has no single athlete, so its cells never
+    # carry the key.
+    if not plan.is_group:
+        from .one_rm import one_rm_values
+
+        one_rm_map = one_rm_values(plan.athlete, cells_by_key.values(), plan.unit)
+    else:
+        one_rm_map = {}
 
     days = []
     for slot in session_slots:
@@ -1073,6 +1092,10 @@ def serialize_mesocycle_grid(mesocycle):
                 if entry:
                     cell_data["adj"] = entry["adj"]
                     cell_data["adjusts"] = entry["adjusts"]
+                one_rm = one_rm_map.get(cell.pk)
+                if one_rm is not None:
+                    cell_data["one_rm"] = _fmt_num(one_rm.value)
+                    cell_data["one_rm_source"] = one_rm.source
                 cells[str(week.pk)] = cell_data
             rows.append(
                 {

--- a/app/store_project/meso/tests/test_serializers.py
+++ b/app/store_project/meso/tests/test_serializers.py
@@ -14,12 +14,14 @@ are intentionally absent here; only the program-schema-owned fields round-trip.
 """
 
 from datetime import date
+from decimal import Decimal
 from types import SimpleNamespace
 
 import pytest
 from django.utils import timezone
 
 from store_project.exercises.factories import ExerciseFactory
+from store_project.meso.factories import AthleteOneRmFactory
 from store_project.meso.factories import CoachAthleteFactory
 from store_project.meso.factories import LoggedSetFactory
 from store_project.meso.factories import MesocycleFactory
@@ -866,3 +868,90 @@ class TestSerializeMesocycleGridGroupAdj:
         result = serialize_mesocycle_grid(f.meso)
         cell = self._cell(result, day_index=0, row_index=0, week=f.week)
         assert "adj" not in cell
+
+
+class TestSerializeMesocycleGridOneRm:
+    """Every individual-plan cell carries the athlete's stored %1RM estimate.
+
+    Issue #455 phase A3, mirroring ``serialize_plan``'s single-week attach —
+    ATTACHED UNIFORMLY per cell regardless of ``load_type`` (the pct gate is a
+    frontend concern, MesoTable.tsx / ExerciseRow.tsx). A group plan has no
+    single athlete, so its cells never carry the key.
+    """
+
+    def _cell(self, result, *, day_index, row_index, week):
+        return result["days"][day_index]["rows"][row_index]["cells"][str(week.pk)]
+
+    def test_individual_cell_carries_one_rm_and_source_when_stored(self):
+        f = _build_grid_meso()
+        AthleteOneRmFactory(
+            athlete=f.plan.athlete, exercise=f.catalog, value=Decimal("140")
+        )
+        result = serialize_mesocycle_grid(f.meso)
+        cell = self._cell(result, day_index=0, row_index=0, week=f.week1)
+        assert cell["one_rm"] == "140"
+        assert cell["one_rm_source"] == "logged"
+
+    def test_lift_with_no_stored_estimate_has_no_one_rm_key(self):
+        f = _build_grid_meso()
+        result = serialize_mesocycle_grid(f.meso)
+        cell = self._cell(result, day_index=0, row_index=0, week=f.week1)
+        assert "one_rm" not in cell
+        assert "one_rm_source" not in cell
+
+    def test_group_grid_cells_never_carry_one_rm(self):
+        # A group plan has no single athlete, so `one_rm_values` is never even
+        # called — seed a matching-identity row on a member to prove that.
+        f = _build_group_grid_meso()
+        AthleteOneRmFactory(
+            athlete=f.membership.relationship.athlete,
+            name="Back Squat",
+            value=Decimal("140"),
+        )
+        result = serialize_mesocycle_grid(f.meso)
+        for day_data in result["days"]:
+            for row in day_data["rows"]:
+                for cell in row["cells"].values():
+                    assert "one_rm" not in cell
+                    assert "one_rm_source" not in cell
+
+    def test_swapped_cell_carries_its_own_resolved_identity_value(self):
+        # KEY regression: a swap changes ``Prescription.exercise_id`` for that
+        # cell only (models.py resolving properties) — the badge must show
+        # THAT identity's estimate, not the row's block identity.
+        f = _build_grid_meso()
+        AthleteOneRmFactory(
+            athlete=f.plan.athlete, exercise=f.catalog, value=Decimal("140")
+        )
+        substitute = ExerciseFactory()
+        AthleteOneRmFactory(
+            athlete=f.plan.athlete, exercise=substitute, value=Decimal("100")
+        )
+        f.squat_cell2.swap_exercise = substitute
+        f.squat_cell2.save(update_fields=["swap_exercise"])
+        result = serialize_mesocycle_grid(f.meso)
+        unswapped = self._cell(result, day_index=0, row_index=0, week=f.week1)
+        swapped = self._cell(result, day_index=0, row_index=0, week=f.week2)
+        assert unswapped["one_rm"] == "140"
+        assert swapped["one_rm"] == "100"
+
+    def test_individual_grid_query_count_is_baseline_plus_one(
+        self, django_assert_num_queries
+    ):
+        # Baseline (no adj/one_rm overlay) is 7: weeks, session slots, sessions,
+        # exercise slots, cells, 2x PlanAction (serialize_plan_history) — this
+        # phase adds exactly ONE query (one_rm_values), establishing the budget.
+        f = _build_grid_meso()
+        AthleteOneRmFactory(
+            athlete=f.plan.athlete, exercise=f.catalog, value=Decimal("140")
+        )
+        with django_assert_num_queries(8):
+            serialize_mesocycle_grid(f.meso)
+
+    def test_group_grid_query_count_is_unaffected(self, django_assert_num_queries):
+        # A group plan skips one_rm_values entirely (short-circuited on
+        # ``plan.is_group``) — the group baseline (8, incl. group_adjustments)
+        # stays exactly where it was.
+        f = _build_group_grid_meso()
+        with django_assert_num_queries(8):
+            serialize_mesocycle_grid(f.meso)

--- a/frontend/designer/src/DesignerRoot.tsx
+++ b/frontend/designer/src/DesignerRoot.tsx
@@ -445,6 +445,7 @@ export function DesignerRoot() {
                 onOpenOverride={(row, cell) => gridOverrideEditor.openOverride(synthesizeCellExercise(row, cell))}
                 onPatchCell={gridState.patchCell}
                 onRenameExercise={gridState.renameExercise}
+                onSetOneRm={gridState.setOneRm}
                 onAddExercise={gridState.addExercise}
                 onRemoveExercise={gridState.removeExercise}
                 onAddDay={gridState.addDay}

--- a/frontend/designer/src/components/MesoTable.test.tsx
+++ b/frontend/designer/src/components/MesoTable.test.tsx
@@ -362,6 +362,73 @@ describe("row 1RM editor (issue #455 phase A3)", () => {
     expect(screen.queryByTestId("row-one-rm-badge-9")).not.toBeInTheDocument();
   });
 
+  it("renders the badge for a MIXED-load row (identity cell abs, a later week pct)", () => {
+    // Codex #455 A3 review: load_type is edited per cell — gating on the
+    // identity cell's own load_type alone hid the row's only 1RM control
+    // when only a later week carries the % load. The save target stays the
+    // identity cell (same lift identity either way).
+    render(
+      <MesoTable
+        {...baseProps({
+          grid: grid({
+            weeks: [week({ id: 1 }), week({ id: 2, label: "Wk 2", current: false })],
+            days: [
+              day({
+                rows: [
+                  row({
+                    cells: {
+                      "1": cell({ prescription_id: 100, load_type: "abs" }),
+                      "2": pctCell({ prescription_id: 101 }),
+                    },
+                  }),
+                ],
+              }),
+            ],
+          }),
+        })}
+      />,
+    );
+    expect(screen.getByTestId("row-one-rm-badge-9")).toBeInTheDocument();
+  });
+
+  it("renders NO badge when the row's only pct cell is a one-week SWAP (different lift identity)", () => {
+    render(
+      <MesoTable
+        {...baseProps({
+          grid: grid({
+            weeks: [week({ id: 1 }), week({ id: 2, label: "Wk 2", current: false })],
+            days: [
+              day({
+                rows: [
+                  row({
+                    cells: {
+                      "1": cell({ prescription_id: 100, load_type: "abs" }),
+                      "2": pctCell({ prescription_id: 101, swap_name: "Leg Press" }),
+                    },
+                  }),
+                ],
+              }),
+            ],
+          }),
+        })}
+      />,
+    );
+    expect(screen.queryByTestId("row-one-rm-badge-9")).not.toBeInTheDocument();
+  });
+
+  it("renders NO badge when the row's only pct cell is skipped", () => {
+    render(
+      <MesoTable
+        {...baseProps({
+          grid: grid({
+            days: [day({ rows: [row({ cells: { "1": pctCell({ skipped: true }) } })] })],
+          }),
+        })}
+      />,
+    );
+    expect(screen.queryByTestId("row-one-rm-badge-9")).not.toBeInTheDocument();
+  });
+
   it("falls back to a live alternative week's identity cell when week[0] has none for this row", () => {
     render(
       <MesoTable

--- a/frontend/designer/src/components/MesoTable.test.tsx
+++ b/frontend/designer/src/components/MesoTable.test.tsx
@@ -416,6 +416,22 @@ describe("row 1RM editor (issue #455 phase A3)", () => {
     expect(screen.queryByTestId("row-one-rm-badge-9")).not.toBeInTheDocument();
   });
 
+  it("Enter in the editor does not save while the table is busy (keyboard path honors the lock)", async () => {
+    const user = userEvent.setup();
+    const onSetOneRm = vi.fn().mockResolvedValue({ one_rm: "140", one_rm_source: "manual" });
+    const props = baseProps({
+      onSetOneRm,
+      grid: grid({ days: [day({ rows: [row({ cells: { "1": pctCell() } })] })] }),
+    });
+    const { rerender } = render(<MesoTable {...props} />);
+    await user.click(screen.getByTestId("row-one-rm-badge-9"));
+    await user.type(screen.getByTestId("row-one-rm-input-9"), "140");
+    // A structural mutation flips busy while the editor is open.
+    rerender(<MesoTable {...props} busy={true} />);
+    await user.type(screen.getByTestId("row-one-rm-input-9"), "{Enter}");
+    expect(onSetOneRm).not.toHaveBeenCalled();
+  });
+
   it("renders NO badge when the row's only pct cell is skipped", () => {
     render(
       <MesoTable

--- a/frontend/designer/src/components/MesoTable.test.tsx
+++ b/frontend/designer/src/components/MesoTable.test.tsx
@@ -4,7 +4,7 @@
 // forward ExerciseRow's dirtySinceFocus semantics (only actually-typed
 // fields persist). Deload marker/skipped em-dash/swap badge are display-only
 // in P1 — no write UX for swap/skip.
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MesoTable } from "./MesoTable";
 import { tableCellDomKey, tableCellAriaLabel } from "../hooks/useTableNav";
@@ -116,6 +116,7 @@ function baseProps(overrides: Partial<Parameters<typeof MesoTable>[0]> = {}) {
     onSwapCell: vi.fn(),
     onFillAcrossWeeks: vi.fn(),
     onAddExerciseThisWeek: vi.fn(),
+    onSetOneRm: vi.fn().mockResolvedValue({ one_rm: "", one_rm_source: "" }),
     ...overrides,
   };
 }
@@ -292,6 +293,221 @@ describe("row rename", () => {
     await user.type(nameInput, "!");
     await user.tab();
     expect(onRenameExercise).toHaveBeenCalledWith(9, "Squat!");
+  });
+});
+
+// --- Issue #455 phase A3: per-ROW %1RM badge/editor (name column, 2nd line) ---
+// A %1RM is a property of the athlete + lift IDENTITY (AthleteOneRm has no
+// week dimension), so — unlike the per-cell adjust badge (P5) — this control
+// is per-ROW, reading/writing the row's IDENTITY cell (rowIdentityCellId,
+// shared with row rename). Mirrors ExerciseRow.tsx's one-week %1RM badge
+// (label text, "1RM: "/"1RM ≈ " prefixes, "+ set 1RM").
+describe("row 1RM editor (issue #455 phase A3)", () => {
+  function pctCell(overrides: Partial<GridCell> = {}) {
+    return cell({ load_type: "pct", ...overrides });
+  }
+
+  it('renders "1RM: <val> <unit>" for a manual estimate on an individual pct row', () => {
+    render(
+      <MesoTable
+        {...baseProps({
+          grid: grid({ days: [day({ rows: [row({ cells: { "1": pctCell({ one_rm: "140", one_rm_source: "manual" }) } })] })] }),
+        })}
+      />,
+    );
+    expect(screen.getByTestId("row-one-rm-badge-9")).toHaveTextContent("1RM: 140 kg");
+  });
+
+  it('renders "1RM ≈ <val> <unit>" for a logged (derived) estimate', () => {
+    render(
+      <MesoTable
+        {...baseProps({
+          grid: grid({ days: [day({ rows: [row({ cells: { "1": pctCell({ one_rm: "140", one_rm_source: "logged" }) } })] })] }),
+        })}
+      />,
+    );
+    expect(screen.getByTestId("row-one-rm-badge-9")).toHaveTextContent("1RM ≈ 140 kg");
+  });
+
+  it('renders "+ set 1RM" when the athlete has no stored estimate', () => {
+    render(<MesoTable {...baseProps({ grid: grid({ days: [day({ rows: [row({ cells: { "1": pctCell() } })] })] }) })} />);
+    expect(screen.getByTestId("row-one-rm-badge-9")).toHaveTextContent("+ set 1RM");
+  });
+
+  it("renders NO badge for an absolute-load row", () => {
+    render(
+      <MesoTable
+        {...baseProps({
+          grid: grid({ days: [day({ rows: [row({ cells: { "1": cell({ load_type: "abs", one_rm: "140" }) } })] })] }),
+        })}
+      />,
+    );
+    expect(screen.queryByTestId("row-one-rm-badge-9")).not.toBeInTheDocument();
+  });
+
+  it("renders NO badge on a group plan, even for a pct row (KEY gating regression: !group, not showAdjust's member-count check)", () => {
+    render(
+      <MesoTable
+        {...baseProps({
+          group: group(),
+          grid: grid({ days: [day({ rows: [row({ cells: { "1": pctCell({ one_rm: "140" } ) } })] })] }),
+        })}
+      />,
+    );
+    expect(screen.queryByTestId("row-one-rm-badge-9")).not.toBeInTheDocument();
+  });
+
+  it("renders NO badge when the row has no live cell at all", () => {
+    render(<MesoTable {...baseProps({ grid: grid({ days: [day({ rows: [row({ cells: {} })] })] }) })} />);
+    expect(screen.queryByTestId("row-one-rm-badge-9")).not.toBeInTheDocument();
+  });
+
+  it("falls back to a live alternative week's identity cell when week[0] has none for this row", () => {
+    render(
+      <MesoTable
+        {...baseProps({
+          grid: grid({
+            weeks: [week({ id: 1 }), week({ id: 2, label: "Wk 2", current: false })],
+            days: [day({ rows: [row({ cells: { "2": pctCell({ prescription_id: 101 }) } })] })],
+          }),
+        })}
+      />,
+    );
+    expect(screen.getByTestId("row-one-rm-badge-9")).toHaveTextContent("+ set 1RM");
+  });
+
+  it("clicking the badge opens the editor seeded with the current value", async () => {
+    const user = userEvent.setup();
+    render(
+      <MesoTable
+        {...baseProps({
+          grid: grid({ days: [day({ rows: [row({ cells: { "1": pctCell({ one_rm: "140" }) } })] })] }),
+        })}
+      />,
+    );
+    await user.click(screen.getByTestId("row-one-rm-badge-9"));
+    expect(screen.getByTestId("row-one-rm-input-9")).toHaveValue("140");
+  });
+
+  it("Enter saves the typed value", async () => {
+    const user = userEvent.setup();
+    const onSetOneRm = vi.fn().mockResolvedValue({ one_rm: "150", one_rm_source: "manual" });
+    render(
+      <MesoTable
+        {...baseProps({
+          onSetOneRm,
+          grid: grid({ days: [day({ rows: [row({ cells: { "1": pctCell() } })] })] }),
+        })}
+      />,
+    );
+    await user.click(screen.getByTestId("row-one-rm-badge-9"));
+    const input = screen.getByTestId("row-one-rm-input-9");
+    await user.clear(input);
+    await user.type(input, "150{enter}");
+    expect(onSetOneRm).toHaveBeenCalledWith(9, "150");
+  });
+
+  it("Escape cancels without saving", async () => {
+    const user = userEvent.setup();
+    const onSetOneRm = vi.fn();
+    render(
+      <MesoTable
+        {...baseProps({
+          onSetOneRm,
+          grid: grid({ days: [day({ rows: [row({ cells: { "1": pctCell() } })] })] }),
+        })}
+      />,
+    );
+    await user.click(screen.getByTestId("row-one-rm-badge-9"));
+    const input = screen.getByTestId("row-one-rm-input-9");
+    await user.type(input, "999{escape}");
+    expect(onSetOneRm).not.toHaveBeenCalled();
+    expect(screen.getByTestId("row-one-rm-badge-9")).toBeInTheDocument();
+  });
+
+  it("an invalid value shows an inline error and does not call onSetOneRm", async () => {
+    const user = userEvent.setup();
+    const onSetOneRm = vi.fn();
+    render(
+      <MesoTable
+        {...baseProps({
+          onSetOneRm,
+          grid: grid({ days: [day({ rows: [row({ cells: { "1": pctCell() } })] })] }),
+        })}
+      />,
+    );
+    await user.click(screen.getByTestId("row-one-rm-badge-9"));
+    const input = screen.getByTestId("row-one-rm-input-9");
+    await user.type(input, "abc");
+    await user.click(screen.getByTestId("row-one-rm-save-9"));
+    expect(screen.getByTestId("row-one-rm-error-9")).toBeInTheDocument();
+    expect(onSetOneRm).not.toHaveBeenCalled();
+  });
+
+  it("a successful save calls onSetOneRm with the ROW id (not the cell id) and closes the editor", async () => {
+    const user = userEvent.setup();
+    const onSetOneRm = vi.fn().mockResolvedValue({ one_rm: "150", one_rm_source: "manual" });
+    render(
+      <MesoTable
+        {...baseProps({
+          onSetOneRm,
+          grid: grid({ days: [day({ rows: [row({ exercise_slot_id: 9, cells: { "1": pctCell({ prescription_id: 100 }) } })] })] }),
+        })}
+      />,
+    );
+    await user.click(screen.getByTestId("row-one-rm-badge-9"));
+    const input = screen.getByTestId("row-one-rm-input-9");
+    await user.clear(input);
+    await user.type(input, "150");
+    await user.click(screen.getByTestId("row-one-rm-save-9"));
+    await waitFor(() => expect(onSetOneRm).toHaveBeenCalledWith(9, "150"));
+    await waitFor(() => expect(screen.queryByTestId("row-one-rm-input-9")).not.toBeInTheDocument());
+  });
+
+  it("a rejected save keeps the editor open with an error", async () => {
+    const user = userEvent.setup();
+    const onSetOneRm = vi.fn().mockRejectedValue(new Error("boom"));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    render(
+      <MesoTable
+        {...baseProps({
+          onSetOneRm,
+          grid: grid({ days: [day({ rows: [row({ cells: { "1": pctCell() } })] })] }),
+        })}
+      />,
+    );
+    await user.click(screen.getByTestId("row-one-rm-badge-9"));
+    const input = screen.getByTestId("row-one-rm-input-9");
+    await user.type(input, "150");
+    await user.click(screen.getByTestId("row-one-rm-save-9"));
+    await waitFor(() => expect(screen.getByTestId("row-one-rm-error-9")).toBeInTheDocument());
+    expect(screen.getByTestId("row-one-rm-input-9")).toBeInTheDocument();
+  });
+
+  it("disables save/cancel while busy", async () => {
+    const user = userEvent.setup();
+    const gridFixture = grid({ days: [day({ rows: [row({ cells: { "1": pctCell() } })] })] });
+    const { rerender } = render(<MesoTable {...baseProps({ grid: gridFixture })} />);
+    await user.click(screen.getByTestId("row-one-rm-badge-9"));
+    // Local state (the open editor) persists across a prop-only re-render of
+    // the same mounted tree — mirrors CellActions' swap-input idiom.
+    rerender(<MesoTable {...baseProps({ busy: true, grid: gridFixture })} />);
+    expect(screen.getByTestId("row-one-rm-save-9")).toBeDisabled();
+    expect(screen.getByTestId("row-one-rm-cancel-9")).toBeDisabled();
+  });
+
+  it("badge and input carry NO data-grid-cell (outside A1 keyboard-nav space)", async () => {
+    const user = userEvent.setup();
+    render(
+      <MesoTable
+        {...baseProps({
+          grid: grid({ days: [day({ rows: [row({ cells: { "1": pctCell({ one_rm: "140" }) } })] })] }),
+        })}
+      />,
+    );
+    expect(screen.getByTestId("row-one-rm-badge-9")).not.toHaveAttribute("data-grid-cell");
+    await user.click(screen.getByTestId("row-one-rm-badge-9"));
+    expect(screen.getByTestId("row-one-rm-input-9")).not.toHaveAttribute("data-grid-cell");
   });
 });
 

--- a/frontend/designer/src/components/MesoTable.tsx
+++ b/frontend/designer/src/components/MesoTable.tsx
@@ -565,7 +565,10 @@ function RowOneRmEditor({ row, cell, unit, busy, onSetOneRm }: RowOneRmEditorPro
   }
 
   async function save() {
-    if (saving) return;
+    // `busy` too, not just `saving`: the save button is disabled during a
+    // structural mutation/refetch, but Enter in the input reaches here
+    // directly (Codex review) — the keyboard path honors the same lock.
+    if (saving || busy) return;
     const parsed = parseOneRm(value);
     if (!parsed.ok) {
       setError("Enter a positive number, or leave blank to clear.");

--- a/frontend/designer/src/components/MesoTable.tsx
+++ b/frontend/designer/src/components/MesoTable.tsx
@@ -51,11 +51,13 @@ import {
 import type { CollisionDetection, DragEndEvent, DragStartEvent, KeyboardCoordinateGetter } from "@dnd-kit/core";
 import { SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import type { GridCell, GridDay, GridHistory, GridRow, GridWeek, GroupIdentity, MesoGrid } from "../lib/api";
-import type { GridCellPatch, Id } from "../hooks/useGrid";
+import type { GridCellOneRmPatch, GridCellPatch, Id } from "../hooks/useGrid";
+import { rowIdentityCellId } from "../hooks/useGrid";
 import { useTableNav, tableCellDomKey, tableCellAriaLabel } from "../hooks/useTableNav";
 import type { EditableField, UseTableNavResult } from "../hooks/useTableNav";
 import type { TableDragData, TableDragEndEvent } from "../hooks/useTableReorder";
 import { TABLE_DAY_DRAG_PREFIX, tableDayDragId, tableRowDragId, tableRowDragPrefix } from "../lib/tableDragIds";
+import { parseOneRm } from "../lib/oneRm";
 
 export interface MesoTableProps {
   grid: MesoGrid | null;
@@ -71,6 +73,11 @@ export interface MesoTableProps {
   onOpenOverride(row: GridRow, cell: GridCell): void;
   onPatchCell(cellId: Id, patch: GridCellPatch): void;
   onRenameExercise(exerciseSlotId: Id, name: string): void;
+  // Issue #455 phase A3: the per-ROW %1RM editor's save verb — AWAITED (the
+  // editor drives its own saving/error UI off the promise; see useGrid.setOneRm's
+  // header for why this is awaited, unlike the fire-and-forget onPatchCell/
+  // onRenameExercise above).
+  onSetOneRm(exerciseSlotId: Id, value: string): Promise<GridCellOneRmPatch>;
   onAddExercise(day: GridDay): void;
   onRemoveExercise(exerciseSlotId: Id): void;
   onAddDay(): void;
@@ -491,6 +498,156 @@ function RowNameEditor({ row, tableNav, onRename }: RowNameEditorProps) {
   );
 }
 
+/** The row's identity CELL object (not just its id) — resolves
+ * `rowIdentityCellId` (useGrid.ts, shared with row rename) against `row.cells`,
+ * which is keyed by WEEK id, not prescription id, so the lookup is a search
+ * over the cell VALUES rather than a direct index. Returns undefined when the
+ * row has no live cell at all. */
+function rowIdentityCell(weeks: GridWeek[], row: GridRow): GridCell | undefined {
+  const cellId = rowIdentityCellId(weeks, row);
+  if (cellId == null) return undefined;
+  return Object.values(row.cells).find((c) => c.prescription_id === cellId);
+}
+
+interface RowOneRmEditorProps {
+  row: GridRow;
+  cell: GridCell | undefined;
+  unit: string;
+  busy: boolean;
+  onSetOneRm(exerciseSlotId: Id, value: string): Promise<GridCellOneRmPatch>;
+}
+
+/** Issue #455 phase A3 — the per-ROW %1RM badge/editor (name column, 2nd
+ * line). A %1RM is a property of the athlete + lift IDENTITY (AthleteOneRm
+ * has no week dimension), NOT a per-week cell value — unlike P5's per-cell
+ * adjust badge (CellActions/`cell-override-badge-*`), this control reads and
+ * writes the row's single IDENTITY cell regardless of which week column the
+ * coach is looking at. Local state (CellActions' idiom) rather than a second
+ * useOneRmEditor instance — that hook needs planId/csrf, which would force
+ * MesoTable to take those directly and break the verbs-as-props boundary
+ * every other control here honors. Mirrors ExerciseRow.tsx's one-week %1RM
+ * badge/editor (label text, "1RM: "/"1RM ≈ " prefixes, "+ set 1RM",
+ * Enter=save/Escape=cancel) — ported, not reused, for the same reason. */
+function RowOneRmEditor({ row, cell, unit, busy, onSetOneRm }: RowOneRmEditorProps) {
+  const [open, setOpen] = useState(false);
+  const [value, setValue] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  // Scope cut (A3): a swapped pct cell gets no editable control here — the
+  // row's identity cell is never the swapped one when a live unswapped week
+  // exists (rowIdentityCellId), so this simply never renders for that case;
+  // server data (one_rm/one_rm_source) stays correct regardless (see this
+  // file's header / the implementation brief's "Risks" section).
+  if (!cell || cell.load_type !== "pct") return null;
+
+  const id = row.exercise_slot_id;
+
+  function openEditor() {
+    setValue(cell!.one_rm || "");
+    setError("");
+    setOpen(true);
+  }
+
+  function cancel() {
+    if (saving) return;
+    setOpen(false);
+    setError("");
+  }
+
+  async function save() {
+    if (saving) return;
+    const parsed = parseOneRm(value);
+    if (!parsed.ok) {
+      setError("Enter a positive number, or leave blank to clear.");
+      return;
+    }
+    setSaving(true);
+    setError("");
+    try {
+      await onSetOneRm(id, parsed.value);
+      setSaving(false);
+      setOpen(false);
+    } catch (err) {
+      console.error("1RM save failed", err);
+      setSaving(false);
+      setError("Couldn't save that 1RM. Please try again.");
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        data-testid={`row-one-rm-badge-${id}`}
+        data-hover="brighten"
+        className={`meso-onerm-badge${cell.one_rm ? " meso-onerm-badge--set" : ""}`}
+        onClick={openEditor}
+        title={
+          cell.one_rm
+            ? cell.one_rm_source === "manual"
+              ? "Athlete's 1RM (manually set) — tap to edit"
+              : "Athlete's estimated 1RM, from their logged history — tap to edit"
+            : "Set this athlete's 1RM so the % target resolves to a load"
+        }
+      >
+        {cell.one_rm
+          ? (cell.one_rm_source === "manual" ? "1RM: " : "1RM ≈ ") + cell.one_rm + (unit ? " " + unit : "")
+          : "+ set 1RM"}
+      </button>
+    );
+  }
+
+  return (
+    <span className="meso-onerm-editor">
+      <input
+        data-testid={`row-one-rm-input-${id}`}
+        className="meso-onerm-input"
+        type="text"
+        inputMode="decimal"
+        placeholder={unit}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            save();
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            cancel();
+          }
+        }}
+      />
+      <button
+        type="button"
+        data-testid={`row-one-rm-save-${id}`}
+        data-hover="brighten"
+        className="meso-onerm-save"
+        disabled={saving || busy}
+        onClick={save}
+      >
+        save
+      </button>
+      <button
+        type="button"
+        data-testid={`row-one-rm-cancel-${id}`}
+        data-hover="brighten"
+        className="meso-onerm-cancel"
+        disabled={saving || busy}
+        title="Cancel"
+        onClick={cancel}
+      >
+        ×
+      </button>
+      {error && (
+        <span data-testid={`row-one-rm-error-${id}`} className="meso-onerm-error">
+          {error}
+        </span>
+      )}
+    </span>
+  );
+}
+
 interface AddThisWeekControlProps {
   day: GridDay;
   weeks: GridWeek[];
@@ -549,6 +706,12 @@ interface TableRowProps {
   busy: boolean;
   unit: string;
   showAdjust: boolean;
+  // Issue #455 phase A3: gates the per-ROW %1RM badge/editor — `!isGroupPlan`
+  // (see MesoTable()'s computation below), DELIBERATELY NOT `showAdjust`'s
+  // member-count check (`!!(group && members.length)`): coach_set_one_rm
+  // 400s on ANY group plan (member count is irrelevant — a group has no
+  // single athlete), so this must gate on group identity alone.
+  showOneRm: boolean;
   tableNav: UseTableNavResult;
   rowArmed: boolean;
   onArmRow(): void;
@@ -557,6 +720,7 @@ interface TableRowProps {
   onOpenOverride(row: GridRow, cell: GridCell): void;
   onPatchCell(cellId: Id, patch: GridCellPatch): void;
   onRenameExercise(exerciseSlotId: Id, name: string): void;
+  onSetOneRm(exerciseSlotId: Id, value: string): Promise<GridCellOneRmPatch>;
   onSkipCell(cellId: number, skipped: boolean): void;
   onSwapCell(cellId: number, swapName: string): void;
   onFillAcrossWeeks(cellId: number): void;
@@ -575,6 +739,7 @@ function TableRow({
   busy,
   unit,
   showAdjust,
+  showOneRm,
   tableNav,
   rowArmed,
   onArmRow,
@@ -583,6 +748,7 @@ function TableRow({
   onOpenOverride,
   onPatchCell,
   onRenameExercise,
+  onSetOneRm,
   onSkipCell,
   onSwapCell,
   onFillAcrossWeeks,
@@ -605,55 +771,68 @@ function TableRow({
       data-testid={`meso-row-${row.exercise_slot_id}`}
     >
       <td className="meso-table-row-name-col">
-        <button
-          type="button"
-          ref={setActivatorNodeRef}
-          data-testid={`row-drag-${row.exercise_slot_id}`}
-          className="meso-drag-handle"
-          aria-label={`Reorder ${row.name || "exercise"}`}
-          disabled={busy}
-          {...attributes}
-          {...listeners}
-        >
-          ⠿
-        </button>
-        <RowNameEditor row={row} tableNav={tableNav} onRename={onRenameExercise} />
-        {!rowArmed && (
+        <div className="meso-table-row-name-row">
           <button
             type="button"
-            data-testid={`remove-exercise-${row.exercise_slot_id}`}
-            className="meso-remove-x meso-remove-x--sm"
+            ref={setActivatorNodeRef}
+            data-testid={`row-drag-${row.exercise_slot_id}`}
+            className="meso-drag-handle"
+            aria-label={`Reorder ${row.name || "exercise"}`}
             disabled={busy}
-            aria-label="Remove exercise"
-            title="Remove exercise"
-            onClick={onArmRow}
+            {...attributes}
+            {...listeners}
           >
-            ×
+            ⠿
           </button>
-        )}
-        {rowArmed && (
-          <span className="meso-confirm-pair">
+          <RowNameEditor row={row} tableNav={tableNav} onRename={onRenameExercise} />
+          {!rowArmed && (
             <button
               type="button"
-              data-testid={`confirm-remove-exercise-${row.exercise_slot_id}`}
-              className="meso-confirm-btn"
+              data-testid={`remove-exercise-${row.exercise_slot_id}`}
+              className="meso-remove-x meso-remove-x--sm"
               disabled={busy}
-              aria-label="Confirm remove exercise"
-              onClick={onConfirmRemoveRow}
+              aria-label="Remove exercise"
+              title="Remove exercise"
+              onClick={onArmRow}
             >
-              Confirm?
+              ×
             </button>
-            <button
-              type="button"
-              data-testid={`cancel-remove-exercise-${row.exercise_slot_id}`}
-              className="meso-cancel-btn"
-              disabled={busy}
-              aria-label="Cancel remove exercise"
-              onClick={onCancelRemoveRow}
-            >
-              Cancel
-            </button>
-          </span>
+          )}
+          {rowArmed && (
+            <span className="meso-confirm-pair">
+              <button
+                type="button"
+                data-testid={`confirm-remove-exercise-${row.exercise_slot_id}`}
+                className="meso-confirm-btn"
+                disabled={busy}
+                aria-label="Confirm remove exercise"
+                onClick={onConfirmRemoveRow}
+              >
+                Confirm?
+              </button>
+              <button
+                type="button"
+                data-testid={`cancel-remove-exercise-${row.exercise_slot_id}`}
+                className="meso-cancel-btn"
+                disabled={busy}
+                aria-label="Cancel remove exercise"
+                onClick={onCancelRemoveRow}
+              >
+                Cancel
+              </button>
+            </span>
+          )}
+        </div>
+        {showOneRm && (
+          <div className="meso-table-row-tags meso-ex-tags">
+            <RowOneRmEditor
+              row={row}
+              cell={rowIdentityCell(weeks, row)}
+              unit={unit}
+              busy={busy}
+              onSetOneRm={onSetOneRm}
+            />
+          </div>
         )}
       </td>
       {weeks.map((week) => {
@@ -740,6 +919,7 @@ interface TableDayBlockProps {
   busy: boolean;
   unit: string;
   showAdjust: boolean;
+  showOneRm: boolean;
   tableNav: UseTableNavResult;
   isArmed(type: ArmedKind, id: Id): boolean;
   arm(type: ArmedKind, id: Id): void;
@@ -747,6 +927,7 @@ interface TableDayBlockProps {
   onOpenOverride(row: GridRow, cell: GridCell): void;
   onPatchCell(cellId: Id, patch: GridCellPatch): void;
   onRenameExercise(exerciseSlotId: Id, name: string): void;
+  onSetOneRm(exerciseSlotId: Id, value: string): Promise<GridCellOneRmPatch>;
   onAddExercise(day: GridDay): void;
   onRemoveExercise(exerciseSlotId: Id): void;
   onRemoveDay(day: GridDay): void;
@@ -768,6 +949,7 @@ function TableDayBlock({
   busy,
   unit,
   showAdjust,
+  showOneRm,
   tableNav,
   isArmed,
   arm,
@@ -775,6 +957,7 @@ function TableDayBlock({
   onOpenOverride,
   onPatchCell,
   onRenameExercise,
+  onSetOneRm,
   onAddExercise,
   onRemoveExercise,
   onRemoveDay,
@@ -887,6 +1070,7 @@ function TableDayBlock({
                   busy={busy}
                   unit={unit}
                   showAdjust={showAdjust}
+                  showOneRm={showOneRm}
                   tableNav={tableNav}
                   rowArmed={isArmed("exercise", row.exercise_slot_id)}
                   onArmRow={() => arm("exercise", row.exercise_slot_id)}
@@ -898,6 +1082,7 @@ function TableDayBlock({
                   onOpenOverride={onOpenOverride}
                   onPatchCell={onPatchCell}
                   onRenameExercise={onRenameExercise}
+                  onSetOneRm={onSetOneRm}
                   onSkipCell={onSkipCell}
                   onSwapCell={onSwapCell}
                   onFillAcrossWeeks={onFillAcrossWeeks}
@@ -935,6 +1120,7 @@ export function MesoTable(props: MesoTableProps) {
     onOpenOverride,
     onPatchCell,
     onRenameExercise,
+    onSetOneRm,
     onAddExercise,
     onRemoveExercise,
     onAddDay,
@@ -959,6 +1145,14 @@ export function MesoTable(props: MesoTableProps) {
   // P5 group: the per-cell adjust badge only exists on a GROUP plan with
   // members — an individual plan carries no `group`, so no cell ever shows it.
   const showAdjust = !!(group && group.members.length);
+
+  // Issue #455 phase A3: the per-ROW %1RM badge/editor exists on an
+  // INDIVIDUAL plan only — DELIBERATELY `!group` rather than showAdjust's
+  // member-count check above. A %1RM belongs to a single athlete
+  // (AthleteOneRm), so coach_set_one_rm 400s on ANY group plan regardless of
+  // member count; gating on member count here (like showAdjust) would try to
+  // open the editor for a 0-member group and hit that 400.
+  const showOneRm = !group;
 
   // Rules of Hooks: called unconditionally, before the `!grid` early return
   // below — useTableNav tolerates a null grid the same way (anchor stays
@@ -1066,6 +1260,7 @@ export function MesoTable(props: MesoTableProps) {
               busy={busy}
               unit={unit}
               showAdjust={showAdjust}
+              showOneRm={showOneRm}
               tableNav={tableNav}
               isArmed={isArmed}
               arm={arm}
@@ -1073,6 +1268,7 @@ export function MesoTable(props: MesoTableProps) {
               onOpenOverride={onOpenOverride}
               onPatchCell={onPatchCell}
               onRenameExercise={onRenameExercise}
+              onSetOneRm={onSetOneRm}
               onAddExercise={onAddExercise}
               onRemoveExercise={onRemoveExercise}
               onRemoveDay={onRemoveDay}

--- a/frontend/designer/src/components/MesoTable.tsx
+++ b/frontend/designer/src/components/MesoTable.tsx
@@ -534,12 +534,21 @@ function RowOneRmEditor({ row, cell, unit, busy, onSetOneRm }: RowOneRmEditorPro
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
 
-  // Scope cut (A3): a swapped pct cell gets no editable control here — the
-  // row's identity cell is never the swapped one when a live unswapped week
-  // exists (rowIdentityCellId), so this simply never renders for that case;
-  // server data (one_rm/one_rm_source) stays correct regardless (see this
-  // file's header / the implementation brief's "Risks" section).
-  if (!cell || cell.load_type !== "pct") return null;
+  // DISPLAY gate: any live, unswapped, non-skipped cell of the row carrying
+  // a % load makes the row 1RM-relevant — load_type is edited PER CELL in
+  // this table, so gating on the identity cell's own load_type alone hides
+  // the only 1RM control from a mixed-load row (identity week abs, a later
+  // week pct — Codex #455 A3 review). The SAVE target stays the identity
+  // cell regardless: all unswapped cells share the row's lift identity, so
+  // any of them keys the same AthleteOneRm row.
+  // Scope cut (A3): a SWAPPED pct cell still gets no control of its own —
+  // its lift identity differs from the row's; server data
+  // (one_rm/one_rm_source) stays correct regardless (see this file's
+  // header / the implementation brief's "Risks" section).
+  const rowHasPct = Object.values(row.cells).some(
+    (c) => c.load_type === "pct" && !c.skipped && c.swap_name === "" && c.swap_exercise_id == null,
+  );
+  if (!cell || !rowHasPct) return null;
 
   const id = row.exercise_slot_id;
 

--- a/frontend/designer/src/hooks/useGrid.test.ts
+++ b/frontend/designer/src/hooks/useGrid.test.ts
@@ -245,6 +245,48 @@ describe("renameExercise", () => {
 });
 
 describe("setOneRm (issue #455 phase A3)", () => {
+  it("flushes a pending rename before POSTing one-rm/, so the 1RM never keys under the old lift name", async () => {
+    // Codex #455 A3 review: the server keys a MANUAL 1RM off the
+    // prescription's RESOLVED name at POST time. A just-blurred free-text
+    // rename whose autosave is still in flight must land first, or the
+    // value is stored under the OLD identity and vanishes on refetch.
+    const { result } = setup();
+    let resolveRename!: (v: unknown) => void;
+    const fetchMock = vi.fn();
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRename = resolve;
+        }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    // Kick off the rename autosave (fire-and-forget) — POST now in flight.
+    act(() => {
+      result.current.renameExercise(9, "Front Squat");
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Save a 1RM while the rename is still unresolved.
+    let saveDone!: Promise<unknown>;
+    act(() => {
+      saveDone = result.current.setOneRm(9, "140");
+    });
+
+    // Blocked on flushPendingWrites(): the one-rm/ POST must not be out yet.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    fetchMock.mockResolvedValueOnce(res({ ok: true, one_rm: "140", source: "manual" }));
+    await act(async () => {
+      resolveRename(res({ ok: true }));
+      await saveDone;
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]![0]).toBe("/meso/api/plan/7/prescription/100/"); // the rename
+    expect(fetchMock.mock.calls[1]![0]).toBe("/meso/api/plan/7/prescription/100/one-rm/"); // only after
+  });
+
   it("POSTs {value} to the row's identity cell and locally patches one_rm/one_rm_source, without refetching", async () => {
     const { result } = setup();
     globalThis.fetch = vi.fn().mockResolvedValue(

--- a/frontend/designer/src/hooks/useGrid.test.ts
+++ b/frontend/designer/src/hooks/useGrid.test.ts
@@ -287,6 +287,42 @@ describe("setOneRm (issue #455 phase A3)", () => {
     expect(fetchMock.mock.calls[1]![0]).toBe("/meso/api/plan/7/prescription/100/one-rm/"); // only after
   });
 
+  it("repaints every cell sharing the lift identity, not just the target (duplicate lift across days)", async () => {
+    // AthleteOneRm is keyed athlete+lift — the same free-text "Squat" on two
+    // days shares one server record, so a save from day 1 must repaint day
+    // 2's badge too or it shows stale until a full refetch (Codex review).
+    const { result } = setup(
+      grid({
+        days: [
+          day({
+            session_slot_id: 1,
+            rows: [
+              row({ exercise_slot_id: 9, name: "Squat", exercise_id: null, cells: { "1": cell({ prescription_id: 100 }) } }),
+            ],
+          }),
+          day({
+            session_slot_id: 2,
+            session_ids: { "1": 22 },
+            rows: [
+              row({ exercise_slot_id: 10, name: "squat ", exercise_id: null, cells: { "1": cell({ prescription_id: 200 }) } }),
+              row({ exercise_slot_id: 11, name: "Bench", exercise_id: null, cells: { "1": cell({ prescription_id: 300 }) } }),
+            ],
+          }),
+        ],
+      }),
+    );
+    globalThis.fetch = vi.fn().mockResolvedValue(res({ ok: true, one_rm: "140", source: "manual" })) as unknown as typeof fetch;
+
+    await act(async () => {
+      await result.current.setOneRm(9, "140");
+    });
+
+    const days = result.current.grid!.days;
+    expect(days[0]!.rows[0]!.cells["1"]!.one_rm).toBe("140"); // the target
+    expect(days[1]!.rows[0]!.cells["1"]!.one_rm).toBe("140"); // same lift ("squat " folds to squat)
+    expect(days[1]!.rows[1]!.cells["1"]!.one_rm).toBeUndefined(); // different lift untouched
+  });
+
   it("POSTs {value} to the row's identity cell and locally patches one_rm/one_rm_source, without refetching", async () => {
     const { result } = setup();
     globalThis.fetch = vi.fn().mockResolvedValue(

--- a/frontend/designer/src/hooks/useGrid.test.ts
+++ b/frontend/designer/src/hooks/useGrid.test.ts
@@ -244,6 +244,83 @@ describe("renameExercise", () => {
   });
 });
 
+describe("setOneRm (issue #455 phase A3)", () => {
+  it("POSTs {value} to the row's identity cell and locally patches one_rm/one_rm_source, without refetching", async () => {
+    const { result } = setup();
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      res({ ok: true, one_rm: "140", source: "manual" }),
+    ) as unknown as typeof fetch;
+
+    let patch: { one_rm?: string; one_rm_source?: string } | undefined;
+    await act(async () => {
+      patch = await result.current.setOneRm(9, "140");
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(url).toBe("/meso/api/plan/7/prescription/100/one-rm/");
+    expect(opts.method).toBe("POST");
+    expect(sentBody()).toEqual({ value: "140" });
+    expect(patch).toEqual({ one_rm: "140", one_rm_source: "manual" });
+    expect(result.current.grid?.days[0]?.rows[0]?.cells["1"]?.one_rm).toBe("140");
+    expect(result.current.grid?.days[0]?.rows[0]?.cells["1"]?.one_rm_source).toBe("manual");
+  });
+
+  it("targets the first NON-swapped week when week[0]'s cell is itself the swap", async () => {
+    const { result } = setup(
+      grid({
+        weeks: [week({ id: 1 }), week({ id: 2, label: "Wk 2", current: false })],
+        days: [
+          day({
+            rows: [
+              row({
+                exercise_slot_id: 9,
+                cells: {
+                  "1": cell({ prescription_id: 100, swap_name: "Leg Press", swap_exercise_id: 77 }),
+                  "2": cell({ prescription_id: 101 }),
+                },
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+    globalThis.fetch = vi.fn().mockResolvedValue(res({ ok: true, one_rm: "100", source: "logged" })) as unknown as typeof fetch;
+
+    await act(async () => {
+      await result.current.setOneRm(9, "100");
+    });
+
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(url).toBe("/meso/api/plan/7/prescription/101/one-rm/"); // week[1]'s (unswapped) cell, not the swapped week[0] one
+  });
+
+  it("rethrows on a rejected save, leaving the grid unchanged", async () => {
+    const { result } = setup();
+    globalThis.fetch = vi.fn().mockResolvedValue(res({}, false, 400)) as unknown as typeof fetch;
+
+    await expect(
+      act(async () => {
+        await result.current.setOneRm(9, "abc");
+      }),
+    ).rejects.toThrow();
+
+    expect(result.current.grid?.days[0]?.rows[0]?.cells["1"]?.one_rm).toBeUndefined();
+  });
+
+  it("leaves history untouched after a save (coach_set_one_rm records no plan action)", async () => {
+    const { result } = setup();
+    globalThis.fetch = vi.fn().mockResolvedValue(res({ ok: true, one_rm: "140", source: "manual" })) as unknown as typeof fetch;
+
+    const before = result.current.history;
+    await act(async () => {
+      await result.current.setOneRm(9, "140");
+    });
+
+    expect(result.current.history).toBe(before);
+  });
+});
+
 describe("addExercise", () => {
   it("POSTs session/{sessionId}/exercise/ with a null body, then refetches the grid", async () => {
     const initial = grid();

--- a/frontend/designer/src/hooks/useGrid.ts
+++ b/frontend/designer/src/hooks/useGrid.ts
@@ -17,7 +17,7 @@
 // every structural verb so a double-click can't race two refetches.
 import { useCallback, useRef, useState } from "react";
 import { apiPost } from "../lib/api";
-import type { GridCell, GridDay, GridHistory, GridRow, MesoGrid } from "../lib/api";
+import type { GridCell, GridDay, GridHistory, GridRow, GridWeek, MesoGrid } from "../lib/api";
 
 export type Id = number | string;
 
@@ -33,6 +33,13 @@ export type GridCellPatch = Partial<
  * repaints without a full grid refetch. The grid analog of usePlanData's
  * `patchExercise({adj, adjusts})` on the single-week path. */
 export type GridCellAdjPatch = Pick<GridCell, "adj" | "adjusts">;
+
+/** Issue #455 phase A3: the one_rm/one_rm_source a coach_set_one_rm save
+ * returns — patched into the row's identity cell (matched by
+ * prescription_id) so its %1RM badge repaints without a full grid refetch.
+ * The grid analog of GridCellAdjPatch above / useOneRmEditor's
+ * `patchExercise({one_rm, one_rm_source})` on the single-week path. */
+export type GridCellOneRmPatch = Pick<GridCell, "one_rm" | "one_rm_source">;
 
 /** Any payload carrying a fresh plan history — accepts BOTH the grid
  * endpoints' `GridHistory` (string labels) AND the override editor's
@@ -79,17 +86,21 @@ function firstWeekCellId(grid: MesoGrid | null, row: GridRow | undefined): Id | 
   return row.cells[String(firstWeek.id)]?.prescription_id;
 }
 
-/** The row's rename target: the first live week's cell that is NOT a one-week
- * swap (prescription_patch only rewrites the block ExerciseSlot.name for an
- * unswapped cell). Falls back to the first week's cell if every week is
- * swapped (rare) — best-effort. */
-function renameTargetCellId(grid: MesoGrid | null, row: GridRow | undefined): Id | undefined {
-  if (!grid || !row) return undefined;
-  for (const week of grid.weeks) {
+/** The row's IDENTITY cell: the first live week's cell that is NOT a one-week
+ * swap. Shared by rename (prescription_patch only rewrites the block
+ * ExerciseSlot.name for an unswapped cell) and setOneRm below (a %1RM is a
+ * property of the ROW's block identity, not a swapped week's substitute
+ * lift — see setOneRm's header). Falls back to the first week's cell if
+ * every week is swapped (rare) — best-effort. Exported so MesoTable can
+ * derive the identity cell to READ (`cell.one_rm`/`one_rm_source`) without
+ * duplicating this rule. */
+export function rowIdentityCellId(weeks: GridWeek[], row: GridRow | undefined): Id | undefined {
+  if (!row) return undefined;
+  for (const week of weeks) {
     const c = row.cells[String(week.id)];
     if (c && c.swap_name === "" && c.swap_exercise_id == null) return c.prescription_id;
   }
-  const first = grid.weeks[0];
+  const first = weeks[0];
   return first ? row.cells[String(first.id)]?.prescription_id : undefined;
 }
 
@@ -217,7 +228,7 @@ export function useGrid(options: UseGridOptions) {
   const renameExercise = useCallback(
     (exerciseSlotId: Id, name: string) => {
       const row = findRow(grid, exerciseSlotId);
-      const cellId = renameTargetCellId(grid, row);
+      const cellId = rowIdentityCellId(grid?.weeks ?? [], row);
       if (cellId == null) return;
       setGrid((prev) => (prev ? updateRowNameInGrid(prev, exerciseSlotId, name) : prev));
       const write = apiPost(`/meso/api/plan/${planId}/prescription/${cellId}/`, { name }, csrf)
@@ -227,6 +238,34 @@ export function useGrid(options: UseGridOptions) {
       write.finally(() => pendingWritesRef.current.delete(write));
     },
     [grid, planId, csrf, adoptGridHistory],
+  );
+
+  // Issue #455 phase A3: the %1RM editor's save verb — AWAITED (unlike
+  // patchCell/renameExercise's fire-and-forget autosave) so RowOneRmEditor
+  // (MesoTable.tsx) can drive its own saving/error UI off the promise, mirror-
+  // ing useOneRmEditor.saveOneRm on the single-week path. A %1RM is a
+  // property of the athlete + lift identity (AthleteOneRm has NO week
+  // dimension), so it always targets the row's IDENTITY cell (rowIdentityCellId
+  // — shared with renameExercise above), never the cell the coach happens to
+  // be looking at. Patches the result LOCALLY (updateCellInGrid, patchCellAdj's
+  // precedent) — no refetchGrid (nothing structural changed) and no
+  // adoptGridHistory (coach_set_one_rm does not record_plan_action, so the
+  // reply carries no `history`).
+  const setOneRm = useCallback(
+    async (exerciseSlotId: Id, value: string): Promise<GridCellOneRmPatch> => {
+      const row = findRow(grid, exerciseSlotId);
+      const cellId = rowIdentityCellId(grid?.weeks ?? [], row);
+      if (cellId == null) throw new Error("No cell to set a 1RM against.");
+      const data = await apiPost<{ one_rm?: string; source?: string }>(
+        `/meso/api/plan/${planId}/prescription/${cellId}/one-rm/`,
+        { value },
+        csrf,
+      );
+      const patch: GridCellOneRmPatch = { one_rm: data.one_rm ?? "", one_rm_source: data.source ?? "" };
+      setGrid((prev) => (prev ? updateCellInGrid(prev, cellId, patch) : prev));
+      return patch;
+    },
+    [grid, planId, csrf],
   );
 
   const addExercise = useCallback(
@@ -476,6 +515,7 @@ export function useGrid(options: UseGridOptions) {
     patchCellAdj,
     adoptGridHistory,
     renameExercise,
+    setOneRm,
     addExercise,
     removeExercise,
     addDay,

--- a/frontend/designer/src/hooks/useGrid.ts
+++ b/frontend/designer/src/hooks/useGrid.ts
@@ -256,6 +256,11 @@ export function useGrid(options: UseGridOptions) {
       const row = findRow(grid, exerciseSlotId);
       const cellId = rowIdentityCellId(grid?.weeks ?? [], row);
       if (cellId == null) throw new Error("No cell to set a 1RM against.");
+      // A just-blurred free-text rename may still be in flight — the server
+      // keys a MANUAL 1RM off the prescription's RESOLVED name, so saving
+      // before the rename lands would store it under the OLD lift identity
+      // (Codex #455 A3 review). Same flush fillAcrossWeeks uses.
+      await flushPendingWrites();
       const data = await apiPost<{ one_rm?: string; source?: string }>(
         `/meso/api/plan/${planId}/prescription/${cellId}/one-rm/`,
         { value },
@@ -265,7 +270,7 @@ export function useGrid(options: UseGridOptions) {
       setGrid((prev) => (prev ? updateCellInGrid(prev, cellId, patch) : prev));
       return patch;
     },
-    [grid, planId, csrf],
+    [grid, planId, csrf, flushPendingWrites],
   );
 
   const addExercise = useCallback(

--- a/frontend/designer/src/hooks/useGrid.ts
+++ b/frontend/designer/src/hooks/useGrid.ts
@@ -136,6 +136,43 @@ function updateCellInGrid(grid: MesoGrid, cellId: Id, patch: Partial<GridCell>):
   };
 }
 
+/** The lift identity a cell RESOLVES to, mirroring the server's
+ * `_exercise_key`/`key_str` rule exactly (serializers.py/one_rm.py):
+ * `"id:<pk>"` for a catalog-linked lift, `"name:<trimmed lower>"` for free
+ * text; a one-week swap overrides the row's block identity for that cell. */
+export function liftIdentityOfCell(row: GridRow, c: GridCell): string {
+  const swapped = c.swap_name !== "" || c.swap_exercise_id != null;
+  const exerciseId = swapped ? c.swap_exercise_id : row.exercise_id;
+  const name = swapped ? c.swap_name : row.name;
+  return exerciseId != null ? `id:${exerciseId}` : `name:${(name || "").trim().toLowerCase()}`;
+}
+
+/** Patch every cell in the grid whose resolved lift identity matches —
+ * an AthleteOneRm is keyed athlete+lift, not per cell, so a save from one
+ * row must repaint the SAME lift's badge everywhere it appears (duplicate
+ * lifts across days, or a swap resolving to another row's lift). */
+function updateCellsByLiftIdentity(grid: MesoGrid, identity: string, patch: Partial<GridCell>): MesoGrid {
+  return {
+    ...grid,
+    days: grid.days.map((day) => ({
+      ...day,
+      rows: day.rows.map((row) => {
+        let changed = false;
+        const cells: Record<string, GridCell> = {};
+        for (const [weekId, c] of Object.entries(row.cells)) {
+          if (liftIdentityOfCell(row, c) === identity) {
+            changed = true;
+            cells[weekId] = { ...c, ...patch };
+          } else {
+            cells[weekId] = c;
+          }
+        }
+        return changed ? { ...row, cells } : row;
+      }),
+    })),
+  };
+}
+
 function updateRowNameInGrid(grid: MesoGrid, exerciseSlotId: Id, name: string): MesoGrid {
   return {
     ...grid,
@@ -267,7 +304,18 @@ export function useGrid(options: UseGridOptions) {
         csrf,
       );
       const patch: GridCellOneRmPatch = { one_rm: data.one_rm ?? "", one_rm_source: data.source ?? "" };
-      setGrid((prev) => (prev ? updateCellInGrid(prev, cellId, patch) : prev));
+      // The server record is keyed athlete+LIFT, not per cell — repaint every
+      // cell resolving to the same lift (duplicate lifts across days would
+      // otherwise show stale badges until a full refetch — Codex review).
+      const targetCell = Object.values(row!.cells).find((c) => c.prescription_id === cellId);
+      const identity = targetCell ? liftIdentityOfCell(row!, targetCell) : null;
+      setGrid((prev) =>
+        prev
+          ? identity != null
+            ? updateCellsByLiftIdentity(prev, identity, patch)
+            : updateCellInGrid(prev, cellId, patch)
+          : prev,
+      );
       return patch;
     },
     [grid, planId, csrf, flushPendingWrites],

--- a/frontend/designer/src/lib/api.ts
+++ b/frontend/designer/src/lib/api.ts
@@ -185,6 +185,13 @@ export interface GridCell {
   /** P5 group: every member's stored diff on this cell (drives the override
    * editor's member dots + draft). Present alongside `adj`; absent otherwise. */
   adjusts?: OverrideAdjust[];
+  /** Issue #455 phase A3: the athlete's persisted %1RM estimate for THIS
+   * cell's resolved lift identity (swap-aware — a swapped cell reads its own
+   * identity's estimate, not the row's block identity). Individual-plan-only
+   * (server attaches uniformly per cell, regardless of `load_type`; absent
+   * for a group plan and when the athlete has no stored estimate). */
+  one_rm?: string;
+  one_rm_source?: string;
 }
 
 export interface GridRow {

--- a/frontend/designer/src/styles/designer-mesotable.css
+++ b/frontend/designer/src/styles/designer-mesotable.css
@@ -110,10 +110,25 @@
   z-index: 1;
   background: var(--surface);
   display: flex;
-  align-items: center;
-  gap: 4px;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 2px;
   min-width: 160px;
 }
+
+.meso-table-row-name-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+/* Issue #455 phase A3: the row-name column's 2nd line — the per-ROW %1RM
+ * badge/editor (RowOneRmEditor, MesoTable.tsx). No new layout rule here on
+ * purpose: the element carries `.meso-ex-tags` (designer-grid.css, unscoped)
+ * alongside `.meso-table-row-tags` for its box layout — true reuse rather
+ * than a duplicate ruleset. An individual plan's non-pct/abs-load row
+ * renders this line EMPTY (RowOneRmEditor returns null), collapsing to
+ * `.meso-ex-tags`'s own small `min-height` allowance. */
 
 .meso-table-cell {
   min-width: 190px;


### PR DESCRIPTION
## Summary

Phase A3 of #455 (MesoTable parity): the per-exercise %1RM badge + inline editor, ported to the multi-week designer table — the third of the four one-week-only capability gaps.

- **Per-ROW badge** in the name column's new second line (not per-cell like the P5 adjust badge — deliberately: `AthleteOneRm` is keyed athlete+lift with **no week dimension**, so "set the athlete's squat max" is a row-level act). Shows `1RM: 140 kg` (manual), `1RM ≈ 128 kg` (derived from the athlete's logged history), or `+ set 1RM`; opens an inline editor (Enter saves, Escape cancels, blank clears back to the log-derived estimate).
- **Server:** `serialize_mesocycle_grid` attaches `one_rm`/`one_rm_source` per cell for individual plans (identity-aware via `one_rm_values`, so a one-week swap's different lift resolves correctly), skipped entirely for groups — symmetric with the adjust overlay being group-only. This phase also **establishes the serializer's query budget as an enforced test** (baseline+1 individual / +0 group; none existed before) — which immediately caught and fixed an N+1 via `select_related("exercise_slot")`.
- **Save flow:** new awaited `useGrid.setOneRm` verb → existing `coach_set_one_rm` endpoint (unchanged) → **local repaint of every cell resolving to the saved lift identity** (mirrors the server's `id:`/`name:` key rule — duplicate lifts across days repaint together; no grid refetch, nothing structural changed). Saves **flush in-flight autosaves first** so a just-blurred free-text rename can't race the 1RM under the old name (Codex finding).
- **Gating:** individual plans only (`!group` — deliberately not `showAdjust`'s member-count check; the endpoint 400s on any group plan) and rows with **any** live unswapped non-skipped `%` cell (load type is per-cell, so a mixed-load row keeps its control — Codex finding). Swapped pct cells get no control of their own in A3 (different lift identity; server data stays correct — documented scope cut). Badge/editor live outside the A1 keyboard-nav space; Enter honors the busy lock.
- Shared identity-cell resolution extracted: `renameTargetCellId` → exported `rowIdentityCellId`, now used by both rename and 1RM.

No migrations. No new endpoints.

## Review + verification
- Codex review loop CLEAN on iteration 3 (4 P2/P3 findings across iterations 1–2 — mixed-load gating, rename race, duplicate-lift stale badges, Enter-bypasses-busy — all fixed red-green).
- Vitest **718 passed** (+25), strict tsc clean, build clean; Django **2105 passed** (+6, incl. the new query-budget tests); `makemigrations --check` clean.
- **Browser-verified on the live designer**: toggling a cell to `%` surfaces `+ set 1RM`, saving 140 updates the badge in place (no grid flash — local patch path), the `AthleteOneRm` row persists (`manual`), a reload renders from the serializer, and the athlete's real logged session from the #456 verification surfaces as a `logged`-source estimate on its lift.

Refs #455 (A3)

https://claude.ai/code/session_01GpaxgUSRbupnkecSo9Pmx4