### PR TITLE
feat(meso): A2.5 — menu-based cross-day exercise move in the table (#455)

### DIFF
--- a/frontend/designer/src/DesignerRoot.tsx
+++ b/frontend/designer/src/DesignerRoot.tsx
@@ -446,6 +446,7 @@ export function DesignerRoot() {
                 onPatchCell={gridState.patchCell}
                 onRenameExercise={gridState.renameExercise}
                 onSetOneRm={gridState.setOneRm}
+                onMoveExerciseToDay={gridState.moveExerciseToDay}
                 onAddExercise={gridState.addExercise}
                 onRemoveExercise={gridState.removeExercise}
                 onAddDay={gridState.addDay}

--- a/frontend/designer/src/components/MesoTable.test.tsx
+++ b/frontend/designer/src/components/MesoTable.test.tsx
@@ -117,6 +117,7 @@ function baseProps(overrides: Partial<Parameters<typeof MesoTable>[0]> = {}) {
     onFillAcrossWeeks: vi.fn(),
     onAddExerciseThisWeek: vi.fn(),
     onSetOneRm: vi.fn().mockResolvedValue({ one_rm: "", one_rm_source: "" }),
+    onMoveExerciseToDay: vi.fn(),
     coachmarkVisible: vi.fn(() => true),
     dismissCoachmark: vi.fn(),
     ...overrides,
@@ -618,6 +619,115 @@ describe("row 1RM editor (issue #455 phase A3)", () => {
     expect(screen.getByTestId("row-one-rm-badge-9")).not.toHaveAttribute("data-grid-cell");
     await user.click(screen.getByTestId("row-one-rm-badge-9"));
     expect(screen.getByTestId("row-one-rm-input-9")).not.toHaveAttribute("data-grid-cell");
+  });
+});
+
+// --- Issue #455 phase A2.5: menu-based cross-day move (row-name column,
+// 2nd line, alongside the A3 %1RM badge) --------------------------------
+// Closes the parity gap A2's drag scope deliberately left out (cross-day row
+// drag — separate <table> containers + sticky columns = high dnd-kit risk).
+// Only rendered on a MULTI-day grid, and only for a row with a live cell for
+// the CURRENT week (the only week `prescription_move`'s block-wide re-point
+// can key off).
+describe("move to day (issue #455 phase A2.5)", () => {
+  function twoDayGrid(overrides: Partial<MesoGrid> = {}) {
+    return grid({
+      days: [
+        day({
+          session_slot_id: 1,
+          name: "Lower",
+          day_number: 1,
+          session_id: 11,
+          session_ids: { "1": 11 },
+          rows: [row({ exercise_slot_id: 9, name: "Squat", cells: { "1": cell({ prescription_id: 100 }) } })],
+        }),
+        day({
+          session_slot_id: 2,
+          name: "Upper",
+          day_number: 2,
+          session_id: 22,
+          session_ids: { "1": 22 },
+          rows: [],
+        }),
+      ],
+      ...overrides,
+    });
+  }
+
+  it("renders a select with one option per OTHER day when the grid has more than one day", () => {
+    render(<MesoTable {...baseProps({ grid: twoDayGrid() })} />);
+    expect(screen.getByTestId("row-move-day-9")).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "D2 · Upper" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /Lower/ })).not.toBeInTheDocument(); // no self-option
+  });
+
+  it("hides the select for a single-day grid", () => {
+    render(<MesoTable {...baseProps()} />); // default fixture has exactly one day
+    expect(screen.queryByTestId("row-move-day-9")).not.toBeInTheDocument();
+  });
+
+  it("hides the select when the row has no current-week cell", () => {
+    render(
+      <MesoTable
+        {...baseProps({
+          grid: twoDayGrid({
+            days: [
+              day({ session_slot_id: 1, rows: [row({ exercise_slot_id: 9, cells: {} })] }),
+              day({ session_slot_id: 2, session_id: 22, session_ids: { "1": 22 }, rows: [] }),
+            ],
+          }),
+        })}
+      />,
+    );
+    expect(screen.queryByTestId("row-move-day-9")).not.toBeInTheDocument();
+  });
+
+  it("disables the option for a target day lacking a current-week session id", () => {
+    render(
+      <MesoTable
+        {...baseProps({
+          grid: twoDayGrid({
+            days: [
+              day({
+                session_slot_id: 1,
+                rows: [row({ exercise_slot_id: 9, cells: { "1": cell({ prescription_id: 100 }) } })],
+              }),
+              day({ session_slot_id: 2, name: "Upper", day_number: 2, session_ids: {}, rows: [] }),
+            ],
+          }),
+        })}
+      />,
+    );
+    const option = screen.getByRole("option", { name: "D2 · Upper" }) as HTMLOptionElement;
+    expect(option.disabled).toBe(true);
+  });
+
+  it("choosing a day calls onMoveExerciseToDay with the row's exercise_slot_id and the chosen day", async () => {
+    const user = userEvent.setup();
+    const onMoveExerciseToDay = vi.fn();
+    render(<MesoTable {...baseProps({ grid: twoDayGrid(), onMoveExerciseToDay })} />);
+    await user.selectOptions(screen.getByTestId("row-move-day-9"), "2");
+    expect(onMoveExerciseToDay).toHaveBeenCalledWith(9, expect.objectContaining({ session_slot_id: 2 }));
+  });
+
+  it("resets the select to the placeholder after choosing", async () => {
+    const user = userEvent.setup();
+    render(<MesoTable {...baseProps({ grid: twoDayGrid() })} />);
+    const select = screen.getByTestId("row-move-day-9") as HTMLSelectElement;
+    await user.selectOptions(select, "2");
+    expect(select.value).toBe("");
+  });
+
+  it("disables the select while busy", () => {
+    render(<MesoTable {...baseProps({ grid: twoDayGrid(), busy: true })} />);
+    expect(screen.getByTestId("row-move-day-9")).toBeDisabled();
+  });
+
+  it("carries no data-grid-cell/data-grid-restore (outside A1 keyboard-nav space, not an Undo/etc. restore target)", () => {
+    render(<MesoTable {...baseProps({ grid: twoDayGrid() })} />);
+    const select = screen.getByTestId("row-move-day-9");
+    expect(select).not.toHaveAttribute("data-grid-cell");
+    expect(select).not.toHaveAttribute("data-grid-restore");
   });
 });
 

--- a/frontend/designer/src/components/MesoTable.tsx
+++ b/frontend/designer/src/components/MesoTable.tsx
@@ -80,6 +80,10 @@ export interface MesoTableProps {
   // header for why this is awaited, unlike the fire-and-forget onPatchCell/
   // onRenameExercise above).
   onSetOneRm(exerciseSlotId: Id, value: string): Promise<GridCellOneRmPatch>;
+  // Issue #455 phase A2.5: the per-ROW "Move to…" menu's structural verb —
+  // fire-and-forget, mirroring onAddExercise/onRemoveExercise etc. below
+  // (useGrid.moveExerciseToDay awaits its own POST + refetch internally).
+  onMoveExerciseToDay(exerciseSlotId: Id, targetDay: GridDay): void;
   onAddExercise(day: GridDay): void;
   onRemoveExercise(exerciseSlotId: Id): void;
   onAddDay(): void;
@@ -667,6 +671,73 @@ function RowOneRmEditor({ row, cell, unit, busy, onSetOneRm }: RowOneRmEditorPro
   );
 }
 
+/** The row's live cell key for the grid's CURRENT week (`grid.weeks.find(w
+ * => w.current)`, falling back to `weeks[0]` — same "current week" notion
+ * useGrid.ts's own local `currentWeekId` helper uses for every structural
+ * verb), or undefined if the grid carries no weeks at all. Shared by
+ * RowMoveToDaySelect below to gate the row's own visibility and to look up
+ * each target day's current-week session id — `prescription_move`'s
+ * block-wide re-point can only key off THIS week (see useGrid.moveExerciseToDay's
+ * header). */
+function currentWeekKey(weeks: GridWeek[]): string | undefined {
+  const id = (weeks.find((w) => w.current) ?? weeks[0])?.id;
+  return id == null ? undefined : String(id);
+}
+
+interface RowMoveToDaySelectProps {
+  row: GridRow;
+  day: GridDay;
+  days: GridDay[];
+  weekKey: string | undefined;
+  busy: boolean;
+  onMoveExerciseToDay(exerciseSlotId: Id, targetDay: GridDay): void;
+}
+
+/** Issue #455 phase A2.5 — a menu-based cross-day move, closing the parity
+ * gap A2's drag scope deliberately left out (separate <table> containers +
+ * sticky columns = high dnd-kit risk; see useTableReorder.ts's header). Row-
+ * name column, 2nd line, alongside RowOneRmEditor — only rendered on a
+ * multi-day grid, and only when this row has a live cell for the CURRENT
+ * week (the only week the server's block-wide re-point can key off). Local
+ * `value` state, mirroring every other row-local toggle in this file
+ * (CellActions/AddThisWeekControl) — resets to the placeholder itself on
+ * every choice rather than depending on a parent re-render to force it back. */
+function RowMoveToDaySelect({ row, day, days, weekKey, busy, onMoveExerciseToDay }: RowMoveToDaySelectProps) {
+  const [value, setValue] = useState("");
+
+  if (days.length <= 1) return null;
+  if (weekKey == null || !row.cells[weekKey]) return null;
+
+  const otherDays = days.filter((d) => d.session_slot_id !== day.session_slot_id);
+  const id = row.exercise_slot_id;
+
+  return (
+    <select
+      data-testid={`row-move-day-${id}`}
+      className="meso-move-day-select"
+      aria-label={`Move ${row.name || "exercise"} to another day`}
+      value={value}
+      disabled={busy}
+      onChange={(e) => {
+        const raw = e.target.value;
+        setValue("");
+        if (!raw) return;
+        const target = otherDays.find((d) => String(d.session_slot_id) === raw);
+        if (target) onMoveExerciseToDay(id, target);
+      }}
+    >
+      <option value="" disabled>
+        Move to…
+      </option>
+      {otherDays.map((d) => (
+        <option key={d.session_slot_id} value={String(d.session_slot_id)} disabled={d.session_ids[weekKey] == null}>
+          {d.name ? `D${d.day_number} · ${d.name}` : `Day ${d.day_number}`}
+        </option>
+      ))}
+    </select>
+  );
+}
+
 interface AddThisWeekControlProps {
   day: GridDay;
   weeks: GridWeek[];
@@ -721,6 +792,7 @@ function AddThisWeekControl({ day, weeks, busy, onAddExerciseThisWeek }: AddThis
 interface TableRowProps {
   row: GridRow;
   day: GridDay;
+  days: GridDay[];
   weeks: GridWeek[];
   busy: boolean;
   unit: string;
@@ -740,6 +812,7 @@ interface TableRowProps {
   onPatchCell(cellId: Id, patch: GridCellPatch): void;
   onRenameExercise(exerciseSlotId: Id, name: string): void;
   onSetOneRm(exerciseSlotId: Id, value: string): Promise<GridCellOneRmPatch>;
+  onMoveExerciseToDay(exerciseSlotId: Id, targetDay: GridDay): void;
   onSkipCell(cellId: number, skipped: boolean): void;
   onSwapCell(cellId: number, swapName: string): void;
   onFillAcrossWeeks(cellId: number): void;
@@ -754,6 +827,7 @@ interface TableRowProps {
 function TableRow({
   row,
   day,
+  days,
   weeks,
   busy,
   unit,
@@ -768,10 +842,13 @@ function TableRow({
   onPatchCell,
   onRenameExercise,
   onSetOneRm,
+  onMoveExerciseToDay,
   onSkipCell,
   onSwapCell,
   onFillAcrossWeeks,
 }: TableRowProps) {
+  const weekKey = currentWeekKey(weeks);
+  const showMoveToDay = days.length > 1;
   const dragData: TableDragData = {
     type: "row",
     daySlotId: day.session_slot_id,
@@ -842,15 +919,27 @@ function TableRow({
             </span>
           )}
         </div>
-        {showOneRm && (
+        {(showOneRm || showMoveToDay) && (
           <div className="meso-table-row-tags meso-ex-tags">
-            <RowOneRmEditor
-              row={row}
-              cell={rowIdentityCell(weeks, row)}
-              unit={unit}
-              busy={busy}
-              onSetOneRm={onSetOneRm}
-            />
+            {showOneRm && (
+              <RowOneRmEditor
+                row={row}
+                cell={rowIdentityCell(weeks, row)}
+                unit={unit}
+                busy={busy}
+                onSetOneRm={onSetOneRm}
+              />
+            )}
+            {showMoveToDay && (
+              <RowMoveToDaySelect
+                row={row}
+                day={day}
+                days={days}
+                weekKey={weekKey}
+                busy={busy}
+                onMoveExerciseToDay={onMoveExerciseToDay}
+              />
+            )}
           </div>
         )}
       </td>
@@ -934,6 +1023,7 @@ function TableRow({
 
 interface TableDayBlockProps {
   day: GridDay;
+  days: GridDay[];
   weeks: GridWeek[];
   busy: boolean;
   unit: string;
@@ -947,6 +1037,7 @@ interface TableDayBlockProps {
   onPatchCell(cellId: Id, patch: GridCellPatch): void;
   onRenameExercise(exerciseSlotId: Id, name: string): void;
   onSetOneRm(exerciseSlotId: Id, value: string): Promise<GridCellOneRmPatch>;
+  onMoveExerciseToDay(exerciseSlotId: Id, targetDay: GridDay): void;
   onAddExercise(day: GridDay): void;
   onRemoveExercise(exerciseSlotId: Id): void;
   onRemoveDay(day: GridDay): void;
@@ -964,6 +1055,7 @@ interface TableDayBlockProps {
  * `.is-dragging` opacity, no CSS.Transform on the block itself. */
 function TableDayBlock({
   day,
+  days,
   weeks,
   busy,
   unit,
@@ -977,6 +1069,7 @@ function TableDayBlock({
   onPatchCell,
   onRenameExercise,
   onSetOneRm,
+  onMoveExerciseToDay,
   onAddExercise,
   onRemoveExercise,
   onRemoveDay,
@@ -1085,6 +1178,7 @@ function TableDayBlock({
                   key={row.exercise_slot_id}
                   row={row}
                   day={day}
+                  days={days}
                   weeks={weeks}
                   busy={busy}
                   unit={unit}
@@ -1102,6 +1196,7 @@ function TableDayBlock({
                   onPatchCell={onPatchCell}
                   onRenameExercise={onRenameExercise}
                   onSetOneRm={onSetOneRm}
+                  onMoveExerciseToDay={onMoveExerciseToDay}
                   onSkipCell={onSkipCell}
                   onSwapCell={onSwapCell}
                   onFillAcrossWeeks={onFillAcrossWeeks}
@@ -1140,6 +1235,7 @@ export function MesoTable(props: MesoTableProps) {
     onPatchCell,
     onRenameExercise,
     onSetOneRm,
+    onMoveExerciseToDay,
     onAddExercise,
     onRemoveExercise,
     onAddDay,
@@ -1298,6 +1394,7 @@ export function MesoTable(props: MesoTableProps) {
             <TableDayBlock
               key={day.session_slot_id}
               day={day}
+              days={grid.days}
               weeks={grid.weeks}
               busy={busy}
               unit={unit}
@@ -1311,6 +1408,7 @@ export function MesoTable(props: MesoTableProps) {
               onPatchCell={onPatchCell}
               onRenameExercise={onRenameExercise}
               onSetOneRm={onSetOneRm}
+              onMoveExerciseToDay={onMoveExerciseToDay}
               onAddExercise={onAddExercise}
               onRemoveExercise={onRemoveExercise}
               onRemoveDay={onRemoveDay}

--- a/frontend/designer/src/hooks/useGrid.test.ts
+++ b/frontend/designer/src/hooks/useGrid.test.ts
@@ -771,6 +771,179 @@ describe("reorderDays", () => {
   });
 });
 
+// --- Issue #455 phase A2.5: menu-based cross-day move ----------------------
+// Closes the parity gap A2's drag scope deliberately left out (separate
+// <table> containers + sticky columns = high dnd-kit risk — see
+// useTableReorder.ts's header). Same STRUCTURAL shape as reorderExercises/
+// reorderDays above: await the POST, then refetch the whole grid, sharing
+// busyRef. `prescription_move` (views.py) re-points the cell's
+// exercise_slot.session_slot BLOCK-WIDE — so both the source cell and the
+// target session_id are keyed off the row's/day's CURRENT week only (never
+// GridDay.session_id, which can silently be a fallback to a different week
+// — the same lesson useTableReorder.ts encodes for A2's row/day reorder).
+
+describe("moveExerciseToDay (issue #455 phase A2.5)", () => {
+  function twoDayGrid(overrides: Partial<MesoGrid> = {}) {
+    return grid({
+      days: [
+        day({
+          session_slot_id: 1,
+          session_id: 11,
+          session_ids: { "1": 11 },
+          rows: [row({ exercise_slot_id: 9, cells: { "1": cell({ prescription_id: 100 }) } })],
+        }),
+        day({
+          session_slot_id: 2,
+          session_id: 22,
+          session_ids: { "1": 22 },
+          rows: [row({ exercise_slot_id: 20, cells: { "1": cell({ prescription_id: 200 }) } })],
+        }),
+      ],
+      ...overrides,
+    });
+  }
+
+  it("POSTs {session_id, index} to prescription/<current week cell pk>/move/, then refetches", async () => {
+    const initial = twoDayGrid();
+    const { result } = setup(initial);
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(res({ ok: true }))
+      .mockResolvedValueOnce(res({ ok: true, ...grid() })) as unknown as typeof fetch;
+
+    await act(async () => {
+      await result.current.moveExerciseToDay(9, initial.days[1]!);
+    });
+
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0]![0]).toBe("/meso/api/plan/7/prescription/100/move/");
+    expect(calls[0]![1].method).toBe("POST");
+    expect(sentBody()).toEqual({ session_id: 22, index: 1 }); // target already has 1 live row
+    expect(calls[1]![0]).toBe("/meso/api/plan/7/grid/");
+  });
+
+  it("targets the CURRENT week's session_ids entry, never the (possibly-fallback) session_id", async () => {
+    const initial = grid({
+      days: [
+        day({
+          session_slot_id: 1,
+          session_id: 11,
+          session_ids: { "1": 11 },
+          rows: [row({ exercise_slot_id: 9, cells: { "1": cell({ prescription_id: 100 }) } })],
+        }),
+        day({
+          session_slot_id: 2,
+          session_id: 99, // a fallback pk belonging to a DIFFERENT week
+          session_ids: { "1": 22 }, // the real current-week session
+          rows: [],
+        }),
+      ],
+    });
+    const { result } = setup(initial);
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(res({ ok: true }))
+      .mockResolvedValueOnce(res({ ok: true, ...grid() })) as unknown as typeof fetch;
+
+    await act(async () => {
+      await result.current.moveExerciseToDay(9, initial.days[1]!);
+    });
+
+    expect(sentBody()).toEqual({ session_id: 22, index: 0 });
+  });
+
+  it("index is the target day's count of rows with a CURRENT-week cell (append at end, skipping add-this-week-only holes)", async () => {
+    const initial = grid({
+      days: [
+        day({
+          session_slot_id: 1,
+          session_id: 11,
+          session_ids: { "1": 11 },
+          rows: [row({ exercise_slot_id: 9, cells: { "1": cell({ prescription_id: 100 }) } })],
+        }),
+        day({
+          session_slot_id: 2,
+          session_id: 22,
+          session_ids: { "1": 22 },
+          rows: [
+            row({ exercise_slot_id: 20, cells: { "1": cell({ prescription_id: 200 }) } }), // live this week
+            row({ exercise_slot_id: 21, cells: {} }), // add-this-week-only hole for THIS week — excluded
+          ],
+        }),
+      ],
+    });
+    const { result } = setup(initial);
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(res({ ok: true }))
+      .mockResolvedValueOnce(res({ ok: true, ...grid() })) as unknown as typeof fetch;
+
+    await act(async () => {
+      await result.current.moveExerciseToDay(9, initial.days[1]!);
+    });
+
+    expect(sentBody()).toEqual({ session_id: 22, index: 1 });
+  });
+
+  it("is a no-op (no fetch) when the row has no live cell for the current week", async () => {
+    const initial = grid({
+      days: [
+        day({
+          session_slot_id: 1,
+          session_id: 11,
+          session_ids: { "1": 11 },
+          rows: [row({ exercise_slot_id: 9, cells: {} })], // no current-week cell
+        }),
+        day({ session_slot_id: 2, session_id: 22, session_ids: { "1": 22 }, rows: [] }),
+      ],
+    });
+    const { result } = setup(initial);
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+
+    await act(async () => {
+      await result.current.moveExerciseToDay(9, initial.days[1]!);
+    });
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op (no fetch) when the target day has no live session for the current week", async () => {
+    const initial = grid({
+      days: [
+        day({
+          session_slot_id: 1,
+          session_id: 11,
+          session_ids: { "1": 11 },
+          rows: [row({ exercise_slot_id: 9, cells: { "1": cell({ prescription_id: 100 }) } })],
+        }),
+        day({ session_slot_id: 2, session_id: 22, session_ids: {}, rows: [] }), // no current-week session
+      ],
+    });
+    const { result } = setup(initial);
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+
+    await act(async () => {
+      await result.current.moveExerciseToDay(9, initial.days[1]!);
+    });
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("console.errors and does not refetch on POST failure", async () => {
+    const initial = twoDayGrid();
+    const { result } = setup(initial);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("boom")) as unknown as typeof fetch;
+
+    await act(async () => {
+      await result.current.moveExerciseToDay(9, initial.days[1]!);
+    });
+
+    expect(console.error).toHaveBeenCalled();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1); // no refetch after a failed POST
+  });
+});
+
 // --- P2 exceptions: skip / swap / fill / add-this-week -------------------
 // These four verbs are STRUCTURAL (contract "useGrid.ts — new verbs"): each
 // awaits its POST then refetches the whole grid, sharing the same busyRef
@@ -1002,6 +1175,51 @@ describe("concurrency guard covers the new P2 verbs", () => {
     let second!: Promise<void>;
     act(() => {
       first = result.current.reorderExercises(11, [100]);
+      second = result.current.addWeek();
+    });
+
+    expect(result.current.busy).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // the second call bailed before POSTing
+
+    fetchMock.mockResolvedValueOnce(res({ ok: true, ...grid() })); // the refetch GET
+
+    await act(async () => {
+      resolvePost(res({ ok: true }));
+      await first;
+      await second;
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2); // POST + GET only — no third/fourth call
+    expect(result.current.busy).toBe(false);
+  });
+
+  it("moveExerciseToDay (issue #455 phase A2.5) also shares the busyRef guard", async () => {
+    const initial = grid({
+      days: [
+        day({
+          session_slot_id: 1,
+          session_id: 11,
+          session_ids: { "1": 11 },
+          rows: [row({ exercise_slot_id: 9, cells: { "1": cell({ prescription_id: 100 }) } })],
+        }),
+        day({ session_slot_id: 2, session_id: 22, session_ids: { "1": 22 }, rows: [] }),
+      ],
+    });
+    const { result } = setup(initial);
+    let resolvePost!: (v: unknown) => void;
+    const fetchMock = vi.fn();
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolvePost = resolve;
+        }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    let first!: Promise<void>;
+    let second!: Promise<void>;
+    act(() => {
+      first = result.current.moveExerciseToDay(9, initial.days[1]!);
       second = result.current.addWeek();
     });
 

--- a/frontend/designer/src/hooks/useGrid.ts
+++ b/frontend/designer/src/hooks/useGrid.ts
@@ -461,6 +461,48 @@ export function useGrid(options: UseGridOptions) {
     [planId, csrf, runStructural, refetchGrid],
   );
 
+  // Issue #455 phase A2.5 (menu-based cross-day move): closes the parity gap
+  // A2's drag scope deliberately left out (separate <table> containers +
+  // sticky columns = high dnd-kit risk — see useTableReorder.ts's header).
+  // Same STRUCTURAL shape as reorderExercises/reorderDays above: await the
+  // POST, then refetch the whole grid, sharing busyRef. `prescription_move`
+  // (views.py) re-points the cell's exercise_slot.session_slot BLOCK-WIDE
+  // (every week follows the move), so both the source cell and the target
+  // session_id must resolve off the row's/day's CURRENT week only — never
+  // GridDay.session_id, which can silently be a fallback to a different week
+  // (the same lesson useTableReorder.ts's rowReorder/dayReorder encode for
+  // A2). A no-op (no fetch) when the row has no live cell for the current
+  // week, or the target day has no live session for it either.
+  const moveExerciseToDay = useCallback(
+    (exerciseSlotId: Id, targetDay: GridDay) =>
+      runStructural(async () => {
+        const weekId = currentWeekId(grid);
+        if (weekId == null) return;
+        const weekKey = String(weekId);
+        const row = findRow(grid, exerciseSlotId);
+        const cellId = row?.cells[weekKey]?.prescription_id;
+        if (cellId == null) return;
+        const sessionId = targetDay.session_ids[weekKey];
+        if (sessionId == null) return;
+        // Append at the end of the target day's CURRENT week rows — mirrors
+        // useTableReorder's liveRows filter / the server's own
+        // session.cells() query for the viewed week.
+        const index = targetDay.rows.filter((r) => r.cells[weekKey]).length;
+        try {
+          await apiPost(
+            `/meso/api/plan/${planId}/prescription/${cellId}/move/`,
+            { session_id: sessionId, index },
+            csrf,
+          );
+        } catch (err) {
+          console.error("Move exercise to day failed", err);
+          return;
+        }
+        await refetchGrid();
+      }),
+    [grid, planId, csrf, runStructural, refetchGrid],
+  );
+
   // --- P2 exceptions: skip / swap / fill / add-this-week -----------------
   // Same STRUCTURAL shape as add/removeExercise|Day|Week above — the grid
   // (not just one cell) can change shape/content in ways only the server
@@ -578,6 +620,7 @@ export function useGrid(options: UseGridOptions) {
     setCurrentWeek,
     reorderExercises,
     reorderDays,
+    moveExerciseToDay,
     skipCell,
     swapCell,
     fillAcrossWeeks,

--- a/frontend/designer/src/styles/designer-mesotable.css
+++ b/frontend/designer/src/styles/designer-mesotable.css
@@ -130,6 +130,28 @@
  * renders this line EMPTY (RowOneRmEditor returns null), collapsing to
  * `.meso-ex-tags`'s own small `min-height` allowance. */
 
+/* Issue #455 phase A2.5: the "Move to…" menu — same 2nd line, alongside
+ * RowOneRmEditor's badge. Table-specific (the one-week view has no
+ * equivalent control), so it lives here rather than the shared
+ * designer-grid.css. Kept visually small/quiet like the %1RM badge it sits
+ * next to — `.meso-onerm-badge`'s font-size (designer-grid.css), not a full
+ * form control. */
+.meso-move-day-select {
+  appearance: none;
+  font: inherit;
+  font-size: 10.5px;
+  color: var(--dim);
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 1px 4px;
+  cursor: pointer;
+}
+.meso-move-day-select:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
 .meso-table-cell {
   min-width: 190px;
 }


### PR DESCRIPTION
## Summary

Closes the parity gap A2 deliberately deferred: moving an exercise to a different training day from the multi-week table. A2's review chose not to ship cross-day *dragging* (separate `<table>` containers + sticky columns are dnd-kit's riskiest territory); this lands the capability as a compact, zero-risk **"Move to…" select** in each row's name column — so the A5 retirement of the one-week view (which had drag-based cross-day moves) loses nothing.

- New `useGrid.moveExerciseToDay(exerciseSlotId, targetDay)` structural verb → the existing `prescription_move` endpoint (block-wide `ExerciseSlot.session_slot` re-point — every week follows; undoable as "Moved <name>"). Appends at the end of the target day; rows can then be drag-reordered within it (A2).
- Current-week correctness inherited from A2's lessons: the source cell is the row's current-week cell and the target session comes from `session_ids[currentWeek]` — never the possibly-fallback `session_id`; missing either → no-op, and a target day without a current-week session renders disabled (visible but explained) rather than omitted.
- Select renders only when the grid has more than one day; disabled while busy; outside the A1 nav space.

Frontend-only; no backend changes; no migrations.

## Review + verification
- Codex review loop **CLEAN on the first pass** (0/0).
- Vitest **736 passed** (+15), strict tsc clean, build clean.
- Browser-verified: each row's select offers only the other days; moving "Box Squat" from Lower to Day 2 re-rendered it appended under Day 2, recorded "Undo: Moved Box Squat", and the DB confirms the block-wide `ExerciseSlot.session_slot` re-point.

Refs #455 (A2.5, follow-up to A2's deferred scope)

https://claude.ai/code/session_01GpaxgUSRbupnkecSo9Pmx4