### PR TITLE
feat(meso): A4 — coachmark for the multi-week table (#455)

### DIFF
--- a/frontend/designer/src/DesignerRoot.tsx
+++ b/frontend/designer/src/DesignerRoot.tsx
@@ -460,6 +460,8 @@ export function DesignerRoot() {
                 onFillAcrossWeeks={gridState.fillAcrossWeeks}
                 onAddExerciseThisWeek={gridState.addExerciseThisWeek}
                 onDragEnd={tableReorder.onDragEnd}
+                coachmarkVisible={coachmarks.coachmarkVisible}
+                dismissCoachmark={coachmarks.dismissCoachmark}
               />
             )}
 

--- a/frontend/designer/src/components/MesoTable.test.tsx
+++ b/frontend/designer/src/components/MesoTable.test.tsx
@@ -117,6 +117,8 @@ function baseProps(overrides: Partial<Parameters<typeof MesoTable>[0]> = {}) {
     onFillAcrossWeeks: vi.fn(),
     onAddExerciseThisWeek: vi.fn(),
     onSetOneRm: vi.fn().mockResolvedValue({ one_rm: "", one_rm_source: "" }),
+    coachmarkVisible: vi.fn(() => true),
+    dismissCoachmark: vi.fn(),
     ...overrides,
   };
 }
@@ -136,6 +138,31 @@ describe("layout", () => {
 
   it("renders nothing when grid is null", () => {
     const { container } = render(<MesoTable {...baseProps({ grid: null })} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+// Issue #455 phase A4 — the table coachmark. Mirrors WeekGrid.test.tsx's
+// "shows the grid coachmark.../hides the grid coachmark..." pair structurally,
+// against the new "table" key (lib/coachmarks.ts's COACHMARK_KEYS).
+describe("coachmark (issue #455 phase A4)", () => {
+  it("shows the table coachmark when coachmarkVisible('table') is true, dismiss wired", async () => {
+    const user = userEvent.setup();
+    const dismissCoachmark = vi.fn();
+    render(<MesoTable {...baseProps({ dismissCoachmark })} />);
+    expect(screen.getByText("The block table")).toBeInTheDocument();
+    expect(screen.getByText(/every change autosaves/i)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(dismissCoachmark).toHaveBeenCalledWith("table");
+  });
+
+  it("hides the table coachmark when dismissed", () => {
+    render(<MesoTable {...baseProps({ coachmarkVisible: vi.fn(() => false) })} />);
+    expect(screen.queryByText("The block table")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing (including the coachmark) when grid is null", () => {
+    const { container } = render(<MesoTable {...baseProps({ grid: null, coachmarkVisible: vi.fn(() => true) })} />);
     expect(container).toBeEmptyDOMElement();
   });
 });

--- a/frontend/designer/src/components/MesoTable.tsx
+++ b/frontend/designer/src/components/MesoTable.tsx
@@ -36,7 +36,9 @@
 // P1: deferred (see docs/archive/meso/fixed-selection-plan.md) — in-cell
 // group override editor / one-rm editor, agent-chat wiring, coachmarks.
 // Swap/skip/add-this-week WRITE UX is P2 — this file only ever DISPLAYS
-// swap_name/skipped.
+// swap_name/skipped. The table's own coachmark landed in issue #455 phase
+// A4 (re-authored copy, not a mechanical port of WeekGrid.tsx's "grid"
+// mark — see this file's coachmarkVisible/dismissCoachmark prop header).
 import { useEffect, useRef, useState } from "react";
 import {
   DndContext,
@@ -98,6 +100,11 @@ export interface MesoTableProps {
   // MesoTable.test.tsx's existing baseProps() (which never sets it) keeps
   // passing untouched.
   onDragEnd?(event: TableDragEndEvent): void;
+  // Issue #455 phase A4: the table's own first-run coachmark — same
+  // useCoachmarks hook slice WeekGrid.tsx takes for its "grid" mark
+  // (lib/coachmarks.ts's COACHMARK_KEYS now carries a "table" entry too).
+  coachmarkVisible(key: string): boolean;
+  dismissCoachmark(key: string): void;
 }
 
 /** The single arm/confirm slot — mirrors usePlanData's PendingDelete
@@ -1147,6 +1154,8 @@ export function MesoTable(props: MesoTableProps) {
     onFillAcrossWeeks,
     onAddExerciseThisWeek,
     onDragEnd,
+    coachmarkVisible,
+    dismissCoachmark,
   } = props;
 
   const [armed, setArmed] = useState<Armed>(null);
@@ -1256,6 +1265,27 @@ export function MesoTable(props: MesoTableProps) {
           + Add week
         </button>
       </div>
+
+      {coachmarkVisible("table") && (
+        <div className="meso-flex meso-coachmark">
+          <div className="meso-coachmark-body">
+            <div className="meso-coachmark-title">The block table</div>
+            <div className="meso-coachmark-text">
+              Tap any cell — sets, reps, load, RPE, rest, or notes — to edit it; arrow keys move cell to
+              cell, and every change autosaves. Drag a ⠿ handle to reorder exercises or days.
+            </div>
+          </div>
+          <button
+            type="button"
+            data-hover="rail"
+            className="meso-coachmark-dismiss"
+            aria-label="Dismiss tip"
+            onClick={() => dismissCoachmark("table")}
+          >
+            ×
+          </button>
+        </div>
+      )}
 
       <DndContext
         sensors={sensors}

--- a/frontend/designer/src/lib/coachmarks.test.ts
+++ b/frontend/designer/src/lib/coachmarks.test.ts
@@ -13,12 +13,13 @@ describe("storageKey", () => {
   it("namespaces each coachmark's storage key", () => {
     expect(storageKey("grid")).toBe("meso-coachmark-designer-grid");
     expect(storageKey("phone")).toBe("meso-coachmark-designer-phone");
+    expect(storageKey("table")).toBe("meso-coachmark-designer-table");
   });
 });
 
 describe("COACHMARK_KEYS", () => {
-  it("lists the two designer region notes", () => {
-    expect(COACHMARK_KEYS).toEqual(["grid", "phone"]);
+  it("lists the designer region notes, including the multi-week table (issue #455 phase A4)", () => {
+    expect(COACHMARK_KEYS).toEqual(["grid", "phone", "table"]);
   });
 });
 

--- a/frontend/designer/src/lib/coachmarks.ts
+++ b/frontend/designer/src/lib/coachmarks.ts
@@ -3,8 +3,11 @@
 // reactive dismissed-map + `coachmarkVisible` derivation moves to
 // useCoachmarks — these are the two storage-facing primitives it calls.
 
-/** The two dismissible region notes on the designer (grid / phone preview). */
-export const COACHMARK_KEYS = ["grid", "phone"] as const;
+/** The dismissible region notes on the designer (one-week grid / phone
+ * preview / multi-week table — the table note added by issue #455 phase A4).
+ * "grid" and "phone" stay untouched: the one-week view they annotate is
+ * slated for deletion in phase A5, not this one. */
+export const COACHMARK_KEYS = ["grid", "phone", "table"] as const;
 
 /**
  * The localStorage key for one region note's dismissal — namespaced under


### PR DESCRIPTION
## Summary

Phase A4 of #455 (MesoTable parity): the table gets its own first-run coachmark — **re-authored, not a mechanical port** of the one-week "grid" mark, per the issue's guidance. The overlap check against the guided demo tour (#430/#441) confirmed the tour teaches page-level purpose only, never control affordances, so the coachmark's job stands.

- New `"table"` key in `COACHMARK_KEYS` (localStorage-dismissed, same `useCoachmarks` slice the "grid"/"phone" marks use; same shared card CSS).
- Renders between the table toolbar and the first day table. Copy teaches the three interaction layers this epic added: **"The block table — Tap any cell — sets, reps, load, RPE, rest, or notes — to edit it; arrow keys move cell to cell, and every change autosaves. Drag a ⠿ handle to reorder exercises or days."**
- The one-week "grid" and preview "phone" marks are untouched ("grid" retires with the one-week view in A5). Dismiss button follows WeekGrid's conventions (no `data-grid-restore`, no `data-grid-cell` — outside the A1 nav space).

Frontend-only; no migrations.

## Review + verification
- Codex review loop **CLEAN on the first pass** (0/0).
- Vitest **721 passed** (+3), strict tsc clean, build clean.
- Browser-verified: card renders with the new copy above the day tables, dismiss hides it immediately and persists across reload (`meso-coachmark-designer-table`).

Refs #455 (A4)

https://claude.ai/code/session_01GpaxgUSRbupnkecSo9Pmx4