### PR TITLE
feat(meso): 3b — template library UI + start-for-client (parity plan §3.4)

### DIFF
--- a/app/store_project/meso/billing/access.py
+++ b/app/store_project/meso/billing/access.py
@@ -226,9 +226,17 @@ def can_edit_plan(plan):
     only when *its own* relationship is soft-suspended, so an over-limit coach
     keeps full control of their oldest ``FREE_SEAT_LIMIT`` athletes' plans and
     is blocked only on the suspended ones. Defended at the mutating endpoints,
-    not just the UI. A relationship-less plan (none exist today; templates may
-    reintroduce them) falls back to the coarse coach-wide freeze.
+    not just the UI.
+
+    A **template** plan is never billing-frozen: a template holds no seat, so
+    an over-limit coach keeps editing (and delivering *from*) their own
+    templates. Billing bites at the copy targets instead — both ``template_use``
+    and ``plan_batch_deliver`` exclude soft-suspended relationships, so a frozen
+    client can't be started or delivered to. Any other relationship-less plan
+    falls back to the coarse coach-wide freeze.
     """
+    if plan.is_template:
+        return True
     if plan.relationship_id is None:
         return can_edit(plan.coach)
     return plan.relationship_id not in suspended_athlete_ids(plan.coach)

--- a/app/store_project/meso/tests/test_template_library.py
+++ b/app/store_project/meso/tests/test_template_library.py
@@ -18,12 +18,17 @@ RED-phase spec tests: these fail until 3b is implemented (NoReverseMatch on the
 new URL names / missing views), not on setup.
 """
 
+from datetime import timedelta
+
 import pytest
 from django.core import mail
 from django.urls import reverse
+from django.utils import timezone
 
+from store_project.meso.billing import access
 from store_project.meso.factories import CoachAthleteFactory
 from store_project.meso.factories import PlanFactory
+from store_project.meso.models import CoachAthlete
 from store_project.meso.models import Plan
 from store_project.meso.models import WeekDelivery
 from store_project.users.factories import UserFactory
@@ -47,6 +52,32 @@ def coach_with_client():
     coach = UserFactory()
     rel = CoachAthleteFactory(coach=coach, athlete=UserFactory())
     return coach, rel
+
+
+def _aged_link(coach, days_ago):
+    """An active ``CoachAthlete`` for ``coach``, back-dated for a stable age.
+
+    ``created_at`` is ``auto_now_add`` → a raw ``.update`` is the only way to set
+    it; the oldest-kept suspension rule (D6) turns on this order.
+    """
+    link = CoachAthleteFactory(coach=coach, athlete=UserFactory())
+    CoachAthlete.objects.filter(pk=link.pk).update(
+        created_at=timezone.now() - timedelta(days=days_ago)
+    )
+    link.refresh_from_db()
+    return link
+
+
+def _over_limit_coach():
+    """A free coach over the seat cap (FREE_SEAT_LIMIT=1).
+
+    The oldest link is kept live, the newest is soft-suspended (D6 freeze).
+    """
+    coach = UserFactory()
+    kept = _aged_link(coach, days_ago=30)
+    suspended = _aged_link(coach, days_ago=1)
+    assert access.is_over_limit(coach) is True
+    return coach, kept, suspended
 
 
 def library_url():
@@ -300,3 +331,79 @@ class TestBatchDeliverFromTemplate:
 
         assert resp.status_code == 302
         assert resp.url == reverse("meso:deliver_plan", kwargs={"plan_id": plan.pk})
+
+
+class TestTemplateUseSuspension:
+    """Finding 1 — ``template_use`` must honour the D6 soft-suspension freeze.
+
+    A soft-suspended (over-seat-limit) relationship is never offered in the UI,
+    so its presence in a POST is a stale/forged form; it must behave exactly like
+    a foreign/invalid pick (flash + redirect to the library, nothing created) and
+    must NOT start a live ACTIVE plan for a frozen client.
+    """
+
+    def test_suspended_relationship_creates_nothing(self, client):
+        coach, _kept, suspended = _over_limit_coach()
+        tpl, _ = template_plan(coach, title="Base Block")
+        client.force_login(coach)
+
+        resp = client.post(use_url(tpl), {"relationship": suspended.pk})
+
+        assert resp.status_code == 302
+        assert resp.url == library_url()
+        assert suspended.plans.count() == 0
+        assert Plan.objects.filter(is_template=False).count() == 0
+
+    def test_kept_relationship_still_works_for_over_limit_coach(self, client):
+        # Guard: the over-limit coach keeps starting templates for their oldest
+        # (non-suspended) client — template_use gates on the target, not coarsely.
+        coach, kept, _suspended = _over_limit_coach()
+        tpl, _ = template_plan(coach, title="Base Block")
+        client.force_login(coach)
+
+        resp = client.post(use_url(tpl), {"relationship": kept.pk})
+
+        copy = kept.plans.get()
+        assert copy.is_template is False
+        assert copy.status == Plan.Status.ACTIVE
+        assert resp.status_code == 302
+        assert resp.url == reverse("meso:designer_plan", kwargs={"plan_id": copy.pk})
+
+
+class TestBatchDeliverFromTemplateSuspension:
+    """Finding 2 — batch-deliver from a TEMPLATE is per-target, not coarse-frozen.
+
+    A template plan has no relationship, so the old ``can_edit_plan`` fell back to
+    the coach-wide freeze and 402'd an over-limit coach entirely. D6 gates at the
+    copy targets instead: an over-limit coach delivers from a template to their
+    kept clients while suspended targets are dropped.
+    """
+
+    def test_over_limit_coach_delivers_only_to_kept_client(
+        self, client, django_capture_on_commit_callbacks
+    ):
+        coach, kept, suspended = _over_limit_coach()
+        tpl, _ = template_plan(coach, title="Squat Base")
+        client.force_login(coach)
+
+        with django_capture_on_commit_callbacks(execute=True):
+            resp = client.post(
+                batch_deliver_url(tpl),
+                {"relationships": [kept.pk, suspended.pk]},
+            )
+
+        # Exactly one copy — for the kept client only; the suspended target is dropped.
+        assert kept.plans.count() == 1
+        assert suspended.plans.count() == 0
+        assert Plan.objects.filter(is_template=False).count() == 1
+        assert kept.plans.get().status == Plan.Status.ACTIVE
+        assert resp.status_code == 302
+        assert resp.url == library_url()
+
+    def test_can_edit_plan_true_for_template_while_coach_frozen(self):
+        # Unit: a template plan is never billing-frozen, even for an over-limit
+        # coach whose coarse ``can_edit`` is False (templates aren't seats).
+        coach, _kept, _suspended = _over_limit_coach()
+        tpl, _ = template_plan(coach, title="Base Block")
+        assert access.can_edit(coach) is False
+        assert access.can_edit_plan(tpl) is True

--- a/app/store_project/meso/tests/test_template_library.py
+++ b/app/store_project/meso/tests/test_template_library.py
@@ -1,0 +1,302 @@
+"""Slice 3b (spreadsheet parity §3.4 / §3.1) — template library + new-from-template.
+
+A template = a ``Plan`` with ``is_template=True``, no relationship, and an
+``owner`` (see ``test_template_plans``). This slice adds the coach-facing UI on
+top of that model:
+
+- ``meso:template_library`` (``templates/``): the owner's library — every
+  template they own, alphabetical, each opening in the designer, each offering
+  "Start for client" + "Batch deliver". Scoped to the requester; login-gated.
+- ``meso:template_use`` (``template/<plan_id>/use/``, POST): "Start for client"
+  — deep-copies the template into a fresh, ACTIVE, *undelivered* client plan for
+  one of the coach's active relationships, then opens it in the designer.
+- ``meso:plan_batch_deliver`` from a template now redirects to the library (a
+  template has no deliver screen to return to); from a normal plan it still
+  redirects to the deliver screen (regression guard).
+
+RED-phase spec tests: these fail until 3b is implemented (NoReverseMatch on the
+new URL names / missing views), not on setup.
+"""
+
+import pytest
+from django.core import mail
+from django.urls import reverse
+
+from store_project.meso.factories import CoachAthleteFactory
+from store_project.meso.factories import PlanFactory
+from store_project.meso.models import Plan
+from store_project.meso.models import WeekDelivery
+from store_project.users.factories import UserFactory
+
+# Reuse the established fixture builders rather than re-deriving them.
+from .test_batch_deliver import comp
+from .test_batch_deliver import seed_source
+from .test_template_plans import template_plan
+
+pytestmark = pytest.mark.django_db
+
+
+def coach_with_client():
+    """A coach who counts as a coach (has one active client) — the library gate.
+
+    ``RosterView`` (which the library mirrors) routes non-coaches to their
+    athlete home, and ``_is_coach`` does NOT count template ownership alone, so
+    every library viewer needs a coach-side link. The active client also makes
+    the per-template "Start for client" / "Batch deliver" forms render.
+    """
+    coach = UserFactory()
+    rel = CoachAthleteFactory(coach=coach, athlete=UserFactory())
+    return coach, rel
+
+
+def library_url():
+    return reverse("meso:template_library")
+
+
+def use_url(plan):
+    return reverse("meso:template_use", kwargs={"plan_id": plan.pk})
+
+
+def batch_deliver_url(plan):
+    return reverse("meso:plan_batch_deliver", kwargs={"plan_id": plan.pk})
+
+
+class TestTemplateLibraryPage:
+    def test_lists_owned_templates_linking_to_the_designer(self, client):
+        coach, _ = coach_with_client()
+        tpl_a, _ = template_plan(coach, title="Base Hypertrophy")
+        tpl_b, _ = template_plan(coach, title="Peaking Block")
+        client.force_login(coach)
+
+        resp = client.get(library_url())
+
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        for tpl in (tpl_a, tpl_b):
+            assert tpl.title in body
+            assert reverse("meso:designer_plan", kwargs={"plan_id": tpl.pk}) in body
+
+    def test_shows_only_the_requesters_templates(self, client):
+        coach, rel = coach_with_client()
+        mine, _ = template_plan(coach, title="My Template")
+        # Another coach's template must not leak in.
+        other, _ = template_plan(UserFactory(), title="Someone Elses Template")
+        # The coach's own NON-template client plan must not appear either.
+        client_plan = PlanFactory(relationship=rel, title="A Client Working Plan")
+        client.force_login(coach)
+
+        resp = client.get(library_url())
+
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert "My Template" in body
+        assert "Someone Elses Template" not in body
+        assert "A Client Working Plan" not in body
+        assert reverse("meso:designer_plan", kwargs={"plan_id": mine.pk}) in body
+        assert reverse("meso:designer_plan", kwargs={"plan_id": other.pk}) not in body
+        assert (
+            reverse("meso:designer_plan", kwargs={"plan_id": client_plan.pk})
+            not in body
+        )
+
+    def test_anonymous_is_redirected_to_login(self, client):
+        # The library is a coach sub-surface (like DeliverView) — login-gated, so
+        # an anonymous visitor is redirected, not shown the library.
+        resp = client.get(library_url())
+        assert resp.status_code == 302
+
+    def test_empty_state_when_the_coach_has_no_templates(self, client):
+        coach, _ = coach_with_client()
+        client.force_login(coach)
+
+        resp = client.get(library_url())
+
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        # Empty-state copy mentioning that templates can be imported. The
+        # implementer must render this literal (or adjust the assertion to match).
+        assert "No templates" in body
+
+    def test_templates_listed_alphabetically_by_title(self, client):
+        coach, _ = coach_with_client()
+        template_plan(coach, title="601 Peak")
+        template_plan(coach, title="101 Base")
+        client.force_login(coach)
+
+        resp = client.get(library_url())
+
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert body.find("101 Base") != -1
+        assert body.find("601 Peak") != -1
+        assert body.find("101 Base") < body.find("601 Peak")
+
+    def test_roster_links_to_the_library(self, client):
+        coach, _ = coach_with_client()
+        client.force_login(coach)
+
+        resp = client.get(reverse("meso:roster"))
+
+        assert resp.status_code == 200
+        assert library_url() in resp.content.decode()
+
+    def test_each_template_offers_use_and_batch_deliver_forms(self, client):
+        coach, _ = coach_with_client()  # active client → forms render
+        tpl, _ = template_plan(coach, title="Base Block")
+        client.force_login(coach)
+
+        resp = client.get(library_url())
+
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert use_url(tpl) in body
+        assert batch_deliver_url(tpl) in body
+
+
+class TestTemplateUseEndpoint:
+    def test_starts_an_active_undelivered_copy_for_the_client(self, client):
+        coach, rel = coach_with_client()
+        tpl, cell = template_plan(coach, title="Base Block")
+        client.force_login(coach)
+
+        resp = client.post(use_url(tpl), {"relationship": rel.pk})
+
+        # Exactly one new client plan for that relationship.
+        copy = rel.plans.get()
+        assert Plan.objects.count() == 2  # template + the one copy
+        # A normal client plan, not another template.
+        assert copy.is_template is False
+        assert copy.owner_id is None
+        assert copy.relationship_id == rel.pk
+        # A live, editable working plan (the status batch-deliver uses).
+        assert copy.status == Plan.Status.ACTIVE
+        # The deep copy carried the tree: same block count + the slot/cell content.
+        assert copy.mesocycles.count() == tpl.mesocycles.count()
+        copied_slot_names = list(
+            copy.mesocycles.get()
+            .session_slots.get()
+            .exercise_slots.values_list("name", flat=True)
+        )
+        assert cell.exercise_slot.name in copied_slot_names
+        assert copy.mesocycles.get().weeks.get().cells.filter(text=cell.text).exists()
+        # Undelivered + unnotified: no week stamped, no snapshots, no email.
+        copy_weeks = copy.mesocycles.get().weeks.all()
+        assert all(w.delivered_at is None for w in copy_weeks)
+        assert WeekDelivery.objects.filter(week__mesocycle__plan=copy).count() == 0
+        assert len(mail.outbox) == 0
+        # The template itself is untouched.
+        tpl.refresh_from_db()
+        assert tpl.is_template is True
+        assert tpl.mesocycles.exists()
+        # Opens the new copy in the designer.
+        assert resp.status_code == 302
+        assert resp.url == reverse("meso:designer_plan", kwargs={"plan_id": copy.pk})
+
+    def test_get_is_not_allowed(self, client):
+        coach, _ = coach_with_client()
+        tpl, _ = template_plan(coach, title="Base Block")
+        client.force_login(coach)
+
+        assert client.get(use_url(tpl)).status_code == 405
+
+    def test_non_owner_coach_404s(self, client):
+        tpl, _ = template_plan(title="Base Block")
+        other_coach = CoachAthleteFactory().coach
+        client.force_login(other_coach)
+
+        resp = client.post(use_url(tpl), {"relationship": 1})
+
+        assert resp.status_code == 404
+        assert not tpl.mesocycles.filter(plan__is_template=False).exists()
+        assert Plan.objects.filter(is_template=False).count() == 0
+
+    def test_non_template_plan_404s(self, client):
+        # The endpoint only serves templates.
+        plan = PlanFactory()  # a normal relationship plan
+        coach = plan.relationship.coach
+        client.force_login(coach)
+
+        resp = client.post(use_url(plan), {"relationship": plan.relationship.pk})
+
+        assert resp.status_code == 404
+
+    def test_relationship_of_a_different_coach_creates_nothing(self, client):
+        coach, _ = coach_with_client()
+        tpl, _ = template_plan(coach, title="Base Block")
+        foreign = CoachAthleteFactory()  # someone else's athlete
+        client.force_login(coach)
+
+        resp = client.post(use_url(tpl), {"relationship": foreign.pk})
+
+        assert resp.status_code == 302
+        assert resp.url == library_url()
+        assert foreign.plans.count() == 0
+        assert Plan.objects.filter(is_template=False).count() == 0
+
+    def test_missing_relationship_creates_nothing(self, client):
+        coach, _ = coach_with_client()
+        tpl, _ = template_plan(coach, title="Base Block")
+        client.force_login(coach)
+
+        resp = client.post(use_url(tpl), {})
+
+        assert resp.status_code == 302
+        assert resp.url == library_url()
+        assert Plan.objects.filter(is_template=False).count() == 0
+
+    def test_garbage_relationship_creates_nothing(self, client):
+        coach, _ = coach_with_client()
+        tpl, _ = template_plan(coach, title="Base Block")
+        client.force_login(coach)
+
+        resp = client.post(use_url(tpl), {"relationship": "not-an-int"})
+
+        assert resp.status_code == 302
+        assert resp.url == library_url()
+        assert Plan.objects.filter(is_template=False).count() == 0
+
+    def test_two_posts_create_two_independent_copies(self, client):
+        coach, rel = coach_with_client()
+        tpl, _ = template_plan(coach, title="Base Block")
+        client.force_login(coach)
+
+        client.post(use_url(tpl), {"relationship": rel.pk})
+        client.post(use_url(tpl), {"relationship": rel.pk})
+
+        assert rel.plans.count() == 2
+        pks = set(rel.plans.values_list("pk", flat=True))
+        assert len(pks) == 2  # two distinct plans
+
+
+class TestBatchDeliverFromTemplate:
+    def test_from_template_redirects_to_the_library(
+        self, client, django_capture_on_commit_callbacks
+    ):
+        coach = comp(UserFactory())
+        tpl, _ = template_plan(coach, title="Squat Base")
+        rel_b = CoachAthleteFactory(coach=coach, athlete=UserFactory())
+        client.force_login(coach)
+
+        with django_capture_on_commit_callbacks(execute=True):
+            resp = client.post(batch_deliver_url(tpl), {"relationships": [rel_b.pk]})
+
+        # Still creates + delivers an ACTIVE copy, exactly as before...
+        copy = rel_b.plans.get()
+        assert copy.status == Plan.Status.ACTIVE
+        # ...but the redirect target is now the library (no template deliver screen).
+        assert resp.status_code == 302
+        assert resp.url == library_url()
+
+    def test_from_normal_plan_still_redirects_to_the_deliver_screen(
+        self, client, django_capture_on_commit_callbacks
+    ):
+        # Regression guard: batch-deliver of a normal plan is unchanged.
+        plan, _ = seed_source(coach=comp(UserFactory()))
+        rel_b = CoachAthleteFactory(coach=plan.coach, athlete=UserFactory())
+        client.force_login(plan.coach)
+
+        with django_capture_on_commit_callbacks(execute=True):
+            resp = client.post(batch_deliver_url(plan), {"relationships": [rel_b.pk]})
+
+        assert resp.status_code == 302
+        assert resp.url == reverse("meso:deliver_plan", kwargs={"plan_id": plan.pk})

--- a/app/store_project/meso/urls.py
+++ b/app/store_project/meso/urls.py
@@ -13,6 +13,7 @@ from .views import OfflineView
 from .views import RelationshipHistoryView
 from .views import ResultsView
 from .views import RosterView
+from .views import TemplateLibraryView
 from .views import UsageDashboardView
 
 app_name = "meso"
@@ -39,6 +40,14 @@ urlpatterns = [
     ),
     path("deliver/", DeliverView.as_view(), name="deliver"),
     path("deliver/<int:plan_id>/", DeliverView.as_view(), name="deliver_plan"),
+    # Template library (parity plan §3.4): the coach's owned templates, each
+    # opening in the designer + offering "Start for client" / "Batch deliver".
+    path("templates/", TemplateLibraryView.as_view(), name="template_library"),
+    path(
+        "template/<int:plan_id>/use/",
+        views.template_use,
+        name="template_use",
+    ),
     path("results/", ResultsView.as_view(), name="results"),
     path(
         "results/<int:session_id>/",

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -19,6 +19,7 @@ from django.core.exceptions import PermissionDenied
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from django.db import transaction
+from django.db.models import Count
 from django.db.models import Max
 from django.http import Http404
 from django.http import HttpResponse
@@ -444,6 +445,46 @@ class RelationshipHistoryView(LoginRequiredMixin, TemplateView):
         ctx["past"] = history["past"]
         ctx["reconnecting"] = history["reconnecting"]
         ctx["is_empty"] = not history["past"] and not history["reconnecting"]
+        return ctx
+
+
+class TemplateLibraryView(LoginRequiredMixin, TemplateView):
+    """The coach's template library (``/meso/templates/``) — parity plan §3.4.
+
+    A template = a ``Plan`` with ``is_template=True`` and an ``owner`` (no
+    athlete), imported via ``meso_import_template`` or authored in the designer.
+    This lists every template the requester owns, alphabetical, each opening in
+    the same designer grid. When the coach has active clients, each row offers
+    "Start for client" (``template_use`` — a live working copy) and "Batch
+    deliver" (``plan_batch_deliver`` — a delivered copy per picked client).
+    Login-gated (like ``DeliverView``): the library is scoped to the requester's
+    own templates, so an anonymous visitor is bounced to login.
+    """
+
+    template_name = "meso/template_library.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx["active"] = "roster"
+        ctx["templates"] = (
+            Plan.objects.filter(is_template=True, owner=self.request.user)
+            .annotate(
+                block_count=Count("mesocycles", distinct=True),
+                week_count=Count("mesocycles__weeks", distinct=True),
+            )
+            .order_by("title")
+        )
+        # The coach's deliverable clients, offered as "Start for client" /
+        # "Batch deliver" targets. Soft-suspended (over-seat-limit, D6) links are
+        # omitted — the endpoints re-check, this just keeps the screen honest.
+        ctx["clients"] = [
+            {"id": rel.pk, "name": rel.athlete.display_name()}
+            for rel in CoachAthlete.objects.for_coach(self.request.user)
+            .active()
+            .exclude(pk__in=billing_access.suspended_athlete_ids(self.request.user))
+            .select_related("athlete")
+            .order_by("athlete__name", "athlete__email")
+        ]
         return ctx
 
 
@@ -3529,16 +3570,24 @@ def plan_batch_deliver(request, plan_id):
     plan, forbidden = _editable_plan_or_response(request, plan_id)
     if forbidden is not None:
         return forbidden
+
+    # A template has no deliver screen to return to (parity plan §3.4) — send the
+    # coach back to their library; a normal plan returns to its deliver screen.
+    def _back():
+        if plan.is_template:
+            return redirect("meso:template_library")
+        return redirect("meso:deliver_plan", plan_id=plan.pk)
+
     if current_week(plan) is None:
         messages.error(request, "This plan has no week to deliver.")
-        return redirect("meso:deliver_plan", plan_id=plan.pk)
+        return _back()
     try:
         picked_ids = [int(raw) for raw in request.POST.getlist("relationships")]
     except (TypeError, ValueError):
         return HttpResponseBadRequest("relationships must be ids.")
     if not picked_ids:
         messages.error(request, "Pick at least one client to deliver a copy to.")
-        return redirect("meso:deliver_plan", plan_id=plan.pk)
+        return _back()
     targets = list(
         CoachAthlete.objects.for_coach(request.user)
         .active()
@@ -3550,7 +3599,7 @@ def plan_batch_deliver(request, plan_id):
     )
     if not targets:
         messages.error(request, "No deliverable clients in that selection.")
-        return redirect("meso:deliver_plan", plan_id=plan.pk)
+        return _back()
     delivered_names = []
     with transaction.atomic():
         for relationship in targets:
@@ -3573,7 +3622,56 @@ def plan_batch_deliver(request, plan_id):
         request,
         f"Delivered an independent copy to {', '.join(delivered_names)}.",
     )
-    return redirect("meso:deliver_plan", plan_id=plan.pk)
+    return _back()
+
+
+@login_required
+@require_POST
+def template_use(request, plan_id):
+    """Start-for-client — deep-copy a template into a fresh client plan (§3.4).
+
+    The working-copy door of the template library: the owner picks one active
+    client and the template is deep-copied (``duplicate_for``) into a live,
+    ACTIVE, *undelivered* plan for that relationship, then opened in the
+    designer. Nothing is stamped or notified — the copy is live per the 2d
+    model (the athlete sees it), but no delivery snapshot is written and no
+    nudge is sent; batch-deliver is the separate "notify" door.
+
+    Only serves templates the requester owns (``editable_by`` + ``is_template``
+    → 404 for a foreign or non-template plan). A missing / non-numeric / foreign
+    ``relationship`` creates nothing and flashes back to the library. The copy
+    is written in one explicit ``transaction.atomic()`` (``ATOMIC_REQUESTS`` is
+    inert here).
+    """
+    plan = get_object_or_404(
+        Plan.objects.editable_by(request.user).filter(is_template=True),
+        pk=plan_id,
+    )
+    try:
+        rel_id = int(request.POST.get("relationship", ""))
+    except (TypeError, ValueError):
+        rel_id = None
+    relationship = None
+    if rel_id is not None:
+        relationship = (
+            CoachAthlete.objects.for_coach(request.user)
+            .active()
+            .filter(pk=rel_id)
+            .select_related("athlete")
+            .first()
+        )
+    if relationship is None:
+        messages.error(
+            request, "Pick one of your active clients to start this template."
+        )
+        return redirect("meso:template_library")
+    with transaction.atomic():
+        copy = plan.duplicate_for(relationship, status=Plan.Status.ACTIVE)
+    messages.success(
+        request,
+        f"Started {copy.title} for {relationship.athlete.display_name()}.",
+    )
+    return redirect("meso:designer_plan", plan_id=copy.pk)
 
 
 def _notify_athlete_block_delivered(request, plan, mesocycle, week_count):

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -3639,7 +3639,10 @@ def template_use(request, plan_id):
 
     Only serves templates the requester owns (``editable_by`` + ``is_template``
     → 404 for a foreign or non-template plan). A missing / non-numeric / foreign
-    ``relationship`` creates nothing and flashes back to the library. The copy
+    ``relationship`` creates nothing and flashes back to the library — as does a
+    soft-suspended (over-seat-limit, D6) link, which the library never offers, so
+    its presence in a POST is a stale/forged form; the suspended-id exclusion
+    mirrors ``plan_batch_deliver`` so a frozen client can't be started. The copy
     is written in one explicit ``transaction.atomic()`` (``ATOMIC_REQUESTS`` is
     inert here).
     """
@@ -3657,6 +3660,7 @@ def template_use(request, plan_id):
             CoachAthlete.objects.for_coach(request.user)
             .active()
             .filter(pk=rel_id)
+            .exclude(pk__in=billing_access.suspended_athlete_ids(request.user))
             .select_related("athlete")
             .first()
         )

--- a/app/store_project/templates/meso/roster.html
+++ b/app/store_project/templates/meso/roster.html
@@ -104,6 +104,7 @@
             <div class="meso-spacer"></div>
             <span class="meso-row-meta">{{ athletes|length }} athlete{{ athletes|length|pluralize }}</span>
             <a href="{% url 'meso:relationship_history' %}" class="meso-row-meta" style="text-decoration:none;color:var(--accent);white-space:nowrap;">· Past athletes →</a>
+            <a href="{% url 'meso:template_library' %}" class="meso-row-meta" style="text-decoration:none;color:var(--accent);white-space:nowrap;">· Templates →</a>
           </div>
           <div data-tour="roster-athlete-rows">
             {% for a in athletes %}

--- a/app/store_project/templates/meso/template_library.html
+++ b/app/store_project/templates/meso/template_library.html
@@ -1,0 +1,75 @@
+{% extends "meso/_meso_base.html" %}
+
+{% block title %}Templates · Meso{% endblock %}
+
+{% block content %}
+  <div class="meso-page">
+    <div class="meso-pagehead">
+      <div>
+        <p class="meso-eyebrow">Coach workspace</p>
+        <h1 class="meso-h1">Templates</h1>
+        <p class="meso-sub">Reusable programs you own. Open one in the designer, start a live copy for a client, or deliver a copy to several at once.</p>
+      </div>
+      <div class="meso-spacer"></div>
+      <a class="meso-btn meso-btn--ghost" href="{% url 'meso:roster' %}">← Back to roster</a>
+    </div>
+
+    <div style="display:flex;flex-direction:column;gap:18px;max-width:640px;">
+
+      {% if not templates %}
+        <div class="meso-card meso-card--pad">
+          <p class="meso-sub" style="margin:0;">No templates yet. Import a program library with the <code>meso_import_template</code> management command.</p>
+        </div>
+      {% else %}
+        <div class="meso-card">
+          <div style="display:flex;align-items:center;gap:10px;padding:13px 16px;border-bottom:1px solid var(--line-2);">
+            <p class="meso-eyebrow" style="margin:0;">Your templates</p>
+            <div class="meso-spacer"></div>
+            <span class="meso-row-meta">{{ templates|length }} template{{ templates|length|pluralize }}</span>
+          </div>
+          {% for t in templates %}
+            <div class="meso-row" style="cursor:default;align-items:flex-start;flex-wrap:wrap;gap:10px;">
+              <div style="min-width:0;flex:1;">
+                <div class="meso-row-name">
+                  <a href="{% url 'meso:designer_plan' plan_id=t.pk %}" style="text-decoration:none;color:inherit;">{{ t.title }}</a>
+                </div>
+                <div class="meso-row-meta">{{ t.block_count }} block{{ t.block_count|pluralize }} · {{ t.week_count }} week{{ t.week_count|pluralize }}</div>
+              </div>
+              {% if clients %}
+                <div style="display:flex;flex-direction:column;gap:8px;align-items:flex-end;">
+                  <!-- Start for client (working copy): one live, undelivered plan. -->
+                  <form method="post" action="{% url 'meso:template_use' plan_id=t.pk %}" style="margin:0;display:flex;gap:6px;align-items:center;">
+                    {% csrf_token %}
+                    <select name="relationship" aria-label="Client">
+                      {% for c in clients %}
+                        <option value="{{ c.id }}">{{ c.name }}</option>
+                      {% endfor %}
+                    </select>
+                    <button type="submit" class="meso-btn meso-btn--ghost" style="padding:5px 10px;font-size:12px;">Start for client</button>
+                  </form>
+                  <!-- Batch deliver: a delivered copy per picked client (2c). -->
+                  <details style="margin:0;">
+                    <summary class="meso-row-meta" style="cursor:pointer;color:var(--accent);">Batch deliver a copy…</summary>
+                    <form method="post" action="{% url 'meso:plan_batch_deliver' plan_id=t.pk %}" style="margin:8px 0 0;">
+                      {% csrf_token %}
+                      <div style="display:flex;flex-direction:column;gap:6px;margin-bottom:8px;">
+                        {% for c in clients %}
+                          <label style="display:flex;align-items:center;gap:8px;font-size:13px;cursor:pointer;">
+                            <input type="checkbox" name="relationships" value="{{ c.id }}">
+                            <span>{{ c.name }}</span>
+                          </label>
+                        {% endfor %}
+                      </div>
+                      <button type="submit" class="meso-btn" style="padding:5px 10px;font-size:12px;">Deliver copies</button>
+                    </form>
+                  </details>
+                </div>
+              {% endif %}
+            </div>
+          {% endfor %}
+        </div>
+      {% endif %}
+
+    </div>
+  </div>
+{% endblock %}

--- a/docs/meso/spreadsheet-parity-plan.md
+++ b/docs/meso/spreadsheet-parity-plan.md
@@ -1,6 +1,6 @@
 # Meso — spreadsheet parity by simplification
 
-**Status:** Phase 3 built 2026-07-17 (import + validate) · Phase 2 COMPLETE (2e UI cleanup built 2026-07-16) · 2d built 2026-07-16 · 2c built 2026-07-16 · 2b built 2026-07-16 · 2a built 2026-07-16 · started 2026-07-16 · next: iterate on template UX gaps / Later-phase extensions
+**Status:** 3b built 2026-07-17 (template library UI) · Phase 3 built 2026-07-17 (import + validate) · Phase 2 COMPLETE (2e UI cleanup built 2026-07-16) · 2d built 2026-07-16 · 2c built 2026-07-16 · 2b built 2026-07-16 · 2a built 2026-07-16 · started 2026-07-16 · next: Later-phase extensions (tracking → PRs → agent)
 **Owner:** Lance
 **North star:** make writing a program in Meso as fast and frictionless as writing it
 in a Google Sheet — keyboard-driven, freeform, one grid — then extend to tracking,
@@ -421,8 +421,21 @@ tempo-heavy, DUP, conjugate, EMOM/AMRAP). The risks and mitigations:
    (`docs/meso/fixtures/templates/{101,102,103,402,601}.xlsx`, now all
    committed): 7 days each; 22/22/22/19/13 exercises; 96/100/100/72/40
    cells; every skip accounted for (banner + date rows + footer).
-   Deferred: a template-library UI and a "new from template" button — the
-   designer URL + batch-deliver endpoint are the only doors for now.
+   ~~Deferred: a template-library UI and a "new from template" button — the
+   designer URL + batch-deliver endpoint are the only doors for now.~~
+   **3b — template library UI ✅ Built 2026-07-17** (branch
+   `meso/3b-template-library-ui`): `/meso/templates/` (`TemplateLibraryView`,
+   login-gated, "Templates" link on the roster) lists the coach's owned
+   templates alphabetically — each opens in the designer and, when the coach
+   has active clients, offers **"Start for client"** (`template_use`, POST-only:
+   deep-copies via `duplicate_for` into a live ACTIVE *undelivered* working
+   plan — no snapshot, no nudge; batch-deliver stays the notify door — then
+   lands in the copy's designer) and **batch deliver** (the 2c endpoint;
+   a template source now redirects back to the library). Billing (D6):
+   suspended relationships are excluded as copy targets at both endpoints,
+   and `can_edit_plan` exempts templates from the coarse coach-wide freeze —
+   templates hold no seat; billing bites at the copy targets (both Codex
+   review findings).
 4. **Later — Extensions.** Tracking (already `LoggedSet`), data retention (snapshots),
    **personal records** (parse layer + prescribed-vs-performed), then the **agent**
    as the main feature, grounded on the parse layer + the FAQ heuristics.


### PR DESCRIPTION
## Summary

Builds the UI door that Phase 3 (#473) deferred: the coach-facing **template library** and **"new from template"** flow (parity plan §3.4).

- **`/meso/templates/`** (`TemplateLibraryView`, login-gated, linked from the roster next to "Past athletes"): lists the coach's owned templates alphabetically with block/week counts; each opens in the existing designer grid.
- **"Start for client"** (`template_use`, POST-only): deep-copies the template via `Plan.duplicate_for` into a live, ACTIVE, **undelivered** working plan for one picked client, then lands in the copy's designer. No `WeekDelivery` snapshot, no notification — batch-deliver remains the notify door.
- **Batch deliver from a template**: reuses the 2c `plan_batch_deliver` endpoint from the library (checkbox picker per template); a template source now redirects back to the library instead of bouncing off the deliver screen.
- **Billing (D6) hardening from Codex review round 1:**
  - `template_use` excludes soft-suspended relationships as copy targets (forged POSTs can't start a plan for a frozen client).
  - `can_edit_plan` exempts `is_template` plans from the coarse coach-wide freeze — templates hold no seat; billing bites at the copy targets (both copy endpoints exclude suspended targets). Over-limit coaches keep editing their own library.

Developed red/green: spec tests first (`test_template_library.py`, 21 tests), then implementation; the D6 fixes got their own red/green pair. **Codex review: round 1 CHANGES REQUESTED (the two billing gates) → fixed → round 2 APPROVED.**

No migrations. No frontend-island changes (server-rendered page reusing existing meso CSS).

## Test plan

- [x] `test_template_library.py` — 21 tests: library listing/scoping/ordering/empty state, roster link, per-template forms, `template_use` copy semantics (deep copy, undelivered, unnotified, redirect) + scoping negatives (405/404/foreign/garbage), template batch-deliver redirect, D6 suspension gates (suspended pick creates nothing; over-limit coach delivers only to kept clients; `can_edit_plan` template exemption)
- [x] Full suite: 2204 passed (`uv run pytest app`)
- [x] `ruff` + pre-commit clean