### PR TITLE
feat(meso): 2b — all-weeks grid keyboard flow

### DIFF
--- a/docs/meso/spreadsheet-parity-plan.md
+++ b/docs/meso/spreadsheet-parity-plan.md
@@ -1,6 +1,6 @@
 # Meso — spreadsheet parity by simplification
 
-**Status:** Phase 2a (text-first cell) built 2026-07-16 · started 2026-07-16
+**Status:** Phase 2b (keyboard flow) built 2026-07-16 · 2a built 2026-07-16 · started 2026-07-16
 **Owner:** Lance
 **North star:** make writing a program in Meso as fast and frictionless as writing it
 in a Google Sheet — keyboard-driven, freeform, one grid — then extend to tracking,
@@ -313,7 +313,29 @@ tempo-heavy, DUP, conjugate, EMOM/AMRAP). The risks and mitigations:
    - 2b **All-weeks grid + keyboard flow** — weeks side-by-side; arrows/Tab/Enter
      navigation; Enter-adds-row, add-week, `Ctrl-C`/`Ctrl-V` duplicate-forward
      (this also *is* the ad-hoc log mode — starting a session = add/duplicate a
-     week/workout).
+     week/workout). **✅ Built 2026-07-16** (branch `meso/2b-grid-keyboard-flow`;
+     frontend-only — weeks-side-by-side and add-week-with-carry-forward already
+     existed from the A-series/2a): `useTableNav`'s cell identity gained a
+     **line** — each week cell's sub-line stack (existing lines + the trailing
+     ghost) is a run of vertical stops, so **ArrowDown from a prescription steps
+     into its stack** (D3's "RPE row reached by arrow-down" made literal — the
+     ghost is a stop, so minting the RPE line never needs the mouse); the
+     per-row **Tempo/Notes/Rest columns joined the horizontal axis** (name →
+     tempo → weeks… → notes → rest, the sheet's order); **Tab/Shift+Tab** walk
+     that axis unconditionally, wrapping between rows (arrows still defer to
+     the caret at text boundaries); **Enter = commit + move down one stop**,
+     and at a day's LAST stop it **appends an exercise row** to that day
+     (Enter never crosses a day boundary; a fully-blank row never appends —
+     the blank check reads the DOM so an uncommitted draft counts as content;
+     after the refetch, focus lands on the new row at the column Enter came
+     from); horizontal moves from a sub-line **clamp to the target cell's
+     nearest stop** (a shorter stack lands on its ghost — the merged-cell
+     feel). **`Ctrl-C`/`Ctrl-V` = cell-stack copy/paste** on the prescription
+     input: copy with nothing selected copies the whole stack newline-joined
+     (a real selection stays native); pasting multi-line text replaces the
+     stack (line 0 + sub-lines, longer old lines blanked); single-line paste
+     stays native. No backend changes — appends reuse `session_add_exercise`,
+     paste reuses `prescription_patch`/`cell_line_write`.
    - 2c **Remove `MesoGroup`** → batch-deliver + client list.
    - 2d **Deliver → live + notify** — repurpose snapshots.
    - 2e **UI cleanup** — strip the chrome the above obsoletes.

--- a/frontend/designer/CONTRACT.md
+++ b/frontend/designer/CONTRACT.md
@@ -447,7 +447,16 @@ top) replaces the whole one-week-at-a-time tree they formed:
   (`row.tempo`/`note`/`rest`, via `patchRowColumns`), matching the source
   spreadsheet's Exercise | Tempo | weeks… | Notes | Rest layout. The
   load-type toggle, the %1RM editor, and the one-week swap badge/menu are
-  retired.
+  retired. Phase 2b (spreadsheet keyboard flow) then pulled ALL of these
+  inputs into `useTableNav`'s axes: cell identity is
+  `(rowId, weekId, field, line)` — sub-lines and the ghost are vertical
+  stops, Tempo/Notes/Rest are horizontal columns, Tab walks the row,
+  Enter commits + moves down (appending a row at a day's last stop via
+  `useTableNav`'s `onAppendRow`, wired to `useGrid.addExercise`), and the
+  prescription input carries cell-stack copy/paste (collapsed-selection
+  Ctrl-C copies the stack; multi-line paste replaces it through
+  `patchCell` + `writeCellLine`). See `useTableNav.ts`'s header for the
+  axis rules.
 
 None of these four are exhaustively re-documented prop-by-prop here the way
 they were before A5 — `MesoTable.tsx` (one file, ~1,500 lines, extensively

--- a/frontend/designer/src/components/MesoTable.test.tsx
+++ b/frontend/designer/src/components/MesoTable.test.tsx
@@ -431,6 +431,16 @@ describe("cell stack copy/paste", () => {
     expect(onWriteCellLine).not.toHaveBeenCalled();
   });
 
+  it("Escape after a multi-line paste reverts to the pasted head, never past the commit", () => {
+    render(<MesoTable {...baseProps({ grid: linesGrid() })} />);
+    const input = screen.getByTestId("cell-text-100") as HTMLInputElement;
+    input.focus(); // seeds the Escape baseline with the pre-paste text
+    fireEvent.paste(input, { clipboardData: clipboard("4 x 6\nRPE 9") });
+    expect(input).toHaveValue("4 x 6");
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(input).toHaveValue("4 x 6"); // the committed paste IS the baseline now
+  });
+
   it("single-line paste stays native caret insertion (no stack write)", () => {
     const onPatchCell = vi.fn();
     const onWriteCellLine = vi.fn();

--- a/frontend/designer/src/components/MesoTable.test.tsx
+++ b/frontend/designer/src/components/MesoTable.test.tsx
@@ -343,10 +343,102 @@ describe("cell sub-lines", () => {
     expect(onWriteCellLine).not.toHaveBeenCalled();
   });
 
-  it("sub-line and ghost inputs carry no data-grid-cell (outside A1 arrow-nav this phase)", () => {
+  it("sub-line and ghost inputs carry line-keyed data-grid-cell (INSIDE nav since 2b)", () => {
     render(<MesoTable {...baseProps({ grid: linesGrid() })} />);
-    expect(screen.getByTestId("cell-line-100-1")).not.toHaveAttribute("data-grid-cell");
-    expect(screen.getByTestId("cell-line-new-100")).not.toHaveAttribute("data-grid-cell");
+    expect(screen.getByTestId("cell-line-100-1")).toHaveAttribute("data-grid-cell", tableCellDomKey(9, 1, "text", 1));
+    expect(screen.getByTestId("cell-line-100-2")).toHaveAttribute("data-grid-cell", tableCellDomKey(9, 1, "text", 2));
+    expect(screen.getByTestId("cell-line-new-100")).toHaveAttribute("data-grid-cell", tableCellDomKey(9, 1, "text", 3));
+  });
+
+  it("ArrowDown from the prescription steps INTO the stack: line 1, line 2, ghost, in order (D3)", async () => {
+    const user = userEvent.setup();
+    render(<MesoTable {...baseProps({ grid: linesGrid() })} />);
+    await user.click(screen.getByTestId("cell-text-100"));
+    await user.keyboard("{ArrowDown}");
+    expect(screen.getByTestId("cell-line-100-1")).toHaveFocus();
+    await user.keyboard("{ArrowDown}");
+    expect(screen.getByTestId("cell-line-100-2")).toHaveFocus();
+    await user.keyboard("{ArrowDown}");
+    expect(screen.getByTestId("cell-line-new-100")).toHaveFocus();
+  });
+});
+
+// --- Phase 2b: cell stack copy/paste (the duplicate-forward primitive) ------
+describe("cell stack copy/paste", () => {
+  const LINES = [
+    { id: 5, line: 1, text: "RPE 8" },
+    { id: 6, line: 2, text: "slow eccentric" },
+  ];
+
+  function linesGrid() {
+    return grid({ days: [day({ rows: [row({ cells: { "1": cell({ lines: LINES }) } })] })] });
+  }
+
+  function clipboard(text = "") {
+    return { getData: vi.fn(() => text), setData: vi.fn() };
+  }
+
+  it("copy with a collapsed selection copies the WHOLE stack, newline-joined", () => {
+    render(<MesoTable {...baseProps({ grid: linesGrid() })} />);
+    const input = screen.getByTestId("cell-text-100") as HTMLInputElement;
+    input.setSelectionRange(2, 2);
+    const clipboardData = clipboard();
+    fireEvent.copy(input, { clipboardData });
+    expect(clipboardData.setData).toHaveBeenCalledWith("text/plain", "3 x 5, RPE 8, 100\nRPE 8\nslow eccentric");
+  });
+
+  it("copy skips blank (cleared-in-place) sub-lines", () => {
+    const CLEARED = grid({
+      days: [day({ rows: [row({ cells: { "1": cell({ lines: [{ id: 5, line: 1, text: "" }, { id: 6, line: 2, text: "cue" }] }) } })] })],
+    });
+    render(<MesoTable {...baseProps({ grid: CLEARED })} />);
+    const input = screen.getByTestId("cell-text-100") as HTMLInputElement;
+    input.setSelectionRange(0, 0);
+    const clipboardData = clipboard();
+    fireEvent.copy(input, { clipboardData });
+    expect(clipboardData.setData).toHaveBeenCalledWith("text/plain", "3 x 5, RPE 8, 100\ncue");
+  });
+
+  it("copy with a REAL text selection stays native (no stack copy)", () => {
+    render(<MesoTable {...baseProps({ grid: linesGrid() })} />);
+    const input = screen.getByTestId("cell-text-100") as HTMLInputElement;
+    input.setSelectionRange(0, 3);
+    const clipboardData = clipboard();
+    fireEvent.copy(input, { clipboardData });
+    expect(clipboardData.setData).not.toHaveBeenCalled();
+  });
+
+  it("multi-line paste replaces the stack: line 0 via onPatchCell, sub-lines via onWriteCellLine, longer old lines blanked", () => {
+    const onPatchCell = vi.fn();
+    const onWriteCellLine = vi.fn();
+    render(<MesoTable {...baseProps({ grid: linesGrid(), onPatchCell, onWriteCellLine })} />);
+    const input = screen.getByTestId("cell-text-100") as HTMLInputElement;
+    fireEvent.paste(input, { clipboardData: clipboard("4 x 6\nRPE 9") });
+    expect(onPatchCell).toHaveBeenCalledWith(100, { text: "4 x 6" });
+    expect(onWriteCellLine).toHaveBeenCalledWith(9, 1, 1, "RPE 9");
+    // Old line 2 ("slow eccentric") is beyond the pasted stack: blanked.
+    expect(onWriteCellLine).toHaveBeenCalledWith(9, 1, 2, "");
+    expect(input).toHaveValue("4 x 6");
+  });
+
+  it("trailing blank pasted lines are dropped, not minted", () => {
+    const onPatchCell = vi.fn();
+    const onWriteCellLine = vi.fn();
+    render(<MesoTable {...baseProps({ onPatchCell, onWriteCellLine })} />); // default fixture: lines []
+    const input = screen.getByTestId("cell-text-100") as HTMLInputElement;
+    fireEvent.paste(input, { clipboardData: clipboard("4 x 6\n\n") });
+    expect(onPatchCell).toHaveBeenCalledWith(100, { text: "4 x 6" });
+    expect(onWriteCellLine).not.toHaveBeenCalled();
+  });
+
+  it("single-line paste stays native caret insertion (no stack write)", () => {
+    const onPatchCell = vi.fn();
+    const onWriteCellLine = vi.fn();
+    render(<MesoTable {...baseProps({ onPatchCell, onWriteCellLine })} />);
+    const input = screen.getByTestId("cell-text-100") as HTMLInputElement;
+    fireEvent.paste(input, { clipboardData: clipboard("4 x 6") });
+    expect(onPatchCell).not.toHaveBeenCalled();
+    expect(onWriteCellLine).not.toHaveBeenCalled();
   });
 });
 
@@ -421,11 +513,11 @@ describe("row columns (tempo / notes / rest)", () => {
     expect(onPatchRowColumns).not.toHaveBeenCalled();
   });
 
-  it("row-column inputs carry no data-grid-cell (outside A1 arrow-nav this phase)", () => {
+  it("row-column inputs carry row-sentinel data-grid-cell keys (INSIDE nav since 2b)", () => {
     render(<MesoTable {...baseProps()} />);
-    expect(screen.getByTestId("row-tempo-9")).not.toHaveAttribute("data-grid-cell");
-    expect(screen.getByTestId("row-note-9")).not.toHaveAttribute("data-grid-cell");
-    expect(screen.getByTestId("row-rest-9")).not.toHaveAttribute("data-grid-cell");
+    expect(screen.getByTestId("row-tempo-9")).toHaveAttribute("data-grid-cell", tableCellDomKey(9, null, "tempo"));
+    expect(screen.getByTestId("row-note-9")).toHaveAttribute("data-grid-cell", tableCellDomKey(9, null, "note"));
+    expect(screen.getByTestId("row-rest-9")).toHaveAttribute("data-grid-cell", tableCellDomKey(9, null, "rest"));
   });
 });
 
@@ -802,8 +894,12 @@ describe("group per-athlete adjust badge", () => {
 // renders the real table and drives real keyboard events through RTL,
 // mirroring WeekGrid.test.tsx's "Phase 3" block (the one-week precedent).
 //
-// Phase 2a: the per-week editable surface is ONE freeform "text" input, so
-// the horizontal axis is name → week 1 text → week 2 text.
+// Phase 2a: the per-week editable surface is ONE freeform "text" input.
+// Phase 2b widened the axes to the full sheet: horizontally name → tempo →
+// week 1 text → week 2 text → notes → rest (Tab-walkable), vertically each
+// cell's sub-line stack (existing lines + the trailing ghost) before the
+// next row; Enter = commit + move down, appending a row at a day's last
+// stop via onAddExercise.
 //
 // Fixture: day 1 (session_slot_id 1) has row 9 "Box Squat" (cells 900/901)
 // and row 10 "RDL" (cells 1000/1001); day 2 (session_slot_id 2) has row 11
@@ -881,33 +977,37 @@ describe("keyboard grid navigation", () => {
       const user = userEvent.setup();
       render(<MesoTable {...baseProps({ grid: NAV_GRID })} />);
       await user.click(screen.getByTestId("cell-text-1000")); // day 1's last row
-      await user.keyboard("{ArrowDown}");
+      await user.keyboard("{ArrowDown}{ArrowDown}"); // through the ghost, into day 2
       expect(screen.getByTestId("cell-text-1100")).toHaveFocus(); // day 2's row
       expect(screen.getByTestId("cell-text-1100")).toHaveAttribute("tabindex", "0");
     });
   });
 
-  describe("ArrowDown / ArrowUp navigate rows across day-table boundaries", () => {
-    it("ArrowDown moves focus to the same week's cell on the next row within a day", async () => {
+  describe("ArrowDown / ArrowUp navigate the stack, then rows, across day-table boundaries", () => {
+    it("ArrowDown from a prescription steps into its ghost, then the next row's cell", async () => {
       const user = userEvent.setup();
       render(<MesoTable {...baseProps({ grid: NAV_GRID })} />);
       await user.click(screen.getByTestId("cell-text-900"));
       await user.keyboard("{ArrowDown}");
+      expect(screen.getByTestId("cell-line-new-900")).toHaveFocus(); // the ghost is a real stop (D3)
+      await user.keyboard("{ArrowDown}");
       expect(screen.getByTestId("cell-text-1000")).toHaveFocus();
     });
 
-    it("ArrowDown crosses a day-table boundary (last row of day 1 -> first row of day 2)", async () => {
+    it("ArrowDown crosses a day-table boundary (last stop of day 1 -> first row of day 2)", async () => {
       const user = userEvent.setup();
       render(<MesoTable {...baseProps({ grid: NAV_GRID })} />);
       await user.click(screen.getByTestId("cell-text-1001"));
-      await user.keyboard("{ArrowDown}");
+      await user.keyboard("{ArrowDown}{ArrowDown}");
       expect(screen.getByTestId("cell-text-1101")).toHaveFocus();
     });
 
-    it("ArrowUp mirrors ArrowDown, crossing day boundaries upward", async () => {
+    it("ArrowUp mirrors ArrowDown, crossing day boundaries upward onto the previous row's last stop", async () => {
       const user = userEvent.setup();
       render(<MesoTable {...baseProps({ grid: NAV_GRID })} />);
       await user.click(screen.getByTestId("cell-text-1100"));
+      await user.keyboard("{ArrowUp}");
+      expect(screen.getByTestId("cell-line-new-1000")).toHaveFocus(); // row 10's ghost
       await user.keyboard("{ArrowUp}");
       expect(screen.getByTestId("cell-text-1000")).toHaveFocus();
     });
@@ -932,40 +1032,134 @@ describe("keyboard grid navigation", () => {
       expect(screen.getByTestId("cell-text-900")).toHaveFocus();
     });
 
-    it("ArrowRight at the end of the name column moves into week 1's text cell", () => {
+    it("ArrowRight at the end of the name column moves into the TEMPO column (the sheet's order)", () => {
       render(<MesoTable {...baseProps({ grid: NAV_GRID })} />);
       const nameInput = screen.getByTestId("row-name-9") as HTMLInputElement;
       nameInput.focus();
       nameInput.setSelectionRange(nameInput.value.length, nameInput.value.length);
       fireEvent.keyDown(nameInput, { key: "ArrowRight" });
+      expect(screen.getByTestId("row-tempo-9")).toHaveFocus();
+    });
+
+    it("ArrowRight at the end of the tempo column moves into week 1's text cell", () => {
+      render(<MesoTable {...baseProps({ grid: NAV_GRID })} />);
+      const tempoInput = screen.getByTestId("row-tempo-9") as HTMLInputElement;
+      tempoInput.focus();
+      tempoInput.setSelectionRange(tempoInput.value.length, tempoInput.value.length);
+      fireEvent.keyDown(tempoInput, { key: "ArrowRight" });
       expect(screen.getByTestId("cell-text-900")).toHaveFocus();
     });
 
-    it("ArrowLeft at the start of week 1's text cell moves back to the name column", () => {
+    it("ArrowRight at the end of the LAST week's cell moves into the notes column", () => {
+      render(<MesoTable {...baseProps({ grid: NAV_GRID })} />);
+      const textInput = screen.getByTestId("cell-text-901") as HTMLInputElement;
+      textInput.focus();
+      textInput.setSelectionRange(textInput.value.length, textInput.value.length);
+      fireEvent.keyDown(textInput, { key: "ArrowRight" });
+      expect(screen.getByTestId("row-note-9")).toHaveFocus();
+    });
+
+    it("ArrowLeft at the start of week 1's text cell moves back to the tempo column", () => {
       render(<MesoTable {...baseProps({ grid: NAV_GRID })} />);
       const textInput = screen.getByTestId("cell-text-900") as HTMLInputElement;
       textInput.focus();
       textInput.setSelectionRange(0, 0);
       fireEvent.keyDown(textInput, { key: "ArrowLeft" });
-      expect(screen.getByTestId("row-name-9")).toHaveFocus();
+      expect(screen.getByTestId("row-tempo-9")).toHaveFocus();
+    });
+  });
+
+  describe("Tab walks the row unconditionally, wrapping between rows (Phase 2b)", () => {
+    it("Tab moves name -> tempo even with the caret mid-text", async () => {
+      const user = userEvent.setup();
+      render(<MesoTable {...baseProps({ grid: NAV_GRID })} />);
+      const nameInput = screen.getByTestId("row-name-9") as HTMLInputElement;
+      await user.click(nameInput);
+      nameInput.setSelectionRange(1, 1);
+      await user.tab();
+      expect(screen.getByTestId("row-tempo-9")).toHaveFocus();
+    });
+
+    it("Tab at the rest column wraps to the next row's name", async () => {
+      const user = userEvent.setup();
+      render(<MesoTable {...baseProps({ grid: NAV_GRID })} />);
+      await user.click(screen.getByTestId("row-rest-9"));
+      await user.tab();
+      expect(screen.getByTestId("row-name-10")).toHaveFocus();
+    });
+
+    it("Shift+Tab at the name column wraps back to the previous row's rest", async () => {
+      const user = userEvent.setup();
+      render(<MesoTable {...baseProps({ grid: NAV_GRID })} />);
+      await user.click(screen.getByTestId("row-name-10"));
+      await user.tab({ shift: true });
+      expect(screen.getByTestId("row-rest-9")).toHaveFocus();
+    });
+  });
+
+  describe("Enter-adds-row (integrated)", () => {
+    it("Enter at a day's last stop calls onAddExercise with that day (row has content)", async () => {
+      const user = userEvent.setup();
+      const onAddExercise = vi.fn();
+      render(<MesoTable {...baseProps({ grid: NAV_GRID, onAddExercise })} />);
+      // Row 10's name is day 1's last vertical stop of the name column.
+      await user.click(screen.getByTestId("row-name-10"));
+      await user.keyboard("{Enter}");
+      expect(onAddExercise).toHaveBeenCalledTimes(1);
+      expect(onAddExercise.mock.calls[0]![0].session_slot_id).toBe(1);
+    });
+
+    it("Enter mid-day moves down instead of appending", async () => {
+      const user = userEvent.setup();
+      const onAddExercise = vi.fn();
+      render(<MesoTable {...baseProps({ grid: NAV_GRID, onAddExercise })} />);
+      await user.click(screen.getByTestId("row-name-9"));
+      await user.keyboard("{Enter}");
+      expect(onAddExercise).not.toHaveBeenCalled();
+      expect(screen.getByTestId("row-name-10")).toHaveFocus();
+    });
+
+    it("Enter at the last stop of a fully blank row does NOT append (the guard), and busy blocks the verb", async () => {
+      const user = userEvent.setup();
+      const onAddExercise = vi.fn();
+      const BLANK_GRID = grid({
+        weeks: NAV_GRID.weeks,
+        days: [
+          day({
+            session_slot_id: 1,
+            rows: [
+              row({
+                exercise_slot_id: 9,
+                name: "",
+                cells: { "1": cell({ prescription_id: 900, text: "" }), "2": cell({ prescription_id: 901, text: "" }) },
+              }),
+            ],
+          }),
+        ],
+      });
+      render(<MesoTable {...baseProps({ grid: BLANK_GRID, onAddExercise })} />);
+      await user.click(screen.getByTestId("row-name-9"));
+      await user.keyboard("{Enter}");
+      expect(onAddExercise).not.toHaveBeenCalled();
     });
   });
 
   describe("Enter commits / Escape reverts (integrated)", () => {
-    it("Enter commits only when the cell is dirty, and keeps focus in place", async () => {
+    it("Enter commits only when the cell is dirty, and moves down to the next stop (the ghost)", async () => {
       const user = userEvent.setup();
       const onPatchCell = vi.fn();
       render(<MesoTable {...baseProps({ grid: NAV_GRID, onPatchCell })} />);
       const textInput = screen.getByTestId("cell-text-900");
       await user.click(textInput);
-      await user.keyboard("{Enter}"); // clean cell: no-op (existing dirty gate)
+      await user.keyboard("{Enter}"); // clean cell: no commit (existing dirty gate) — still moves
       expect(onPatchCell).not.toHaveBeenCalled();
-      await user.clear(textInput);
+      expect(screen.getByTestId("cell-line-new-900")).toHaveFocus();
+      await user.clear(textInput); // refocuses the prescription input
       await user.type(textInput, "4 x 6");
       await user.keyboard("{Enter}");
       expect(onPatchCell).toHaveBeenCalledWith(900, { text: "4 x 6" });
       expect(onPatchCell).toHaveBeenCalledTimes(1);
-      expect(textInput).toHaveFocus();
+      expect(screen.getByTestId("cell-line-new-900")).toHaveFocus(); // spreadsheet Enter: down one stop
     });
 
     it("Escape reverts only the focused cell's draft, leaving a different dirty cell untouched", () => {

--- a/frontend/designer/src/components/MesoTable.tsx
+++ b/frontend/designer/src/components/MesoTable.tsx
@@ -22,8 +22,15 @@
 // Keyboard grid navigation (issue #455 A1) is owned by useTableNav
 // (../hooks/useTableNav), a sibling of the one-week path's useGridNav —
 // instantiated ONCE here, below, and threaded into GridCellEditor/
-// RowNameEditor as a required prop (they're module-private, so there's no
-// INERT-fallback case to support).
+// RowNameEditor/CellSubLineInput/RowColumnInput as a required prop (they're
+// module-private, so there's no INERT-fallback case to support). Phase 2b
+// (spreadsheet keyboard flow) widened its axes to the full sheet: sub-lines
+// are vertical stops (D3's arrow-down RPE row, ghost included), Tempo/
+// Notes/Rest are horizontal columns, Tab walks the row, Enter commits +
+// moves down and appends a row at a day's last stop (wired to onAddExercise
+// via useTableNav's onAppendRow), and the prescription input carries the
+// stack copy/paste handlers (Ctrl-C with no selection copies the whole
+// stack; multi-line paste replaces it — the duplicate-forward primitive).
 //
 // Drag reordering (issue #455 A2) — row + day — is owned by useTableReorder
 // (a sibling of DesignerRoot's instantiation, NOT this file): MesoTable only
@@ -49,6 +56,7 @@
 // copy, not a mechanical port of WeekGrid.tsx's "grid" mark — see this
 // file's coachmarkVisible/dismissCoachmark prop header).
 import { useEffect, useRef, useState } from "react";
+import type { ClipboardEvent } from "react";
 import {
   DndContext,
   DragOverlay,
@@ -186,22 +194,27 @@ export const tableKeyboardCoordinates: KeyboardCoordinateGetter = (event, args) 
 
 interface CellSubLineInputProps {
   cellId: number;
+  rowId: number;
+  weekId: number;
   line: number;
   text: string;
   /** The trailing "next line" input — commits only non-blank (a blank ghost
    * has nothing to create), and remounts empty via its parent's key once the
    * optimistic upsert promotes its text to a real `cell.lines` entry. */
   ghost?: boolean;
+  tableNav: UseTableNavResult;
   onWrite(line: number, text: string): void;
 }
 
 /** One freeform sub-line of a cell's stack (Phase 2a) — same dirty-tracking
  * commit-on-blur/Enter + Escape-revert shape as GridCellEditor's main text
- * input, but local-only (sub-line inputs are outside useTableNav's arrow
- * grid this phase, so Escape reverts to the last synced `text` directly).
+ * input. Phase 2b put sub-lines INSIDE useTableNav's axes (each line is a
+ * vertical stop at (rowId, weekId, "text", line) — including the ghost, so
+ * D3's RPE row is literally "arrow down and type"), so Enter/Escape and the
+ * arrows all come from cellProps now instead of a local onKeyDown.
  * Blanking an EXISTING line commits "" — the line clears in place (the row
  * stays), mirroring the server's blank-text upsert. */
-function CellSubLineInput({ cellId, line, text, ghost, onWrite }: CellSubLineInputProps) {
+function CellSubLineInput({ cellId, rowId, weekId, line, text, ghost, tableNav, onWrite }: CellSubLineInputProps) {
   const [draft, setDraft] = useState(text);
   const dirtyRef = useRef(false);
 
@@ -217,10 +230,25 @@ function CellSubLineInput({ cellId, line, text, ghost, onWrite }: CellSubLineInp
     onWrite(line, draft);
   }
 
+  const navProps = tableNav.cellProps(
+    rowId,
+    weekId,
+    "text",
+    {
+      onCommit: commitIfDirty,
+      onRevert: (value) => {
+        dirtyRef.current = false;
+        setDraft(value);
+      },
+    },
+    line,
+  );
+
   return (
     <input
       className="meso-cell meso-line-input"
       data-testid={ghost ? `cell-line-new-${cellId}` : `cell-line-${cellId}-${line}`}
+      data-grid-cell={tableCellDomKey(rowId, weekId, "text", line)}
       aria-label={ghost ? "Add a line" : `Line ${line}`}
       placeholder={ghost ? "+ line" : "—"}
       value={draft}
@@ -229,16 +257,7 @@ function CellSubLineInput({ cellId, line, text, ghost, onWrite }: CellSubLineInp
         setDraft(e.target.value);
       }}
       onBlur={commitIfDirty}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") {
-          e.preventDefault();
-          commitIfDirty();
-        } else if (e.key === "Escape") {
-          e.preventDefault();
-          dirtyRef.current = false;
-          setDraft(text);
-        }
-      }}
+      {...navProps}
     />
   );
 }
@@ -258,7 +277,16 @@ interface GridCellEditorProps {
  * (week × line) via onWriteCellLine), then a trailing ghost input that mints
  * the NEXT sub-line (max existing line + 1, or 1) on its first non-blank
  * commit. Dirty-tracking commit-on-blur/Enter + Escape-revert carries
- * forward from the retired six-field editor unchanged in kind. */
+ * forward from the retired six-field editor unchanged in kind.
+ *
+ * Phase 2b adds stack copy/paste on the prescription input (the cell-level
+ * duplicate-forward primitive — copy a cell, arrow to another week, paste):
+ * Ctrl-C with NOTHING selected copies the whole stack (line 0 + non-blank
+ * sub-lines, newline-joined) — a real text selection keeps native copy —
+ * and pasting MULTI-LINE text replaces the whole stack (line 0 via
+ * onPatchCell, the rest via onWriteCellLine, any longer existing lines
+ * blanked so the result equals the source). Single-line paste stays native
+ * caret insertion into the draft. */
 function GridCellEditor({ cell, row, week, tableNav, onPatchCell, onWriteCellLine }: GridCellEditorProps) {
   const [draft, setDraft] = useState(cell.text);
   const dirtyRef = useRef(false);
@@ -292,6 +320,34 @@ function GridCellEditor({ cell, row, week, tableNav, onPatchCell, onWriteCellLin
   const lines = cell.lines ?? [];
   const nextLine = lines.reduce((max, l) => Math.max(max, l.line), 0) + 1;
 
+  function onCopy(e: ClipboardEvent<HTMLInputElement>) {
+    const el = e.currentTarget;
+    if (el.selectionStart !== el.selectionEnd) return; // real selection: native copy wins.
+    e.preventDefault();
+    const stack = [draft, ...lines.filter((l) => l.text.trim() !== "").map((l) => l.text)].join("\n");
+    e.clipboardData.setData("text/plain", stack);
+  }
+
+  function onPaste(e: ClipboardEvent<HTMLInputElement>) {
+    const pasted = e.clipboardData.getData("text/plain");
+    if (!pasted.includes("\n")) return; // single line: native caret insertion into the draft.
+    e.preventDefault();
+    const parts = pasted.replace(/\r\n/g, "\n").split("\n");
+    const head = parts[0] ?? "";
+    const rest = parts.slice(1);
+    while (rest.length && (rest[rest.length - 1] ?? "").trim() === "") rest.pop();
+    dirtyRef.current = false;
+    setDraft(head);
+    onPatchCell(cellId, { text: head });
+    rest.forEach((text, i) => onWriteCellLine(row.exercise_slot_id, week.id, i + 1, text));
+    // Blank any existing line beyond the pasted stack so the result equals
+    // the source cell (a cleared line stays rendered in place — Phase 2a's
+    // blank-upsert semantics — rather than carrying stale text).
+    for (const l of lines) {
+      if (l.line > rest.length && l.text !== "") onWriteCellLine(row.exercise_slot_id, week.id, l.line, "");
+    }
+  }
+
   return (
     <div className="meso-table-cell-editor">
       <input
@@ -306,23 +362,31 @@ function GridCellEditor({ cell, row, week, tableNav, onPatchCell, onWriteCellLin
           setDraft(e.target.value);
         }}
         onBlur={commitIfDirty}
+        onCopy={onCopy}
+        onPaste={onPaste}
         {...navProps}
       />
       {lines.map((l) => (
         <CellSubLineInput
           key={l.line}
           cellId={cellId}
+          rowId={row.exercise_slot_id}
+          weekId={week.id}
           line={l.line}
           text={l.text}
+          tableNav={tableNav}
           onWrite={(line, text) => onWriteCellLine(row.exercise_slot_id, week.id, line, text)}
         />
       ))}
       <CellSubLineInput
         key={`ghost-${nextLine}`}
         cellId={cellId}
+        rowId={row.exercise_slot_id}
+        weekId={week.id}
         line={nextLine}
         text=""
         ghost
+        tableNav={tableNav}
         onWrite={(line, text) => onWriteCellLine(row.exercise_slot_id, week.id, line, text)}
       />
     </div>
@@ -333,14 +397,18 @@ interface RowColumnInputProps {
   row: GridRow;
   field: "tempo" | "rest" | "note";
   label: string;
+  tableNav: UseTableNavResult;
   onPatchRowColumns(exerciseSlotId: Id, patch: GridRowPatch): void;
 }
 
 /** Phase 2a (D2): one per-exercise row column (Tempo / Notes / Rest) — a row
  * attribute off the block-shared ExerciseSlot, NOT a per-week cell value.
- * Same local dirty-tracking commit-on-blur/Enter + Escape-revert shape as
- * CellSubLineInput above (row columns are outside arrow-nav this phase). */
-function RowColumnInput({ row, field, label, onPatchRowColumns }: RowColumnInputProps) {
+ * Same dirty-tracking commit-on-blur/Enter + Escape-revert shape as
+ * CellSubLineInput above. Phase 2b put these columns INSIDE useTableNav's
+ * horizontal axis (name → tempo → weeks… → notes → rest, the source
+ * spreadsheet's order), so Enter/Escape and the arrows come from cellProps
+ * now instead of a local onKeyDown. */
+function RowColumnInput({ row, field, label, tableNav, onPatchRowColumns }: RowColumnInputProps) {
   const synced = row[field];
   const [draft, setDraft] = useState(synced);
   const dirtyRef = useRef(false);
@@ -356,10 +424,19 @@ function RowColumnInput({ row, field, label, onPatchRowColumns }: RowColumnInput
     onPatchRowColumns(row.exercise_slot_id, { [field]: draft });
   }
 
+  const navProps = tableNav.cellProps(row.exercise_slot_id, null, field, {
+    onCommit: commitIfDirty,
+    onRevert: (value) => {
+      dirtyRef.current = false;
+      setDraft(value);
+    },
+  });
+
   return (
     <input
       className="meso-cell meso-row-col-input"
       data-testid={`row-${field}-${row.exercise_slot_id}`}
+      data-grid-cell={tableCellDomKey(row.exercise_slot_id, null, field)}
       aria-label={`${row.name || "exercise"} — ${label}`}
       placeholder="—"
       value={draft}
@@ -368,16 +445,7 @@ function RowColumnInput({ row, field, label, onPatchRowColumns }: RowColumnInput
         setDraft(e.target.value);
       }}
       onBlur={commitIfDirty}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") {
-          e.preventDefault();
-          commitIfDirty();
-        } else if (e.key === "Escape") {
-          e.preventDefault();
-          dirtyRef.current = false;
-          setDraft(synced);
-        }
-      }}
+      {...navProps}
     />
   );
 }
@@ -762,7 +830,7 @@ function TableRow({
         )}
       </td>
       <td className="meso-table-row-col meso-table-row-col--tempo">
-        <RowColumnInput row={row} field="tempo" label="tempo" onPatchRowColumns={onPatchRowColumns} />
+        <RowColumnInput row={row} field="tempo" label="tempo" tableNav={tableNav} onPatchRowColumns={onPatchRowColumns} />
       </td>
       {weeks.map((week) => {
         const cell = row.cells[String(week.id)];
@@ -825,10 +893,10 @@ function TableRow({
         );
       })}
       <td className="meso-table-row-col meso-table-row-col--note">
-        <RowColumnInput row={row} field="note" label="notes" onPatchRowColumns={onPatchRowColumns} />
+        <RowColumnInput row={row} field="note" label="notes" tableNav={tableNav} onPatchRowColumns={onPatchRowColumns} />
       </td>
       <td className="meso-table-row-col meso-table-row-col--rest">
-        <RowColumnInput row={row} field="rest" label="rest" onPatchRowColumns={onPatchRowColumns} />
+        <RowColumnInput row={row} field="rest" label="rest" tableNav={tableNav} onPatchRowColumns={onPatchRowColumns} />
       </td>
     </tr>
   );
@@ -1074,8 +1142,16 @@ export function MesoTable(props: MesoTableProps) {
 
   // Rules of Hooks: called unconditionally, before the `!grid` early return
   // below — useTableNav tolerates a null grid the same way (anchor stays
-  // null, no throw).
-  const tableNav = useTableNav({ grid });
+  // null, no throw). Phase 2b: Enter at the last stop of a day appends a
+  // blank exercise row to THAT day (Enter-adds-row) — same verb as the day's
+  // "+ Add exercise" button, same busy gate.
+  const tableNav = useTableNav({
+    grid,
+    onAppendRow: (dayId) => {
+      const day = grid?.days.find((d) => d.session_slot_id === dayId);
+      if (day && !busy) onAddExercise(day);
+    },
+  });
 
   // Issue #455 phase A2 (drag reordering): PointerSensor gets a small
   // activation distance so a plain click into a cell input doesn't start a
@@ -1169,8 +1245,8 @@ export function MesoTable(props: MesoTableProps) {
             <div className="meso-coachmark-title">The block table</div>
             <div className="meso-coachmark-text">
               Tap any cell and type the prescription — “4 x 6, RPE 9” — with extra lines below it for
-              cues or substitutions; arrow keys move cell to cell, and every change autosaves. Drag a ⠿
-              handle to reorder exercises or days.
+              cues or substitutions; arrows, Tab and Enter move cell to cell (Enter at the bottom of a
+              day adds a row), and every change autosaves. Drag a ⠿ handle to reorder exercises or days.
             </div>
           </div>
           <button

--- a/frontend/designer/src/components/MesoTable.tsx
+++ b/frontend/designer/src/components/MesoTable.tsx
@@ -1144,12 +1144,16 @@ export function MesoTable(props: MesoTableProps) {
   // below — useTableNav tolerates a null grid the same way (anchor stays
   // null, no throw). Phase 2b: Enter at the last stop of a day appends a
   // blank exercise row to THAT day (Enter-adds-row) — same verb as the day's
-  // "+ Add exercise" button, same busy gate.
+  // "+ Add exercise" button, same busy gate. Returning false on a dropped
+  // dispatch keeps the hook from recording a focus intent for an append
+  // that never happened.
   const tableNav = useTableNav({
     grid,
     onAppendRow: (dayId) => {
       const day = grid?.days.find((d) => d.session_slot_id === dayId);
-      if (day && !busy) onAddExercise(day);
+      if (!day || busy) return false;
+      onAddExercise(day);
+      return true;
     },
   });
 

--- a/frontend/designer/src/components/MesoTable.tsx
+++ b/frontend/designer/src/components/MesoTable.tsx
@@ -339,6 +339,10 @@ function GridCellEditor({ cell, row, week, tableNav, onPatchCell, onWriteCellLin
     dirtyRef.current = false;
     setDraft(head);
     onPatchCell(cellId, { text: head });
+    // The pasted head is committed while focus stays here — it's the new
+    // Escape baseline (same rule as the Enter handler's), or Escape would
+    // roll the UI back past the commit.
+    tableNav.setRevertBaseline(row.exercise_slot_id, week.id, "text", head);
     rest.forEach((text, i) => onWriteCellLine(row.exercise_slot_id, week.id, i + 1, text));
     // Blank any existing line beyond the pasted stack so the result equals
     // the source cell (a cleared line stays rendered in place — Phase 2a's

--- a/frontend/designer/src/hooks/useTableNav.test.tsx
+++ b/frontend/designer/src/hooks/useTableNav.test.tsx
@@ -841,6 +841,27 @@ describe("Enter-adds-row (onAppendRow)", () => {
     expect(result.current.anchor).toEqual({ rowId: 12, weekId: 1, field: "text", line: 0 });
   });
 
+  it("onAppendRow returning false (dropped dispatch, e.g. busy) records NO focus intent", () => {
+    let cells = mountCells(GRID);
+    const onAppendRow = vi.fn(() => false as const); // MesoTable drops the verb while busy.
+    const { result, rerender } = renderHook(({ grid: g }) => useTableNav({ grid: g, onAppendRow }), {
+      initialProps: { grid: GRID },
+    });
+    focus(result.current, cells, 10, null, "name");
+    act(() => {
+      result.current.cellProps(10, null, "name", NOOP_CALLBACKS).onKeyDown(keyEvent("Enter", cells[tableCellDomKey(10, null, "name")]!));
+    });
+    expect(onAppendRow).toHaveBeenCalledWith(1);
+
+    // Day 1's last row later changes for an unrelated reason (someone
+    // clicked "+ Add exercise") — the dropped dispatch must not move focus.
+    const LATER = grid({ days: [day(1, [row(9, [1, 2]), row(10, [1, 2]), row(12, [1, 2], { name: "" })]), day(2, [row(11, [1, 2])])] });
+    cells = resyncCells(LATER);
+    act(() => rerender({ grid: LATER }));
+    expect(result.current.anchor).toEqual({ rowId: 10, weekId: null, field: "name", line: 0 });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(10, null, "name")]);
+  });
+
   it("a stale append intent expires instead of stealing focus on a later unrelated change", () => {
     let cells = mountCells(GRID);
     const onAppendRow = vi.fn(); // the POST fails silently: no row ever appears.

--- a/frontend/designer/src/hooks/useTableNav.test.tsx
+++ b/frontend/designer/src/hooks/useTableNav.test.tsx
@@ -6,18 +6,25 @@
 // sibling-not-shared rationale).
 //
 // Phase 2a (text-first cells) collapsed the per-week editable surface from
-// six structured fields to ONE freeform "text" input, so the horizontal
-// axis is now name → week 1 text → week 2 text → … (sub-line inputs and
-// the per-row Tempo/Notes/Rest columns are outside arrow-nav this phase).
+// six structured fields to ONE freeform "text" input. Phase 2b (spreadsheet
+// keyboard flow) then widened both axes to the full sheet: the horizontal
+// axis is name → tempo → week 1 text → … → week N text → notes → rest (the
+// source spreadsheet's column order, Tab-walkable), and cell identity gained
+// a LINE — each week cell's sub-line stack (existing `cell.lines` entries
+// plus the trailing ghost at max line + 1) is a run of vertical stops, so
+// ArrowDown from a prescription steps INTO its stack before the next row.
+// Enter = commit + move down one stop, appending a row at a day's last stop
+// (Enter-adds-row) via the onAppendRow option.
 //
 // Fixture: day 1 (session_slot_id 1) has rows 9, 10; day 2 (session_slot_id
 // 2) has row 11 — flattened row order (day-major/row-minor): (9), (10),
 // (11). Two weeks (id 1 "Wk 1", id 2 "Wk 2") so ArrowRight/Left week-
 // crossing and tier 2b (a week removed, row survives) are exercisable
-// without a second fixture.
+// without a second fixture. Every cell has an empty `lines` stack unless a
+// test says otherwise, so its stops are [0, 1(ghost)].
 import { act, renderHook } from "@testing-library/react";
 import type { FocusEvent, KeyboardEvent } from "react";
-import { useTableNav, tableCellDomKey, tableCellAriaLabel, TABLE_FIELDS } from "./useTableNav";
+import { useTableNav, tableCellDomKey, tableCellAriaLabel } from "./useTableNav";
 import type { TableColumn, UseTableNavResult } from "./useTableNav";
 import type { GridCell, GridDay, GridRow, GridWeek, MesoGrid } from "../lib/api";
 
@@ -91,31 +98,48 @@ const GRID: MesoGrid = grid();
 
 const NOOP_CALLBACKS = { onCommit: vi.fn(), onRevert: vi.fn() };
 
-/** Mounts one real `<input>` per (rowId, weekId, field) in `g`, so the
- * hook's `document.querySelector`-based focus moves have somewhere real to
- * land — mirrors what GridCellEditor/RowNameEditor would render, without
- * needing a full React render of the table tree. */
+const ROW_COLUMNS: TableColumn[] = ["tempo", "note", "rest"];
+
+/** Mounts one real `<input>` per rendered position of `g` — the full 2b
+ * sheet: name, tempo, each week cell's text (line 0) + its sub-lines + its
+ * trailing ghost (max line + 1), notes, rest — so the hook's
+ * `document.querySelector`-based focus moves have somewhere real to land.
+ * Mirrors what GridCellEditor/RowNameEditor/CellSubLineInput/RowColumnInput
+ * would render, without needing a full React render of the table tree. A
+ * row's OWN `cells` map decides what actually mounts: a week id missing
+ * from `row.cells` gets no node for any of its lines — the same "no
+ * rendered input at all" shape MesoTable produces for a hole (an
+ * add-this-week row's bare `<td/>`, no GridCellEditor) or a skipped cell
+ * (em-dash + Unskip button). Fixtures express holes just by leaving a
+ * weekId out of `row(id, weekIds)`. The row-scoped columns always mount —
+ * MesoTable renders RowNameEditor/RowColumnInput unconditionally,
+ * independent of any week's holes. */
 function mountCells(g: MesoGrid) {
   const nodes: Record<string, HTMLInputElement> = {};
+  function mount(key: string, value: string) {
+    const input = document.createElement("input");
+    input.type = "text";
+    input.value = value;
+    input.setAttribute("data-grid-cell", key);
+    document.body.appendChild(input);
+    nodes[key] = input;
+  }
   for (const d of g.days) {
     for (const r of d.rows) {
-      const nameInput = document.createElement("input");
-      nameInput.type = "text";
-      nameInput.value = r.name;
-      nameInput.setAttribute("data-grid-cell", tableCellDomKey(r.exercise_slot_id, null, "name"));
-      document.body.appendChild(nameInput);
-      nodes[tableCellDomKey(r.exercise_slot_id, null, "name")] = nameInput;
-
+      mount(tableCellDomKey(r.exercise_slot_id, null, "name"), r.name);
+      for (const field of ROW_COLUMNS) {
+        mount(tableCellDomKey(r.exercise_slot_id, null, field), String(r[field as "tempo" | "note" | "rest"] ?? ""));
+      }
       for (const w of g.weeks) {
         const c = r.cells[String(w.id)];
-        for (const field of TABLE_FIELDS) {
-          const input = document.createElement("input");
-          input.type = "text";
-          input.value = c ? String((c as unknown as Record<string, unknown>)[field] ?? "") : "";
-          input.setAttribute("data-grid-cell", tableCellDomKey(r.exercise_slot_id, w.id, field));
-          document.body.appendChild(input);
-          nodes[tableCellDomKey(r.exercise_slot_id, w.id, field)] = input;
+        if (!c) continue; // hole: no cell for this row this week, no inputs at all.
+        mount(tableCellDomKey(r.exercise_slot_id, w.id, "text"), c.text);
+        const lineNos = (c.lines ?? []).map((l) => l.line).sort((a, b) => a - b);
+        for (const l of c.lines ?? []) {
+          mount(tableCellDomKey(r.exercise_slot_id, w.id, "text", l.line), l.text);
         }
+        const ghost = (lineNos[lineNos.length - 1] ?? 0) + 1;
+        mount(tableCellDomKey(r.exercise_slot_id, w.id, "text", ghost), "");
       }
     }
   }
@@ -129,46 +153,10 @@ function resyncCells(g: MesoGrid) {
   return mountCells(g);
 }
 
-/** Like mountCells, but a row's OWN `cells` map decides what actually
- * mounts: a week id missing from `row.cells` gets no `data-grid-cell` node
- * for any of its fields — the same "no rendered input at all" shape
- * MesoTable produces for a hole (an add-this-week row's bare `<td/>`, no
- * GridCellEditor) or a skipped cell (em-dash + Unskip button, no
- * GridCellEditor). Fixtures express holes just by leaving a weekId out of
- * `row(id, weekIds)`. The row-name column always mounts — MesoTable renders
- * RowNameEditor unconditionally, independent of any week's holes. */
-function mountCellsWithHoles(g: MesoGrid) {
-  const nodes: Record<string, HTMLInputElement> = {};
-  for (const d of g.days) {
-    for (const r of d.rows) {
-      const nameInput = document.createElement("input");
-      nameInput.type = "text";
-      nameInput.value = r.name;
-      nameInput.setAttribute("data-grid-cell", tableCellDomKey(r.exercise_slot_id, null, "name"));
-      document.body.appendChild(nameInput);
-      nodes[tableCellDomKey(r.exercise_slot_id, null, "name")] = nameInput;
-
-      for (const w of g.weeks) {
-        const c = r.cells[String(w.id)];
-        if (!c) continue; // hole: no cell for this row this week, no inputs at all.
-        for (const field of TABLE_FIELDS) {
-          const input = document.createElement("input");
-          input.type = "text";
-          input.value = String((c as unknown as Record<string, unknown>)[field] ?? "");
-          input.setAttribute("data-grid-cell", tableCellDomKey(r.exercise_slot_id, w.id, field));
-          document.body.appendChild(input);
-          nodes[tableCellDomKey(r.exercise_slot_id, w.id, field)] = input;
-        }
-      }
-    }
-  }
-  return nodes;
-}
-
 function keyEvent(
   key: string,
   target: HTMLInputElement,
-  extra: Partial<{ ctrlKey: boolean; metaKey: boolean; shiftKey: boolean }> = {},
+  extra: Partial<{ ctrlKey: boolean; metaKey: boolean; shiftKey: boolean; altKey: boolean }> = {},
 ): KeyboardEvent<HTMLInputElement> {
   return {
     key,
@@ -178,6 +166,7 @@ function keyEvent(
     ctrlKey: false,
     metaKey: false,
     shiftKey: false,
+    altKey: false,
     ...extra,
   } as unknown as KeyboardEvent<HTMLInputElement>;
 }
@@ -192,9 +181,12 @@ function focus(
   rowId: number,
   weekId: number | null,
   field: TableColumn,
+  line = 0,
 ) {
   act(() => {
-    result.cellProps(rowId, weekId, field, NOOP_CALLBACKS).onFocus(focusEvent(cells[tableCellDomKey(rowId, weekId, field)]!));
+    result
+      .cellProps(rowId, weekId, field, NOOP_CALLBACKS, line)
+      .onFocus(focusEvent(cells[tableCellDomKey(rowId, weekId, field, line)]!));
   });
 }
 
@@ -212,8 +204,14 @@ describe("pure helpers", () => {
       expect(tableCellDomKey(9, 2, "text")).toBe("9:2:text");
     });
 
-    it("uses the 'row' sentinel for a null weekId (the name column)", () => {
+    it("uses the 'row' sentinel for a null weekId (the row-scoped columns)", () => {
       expect(tableCellDomKey(9, null, "name")).toBe("9:row:name");
+      expect(tableCellDomKey(9, null, "tempo")).toBe("9:row:tempo");
+    });
+
+    it("line 0 keeps the legacy 3-part key; a sub-line appends its number", () => {
+      expect(tableCellDomKey(9, 2, "text", 0)).toBe("9:2:text");
+      expect(tableCellDomKey(9, 2, "text", 1)).toBe("9:2:text:1");
     });
   });
 
@@ -222,8 +220,9 @@ describe("pure helpers", () => {
       expect(tableCellAriaLabel("Box Squat", "Wk 2", "text")).toBe("Box Squat — Wk 2 — prescription");
     });
 
-    it("labels the name column as '<name> — exercise name' regardless of weekLabel", () => {
+    it("labels a row-scoped column as '<name> — <field label>' (no week context)", () => {
       expect(tableCellAriaLabel("Box Squat", null, "name")).toBe("Box Squat — exercise name");
+      expect(tableCellAriaLabel("Box Squat", null, "tempo")).toBe("Box Squat — tempo");
     });
 
     it("falls back to 'exercise' when the row has no name yet", () => {
@@ -236,7 +235,7 @@ describe("anchor + roving tabindex", () => {
   it("starts anchored on the first row's name column", () => {
     mountCells(GRID);
     const { result } = renderHook(() => useTableNav({ grid: GRID }));
-    expect(result.current.anchor).toEqual({ rowId: 9, weekId: null, field: "name" });
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: null, field: "name", line: 0 });
   });
 
   it("exactly one cell is tabbable (0) initially — every other cell is -1", () => {
@@ -244,6 +243,7 @@ describe("anchor + roving tabindex", () => {
     const { result } = renderHook(() => useTableNav({ grid: GRID }));
     expect(result.current.cellProps(9, null, "name", NOOP_CALLBACKS).tabIndex).toBe(0);
     expect(result.current.cellProps(9, 1, "text", NOOP_CALLBACKS).tabIndex).toBe(-1);
+    expect(result.current.cellProps(9, null, "tempo", NOOP_CALLBACKS).tabIndex).toBe(-1);
     expect(result.current.cellProps(10, null, "name", NOOP_CALLBACKS).tabIndex).toBe(-1);
     expect(result.current.cellProps(11, 2, "text", NOOP_CALLBACKS).tabIndex).toBe(-1);
   });
@@ -254,63 +254,104 @@ describe("anchor + roving tabindex", () => {
     act(() => {
       result.current.cellProps(10, 2, "text", NOOP_CALLBACKS).onFocus(focusEvent(cells[tableCellDomKey(10, 2, "text")]!));
     });
-    expect(result.current.anchor).toEqual({ rowId: 10, weekId: 2, field: "text" });
+    expect(result.current.anchor).toEqual({ rowId: 10, weekId: 2, field: "text", line: 0 });
     expect(result.current.cellProps(10, 2, "text", NOOP_CALLBACKS).tabIndex).toBe(0);
     expect(result.current.cellProps(9, null, "name", NOOP_CALLBACKS).tabIndex).toBe(-1);
   });
 
-  it("cell identity is (rowId, weekId, field), never an index — the same field on a different row/week is a different cell", () => {
-    mountCells(GRID);
+  it("cell identity is (rowId, weekId, field, line), never an index — the same field on a different row/week/line is a different cell", () => {
+    const cells = mountCells(GRID);
     const { result } = renderHook(() => useTableNav({ grid: GRID }));
     expect(result.current.cellProps(9, 1, "text", NOOP_CALLBACKS).tabIndex).toBe(-1);
     expect(result.current.cellProps(9, 2, "text", NOOP_CALLBACKS).tabIndex).toBe(-1);
     expect(result.current.cellProps(10, 1, "text", NOOP_CALLBACKS).tabIndex).toBe(-1);
+    // A sub-line is its own cell: focusing the ghost anchors (…, line 1),
+    // not the prescription at line 0.
+    act(() => {
+      result.current.cellProps(9, 1, "text", NOOP_CALLBACKS, 1).onFocus(focusEvent(cells[tableCellDomKey(9, 1, "text", 1)]!));
+    });
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 1, field: "text", line: 1 });
+    expect(result.current.cellProps(9, 1, "text", NOOP_CALLBACKS, 1).tabIndex).toBe(0);
+    expect(result.current.cellProps(9, 1, "text", NOOP_CALLBACKS).tabIndex).toBe(-1);
   });
 });
 
 describe("ArrowDown / ArrowUp", () => {
-  it("ArrowDown moves focus to the same (weekId, field) on the next row within a day", () => {
+  it("ArrowDown from a prescription steps INTO its stack first (the ghost when there are no sub-lines)", () => {
     const cells = mountCells(GRID);
     const { result } = renderHook(() => useTableNav({ grid: GRID }));
     const event = keyEvent("ArrowDown", cells[tableCellDomKey(9, 1, "text")]!);
     act(() => {
       result.current.cellProps(9, 1, "text", NOOP_CALLBACKS).onKeyDown(event);
     });
-    expect(document.activeElement).toBe(cells[tableCellDomKey(10, 1, "text")]);
+    expect(document.activeElement).toBe(cells[tableCellDomKey(9, 1, "text", 1)]);
     expect(event.preventDefault).toHaveBeenCalled();
-    expect(result.current.anchor).toEqual({ rowId: 10, weekId: 1, field: "text" });
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 1, field: "text", line: 1 });
   });
 
-  it("ArrowDown crosses a day-table boundary (last row of day 1 -> first row of day 2)", () => {
+  it("ArrowDown from the last stop of a row's stack moves to the next row's prescription", () => {
     const cells = mountCells(GRID);
     const { result } = renderHook(() => useTableNav({ grid: GRID }));
-    const event = keyEvent("ArrowDown", cells[tableCellDomKey(10, 2, "text")]!);
+    const event = keyEvent("ArrowDown", cells[tableCellDomKey(9, 1, "text", 1)]!);
     act(() => {
-      result.current.cellProps(10, 2, "text", NOOP_CALLBACKS).onKeyDown(event);
+      result.current.cellProps(9, 1, "text", NOOP_CALLBACKS, 1).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(10, 1, "text")]);
+    expect(result.current.anchor).toEqual({ rowId: 10, weekId: 1, field: "text", line: 0 });
+  });
+
+  it("ArrowDown walks an existing sub-line stack in order: line 0 → line 1 → ghost (D3's RPE row)", () => {
+    const STACK_GRID = grid({
+      days: [day(1, [row(9, [1, 2], { cells: { "1": cell({ prescription_id: 900, lines: [{ line: 1, text: "RPE 8" }] }), "2": cell({ prescription_id: 901 }) } }), row(10, [1, 2])]), day(2, [row(11, [1, 2])])],
+    });
+    const cells = mountCells(STACK_GRID);
+    const { result } = renderHook(() => useTableNav({ grid: STACK_GRID }));
+    act(() => {
+      result.current.cellProps(9, 1, "text", NOOP_CALLBACKS).onKeyDown(keyEvent("ArrowDown", cells[tableCellDomKey(9, 1, "text")]!));
+    });
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 1, field: "text", line: 1 });
+    act(() => {
+      result.current.cellProps(9, 1, "text", NOOP_CALLBACKS, 1).onKeyDown(keyEvent("ArrowDown", cells[tableCellDomKey(9, 1, "text", 1)]!));
+    });
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 1, field: "text", line: 2 });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(9, 1, "text", 2)]);
+    act(() => {
+      result.current.cellProps(9, 1, "text", NOOP_CALLBACKS, 2).onKeyDown(keyEvent("ArrowDown", cells[tableCellDomKey(9, 1, "text", 2)]!));
+    });
+    expect(result.current.anchor).toEqual({ rowId: 10, weekId: 1, field: "text", line: 0 });
+  });
+
+  it("ArrowUp mirrors: from a prescription it lands on the PREVIOUS row's last stop (its ghost)", () => {
+    const cells = mountCells(GRID);
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const event = keyEvent("ArrowUp", cells[tableCellDomKey(10, 1, "text")]!);
+    act(() => {
+      result.current.cellProps(10, 1, "text", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(9, 1, "text", 1)]);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 1, field: "text", line: 1 });
+  });
+
+  it("ArrowDown crosses a day-table boundary (last stop of day 1 -> first row of day 2)", () => {
+    const cells = mountCells(GRID);
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const event = keyEvent("ArrowDown", cells[tableCellDomKey(10, 2, "text", 1)]!);
+    act(() => {
+      result.current.cellProps(10, 2, "text", NOOP_CALLBACKS, 1).onKeyDown(event);
     });
     expect(document.activeElement).toBe(cells[tableCellDomKey(11, 2, "text")]);
   });
 
-  it("ArrowDown at the very last row is a no-op but still preventDefault", () => {
+  it("ArrowDown at the table's very last stop is a no-op but still preventDefault", () => {
     const cells = mountCells(GRID);
     const { result } = renderHook(() => useTableNav({ grid: GRID }));
-    const event = keyEvent("ArrowDown", cells[tableCellDomKey(11, 2, "text")]!);
+    const event = keyEvent("ArrowDown", cells[tableCellDomKey(11, 2, "text", 1)]!);
     act(() => {
-      result.current.cellProps(11, 2, "text", NOOP_CALLBACKS).onKeyDown(event);
+      result.current.cellProps(11, 2, "text", NOOP_CALLBACKS, 1).onKeyDown(event);
     });
     expect(event.preventDefault).toHaveBeenCalled();
-    expect(result.current.anchor).toEqual({ rowId: 11, weekId: 2, field: "text" });
-  });
-
-  it("ArrowUp mirrors ArrowDown, crossing day boundaries upward", () => {
-    const cells = mountCells(GRID);
-    const { result } = renderHook(() => useTableNav({ grid: GRID }));
-    const event = keyEvent("ArrowUp", cells[tableCellDomKey(11, 1, "text")]!);
-    act(() => {
-      result.current.cellProps(11, 1, "text", NOOP_CALLBACKS).onKeyDown(event);
-    });
-    expect(document.activeElement).toBe(cells[tableCellDomKey(10, 1, "text")]);
-    expect(event.preventDefault).toHaveBeenCalled();
+    expect(result.current.anchor).toEqual({ rowId: 11, weekId: 2, field: "text", line: 1 });
   });
 
   it("ArrowUp at the very first row is a no-op but still preventDefault", () => {
@@ -323,7 +364,7 @@ describe("ArrowDown / ArrowUp", () => {
     expect(event.preventDefault).toHaveBeenCalled();
   });
 
-  it("the name column moves vertically too, keeping weekId null", () => {
+  it("the name column moves vertically too, keeping weekId null (single-line: row to row)", () => {
     const cells = mountCells(GRID);
     const { result } = renderHook(() => useTableNav({ grid: GRID }));
     const event = keyEvent("ArrowDown", cells[tableCellDomKey(9, null, "name")]!);
@@ -331,7 +372,18 @@ describe("ArrowDown / ArrowUp", () => {
       result.current.cellProps(9, null, "name", NOOP_CALLBACKS).onKeyDown(event);
     });
     expect(document.activeElement).toBe(cells[tableCellDomKey(10, null, "name")]);
-    expect(result.current.anchor).toEqual({ rowId: 10, weekId: null, field: "name" });
+    expect(result.current.anchor).toEqual({ rowId: 10, weekId: null, field: "name", line: 0 });
+  });
+
+  it("the row columns (tempo/notes/rest) move vertically row to row too", () => {
+    const cells = mountCells(GRID);
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const event = keyEvent("ArrowDown", cells[tableCellDomKey(9, null, "tempo")]!);
+    act(() => {
+      result.current.cellProps(9, null, "tempo", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(10, null, "tempo")]);
+    expect(result.current.anchor).toEqual({ rowId: 10, weekId: null, field: "tempo", line: 0 });
   });
 });
 
@@ -348,7 +400,7 @@ describe("ArrowRight / ArrowLeft (caret-conditional)", () => {
     });
     expect(document.activeElement).toBe(cells[tableCellDomKey(9, 2, "text")]);
     expect(event.preventDefault).toHaveBeenCalled();
-    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 2, field: "text" });
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 2, field: "text", line: 0 });
   });
 
   it("ArrowLeft at the start of the text moves back to the previous week's text cell", () => {
@@ -365,30 +417,83 @@ describe("ArrowRight / ArrowLeft (caret-conditional)", () => {
     expect(event.preventDefault).toHaveBeenCalled();
   });
 
-  it("ArrowRight at the end of the name column moves to week 1's text cell", () => {
+  it("the horizontal axis is the sheet's column order: name → tempo → weeks → notes → rest", () => {
     const cells = mountCells(GRID);
-    const nameInput = cells[tableCellDomKey(9, null, "name")]!;
-    nameInput.value = "Ex 9";
-    nameInput.setSelectionRange(4, 4);
     const { result } = renderHook(() => useTableNav({ grid: GRID }));
-    const event = keyEvent("ArrowRight", nameInput);
-    act(() => {
-      result.current.cellProps(9, null, "name", NOOP_CALLBACKS).onKeyDown(event);
-    });
-    expect(document.activeElement).toBe(cells[tableCellDomKey(9, 1, "text")]);
+    const path: Array<[number | null, TableColumn]> = [
+      [null, "name"],
+      [null, "tempo"],
+      [1, "text"],
+      [2, "text"],
+      [null, "note"],
+      [null, "rest"],
+    ];
+    for (let i = 0; i < path.length - 1; i++) {
+      const [fromWeek, fromField] = path[i]!;
+      const [toWeek, toField] = path[i + 1]!;
+      const input = cells[tableCellDomKey(9, fromWeek, fromField)]!;
+      input.setSelectionRange(input.value.length, input.value.length);
+      act(() => {
+        result.current.cellProps(9, fromWeek, fromField, NOOP_CALLBACKS).onKeyDown(keyEvent("ArrowRight", input));
+      });
+      expect(document.activeElement).toBe(cells[tableCellDomKey(9, toWeek, toField)]);
+      expect(result.current.anchor).toEqual({ rowId: 9, weekId: toWeek, field: toField, line: 0 });
+    }
   });
 
-  it("ArrowLeft at the start of week 1's text cell moves back to the name column", () => {
+  it("ArrowLeft at the start of the tempo column moves back to the name column", () => {
     const cells = mountCells(GRID);
-    const textInput = cells[tableCellDomKey(9, 1, "text")]!;
-    textInput.value = "3 x 5";
-    textInput.setSelectionRange(0, 0);
+    const tempoInput = cells[tableCellDomKey(9, null, "tempo")]!;
+    tempoInput.setSelectionRange(0, 0);
     const { result } = renderHook(() => useTableNav({ grid: GRID }));
-    const event = keyEvent("ArrowLeft", textInput);
+    const event = keyEvent("ArrowLeft", tempoInput);
     act(() => {
-      result.current.cellProps(9, 1, "text", NOOP_CALLBACKS).onKeyDown(event);
+      result.current.cellProps(9, null, "tempo", NOOP_CALLBACKS).onKeyDown(event);
     });
     expect(document.activeElement).toBe(cells[tableCellDomKey(9, null, "name")]);
+  });
+
+  it("a sub-line moves horizontally at its own line, clamping to a shorter stack's nearest stop (the ghost)", () => {
+    // Row 9's week 1 has a sub-line (stops 0,1,2-ghost); week 2 has none
+    // (stops 0,1-ghost). Moving right from week 1's line-2 ghost clamps to
+    // week 2's line-1 ghost — the spreadsheet's "the merged cell is still
+    // there" feel, never a skid past the whole cell.
+    const STACK_GRID = grid({
+      days: [day(1, [row(9, [1, 2], { cells: { "1": cell({ prescription_id: 900, lines: [{ line: 1, text: "RPE 8" }] }), "2": cell({ prescription_id: 901 }) } }), row(10, [1, 2])]), day(2, [row(11, [1, 2])])],
+    });
+    const cells = mountCells(STACK_GRID);
+    const { result } = renderHook(() => useTableNav({ grid: STACK_GRID }));
+    const ghost = cells[tableCellDomKey(9, 1, "text", 2)]!;
+    ghost.setSelectionRange(0, 0);
+    const event = keyEvent("ArrowRight", ghost);
+    act(() => {
+      result.current.cellProps(9, 1, "text", NOOP_CALLBACKS, 2).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(9, 2, "text", 1)]);
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 2, field: "text", line: 1 });
+  });
+
+  it("a sub-line keeps its line when the next week has the same stop", () => {
+    const cells = mountCells(GRID); // every cell: stops [0, 1(ghost)]
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const ghost = cells[tableCellDomKey(9, 1, "text", 1)]!;
+    ghost.setSelectionRange(0, 0);
+    act(() => {
+      result.current.cellProps(9, 1, "text", NOOP_CALLBACKS, 1).onKeyDown(keyEvent("ArrowRight", ghost));
+    });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(9, 2, "text", 1)]);
+  });
+
+  it("a sub-line moving into a row-scoped column lands at line 0 (the sheet's merged cell)", () => {
+    const cells = mountCells(GRID);
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const ghost = cells[tableCellDomKey(9, 2, "text", 1)]!;
+    ghost.setSelectionRange(0, 0);
+    act(() => {
+      result.current.cellProps(9, 2, "text", NOOP_CALLBACKS, 1).onKeyDown(keyEvent("ArrowRight", ghost));
+    });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(9, null, "note")]);
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: null, field: "note", line: 0 });
   });
 
   it("ArrowRight mid-text does NOT move focus or preventDefault (native caret move wins)", () => {
@@ -435,24 +540,109 @@ describe("ArrowRight / ArrowLeft (caret-conditional)", () => {
     expect(event.preventDefault).not.toHaveBeenCalled();
   });
 
-  it("no wrap at an absolute extreme: ArrowRight at the end of the very last column (text, week 2, row 9) is a pure no-op", () => {
+  it("no wrap at an absolute extreme: ArrowRight at the end of the very last column (rest, row 9) is a pure no-op", () => {
     const cells = mountCells(GRID);
-    const textInput = cells[tableCellDomKey(9, 2, "text")]!;
-    textInput.value = "";
-    textInput.setSelectionRange(0, 0);
-    textInput.focus();
+    const restInput = cells[tableCellDomKey(9, null, "rest")]!;
+    restInput.value = "";
+    restInput.setSelectionRange(0, 0);
+    restInput.focus();
     const { result } = renderHook(() => useTableNav({ grid: GRID }));
-    const event = keyEvent("ArrowRight", textInput);
+    const event = keyEvent("ArrowRight", restInput);
     act(() => {
-      result.current.cellProps(9, 2, "text", NOOP_CALLBACKS).onKeyDown(event);
+      result.current.cellProps(9, null, "rest", NOOP_CALLBACKS).onKeyDown(event);
     });
-    expect(document.activeElement).toBe(textInput);
+    expect(document.activeElement).toBe(restInput);
     expect(event.preventDefault).not.toHaveBeenCalled();
   });
 });
 
-describe("Enter (commit) / Escape (revert)", () => {
-  it("Enter calls the cell's onCommit, preventDefaults, and does not move focus", () => {
+describe("Tab / Shift+Tab (unconditional column walk)", () => {
+  it("Tab moves to the next column regardless of caret position", () => {
+    const cells = mountCells(GRID);
+    const nameInput = cells[tableCellDomKey(9, null, "name")]!;
+    nameInput.value = "Ex 9";
+    nameInput.setSelectionRange(1, 1); // mid-text: Tab still moves (arrows wouldn't)
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const event = keyEvent("Tab", nameInput);
+    act(() => {
+      result.current.cellProps(9, null, "name", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(9, null, "tempo")]);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: null, field: "tempo", line: 0 });
+  });
+
+  it("Shift+Tab moves to the previous column", () => {
+    const cells = mountCells(GRID);
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const event = keyEvent("Tab", cells[tableCellDomKey(9, 1, "text")]!, { shiftKey: true });
+    act(() => {
+      result.current.cellProps(9, 1, "text", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(9, null, "tempo")]);
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it("Tab at the row's last column (rest) wraps to the NEXT row's name column", () => {
+    const cells = mountCells(GRID);
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const event = keyEvent("Tab", cells[tableCellDomKey(9, null, "rest")]!);
+    act(() => {
+      result.current.cellProps(9, null, "rest", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(10, null, "name")]);
+    expect(result.current.anchor).toEqual({ rowId: 10, weekId: null, field: "name", line: 0 });
+  });
+
+  it("Shift+Tab at the row's first column (name) wraps to the PREVIOUS row's rest column", () => {
+    const cells = mountCells(GRID);
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const event = keyEvent("Tab", cells[tableCellDomKey(10, null, "name")]!, { shiftKey: true });
+    act(() => {
+      result.current.cellProps(10, null, "name", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(9, null, "rest")]);
+  });
+
+  it("Tab from a sub-line keeps its line across week columns (clamping like the arrows)", () => {
+    const cells = mountCells(GRID);
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const event = keyEvent("Tab", cells[tableCellDomKey(9, 1, "text", 1)]!);
+    act(() => {
+      result.current.cellProps(9, 1, "text", NOOP_CALLBACKS, 1).onKeyDown(event);
+    });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(9, 2, "text", 1)]);
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 2, field: "text", line: 1 });
+  });
+
+  it("Tab at the table's very last cell is NOT preventDefault'd (native tab order leaves the grid)", () => {
+    const cells = mountCells(GRID);
+    const restInput = cells[tableCellDomKey(11, null, "rest")]!;
+    restInput.focus();
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const event = keyEvent("Tab", restInput);
+    act(() => {
+      result.current.cellProps(11, null, "rest", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(restInput);
+  });
+
+  it("Ctrl+Tab / Alt+Tab are browser chrome, never grid moves", () => {
+    const cells = mountCells(GRID);
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    for (const extra of [{ ctrlKey: true }, { altKey: true }, { metaKey: true }]) {
+      const event = keyEvent("Tab", cells[tableCellDomKey(9, 1, "text")]!, extra);
+      act(() => {
+        result.current.cellProps(9, 1, "text", NOOP_CALLBACKS).onKeyDown(event);
+      });
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    }
+  });
+});
+
+describe("Enter (commit + move down) / Escape (revert)", () => {
+  it("Enter calls the cell's onCommit, preventDefaults, and moves down one stop (the ghost)", () => {
     const cells = mountCells(GRID);
     cells[tableCellDomKey(9, 1, "text")]!.focus();
     const { result } = renderHook(() => useTableNav({ grid: GRID }));
@@ -463,7 +653,30 @@ describe("Enter (commit) / Escape (revert)", () => {
     });
     expect(onCommit).toHaveBeenCalledTimes(1);
     expect(event.preventDefault).toHaveBeenCalled();
-    expect(document.activeElement).toBe(cells[tableCellDomKey(9, 1, "text")]);
+    expect(document.activeElement).toBe(cells[tableCellDomKey(9, 1, "text", 1)]);
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 1, field: "text", line: 1 });
+  });
+
+  it("Enter on the name column moves to the next row's name (single-line column)", () => {
+    const cells = mountCells(GRID);
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    act(() => {
+      result.current.cellProps(9, null, "name", NOOP_CALLBACKS).onKeyDown(keyEvent("Enter", cells[tableCellDomKey(9, null, "name")]!));
+    });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(10, null, "name")]);
+  });
+
+  it("Enter never crosses a day boundary: at day 1's last stop with no onAppendRow it stays put", () => {
+    const cells = mountCells(GRID);
+    const input = cells[tableCellDomKey(10, null, "name")]!;
+    input.focus();
+    const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const event = keyEvent("Enter", input);
+    act(() => {
+      result.current.cellProps(10, null, "name", NOOP_CALLBACKS).onKeyDown(event);
+    });
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(document.activeElement).toBe(input);
   });
 
   it("Escape reverts to the focus-time value via onRevert, preventDefaults, and keeps focus", () => {
@@ -525,22 +738,156 @@ describe("Enter (commit) / Escape (revert)", () => {
   });
 });
 
+describe("Enter-adds-row (onAppendRow)", () => {
+  // Day 1's last vertical stop at the name column is row 10's name (single-
+  // line column). Rows are non-blank by default (mountCells seeds "Ex 10"),
+  // so Enter there fires the append.
+  it("Enter at a day's last stop appends: fires onAppendRow with the day id, no focus move yet", () => {
+    const cells = mountCells(GRID);
+    const input = cells[tableCellDomKey(10, null, "name")]!;
+    input.focus();
+    const onAppendRow = vi.fn();
+    const { result } = renderHook(() => useTableNav({ grid: GRID, onAppendRow }));
+    act(() => {
+      result.current.cellProps(10, null, "name", NOOP_CALLBACKS).onKeyDown(keyEvent("Enter", input));
+    });
+    expect(onAppendRow).toHaveBeenCalledTimes(1);
+    expect(onAppendRow).toHaveBeenCalledWith(1);
+    expect(document.activeElement).toBe(input); // focus lands only once the refetch delivers the row.
+  });
+
+  it("Enter mid-day still just moves down — never appends", () => {
+    const cells = mountCells(GRID);
+    const onAppendRow = vi.fn();
+    const { result } = renderHook(() => useTableNav({ grid: GRID, onAppendRow }));
+    act(() => {
+      result.current.cellProps(9, null, "name", NOOP_CALLBACKS).onKeyDown(keyEvent("Enter", cells[tableCellDomKey(9, null, "name")]!));
+    });
+    expect(onAppendRow).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(cells[tableCellDomKey(10, null, "name")]);
+  });
+
+  it("a fully blank row never appends another (the Enter-Enter-Enter guard)", () => {
+    // Row 10 (day 1's last) renders entirely blank — name, tempo, cells,
+    // notes, rest all empty — exactly what a just-appended row looks like.
+    const BLANK_LAST = grid({
+      days: [
+        day(1, [row(9, [1, 2]), row(10, [1, 2], { name: "", cells: { "1": cell({ prescription_id: 1000, text: "" }), "2": cell({ prescription_id: 1001, text: "" }) } })]),
+        day(2, [row(11, [1, 2])]),
+      ],
+    });
+    const cells = mountCells(BLANK_LAST);
+    const input = cells[tableCellDomKey(10, null, "name")]!;
+    input.focus();
+    const onAppendRow = vi.fn();
+    const { result } = renderHook(() => useTableNav({ grid: BLANK_LAST, onAppendRow }));
+    act(() => {
+      result.current.cellProps(10, null, "name", NOOP_CALLBACKS).onKeyDown(keyEvent("Enter", input));
+    });
+    expect(onAppendRow).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(input);
+  });
+
+  it("an uncommitted draft counts as content: the blank check reads the DOM, not the grid", () => {
+    const BLANK_LAST = grid({
+      days: [
+        day(1, [row(9, [1, 2]), row(10, [1, 2], { name: "", cells: { "1": cell({ prescription_id: 1000, text: "" }), "2": cell({ prescription_id: 1001, text: "" }) } })]),
+        day(2, [row(11, [1, 2])]),
+      ],
+    });
+    const cells = mountCells(BLANK_LAST);
+    const input = cells[tableCellDomKey(10, null, "name")]!;
+    input.value = "Front squat"; // typed but not yet in the grid payload
+    input.focus();
+    const onAppendRow = vi.fn();
+    const { result } = renderHook(() => useTableNav({ grid: BLANK_LAST, onAppendRow }));
+    act(() => {
+      result.current.cellProps(10, null, "name", NOOP_CALLBACKS).onKeyDown(keyEvent("Enter", input));
+    });
+    expect(onAppendRow).toHaveBeenCalledWith(1);
+  });
+
+  it("once the day's last row changes on a grid swap, focus lands on the new row at the column Enter came from", () => {
+    let cells = mountCells(GRID);
+    const onAppendRow = vi.fn();
+    const { result, rerender } = renderHook(({ grid: g }) => useTableNav({ grid: g, onAppendRow }), {
+      initialProps: { grid: GRID },
+    });
+    focus(result.current, cells, 10, 1, "text");
+    act(() => {
+      // (10,1,text) line 0 -> ghost line 1 first…
+      result.current.cellProps(10, 1, "text", NOOP_CALLBACKS).onKeyDown(keyEvent("Enter", cells[tableCellDomKey(10, 1, "text")]!));
+    });
+    act(() => {
+      // …then Enter at the ghost (day 1's last stop of this column) appends.
+      result.current.cellProps(10, 1, "text", NOOP_CALLBACKS, 1).onKeyDown(keyEvent("Enter", cells[tableCellDomKey(10, 1, "text", 1)]!));
+    });
+    expect(onAppendRow).toHaveBeenCalledWith(1);
+
+    // The commit's own optimistic grid change arrives FIRST — same last row,
+    // so the intent must survive it without focusing anything new.
+    const OPTIMISTIC = grid({ days: [day(1, [row(9, [1, 2]), row(10, [1, 2], { name: "Ex 10 v2" })]), day(2, [row(11, [1, 2])])] });
+    cells = resyncCells(OPTIMISTIC);
+    act(() => rerender({ grid: OPTIMISTIC }));
+    expect(result.current.anchor).toEqual({ rowId: 10, weekId: 1, field: "text", line: 1 });
+
+    // The refetch lands with the appended row 12 — focus jumps to it.
+    const APPENDED = grid({
+      days: [day(1, [row(9, [1, 2]), row(10, [1, 2], { name: "Ex 10 v2" }), row(12, [1, 2], { name: "" })]), day(2, [row(11, [1, 2])])],
+    });
+    cells = resyncCells(APPENDED);
+    act(() => rerender({ grid: APPENDED }));
+    expect(document.activeElement).toBe(cells[tableCellDomKey(12, 1, "text")]);
+    expect(result.current.anchor).toEqual({ rowId: 12, weekId: 1, field: "text", line: 0 });
+  });
+
+  it("a stale append intent expires instead of stealing focus on a later unrelated change", () => {
+    let cells = mountCells(GRID);
+    const onAppendRow = vi.fn(); // the POST fails silently: no row ever appears.
+    const { result, rerender } = renderHook(({ grid: g }) => useTableNav({ grid: g, onAppendRow }), {
+      initialProps: { grid: GRID },
+    });
+    focus(result.current, cells, 10, null, "name");
+    act(() => {
+      result.current.cellProps(10, null, "name", NOOP_CALLBACKS).onKeyDown(keyEvent("Enter", cells[tableCellDomKey(10, null, "name")]!));
+    });
+    expect(onAppendRow).toHaveBeenCalled();
+
+    // Four unrelated grid identity changes exhaust the intent's ttl…
+    for (let i = 0; i < 4; i++) {
+      const NEXT = grid({ days: [day(1, [row(9, [1, 2], { name: `Ex 9 v${i}` }), row(10, [1, 2])]), day(2, [row(11, [1, 2])])] });
+      cells = resyncCells(NEXT);
+      act(() => rerender({ grid: NEXT }));
+    }
+    // …so a LATER append (someone clicking "+ Add exercise") doesn't get its
+    // focus stolen to the tail of day 1.
+    const LATER = grid({ days: [day(1, [row(9, [1, 2]), row(10, [1, 2]), row(12, [1, 2], { name: "" })]), day(2, [row(11, [1, 2])])] });
+    cells = resyncCells(LATER);
+    act(() => rerender({ grid: LATER }));
+    // Normal tier-1 restoration keeps the anchor (and any restored focus) on
+    // row 10's name — the expired intent never drags it to row 12.
+    expect(result.current.anchor).toEqual({ rowId: 10, weekId: null, field: "name", line: 0 });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(10, null, "name")]);
+  });
+});
+
 describe("undo/redo bypass + native keys", () => {
   it("Ctrl+Z / Cmd+Z / Shift+Ctrl+Z on a cell are NOT intercepted", () => {
     const cells = mountCells(GRID);
     const { result } = renderHook(() => useTableNav({ grid: GRID }));
+    const callbacks = { onCommit: vi.fn(), onRevert: vi.fn() };
     for (const extra of [{ ctrlKey: true }, { metaKey: true }, { ctrlKey: true, shiftKey: true }]) {
       const event = keyEvent("z", cells[tableCellDomKey(9, null, "name")]!, extra);
       act(() => {
-        result.current.cellProps(9, null, "name", NOOP_CALLBACKS).onKeyDown(event);
+        result.current.cellProps(9, null, "name", callbacks).onKeyDown(event);
       });
       expect(event.preventDefault).not.toHaveBeenCalled();
     }
-    expect(NOOP_CALLBACKS.onCommit).not.toHaveBeenCalled();
-    expect(NOOP_CALLBACKS.onRevert).not.toHaveBeenCalled();
+    expect(callbacks.onCommit).not.toHaveBeenCalled();
+    expect(callbacks.onRevert).not.toHaveBeenCalled();
   });
 
-  it.each(["Home", "End", "PageUp", "PageDown", "a", "Tab"])("%s is not preventDefault'd", (key) => {
+  it.each(["Home", "End", "PageUp", "PageDown", "a"])("%s is not preventDefault'd", (key) => {
     const cells = mountCells(GRID);
     const { result } = renderHook(() => useTableNav({ grid: GRID }));
     const event = keyEvent(key, cells[tableCellDomKey(9, 1, "text")]!);
@@ -579,7 +926,7 @@ describe("undo/redo bypass + native keys", () => {
 });
 
 describe("focus restoration across a grid swap", () => {
-  it("tier 1: re-focuses the same (rowId, weekId, field) when it survives the swap", () => {
+  it("tier 1: re-focuses the same (rowId, weekId, field, line) when it survives the swap", () => {
     let cells = mountCells(GRID);
     const { result, rerender } = renderHook(({ grid: g }) => useTableNav({ grid: g }), {
       initialProps: { grid: GRID },
@@ -591,7 +938,7 @@ describe("focus restoration across a grid swap", () => {
     act(() => rerender({ grid: NEXT }));
 
     expect(document.activeElement).toBe(cells[tableCellDomKey(9, 1, "text")]);
-    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 1, field: "text" });
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 1, field: "text", line: 0 });
   });
 
   it("tier 2a: falls back to the first row of the same day (name column) when the row is gone but the day survives", () => {
@@ -607,7 +954,7 @@ describe("focus restoration across a grid swap", () => {
     act(() => rerender({ grid: NEXT }));
 
     expect(document.activeElement).toBe(cells[tableCellDomKey(10, null, "name")]);
-    expect(result.current.anchor).toEqual({ rowId: 10, weekId: null, field: "name" });
+    expect(result.current.anchor).toEqual({ rowId: 10, weekId: null, field: "name", line: 0 });
   });
 
   it("tier 2b: keeps the row+field but snaps to the first remaining week when the focused week is removed", () => {
@@ -623,7 +970,34 @@ describe("focus restoration across a grid swap", () => {
     act(() => rerender({ grid: NEXT }));
 
     expect(document.activeElement).toBe(cells[tableCellDomKey(9, 1, "text")]);
-    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 1, field: "text" });
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 1, field: "text", line: 0 });
+  });
+
+  it("post-tier guard: a surviving cell whose focused SUB-LINE vanished falls back to its line 0", () => {
+    // Focus week 1's sub-line 1 (a real line, not the ghost), then swap in a
+    // grid where that line is gone (an undo dropped it): row, week and cell
+    // all survive, but (…, line 1) is now only the ghost's coordinate —
+    // which still renders, so tier 1 holds. Drop the GHOST too (a skip
+    // would) to force the line-0 fallback.
+    const STACK_GRID = grid({
+      days: [day(1, [row(9, [1, 2], { cells: { "1": cell({ prescription_id: 900, lines: [{ line: 1, text: "RPE 8" }, { line: 2, text: "cue" }] }), "2": cell({ prescription_id: 901 }) } }), row(10, [1, 2])]), day(2, [row(11, [1, 2])])],
+    });
+    let cells = mountCells(STACK_GRID);
+    const { result, rerender } = renderHook(({ grid: g }) => useTableNav({ grid: g }), {
+      initialProps: { grid: STACK_GRID },
+    });
+    focus(result.current, cells, 9, 1, "text", 2);
+
+    // The stack shrank to nothing: stops are [0, 1(ghost)] now — line 2
+    // renders nowhere, so restoration falls back to the cell's line 0.
+    const SHRUNK = grid({
+      days: [day(1, [row(9, [1, 2], { cells: { "1": cell({ prescription_id: 900 }), "2": cell({ prescription_id: 901 }) } }), row(10, [1, 2])]), day(2, [row(11, [1, 2])])],
+    });
+    cells = resyncCells(SHRUNK);
+    act(() => rerender({ grid: SHRUNK }));
+
+    expect(document.activeElement).toBe(cells[tableCellDomKey(9, 1, "text")]);
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 1, field: "text", line: 0 });
   });
 
   it("post-tier guard: skids forward off a surviving-but-hollow coordinate (skip on the focused cell)", () => {
@@ -640,11 +1014,10 @@ describe("focus restoration across a grid swap", () => {
     focus(result.current, cells, 9, 1, "text");
 
     const NEXT = grid({ days: [day(1, [row(9, [2]), row(10, [1, 2])]), day(2, [row(11, [1, 2])])] });
-    document.querySelectorAll("[data-grid-cell]").forEach((n) => n.remove());
-    cells = mountCellsWithHoles(NEXT);
+    cells = resyncCells(NEXT);
     act(() => rerender({ grid: NEXT }));
 
-    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 2, field: "text" });
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 2, field: "text", line: 0 });
     expect(document.activeElement).toBe(cells[tableCellDomKey(9, 2, "text")]);
     expect(result.current.cellProps(9, 2, "text", NOOP_CALLBACKS).tabIndex).toBe(0);
     expect(result.current.cellProps(9, 1, "text", NOOP_CALLBACKS).tabIndex).toBe(-1);
@@ -657,17 +1030,16 @@ describe("focus restoration across a grid swap", () => {
     });
     focus(result.current, cells, 9, 2, "text");
 
-    // Row 9 keeps only week 1 — the focused week-2 coordinate and every
-    // column after it are gone, so the guard scans backward and lands on
-    // week 1's text cell (the nearest rendered column).
+    // Row 9 keeps only week 1 — the focused week-2 coordinate is gone, so
+    // the guard scans forward (notes/rest always render) — landing on the
+    // nearest rendered column after it: the notes column.
     const NEXT = grid({ days: [day(1, [row(9, [1]), row(10, [1, 2])]), day(2, [row(11, [1, 2])])] });
-    document.querySelectorAll("[data-grid-cell]").forEach((n) => n.remove());
-    cells = mountCellsWithHoles(NEXT);
+    cells = resyncCells(NEXT);
     act(() => rerender({ grid: NEXT }));
 
-    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 1, field: "text" });
-    expect(document.activeElement).toBe(cells[tableCellDomKey(9, 1, "text")]);
-    expect(result.current.cellProps(9, 1, "text", NOOP_CALLBACKS).tabIndex).toBe(0);
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: null, field: "note", line: 0 });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(9, null, "note")]);
+    expect(result.current.cellProps(9, null, "note", NOOP_CALLBACKS).tabIndex).toBe(0);
   });
 
   it("tier 3: falls back to the table's first cell when the day itself is gone", () => {
@@ -683,7 +1055,7 @@ describe("focus restoration across a grid swap", () => {
     act(() => rerender({ grid: NEXT }));
 
     expect(document.activeElement).toBe(cells[tableCellDomKey(9, null, "name")]);
-    expect(result.current.anchor).toEqual({ rowId: 9, weekId: null, field: "name" });
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: null, field: "name", line: 0 });
   });
 
   it("tier 4: does nothing (no throw, no focus) when the whole table is emptied", () => {
@@ -775,17 +1147,18 @@ describe("focus restoration across a grid swap", () => {
 
 describe("holes (missing DOM cells)", () => {
   it("arrowing onto a hole doesn't throw and doesn't move activeElement", () => {
-    // Mount only row 9's name + week 1 cell — week 2 is a total hole (as
+    // Mount only row 9's tempo + week 1 cell — week 2 is a total hole (as
     // add-this-week rows and skipped-cell display leave gaps in the real
-    // app; MesoTable's own <td/> with no GridCellEditor is the same shape).
-    const nameInput = document.createElement("input");
-    nameInput.setAttribute("data-grid-cell", tableCellDomKey(9, null, "name"));
-    document.body.appendChild(nameInput);
+    // app; MesoTable's own <td/> with no GridCellEditor is the same shape),
+    // and the notes/rest columns after it are unmounted too.
+    const tempoInput = document.createElement("input");
+    tempoInput.setAttribute("data-grid-cell", tableCellDomKey(9, null, "tempo"));
+    document.body.appendChild(tempoInput);
     const textInput = document.createElement("input");
     textInput.value = "";
     textInput.setAttribute("data-grid-cell", tableCellDomKey(9, 1, "text"));
     document.body.appendChild(textInput);
-    // Week 2's "text" cell is intentionally never mounted.
+    // Week 2's "text" cell (and everything after) is intentionally never mounted.
 
     const { result } = renderHook(() => useTableNav({ grid: GRID }));
     textInput.focus();
@@ -804,8 +1177,12 @@ describe("holes (missing DOM cells)", () => {
 // on a hole left the old input with real DOM focus but tabIndex -1, and no
 // cell anywhere holding tabIndex 0 (the grid drops out of the tab order).
 // The fix scans past holes, at keydown time, to the first coordinate that
-// DOES render — using mountCellsWithHoles so a fixture's holes are just a
-// row's own `cells` map, exactly like MesoTable's `!cell` bare <td/> case.
+// DOES render — mountCells expresses a hole as a weekId left out of a row's
+// `cells` map, exactly like MesoTable's `!cell` bare <td/> case. Phase 2b:
+// the row-scoped notes/rest columns now sit AFTER the last week and always
+// render, so "everything right of here is holes" needs the horizontal cases
+// to compare against them, and pure row-extreme no-ops live on the rest
+// column (see the arrow describe above).
 describe("hole-skidding: arrows land on the next RENDERED cell, never a phantom coordinate", () => {
   it("(1) ArrowRight over a hole in the middle of a row skips the entire missing week and lands on the next rendered cell", () => {
     // Row 9 has cells for weeks 1 and 3 only — week 2 is a total hole.
@@ -813,7 +1190,7 @@ describe("hole-skidding: arrows land on the next RENDERED cell, never a phantom 
       weeks: [week({ id: 1, label: "Wk 1" }), week({ id: 2, label: "Wk 2", current: false }), week({ id: 3, label: "Wk 3", current: false })],
       days: [day(1, [row(9, [1, 3])])],
     });
-    const cells = mountCellsWithHoles(HOLE_GRID);
+    const cells = mountCells(HOLE_GRID);
     const { result } = renderHook(() => useTableNav({ grid: HOLE_GRID }));
     const textInput = cells[tableCellDomKey(9, 1, "text")]!;
     textInput.setSelectionRange(textInput.value.length, textInput.value.length);
@@ -822,21 +1199,21 @@ describe("hole-skidding: arrows land on the next RENDERED cell, never a phantom 
       result.current.cellProps(9, 1, "text", NOOP_CALLBACKS).onKeyDown(event);
     });
     expect(document.activeElement).toBe(cells[tableCellDomKey(9, 3, "text")]);
-    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 3, field: "text" });
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 3, field: "text", line: 0 });
     expect(event.preventDefault).toHaveBeenCalled();
     // (5) invariant: the anchor addresses a real node holding tabIndex 0.
     expect(result.current.cellProps(9, 3, "text", NOOP_CALLBACKS).tabIndex).toBe(0);
     expect(result.current.cellProps(9, 1, "text", NOOP_CALLBACKS).tabIndex).toBe(-1);
   });
 
-  it("(2) ArrowRight when everything to the right is holes leaves the anchor/focus unchanged, but still preventDefaults", () => {
-    // Row 9 has a cell for week 1 only — week 2 (the only thing to its
-    // right) is a total hole all the way to the table's edge.
+  it("(2) ArrowRight skids past a trailing hole week onto the notes column (always rendered)", () => {
+    // Row 9 has a cell for week 1 only — week 2 is a total hole, but the
+    // notes/rest columns after it always render, so the skid lands there.
     const HOLE_GRID = grid({
       weeks: [week({ id: 1, label: "Wk 1" }), week({ id: 2, label: "Wk 2", current: false })],
       days: [day(1, [row(9, [1])])],
     });
-    const cells = mountCellsWithHoles(HOLE_GRID);
+    const cells = mountCells(HOLE_GRID);
     const { result } = renderHook(() => useTableNav({ grid: HOLE_GRID }));
     const textInput = cells[tableCellDomKey(9, 1, "text")]!;
     textInput.focus();
@@ -845,11 +1222,10 @@ describe("hole-skidding: arrows land on the next RENDERED cell, never a phantom 
     act(() => {
       result.current.cellProps(9, 1, "text", NOOP_CALLBACKS).onKeyDown(event);
     });
-    expect(document.activeElement).toBe(textInput);
-    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 1, field: "text" });
+    expect(document.activeElement).toBe(cells[tableCellDomKey(9, null, "note")]);
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: null, field: "note", line: 0 });
     expect(event.preventDefault).toHaveBeenCalled();
-    // (5) invariant: the anchor still addresses the real node it started at.
-    expect(result.current.cellProps(9, 1, "text", NOOP_CALLBACKS).tabIndex).toBe(0);
+    expect(result.current.cellProps(9, null, "note", NOOP_CALLBACKS).tabIndex).toBe(0);
   });
 
   it("(3) ArrowLeft mirrors (1): skips the entire missing week backwards, landing on the previous rendered cell", () => {
@@ -857,7 +1233,7 @@ describe("hole-skidding: arrows land on the next RENDERED cell, never a phantom 
       weeks: [week({ id: 1, label: "Wk 1" }), week({ id: 2, label: "Wk 2", current: false }), week({ id: 3, label: "Wk 3", current: false })],
       days: [day(1, [row(9, [1, 3])])],
     });
-    const cells = mountCellsWithHoles(HOLE_GRID);
+    const cells = mountCells(HOLE_GRID);
     const { result } = renderHook(() => useTableNav({ grid: HOLE_GRID }));
     const textInput = cells[tableCellDomKey(9, 3, "text")]!;
     textInput.setSelectionRange(0, 0);
@@ -866,7 +1242,7 @@ describe("hole-skidding: arrows land on the next RENDERED cell, never a phantom 
       result.current.cellProps(9, 3, "text", NOOP_CALLBACKS).onKeyDown(event);
     });
     expect(document.activeElement).toBe(cells[tableCellDomKey(9, 1, "text")]);
-    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 1, field: "text" });
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 1, field: "text", line: 0 });
     expect(event.preventDefault).toHaveBeenCalled();
     // (5) invariant.
     expect(result.current.cellProps(9, 1, "text", NOOP_CALLBACKS).tabIndex).toBe(0);
@@ -874,24 +1250,26 @@ describe("hole-skidding: arrows land on the next RENDERED cell, never a phantom 
   });
 
   it("(4) ArrowDown skips a row whose cell at (weekId, field) is unrendered, landing on the next row that has it", () => {
-    // Row 10 (between 9 and 11) has no week-1 cell at all.
+    // Row 10 (between 9 and 11) has no week-1 cell at all. From row 9's
+    // GHOST (its last stop), down lands on row 11's line 0 — skipping every
+    // stop row 10 doesn't render at this column.
     const HOLE_GRID = grid({
       weeks: [week({ id: 1, label: "Wk 1" }), week({ id: 2, label: "Wk 2", current: false })],
       days: [day(1, [row(9, [1, 2]), row(10, [2]), row(11, [1, 2])])],
     });
-    const cells = mountCellsWithHoles(HOLE_GRID);
+    const cells = mountCells(HOLE_GRID);
     const { result } = renderHook(() => useTableNav({ grid: HOLE_GRID }));
-    const event = keyEvent("ArrowDown", cells[tableCellDomKey(9, 1, "text")]!);
+    const event = keyEvent("ArrowDown", cells[tableCellDomKey(9, 1, "text", 1)]!);
     act(() => {
-      result.current.cellProps(9, 1, "text", NOOP_CALLBACKS).onKeyDown(event);
+      result.current.cellProps(9, 1, "text", NOOP_CALLBACKS, 1).onKeyDown(event);
     });
     expect(document.activeElement).toBe(cells[tableCellDomKey(11, 1, "text")]);
-    expect(result.current.anchor).toEqual({ rowId: 11, weekId: 1, field: "text" });
+    expect(result.current.anchor).toEqual({ rowId: 11, weekId: 1, field: "text", line: 0 });
     expect(event.preventDefault).toHaveBeenCalled();
     // (5) invariant: row 10 (skipped over, never had this cell) never became
     // the anchor; row 11 (the real landing) holds the roving tabIndex 0.
     expect(result.current.cellProps(11, 1, "text", NOOP_CALLBACKS).tabIndex).toBe(0);
-    expect(result.current.cellProps(9, 1, "text", NOOP_CALLBACKS).tabIndex).toBe(-1);
+    expect(result.current.cellProps(9, 1, "text", NOOP_CALLBACKS, 1).tabIndex).toBe(-1);
   });
 
   it("(5) invariant holds across a repeated skid in both horizontal directions: the anchor always addresses an existing, tabIndex-0 node", () => {
@@ -899,15 +1277,15 @@ describe("hole-skidding: arrows land on the next RENDERED cell, never a phantom 
       weeks: [week({ id: 1, label: "Wk 1" }), week({ id: 2, label: "Wk 2", current: false }), week({ id: 3, label: "Wk 3", current: false })],
       days: [day(1, [row(9, [1, 3])])],
     });
-    const cells = mountCellsWithHoles(HOLE_GRID);
+    const cells = mountCells(HOLE_GRID);
     const { result } = renderHook(() => useTableNav({ grid: HOLE_GRID }));
 
     function assertAnchorIsReal() {
       const a = result.current.anchor;
       expect(a).not.toBeNull();
       if (!a) return;
-      expect(document.querySelector(`[data-grid-cell="${tableCellDomKey(a.rowId, a.weekId, a.field)}"]`)).not.toBeNull();
-      expect(result.current.cellProps(a.rowId, a.weekId, a.field, NOOP_CALLBACKS).tabIndex).toBe(0);
+      expect(document.querySelector(`[data-grid-cell="${tableCellDomKey(a.rowId, a.weekId, a.field, a.line)}"]`)).not.toBeNull();
+      expect(result.current.cellProps(a.rowId, a.weekId, a.field, NOOP_CALLBACKS, a.line).tabIndex).toBe(0);
     }
 
     const w1Input = cells[tableCellDomKey(9, 1, "text")]!;
@@ -915,7 +1293,7 @@ describe("hole-skidding: arrows land on the next RENDERED cell, never a phantom 
     act(() => {
       result.current.cellProps(9, 1, "text", NOOP_CALLBACKS).onKeyDown(keyEvent("ArrowRight", w1Input));
     });
-    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 3, field: "text" });
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 3, field: "text", line: 0 });
     assertAnchorIsReal();
 
     const w3Input = cells[tableCellDomKey(9, 3, "text")]!;
@@ -923,7 +1301,7 @@ describe("hole-skidding: arrows land on the next RENDERED cell, never a phantom 
     act(() => {
       result.current.cellProps(9, 3, "text", NOOP_CALLBACKS).onKeyDown(keyEvent("ArrowLeft", w3Input));
     });
-    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 1, field: "text" });
+    expect(result.current.anchor).toEqual({ rowId: 9, weekId: 1, field: "text", line: 0 });
     assertAnchorIsReal();
   });
 });

--- a/frontend/designer/src/hooks/useTableNav.ts
+++ b/frontend/designer/src/hooks/useTableNav.ts
@@ -122,6 +122,12 @@ export interface UseTableNavResult {
     callbacks: TableCellCallbacks,
     line?: number,
   ): TableCellBindings;
+  /** Reset a cell's Escape baseline after an out-of-band commit that KEEPS
+   * focus — the multi-line stack paste. Mirrors what the Enter handler does
+   * for its own commit: without it, Escape after a paste would roll the UI
+   * back PAST the committed write, desyncing it from the server. (Blur
+   * commits don't need this — the next focus reseeds the baseline.) */
+  setRevertBaseline(rowId: number, weekId: number | null, field: TableColumn, value: string, line?: number): void;
 }
 
 export interface UseTableNavOptions {
@@ -645,5 +651,9 @@ export function useTableNav(options: UseTableNavOptions): UseTableNavResult {
     return { tabIndex, onFocus, onKeyDown };
   }
 
-  return { anchor, cellProps };
+  function setRevertBaseline(rowId: number, weekId: number | null, field: TableColumn, value: string, line = 0) {
+    focusValuesRef.current[tableCellDomKey(rowId, weekId, field, line)] = value;
+  }
+
+  return { anchor, cellProps, setRevertBaseline };
 }

--- a/frontend/designer/src/hooks/useTableNav.ts
+++ b/frontend/designer/src/hooks/useTableNav.ts
@@ -15,7 +15,26 @@
 // the result as a required prop; no INERT fallback is needed since they
 // never render outside MesoTable.
 //
-// Cell identity is (rowId, weekId, field) — NEVER an index, and NEVER
+// Phase 2b (spreadsheet keyboard flow) widens both axes to the FULL sheet:
+// - Horizontal: the per-row Tempo/Notes/Rest columns join the axis
+//   (name → tempo → week 1..N text → notes → rest, the source spreadsheet's
+//   column order), and Tab/Shift+Tab walk it unconditionally — wrapping to
+//   the next/previous row at the row's ends — where arrows still defer to
+//   the caret at a text boundary.
+// - Vertical: cell identity gains a LINE — (rowId, weekId, field, line) —
+//   so ArrowDown from a week cell's prescription (line 0) steps INTO its
+//   sub-line stack (each `cell.lines` entry, then the trailing ghost input
+//   that mints the next line), then on to the next row. This is D3's "RPE is
+//   a sub-row reached by arrow-down" made literal: the ghost is a real
+//   vertical stop, so minting the RPE line never needs the mouse.
+// - Enter = commit + move DOWN one stop (the spreadsheet's Enter), and at
+//   the last stop of a DAY it appends a new exercise row to that day
+//   instead (Enter-adds-row) — unless the current row is still entirely
+//   blank, so leaning on Enter can never mint a stack of empty rows. Enter
+//   never crosses a day boundary (ArrowDown still does): Enter is the
+//   fill/extend key, arrows are pure movement.
+//
+// Cell identity is (rowId, weekId, field, line) — NEVER an index, and NEVER
 // prescription_id: the row-name column and "holes" (a week with no cell for
 // a row — add-this-week rows; see MesoTable.tsx's bare <td/> case) have no
 // prescription_id. exercise_slot_id/session_slot_id/week.id are fixed-
@@ -26,49 +45,58 @@
 // like useGridNav, so arrow-key moves and focus restoration work
 // identically for a hook-only unit test and the real mounted app.
 //
-// Arrow moves SKID over holes rather than landing on them: useGridNav's
-// one-week grid has no gaps (every ExerciseRow field always renders), so its
-// "extreme: no-op, preventDefault already fired" precedent only ever had to
-// handle running off the end of the row/column. A 2D table isn't that
-// simple — a hole (an add-this-week row's missing week) or a skipped cell
-// (em-dash + Unskip, no GridCellEditor) can sit in the MIDDLE of a row or
-// column, with no `data-grid-cell` node at all. Committing the anchor to
-// that coordinate would drop the whole grid out of the tab order (no
-// rendered cell left holding tabIndex 0) and leave the anchor pointing at
-// nothing. So every arrow move re-checks `cellExists` at keydown time and
-// keeps stepping in the same direction, past any hole, to the first
-// coordinate that actually renders. If none exists all the way to the edge,
-// the anchor is left exactly where it was — vertical moves still
-// preventDefault regardless (matching ArrowDown/Up's original unconditional
-// behavior), while a horizontal move only preventDefaults once it has
-// confirmed at least one adjacent column POSITION exists to attempt (a true
-// row-extreme with zero columns left, holes or otherwise, is still a pure
-// no-op, exactly as before).
+// Arrow moves SKID over holes rather than landing on them: a hole (an
+// add-this-week row's missing week) or a skipped cell (em-dash + Unskip, no
+// GridCellEditor) can sit in the MIDDLE of a row or column, with no
+// `data-grid-cell` node at all. Committing the anchor to that coordinate
+// would drop the whole grid out of the tab order (no rendered cell left
+// holding tabIndex 0) and leave the anchor pointing at nothing. So every
+// move re-checks `cellExists` at keydown time and keeps stepping in the
+// same direction, past any hole, to the first coordinate that actually
+// renders. If none exists all the way to the edge, the anchor is left
+// exactly where it was — vertical moves still preventDefault regardless
+// (matching ArrowDown/Up's original unconditional behavior), while a
+// horizontal arrow move only preventDefaults once it has confirmed at least
+// one adjacent column POSITION exists to attempt, and Tab preventDefaults
+// only once a landable target is found (so tabbing off the table's last
+// cell hands focus to the browser's native order — the grid is not a focus
+// trap). Sub-line stops skid by LINE too: moving horizontally from line L
+// lands on the target cell's nearest stop at-or-above it (its ghost when the
+// stack is shorter — the spreadsheet's merged-cell feel), never on a line
+// that doesn't render.
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { FocusEvent, KeyboardEvent } from "react";
-import type { MesoGrid } from "../lib/api";
+import type { GridRow, MesoGrid } from "../lib/api";
 
-export type TableColumn = "name" | "text";
+export type TableColumn = "name" | "tempo" | "text" | "note" | "rest";
 
 /** Editable per-cell fields, visual order (excludes "name" — that's the
  * leading row-identity column, not a per-week field). Phase 2a collapsed the
  * six structured fields (sets/reps/load/rpe/rest/note) to ONE freeform text
- * input per (row, week) — sub-line inputs and the per-row Tempo/Notes/Rest
- * columns are deliberately outside arrow-nav this phase. */
+ * input per (row, week); 2b then put the sub-line stack and the per-row
+ * Tempo/Notes/Rest columns INSIDE the nav axes (see the header) — those are
+ * axis positions now, not extra per-week fields, so this stays ["text"]. */
 export const TABLE_FIELDS = ["text"] as const;
 export type EditableField = (typeof TABLE_FIELDS)[number];
 
 export const TABLE_FIELD_LABELS: Record<TableColumn, string> = {
   name: "exercise name",
+  tempo: "tempo",
   text: "prescription",
+  note: "notes",
+  rest: "rest",
 };
 
 export interface TableCellId {
   /** GridRow.exercise_slot_id — vertical identity, never an index. */
   rowId: number;
-  /** GridWeek.id, or null for the row-name column. */
+  /** GridWeek.id, or null for the row-scoped columns (name/tempo/notes/rest). */
   weekId: number | null;
   field: TableColumn;
+  /** Sub-line within a week cell's stack (Phase 2b): 0 = the prescription
+   * input, >=1 = a sub-line — including the trailing ghost (max existing
+   * line + 1, GridCellEditor's nextLine). Always 0 outside week "text". */
+  line: number;
 }
 
 // No onChange here — verified dead surface in useGridNav's GridCellCallbacks
@@ -92,46 +120,64 @@ export interface UseTableNavResult {
     weekId: number | null,
     field: TableColumn,
     callbacks: TableCellCallbacks,
+    line?: number,
   ): TableCellBindings;
 }
 
 export interface UseTableNavOptions {
   grid: MesoGrid | null;
+  /** Enter-adds-row (Phase 2b): called when Enter fires at the last vertical
+   * stop of a day whose row has content — the caller appends a blank
+   * exercise row to that day (useGrid.addExercise). Once the day's LAST ROW
+   * actually changes on a grid refetch, the hook focuses the new row at the
+   * column Enter came from. Optional so hook-only tests without an append
+   * path keep their old "Enter at the bottom stays put" behavior. */
+  onAppendRow?(dayId: number): void;
 }
 
 /** DOM identity for a cell's `data-grid-cell` attribute / querySelector key.
  * `weekId ?? "row"` sentinel means this can never collide with a real week
- * id (a number), e.g. "9:2:sets", "9:row:name". */
-export function tableCellDomKey(rowId: number, weekId: number | null, field: TableColumn): string {
-  return `${rowId}:${weekId ?? "row"}:${field}`;
+ * id (a number), e.g. "9:2:text", "9:row:name". Line 0 keeps the legacy
+ * 3-part key; sub-lines append their line number ("9:2:text:1") so every
+ * stop of a cell's stack is independently addressable. */
+export function tableCellDomKey(rowId: number, weekId: number | null, field: TableColumn, line = 0): string {
+  const base = `${rowId}:${weekId ?? "row"}:${field}`;
+  return line === 0 ? base : `${base}:${line}`;
 }
 
 /** "<row name or 'exercise'> — <week label> — <field label>", or
- * "<name> — exercise name" for the row-name column (no week context). */
+ * "<name> — <field label>" for the row-scoped columns (no week context). */
 export function tableCellAriaLabel(rowName: string, weekLabel: string | null, field: TableColumn): string {
   const name = rowName || "exercise";
-  if (field === "name") return `${name} — exercise name`;
+  if (weekLabel === null) return `${name} — ${TABLE_FIELD_LABELS[field]}`;
   return `${name} — ${weekLabel} — ${TABLE_FIELD_LABELS[field]}`;
 }
 
 /** One entry of the horizontal (within-row) axis: the leading name column,
- * then every week's fields in visual order. Identical for every row, so
- * it's derived once from `grid.weeks` — walking it with `.findIndex` drives
- * ArrowRight/Left, including the "no special-case" week-to-week crossing
- * (last field of week N sits immediately before week N+1's first field). */
+ * the per-row Tempo column, every week's fields in visual order, then the
+ * per-row Notes and Rest columns — the source spreadsheet's Exercise |
+ * Tempo | weeks… | Notes | Rest order (Phase 2b). Identical for every row,
+ * so it's derived once from `grid.weeks` — walking it with `.findIndex`
+ * drives ArrowRight/Left and Tab, including the "no special-case"
+ * week-to-week crossing (week N sits immediately before week N+1). */
 interface TableColumnPos {
   weekId: number | null;
   field: TableColumn;
 }
 
 function buildColumns(grid: MesoGrid | null): TableColumnPos[] {
-  const columns: TableColumnPos[] = [{ weekId: null, field: "name" }];
+  const columns: TableColumnPos[] = [
+    { weekId: null, field: "name" },
+    { weekId: null, field: "tempo" },
+  ];
   if (!grid) return columns;
   for (const week of grid.weeks) {
     for (const field of TABLE_FIELDS) {
       columns.push({ weekId: week.id, field });
     }
   }
+  columns.push({ weekId: null, field: "note" });
+  columns.push({ weekId: null, field: "rest" });
   return columns;
 }
 
@@ -142,70 +188,148 @@ interface FlatTable {
   weekOrder: number[];
   dayIdByRow: Map<number, number>;
   firstRowByDay: Map<number, number>;
+  lastRowByDay: Map<number, number>;
+  rowsById: Map<number, GridRow>;
 }
 
 function flattenGrid(grid: MesoGrid | null): FlatTable {
   const rowOrder: number[] = [];
   const dayIdByRow = new Map<number, number>();
   const firstRowByDay = new Map<number, number>();
-  if (!grid) return { rowOrder, weekOrder: [], dayIdByRow, firstRowByDay };
+  const lastRowByDay = new Map<number, number>();
+  const rowsById = new Map<number, GridRow>();
+  if (!grid) return { rowOrder, weekOrder: [], dayIdByRow, firstRowByDay, lastRowByDay, rowsById };
   for (const day of grid.days) {
     for (const row of day.rows) {
       rowOrder.push(row.exercise_slot_id);
       dayIdByRow.set(row.exercise_slot_id, day.session_slot_id);
+      rowsById.set(row.exercise_slot_id, row);
       if (!firstRowByDay.has(day.session_slot_id)) firstRowByDay.set(day.session_slot_id, row.exercise_slot_id);
+      lastRowByDay.set(day.session_slot_id, row.exercise_slot_id);
     }
   }
   const weekOrder = grid.weeks.map((w) => w.id);
-  return { rowOrder, weekOrder, dayIdByRow, firstRowByDay };
+  return { rowOrder, weekOrder, dayIdByRow, firstRowByDay, lastRowByDay, rowsById };
 }
 
 function firstCellOf(flat: FlatTable): TableCellId | null {
   const id = flat.rowOrder[0];
-  return id === undefined ? null : { rowId: id, weekId: null, field: "name" };
+  return id === undefined ? null : { rowId: id, weekId: null, field: "name", line: 0 };
 }
 
-function cellSelector(rowId: number, weekId: number | null, field: TableColumn): string {
-  return `[data-grid-cell="${tableCellDomKey(rowId, weekId, field)}"]`;
+function cellSelector(rowId: number, weekId: number | null, field: TableColumn, line = 0): string {
+  return `[data-grid-cell="${tableCellDomKey(rowId, weekId, field, line)}"]`;
 }
 
-function focusCell(rowId: number, weekId: number | null, field: TableColumn) {
-  document.querySelector<HTMLElement>(cellSelector(rowId, weekId, field))?.focus();
+function focusCell(rowId: number, weekId: number | null, field: TableColumn, line = 0) {
+  document.querySelector<HTMLElement>(cellSelector(rowId, weekId, field, line))?.focus();
 }
 
 /** Whether a cell actually has a rendered `data-grid-cell` node right now.
  * Checked fresh at keydown time (never precomputed/cached) — cells appear
- * and disappear with skip/unskip and add-this-week, so the DOM is the only
- * source of truth for "is this coordinate landable". Arrow moves use this
- * to skid over holes (see the header comment) instead of committing the
- * anchor to a coordinate nothing renders. */
-function cellExists(rowId: number, weekId: number | null, field: TableColumn): boolean {
-  return document.querySelector(cellSelector(rowId, weekId, field)) !== null;
+ * and disappear with skip/unskip, add-this-week and sub-line minting, so the
+ * DOM is the only source of truth for "is this coordinate landable". Moves
+ * use this to skid over holes (see the header comment) instead of
+ * committing the anchor to a coordinate nothing renders. */
+function cellExists(rowId: number, weekId: number | null, field: TableColumn, line = 0): boolean {
+  return document.querySelector(cellSelector(rowId, weekId, field, line)) !== null;
+}
+
+/** The ordered line stops of one row at one column, top-down as rendered:
+ * 0 (the prescription input), each existing `cell.lines` entry, then the
+ * ghost (max existing line + 1 — GridCellEditor's nextLine). Row-scoped
+ * columns, hole rows and skipped cells contribute just [0]; the DOM check
+ * downstream stays the arbiter of whether that stop actually renders. */
+function lineStops(row: GridRow | undefined, weekId: number | null, field: TableColumn): number[] {
+  if (field !== "text" || weekId === null || !row) return [0];
+  const cell = row.cells[String(weekId)];
+  if (!cell || cell.skipped) return [0];
+  const lineNos = (cell.lines ?? []).map((l) => l.line).sort((a, b) => a - b);
+  const ghost = (lineNos[lineNos.length - 1] ?? 0) + 1;
+  return [0, ...lineNos, ghost];
+}
+
+/** The stop a horizontal move from line `line` should land on in a cell
+ * whose stops are `stops` (ascending): the largest stop at-or-below it, so a
+ * shorter stack clamps to its ghost/last line rather than skidding the whole
+ * cell — the spreadsheet's "the merged cell is still there" feel. */
+function nearestLineStop(stops: number[], line: number): number {
+  let best = stops[0] ?? 0;
+  for (const s of stops) {
+    if (s <= line) best = s;
+    else break;
+  }
+  return best;
+}
+
+/** Every (rowId, line) of one column, day-major/row-minor/line-inner — the
+ * vertical axis ArrowDown/Up and Enter walk. */
+interface VerticalStop {
+  rowId: number;
+  line: number;
+}
+
+function verticalStops(flat: FlatTable, weekId: number | null, field: TableColumn): VerticalStop[] {
+  const out: VerticalStop[] = [];
+  for (const rowId of flat.rowOrder) {
+    for (const line of lineStops(flat.rowsById.get(rowId), weekId, field)) out.push({ rowId, line });
+  }
+  return out;
+}
+
+/** Whether every rendered input of this row is blank RIGHT NOW — read from
+ * the DOM, not the grid, so an uncommitted draft (the name the coach just
+ * typed, an in-flight optimistic write) counts as content. Guards
+ * Enter-adds-row: a fully blank row never appends another. */
+function rowDomBlank(rowId: number): boolean {
+  const inputs = document.querySelectorAll<HTMLInputElement>(`input[data-grid-cell^="${rowId}:"]`);
+  for (const el of Array.from(inputs)) {
+    if (el.value.trim() !== "") return false;
+  }
+  return true;
 }
 
 /** The nearest rendered column of `cell`'s own row — forward first, then
- * backward. Restoration's post-tier guard uses this when a surviving
- * (row, week) coordinate turns out to be hollow (see the effect below);
- * the leading name column always renders for a live row, so the backward
- * scan terminates there at worst. */
+ * backward, at line 0. Restoration's post-tier guard uses this when a
+ * surviving (row, week) coordinate turns out to be hollow (see the effect
+ * below); the leading name column always renders for a live row, so the
+ * backward scan terminates there at worst. */
 function nearestRenderedInRow(cell: TableCellId, columns: TableColumnPos[]): TableCellId | null {
   const at = columns.findIndex((c) => c.weekId === cell.weekId && c.field === cell.field);
   if (at === -1) return null;
   for (let i = at + 1; i < columns.length; i++) {
     const col = columns[i];
-    if (col && cellExists(cell.rowId, col.weekId, col.field)) return { rowId: cell.rowId, weekId: col.weekId, field: col.field };
+    if (col && cellExists(cell.rowId, col.weekId, col.field)) {
+      return { rowId: cell.rowId, weekId: col.weekId, field: col.field, line: 0 };
+    }
   }
   for (let i = at - 1; i >= 0; i--) {
     const col = columns[i];
-    if (col && cellExists(cell.rowId, col.weekId, col.field)) return { rowId: cell.rowId, weekId: col.weekId, field: col.field };
+    if (col && cellExists(cell.rowId, col.weekId, col.field)) {
+      return { rowId: cell.rowId, weekId: col.weekId, field: col.field, line: 0 };
+    }
   }
   return null;
 }
 
-const HANDLED_KEYS = new Set(["ArrowDown", "ArrowUp", "ArrowLeft", "ArrowRight", "Enter", "Escape"]);
+const HANDLED_KEYS = new Set(["ArrowDown", "ArrowUp", "ArrowLeft", "ArrowRight", "Enter", "Escape", "Tab"]);
+
+/** Enter-adds-row in flight: set when Enter fires the append, consumed by
+ * the restoration effect once the day's last row actually CHANGES (the
+ * refetch landed) — the grid also changes for the commit's own optimistic
+ * write first, so "changed last row" is the signal, not "any grid change".
+ * `ttl` caps how many grid changes the intent survives (a failed POST never
+ * changes the last row, and a stale intent must not steal focus later). */
+interface AppendPending {
+  dayId: number;
+  weekId: number | null;
+  field: TableColumn;
+  prevLastRow: number | undefined;
+  ttl: number;
+}
 
 export function useTableNav(options: UseTableNavOptions): UseTableNavResult {
-  const { grid } = options;
+  const { grid, onAppendRow } = options;
   const columns = useMemo(() => buildColumns(grid), [grid]);
   const flat = useMemo(() => flattenGrid(grid), [grid]);
 
@@ -217,12 +341,33 @@ export function useTableNav(options: UseTableNavOptions): UseTableNavResult {
   const focusedOnceRef = useRef(false);
   // Cell key -> value captured at focus time, for Escape's revert target.
   const focusValuesRef = useRef<Record<string, string>>({});
+  const appendPendingRef = useRef<AppendPending | null>(null);
 
   function commitAnchor(next: TableCellId | null, flatForLookup: FlatTable, shouldFocus: boolean) {
     anchorRef.current = next;
     lastDayIdRef.current = next ? (flatForLookup.dayIdByRow.get(next.rowId) ?? null) : null;
     setAnchor(next);
-    if (next && shouldFocus) focusCell(next.rowId, next.weekId, next.field);
+    if (next && shouldFocus) focusCell(next.rowId, next.weekId, next.field, next.line);
+  }
+
+  /** ArrowDown/Up's shared step: the adjacent vertical stop of this column,
+   * skidding holes. Returns undefined at the axis edge. */
+  function stepVertical(from: TableCellId, step: 1 | -1): TableCellId | undefined {
+    const stops = verticalStops(flat, from.weekId, from.field);
+    let idx = stops.findIndex((s) => s.rowId === from.rowId && s.line === from.line);
+    // The line can vanish mid-flight (an undo dropped the sub-line the
+    // anchor sat on): fall back to this row's line 0, which always exists
+    // as a stop for a live row.
+    if (idx === -1) idx = stops.findIndex((s) => s.rowId === from.rowId && s.line === 0);
+    if (idx === -1) return undefined;
+    let nextIdx = idx + step;
+    let cand = stops[nextIdx];
+    while (cand !== undefined && !cellExists(cand.rowId, from.weekId, from.field, cand.line)) {
+      nextIdx += step;
+      cand = stops[nextIdx];
+    }
+    if (cand === undefined) return undefined;
+    return { rowId: cand.rowId, weekId: from.weekId, field: from.field, line: cand.line };
   }
 
   // Restoration: recompute the anchor on EVERY grid identity change so
@@ -231,6 +376,44 @@ export function useTableNav(options: UseTableNavOptions): UseTableNavResult {
   // (remove-exercise/day vs remove-week), so tier 2 splits in two — see
   // brief §4 for the four-tier rationale (mirrors useGridNav's tiers 1/3/4).
   useEffect(() => {
+    // Restoration may move focus ONLY when it won't steal it: the active
+    // element is a grid cell, focus was orphaned by the swap (fell to
+    // body), or the coach is on a control explicitly marked
+    // data-grid-restore (undo/redo, add-week, make-current, remove-week —
+    // swap initiators whose result should return them to the table).
+    // Anything else — the chat composer re-rendering under focus on a cell
+    // patch — keeps focus.
+    const active = document.activeElement as HTMLElement | null;
+    const allowFocusMove =
+      !active ||
+      active === document.body ||
+      active.hasAttribute("data-grid-cell") ||
+      active.closest("[data-grid-restore]") !== null;
+
+    // Enter-adds-row landing (Phase 2b): once the day's last row CHANGED,
+    // the appended row is in this grid — focus it at the column Enter came
+    // from (its name column when Enter fired there), falling back through
+    // the same guards as normal restoration.
+    const pending = appendPendingRef.current;
+    if (pending) {
+      const lastRow = flat.lastRowByDay.get(pending.dayId);
+      if (lastRow !== undefined && lastRow !== pending.prevLastRow) {
+        appendPendingRef.current = null;
+        let target: TableCellId | null = { rowId: lastRow, weekId: pending.weekId, field: pending.field, line: 0 };
+        if (!cellExists(target.rowId, target.weekId, target.field)) {
+          target = nearestRenderedInRow(target, columns) ?? firstCellOf(flat);
+        }
+        if (target) {
+          commitAnchor(target, flat, focusedOnceRef.current && allowFocusMove);
+          return;
+        }
+      } else if (lastRow === undefined || --pending.ttl <= 0) {
+        // Day gone, or the append never landed (failed POST) — drop the
+        // intent rather than letting it steal focus on a later change.
+        appendPendingRef.current = null;
+      }
+    }
+
     const prev = anchorRef.current;
     if (prev === null) {
       commitAnchor(firstCellOf(flat), flat, false);
@@ -242,11 +425,11 @@ export function useTableNav(options: UseTableNavOptions): UseTableNavResult {
 
     let next: TableCellId | null;
     if (rowSurvives && weekSurvives) {
-      // Tier 1: same (rowId, weekId, field) survives — row/week EXISTENCE
-      // only; whether the coordinate still RENDERS is the post-tier guard
-      // below's job (a skip can hollow out one coordinate while its row and
-      // week both live on).
-      next = { rowId: prev.rowId, weekId: prev.weekId, field: prev.field };
+      // Tier 1: same (rowId, weekId, field, line) survives — row/week
+      // EXISTENCE only; whether the coordinate still RENDERS is the
+      // post-tier guard below's job (a skip can hollow out one coordinate
+      // while its row and week both live on).
+      next = { rowId: prev.rowId, weekId: prev.weekId, field: prev.field, line: prev.line };
     } else if (rowSurvives) {
       // Tier 2b: the week is gone (remove-week) but the row survives — keep
       // the row+field, snap to the first remaining week (simplest rule
@@ -254,43 +437,37 @@ export function useTableNav(options: UseTableNavOptions): UseTableNavResult {
       const firstWeek = flat.weekOrder[0];
       next =
         firstWeek !== undefined
-          ? { rowId: prev.rowId, weekId: firstWeek, field: prev.field }
-          : { rowId: prev.rowId, weekId: null, field: "name" };
+          ? { rowId: prev.rowId, weekId: firstWeek, field: prev.field, line: 0 }
+          : { rowId: prev.rowId, weekId: null, field: "name", line: 0 };
     } else {
       // Row gone (remove-exercise, or its whole day removed).
       const dayId = lastDayIdRef.current;
       const firstOfDay = dayId == null ? undefined : flat.firstRowByDay.get(dayId);
       // Tier 2a: first row of the same day, else Tier 3: table's first cell
       // (firstCellOf returns null for Tier 4 — the whole table is empty).
-      next = firstOfDay !== undefined ? { rowId: firstOfDay, weekId: null, field: "name" } : firstCellOf(flat);
+      next =
+        firstOfDay !== undefined ? { rowId: firstOfDay, weekId: null, field: "name", line: 0 } : firstCellOf(flat);
     }
 
     // Post-tier guard (#455 review): a SURVIVING coordinate can still be
     // hollow — skipping the focused cell (or dropping an add-this-week
     // cell) refetches the grid with that input gone while its row and week
-    // both live on. Committing the anchor there would zero the whole table
-    // out of the tab order (every rendered cell gets tabIndex=-1 and
-    // focusCell no-ops). This effect runs after React committed the new
-    // DOM, so cellExists sees the post-refetch truth: skid to the nearest
+    // both live on; an undo can drop the SUB-LINE the anchor sat on while
+    // the cell itself lives on. Committing the anchor there would zero the
+    // whole table out of the tab order (every rendered cell gets
+    // tabIndex=-1 and focusCell no-ops). This effect runs after React
+    // committed the new DOM, so cellExists sees the post-refetch truth:
+    // fall back to the cell's line 0 first, then skid to the nearest
     // rendered column of the same row (the name column always renders for
     // a live row), else the table's first cell.
-    if (next && !cellExists(next.rowId, next.weekId, next.field)) {
-      next = nearestRenderedInRow(next, columns) ?? firstCellOf(flat);
+    if (next && !cellExists(next.rowId, next.weekId, next.field, next.line)) {
+      if (next.line !== 0 && cellExists(next.rowId, next.weekId, next.field)) {
+        next = { ...next, line: 0 };
+      } else {
+        next = nearestRenderedInRow(next, columns) ?? firstCellOf(flat);
+      }
     }
 
-    // Restoration may move focus ONLY when it won't steal it: the active
-    // element is a grid cell, focus was orphaned by the swap (fell to
-    // body), or the coach is on a control explicitly marked
-    // data-grid-restore (undo/redo, add-week, make-current, remove-week —
-    // swap initiators whose result should return them to the table).
-    // Anything else — the chat composer, the load-type toggle re-rendering
-    // under focus on a cell patch — keeps focus.
-    const active = document.activeElement as HTMLElement | null;
-    const allowFocusMove =
-      !active ||
-      active === document.body ||
-      active.hasAttribute("data-grid-cell") ||
-      active.closest("[data-grid-restore]") !== null;
     commitAnchor(next, flat, focusedOnceRef.current && allowFocusMove);
     // grid is the only externally-driven trigger for restoration; flat/
     // columns are derived from it in lockstep, and the anchor/ref reads are
@@ -303,49 +480,40 @@ export function useTableNav(options: UseTableNavOptions): UseTableNavResult {
     weekId: number | null,
     field: TableColumn,
     callbacks: TableCellCallbacks,
+    line = 0,
   ): TableCellBindings {
     const tabIndex: 0 | -1 =
-      anchor && anchor.rowId === rowId && anchor.weekId === weekId && anchor.field === field ? 0 : -1;
+      anchor && anchor.rowId === rowId && anchor.weekId === weekId && anchor.field === field && anchor.line === line
+        ? 0
+        : -1;
 
     const onFocus = (event: FocusEvent<HTMLInputElement>) => {
       focusedOnceRef.current = true;
-      focusValuesRef.current[tableCellDomKey(rowId, weekId, field)] = event.currentTarget.value;
-      commitAnchor({ rowId, weekId, field }, flat, false);
+      focusValuesRef.current[tableCellDomKey(rowId, weekId, field, line)] = event.currentTarget.value;
+      commitAnchor({ rowId, weekId, field, line }, flat, false);
     };
 
     const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
       if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "z") return; // undo/redo: untouched.
       if (!HANDLED_KEYS.has(event.key)) return;
       // Modified keys are native text editing (Shift+Arrow selection,
-      // Ctrl/Alt/Cmd+Arrow word- and line-navigation) — never grid moves.
-      if (event.shiftKey || event.ctrlKey || event.metaKey || event.altKey) return;
+      // Ctrl/Alt/Cmd+Arrow word- and line-navigation) or browser chrome
+      // (Ctrl+Tab) — never grid moves. Shift is a real modifier for
+      // everything except Tab, where it's the reverse direction.
+      if (event.ctrlKey || event.metaKey || event.altKey) return;
+      if (event.shiftKey && event.key !== "Tab") return;
 
       // Any handled keydown implies this cell currently holds focus — keep
       // the anchor synced even if no onFocus round-trip preceded it.
-      commitAnchor({ rowId, weekId, field }, flat, false);
+      commitAnchor({ rowId, weekId, field, line }, flat, false);
 
       switch (event.key) {
         case "ArrowDown":
         case "ArrowUp": {
           event.preventDefault();
-          const idx = flat.rowOrder.indexOf(rowId);
-          if (idx === -1) return;
-          const step = event.key === "ArrowDown" ? 1 : -1;
-          // Skid past any row that has no rendered cell at this (weekId,
-          // field) — a row's holes are independent of its neighbors' (a
-          // missing week or a skipped cell), so the next INDEX isn't
-          // necessarily the next LANDABLE row. Stop at the first row that
-          // actually renders this column, or fall off the end: either way
-          // the key was handled (preventDefault already fired above).
-          let nextIdx = idx + step;
-          let candidateRowId = flat.rowOrder[nextIdx];
-          while (candidateRowId !== undefined && !cellExists(candidateRowId, weekId, field)) {
-            nextIdx += step;
-            candidateRowId = flat.rowOrder[nextIdx];
-          }
-          const targetRowId = candidateRowId;
-          if (targetRowId === undefined) return; // no rendered cell to the edge: stay put.
-          commitAnchor({ rowId: targetRowId, weekId, field }, flat, true);
+          const next = stepVertical({ rowId, weekId, field, line }, event.key === "ArrowDown" ? 1 : -1);
+          if (next === undefined) return; // no rendered stop to the edge: stay put.
+          commitAnchor(next, flat, true);
           return;
         }
         case "ArrowRight":
@@ -370,15 +538,59 @@ export function useTableNav(options: UseTableNavOptions): UseTableNavResult {
           // (em-dash + Unskip, no GridCellEditor) both leave no
           // `data-grid-cell` node, so arrowing across one jumps straight to
           // the next editable cell instead of stranding the anchor on a
-          // coordinate nothing renders.
-          while (candidateCol !== undefined && !cellExists(rowId, candidateCol.weekId, candidateCol.field)) {
+          // coordinate nothing renders. A sub-line move clamps to each
+          // candidate's nearest stop (see nearestLineStop).
+          while (candidateCol !== undefined) {
+            const candLine =
+              candidateCol.field === "text" && candidateCol.weekId !== null
+                ? nearestLineStop(lineStops(flat.rowsById.get(rowId), candidateCol.weekId, candidateCol.field), line)
+                : 0;
+            if (cellExists(rowId, candidateCol.weekId, candidateCol.field, candLine)) {
+              commitAnchor({ rowId, weekId: candidateCol.weekId, field: candidateCol.field, line: candLine }, flat, true);
+              return;
+            }
             nextColIdx += step;
             candidateCol = columns[nextColIdx];
           }
-          const nextCol = candidateCol;
-          if (nextCol === undefined) return; // ran out of columns while skidding past holes: stay put, key already handled.
-          commitAnchor({ rowId, weekId: nextCol.weekId, field: nextCol.field }, flat, true);
-          return;
+          return; // ran out of columns while skidding past holes: stay put, key already handled.
+        }
+        case "Tab": {
+          // Spreadsheet Tab: next/previous column unconditionally (no caret
+          // gate — Tab is never text editing), wrapping to the next/
+          // previous row's first/last column at the row's ends. Only
+          // preventDefault once a landable target is found, so tabbing off
+          // the table's edge falls back to the browser's native order.
+          const step = event.shiftKey ? -1 : 1;
+          const colIdx = columns.findIndex((c) => c.weekId === weekId && c.field === field);
+          const rowIdx = flat.rowOrder.indexOf(rowId);
+          if (colIdx === -1 || rowIdx === -1) return;
+          let r = rowIdx;
+          let c = colIdx + step;
+          let ln = line;
+          for (;;) {
+            if (c < 0) {
+              r -= 1;
+              c = columns.length - 1;
+              ln = 0;
+            } else if (c >= columns.length) {
+              r += 1;
+              c = 0;
+              ln = 0;
+            }
+            const rowAt = flat.rowOrder[r];
+            const col = columns[c];
+            if (rowAt === undefined || col === undefined) return; // ran off the table: native Tab leaves the grid.
+            const candLine =
+              col.field === "text" && col.weekId !== null
+                ? nearestLineStop(lineStops(flat.rowsById.get(rowAt), col.weekId, col.field), ln)
+                : 0;
+            if (cellExists(rowAt, col.weekId, col.field, candLine)) {
+              event.preventDefault();
+              commitAnchor({ rowId: rowAt, weekId: col.weekId, field: col.field, line: candLine }, flat, true);
+              return;
+            }
+            c += step;
+          }
         }
         case "Enter": {
           event.preventDefault();
@@ -386,12 +598,35 @@ export function useTableNav(options: UseTableNavOptions): UseTableNavResult {
           // The committed value is the new Escape baseline — without this, a
           // fresh draft + Escape would roll the UI back PAST the commit,
           // desyncing it from the server.
-          focusValuesRef.current[tableCellDomKey(rowId, weekId, field)] = event.currentTarget.value;
+          focusValuesRef.current[tableCellDomKey(rowId, weekId, field, line)] = event.currentTarget.value;
+          // Spreadsheet Enter (Phase 2b): commit + move DOWN one stop —
+          // through this row's own sub-line stack first (D3's arrow-down RPE
+          // row), then the next row of the SAME day. At the day's last stop,
+          // append a new exercise row instead (Enter-adds-row) — unless this
+          // row is still entirely blank, so Enter can never mint a stack of
+          // empty rows. Enter never crosses into the next day; that's
+          // ArrowDown's job.
+          const next = stepVertical({ rowId, weekId, field, line }, 1);
+          const dayId = flat.dayIdByRow.get(rowId);
+          if (next !== undefined && flat.dayIdByRow.get(next.rowId) === dayId) {
+            commitAnchor(next, flat, true);
+            return;
+          }
+          if (dayId === undefined || !onAppendRow) return;
+          if (rowDomBlank(rowId)) return;
+          appendPendingRef.current = {
+            dayId,
+            weekId,
+            field,
+            prevLastRow: flat.lastRowByDay.get(dayId),
+            ttl: 4,
+          };
+          onAppendRow(dayId);
           return;
         }
         case "Escape": {
           event.preventDefault();
-          const key = tableCellDomKey(rowId, weekId, field);
+          const key = tableCellDomKey(rowId, weekId, field, line);
           const value = focusValuesRef.current[key] ?? event.currentTarget.value;
           callbacks.onRevert(value);
           return;

--- a/frontend/designer/src/hooks/useTableNav.ts
+++ b/frontend/designer/src/hooks/useTableNav.ts
@@ -61,7 +61,7 @@
 // only once a landable target is found (so tabbing off the table's last
 // cell hands focus to the browser's native order — the grid is not a focus
 // trap). Sub-line stops skid by LINE too: moving horizontally from line L
-// lands on the target cell's nearest stop at-or-above it (its ghost when the
+// lands on the target cell's largest stop at-or-below it (its ghost when the
 // stack is shorter — the spreadsheet's merged-cell feel), never on a line
 // that doesn't render.
 import { useEffect, useMemo, useRef, useState } from "react";

--- a/frontend/designer/src/hooks/useTableNav.ts
+++ b/frontend/designer/src/hooks/useTableNav.ts
@@ -130,9 +130,12 @@ export interface UseTableNavOptions {
    * stop of a day whose row has content — the caller appends a blank
    * exercise row to that day (useGrid.addExercise). Once the day's LAST ROW
    * actually changes on a grid refetch, the hook focuses the new row at the
-   * column Enter came from. Optional so hook-only tests without an append
-   * path keep their old "Enter at the bottom stays put" behavior. */
-  onAppendRow?(dayId: number): void;
+   * column Enter came from. Return `false` when the append was NOT
+   * dispatched (e.g. the grid is busy) so no focus intent is recorded — a
+   * dropped dispatch must never move focus when that day's last row later
+   * changes for an unrelated reason. Optional so hook-only tests without an
+   * append path keep their old "Enter at the bottom stays put" behavior. */
+  onAppendRow?(dayId: number): boolean | void;
 }
 
 /** DOM identity for a cell's `data-grid-cell` attribute / querySelector key.
@@ -260,6 +263,14 @@ function nearestLineStop(stops: number[], line: number): number {
     else break;
   }
   return best;
+}
+
+/** The line a horizontal move (arrow or Tab) into `col` should land on:
+ * week-text columns clamp to the target cell's nearest stop at-or-below
+ * `line` (see nearestLineStop); row-scoped columns are single-line. */
+function clampLine(row: GridRow | undefined, col: TableColumnPos, line: number): number {
+  if (col.field !== "text" || col.weekId === null) return 0;
+  return nearestLineStop(lineStops(row, col.weekId, col.field), line);
 }
 
 /** Every (rowId, line) of one column, day-major/row-minor/line-inner — the
@@ -541,10 +552,7 @@ export function useTableNav(options: UseTableNavOptions): UseTableNavResult {
           // coordinate nothing renders. A sub-line move clamps to each
           // candidate's nearest stop (see nearestLineStop).
           while (candidateCol !== undefined) {
-            const candLine =
-              candidateCol.field === "text" && candidateCol.weekId !== null
-                ? nearestLineStop(lineStops(flat.rowsById.get(rowId), candidateCol.weekId, candidateCol.field), line)
-                : 0;
+            const candLine = clampLine(flat.rowsById.get(rowId), candidateCol, line);
             if (cellExists(rowId, candidateCol.weekId, candidateCol.field, candLine)) {
               commitAnchor({ rowId, weekId: candidateCol.weekId, field: candidateCol.field, line: candLine }, flat, true);
               return;
@@ -580,10 +588,7 @@ export function useTableNav(options: UseTableNavOptions): UseTableNavResult {
             const rowAt = flat.rowOrder[r];
             const col = columns[c];
             if (rowAt === undefined || col === undefined) return; // ran off the table: native Tab leaves the grid.
-            const candLine =
-              col.field === "text" && col.weekId !== null
-                ? nearestLineStop(lineStops(flat.rowsById.get(rowAt), col.weekId, col.field), ln)
-                : 0;
+            const candLine = clampLine(flat.rowsById.get(rowAt), col, ln);
             if (cellExists(rowAt, col.weekId, col.field, candLine)) {
               event.preventDefault();
               commitAnchor({ rowId: rowAt, weekId: col.weekId, field: col.field, line: candLine }, flat, true);
@@ -614,14 +619,15 @@ export function useTableNav(options: UseTableNavOptions): UseTableNavResult {
           }
           if (dayId === undefined || !onAppendRow) return;
           if (rowDomBlank(rowId)) return;
-          appendPendingRef.current = {
+          const pending: AppendPending = {
             dayId,
             weekId,
             field,
             prevLastRow: flat.lastRowByDay.get(dayId),
             ttl: 4,
           };
-          onAppendRow(dayId);
+          if (onAppendRow(dayId) === false) return; // dropped (busy): record no intent.
+          appendPendingRef.current = pending;
           return;
         }
         case "Escape": {


### PR DESCRIPTION
Phase 2b of the spreadsheet-parity plan ([`docs/meso/spreadsheet-parity-plan.md`](../blob/main/docs/meso/spreadsheet-parity-plan.md) §6): make the multi-week table fully keyboard-drivable, spreadsheet-style. Frontend-only — weeks-side-by-side and add-week-with-carry-forward already shipped in the A-series/2a.

## What changed

- **Sub-lines join vertical nav (D3).** `useTableNav` cell identity gains a *line*: each week cell's sub-line stack (existing lines + the trailing ghost) is a run of vertical stops, so ArrowDown from a prescription steps into its stack. The ghost is a real stop — minting the RPE line is literally "arrow down and type", no mouse.
- **Tempo/Notes/Rest join horizontal nav.** The axis is now name → tempo → weeks… → notes → rest (the source sheet's column order).
- **Tab / Shift+Tab** walk that axis unconditionally (arrows still defer to the caret at text boundaries), wrapping between rows. Tabbing off the table's edge stays native — the grid is not a focus trap.
- **Enter = commit + move down one stop**, and at a day's *last* stop it **appends an exercise row** to that day (Enter-adds-row — the ad-hoc log-mode primitive). Enter never crosses a day boundary (that's ArrowDown's job); a fully blank row never appends (the guard reads the DOM, so an uncommitted draft counts as content). After the refetch, focus lands on the new row at the column Enter came from — with a ttl'd intent so a failed POST can never steal focus later.
- **Sub-line horizontal moves clamp** to the target cell's nearest stop (a shorter stack lands on its ghost — the sheet's merged-cell feel), never skidding past the whole cell.
- **Ctrl-C/Ctrl-V cell-stack copy/paste** on the prescription input: copy with nothing selected copies the whole stack newline-joined (a real text selection keeps native copy); multi-line paste replaces the stack (line 0 via `prescription_patch`, sub-lines via `cell_line_write`, longer old lines blanked so the result equals the source); single-line paste stays native.

No backend changes — Enter-adds-row reuses `session_add_exercise`, paste reuses the 2a cell-write endpoints.

## Tests

- `useTableNav.test.tsx` rewritten to the widened axes: 76 hook specs (line stops, clamping, Tab, Enter-adds-row incl. the optimistic-change/refetch ordering and the stale-intent expiry).
- `MesoTable.test.tsx`: 104 specs — integrated nav through the real render, stack copy/paste, Enter-adds-row wiring to `onAddExercise` with the blank-row guard.
- **2395 pytest + 569 vitest green; `tsc --noEmit` clean; `vite build` clean.**

https://claude.ai/code/session_01M8RejqmwnQuUybGh3m89fc