### PR TITLE
feat(meso): 4b — personal records derivation (best e1RM + provenance + new-PR detection)

### DIFF
--- a/app/store_project/meso/personal_records.py
+++ b/app/store_project/meso/personal_records.py
@@ -1,0 +1,214 @@
+"""Personal records — derive-on-read best e1RM *with provenance*, and new-PR detection.
+
+Parity plan §6 ("Later — Extensions" → personal records). The athlete's estimated
+1RM per lift already exists (``AthleteOneRm`` + ``one_rm.derive_one_rm_values``);
+this slice adds the two things that make a *record* rather than a bare number:
+
+- **provenance** — which logged set, on which date, achieved the best;
+- **new-PR detection** — did a just-logged session beat the athlete's prior best.
+
+Both ride on the same structured performed record, ``LoggedSet`` — never parsed
+free text — and reuse the pinned Epley math verbatim (``one_rm.epley_one_rm``) and
+the hybrid B4 lift identity (``serializers._exercise_key`` via
+``one_rm.key_str``). The scan is DONE-only and unit-scoped exactly as
+``derive_one_rm_values`` (a bare logged load is denominated in its plan's unit, so
+kg and lb sets for one lift must never pool).
+
+Nothing is persisted (no ``PersonalRecord`` table — that is a deliberate later
+slice) and ``new_records_in`` has no side effects (no writes, no ``PlanAction``).
+
+**Seam.** The best-per-lift computation consumes an *iterable of normalized
+performed sets* (:class:`_PerformedSet` tuples: key, name, unit, reps, load,
+e1rm, provenance) via :func:`_best_per_lift`; the ``LoggedSet`` query only feeds
+that helper (:func:`_performed_sets`). A future free-text/parsed performance feed
+can drive the SAME computation by yielding the same tuples — no rework here.
+"""
+
+from dataclasses import dataclass
+from datetime import date as date_cls
+
+from . import models
+from .one_rm import epley_one_rm
+from .one_rm import key_str
+
+
+@dataclass(frozen=True)
+class _PerformedSet:
+    """One normalized performed set — the seam's input tuple.
+
+    Unit-agnostic to its source: a ``LoggedSet`` produces it today, a parsed
+    free-text feed could produce it tomorrow, and :func:`_best_per_lift` treats
+    them identically. ``e1rm`` is whatever :func:`one_rm.epley_one_rm` returned
+    (never re-derived here), so the winning set's estimate is exactly the pinned
+    Epley value the client and server agree on.
+    """
+
+    key: str
+    name: str
+    unit: str
+    reps: str
+    load: str
+    e1rm: float
+    logged_set_id: int
+    session_log_id: int
+    date: date_cls | None
+
+
+@dataclass(frozen=True)
+class PersonalRecord:
+    """The best e1RM for one lift, with the provenance that produced it."""
+
+    key: str
+    name: str
+    unit: str
+    e1rm: float
+    reps: str
+    load: str
+    date: date_cls | None
+    logged_set_id: int
+    session_log_id: int
+
+
+@dataclass(frozen=True)
+class NewRecord:
+    """A lift in a just-logged session that beat the athlete's prior best."""
+
+    key: str
+    name: str
+    unit: str
+    value: float
+    previous: float | None
+    reps: str
+    load: str
+    logged_set_id: int
+
+
+def _completed_logged_sets(athlete, *, unit):
+    """The athlete's DONE, prescription-linked logged sets, scoped to ``unit``.
+
+    Mirrors ``one_rm.derive_one_rm_values``'s query: a pending "Save progress"
+    draft is not a finished performance, and a bare logged load is denominated in
+    its plan's unit — pooling kg and lb sets for one lift would be unit-confused.
+    """
+    return models.LoggedSet.objects.filter(
+        session_log__athlete=athlete,
+        session_log__status=models.SessionLog.Status.DONE,
+        session_log__session__week__mesocycle__plan__unit=unit,
+        prescription__isnull=False,
+    ).select_related("prescription__exercise_slot", "session_log")
+
+
+def _performed_sets(logged_sets, *, unit):
+    """Normalize a ``LoggedSet`` iterable into :class:`_PerformedSet` tuples.
+
+    The bridge from the stored record to the seam: identity via
+    ``one_rm.key_str`` (``serializers._exercise_key``), estimate via
+    ``one_rm.epley_one_rm``. A set whose load/reps aren't a usable number ("BW",
+    "AMRAP", "") yields ``None`` from Epley and is dropped (never a crash).
+    """
+    for ls in logged_sets:
+        est = epley_one_rm(ls.load, ls.reps)
+        if est is None:
+            continue
+        yield _PerformedSet(
+            key=key_str(ls.prescription.exercise_id, ls.prescription.name),
+            name=ls.prescription.name,
+            unit=unit,
+            reps=ls.reps,
+            load=ls.load,
+            e1rm=est,
+            logged_set_id=ls.id,
+            session_log_id=ls.session_log_id,
+            date=ls.session_log.date,
+        )
+
+
+def _best_per_lift(performed):
+    """Best (max e1RM) :class:`PersonalRecord` per lift identity — the seam.
+
+    Consumes any iterable of :class:`_PerformedSet`; ties keep the first-seen set
+    (a strict ``>`` never displaces an equal earlier best). This is the whole
+    computation both public functions share.
+    """
+    best: dict[str, PersonalRecord] = {}
+    for ps in performed:
+        current = best.get(ps.key)
+        if current is None or ps.e1rm > current.e1rm:
+            best[ps.key] = PersonalRecord(
+                key=ps.key,
+                name=ps.name,
+                unit=ps.unit,
+                e1rm=ps.e1rm,
+                reps=ps.reps,
+                load=ps.load,
+                date=ps.date,
+                logged_set_id=ps.logged_set_id,
+                session_log_id=ps.session_log_id,
+            )
+    return best
+
+
+def _session_unit(session_log):
+    """The unit a session's logged loads are denominated in (its plan's)."""
+    return session_log.session.week.mesocycle.plan.unit
+
+
+def personal_records(athlete, *, unit):
+    """Best e1RM per lift for ``athlete`` in ``unit``, keyed by B4 identity.
+
+    Derive-on-read (nothing persisted): ``{key: PersonalRecord}`` over the
+    athlete's DONE, same-unit logged sets, each record carrying the display name,
+    best Epley e1RM (the raw ``epley_one_rm`` value), the winning reps/load
+    strings, the date, and the source ``LoggedSet``/``SessionLog`` ids. A lift
+    with no usable set is absent.
+    """
+    logged_sets = _completed_logged_sets(athlete, unit=unit)
+    return _best_per_lift(_performed_sets(logged_sets, unit=unit))
+
+
+def new_records_in(session_log):
+    """Lifts in ``session_log`` that beat the athlete's prior best — pure detection.
+
+    No side effects (no writes, no ``PlanAction``): returns a list of
+    :class:`NewRecord`, one per lift in this DONE session whose best e1RM exceeds
+    the athlete's best over *all other* same-unit DONE sets. The comparison
+    excludes the session under test, so a lone first-ever log is a PR (``previous``
+    is ``None``) rather than a tie against itself; a tie or a lighter session is
+    not a PR. A pending session (not a finished performance) yields nothing.
+    """
+    if session_log.status != models.SessionLog.Status.DONE:
+        return []
+
+    unit = _session_unit(session_log)
+    this_sets = models.LoggedSet.objects.filter(
+        session_log=session_log, prescription__isnull=False
+    ).select_related("prescription__exercise_slot", "session_log")
+    this_best = _best_per_lift(_performed_sets(this_sets, unit=unit))
+    if not this_best:
+        return []
+
+    # Prior best over the athlete's OTHER same-unit DONE sets — excluding this
+    # session, so the session can't be its own prior record.
+    prior_qs = _completed_logged_sets(session_log.athlete, unit=unit).exclude(
+        session_log=session_log
+    )
+    prior_best = _best_per_lift(_performed_sets(prior_qs, unit=unit))
+
+    records = []
+    for key, record in this_best.items():
+        previous = prior_best.get(key)
+        previous_value = previous.e1rm if previous is not None else None
+        if previous_value is None or record.e1rm > previous_value:
+            records.append(
+                NewRecord(
+                    key=key,
+                    name=record.name,
+                    unit=record.unit,
+                    value=record.e1rm,
+                    previous=previous_value,
+                    reps=record.reps,
+                    load=record.load,
+                    logged_set_id=record.logged_set_id,
+                )
+            )
+    return records

--- a/app/store_project/meso/tests/test_personal_records.py
+++ b/app/store_project/meso/tests/test_personal_records.py
@@ -1,0 +1,310 @@
+"""Personal records (parity plan §6 "Later — Extensions" → PRs).
+
+The first PR slice: derive-on-read best estimated-1RM *with provenance* from the
+athlete's structured performed record (``LoggedSet``), and detect whether a
+just-logged session beat the athlete's prior best. It rides on the same DONE-only,
+unit-scoped Epley scan as ``one_rm.derive_one_rm_values`` — reusing
+``epley_one_rm`` and the ``_exercise_key`` identity — but adds (a) which logged
+set on which date produced the best, and (b) new-PR detection.
+
+These tests pin: the Epley tie, best-per-lift with provenance, lift-identity
+keying (catalog FK vs case-folded name), unit scoping, DONE-only, non-numeric
+skipping, and ``new_records_in`` true/false/tie against the best EXCLUDING the
+session under test.
+"""
+
+import datetime
+
+import pytest
+from django.utils import timezone
+
+from store_project.meso import personal_records as pr
+from store_project.meso.factories import CoachAthleteFactory
+from store_project.meso.factories import LoggedSetFactory
+from store_project.meso.factories import MesocycleFactory
+from store_project.meso.factories import PlanFactory
+from store_project.meso.factories import SessionLogFactory
+from store_project.meso.factories import WeekFactory
+from store_project.meso.models import CoachAthlete
+from store_project.meso.models import Plan
+from store_project.meso.models import SessionLog
+from store_project.meso.models import Unit
+from store_project.meso.one_rm import epley_one_rm
+from store_project.users.factories import UserFactory
+
+from ._helpers import day
+from ._helpers import presc as build_presc
+
+pytestmark = pytest.mark.django_db
+
+
+# -- fixtures / helpers (mirror test_one_rm.py) ----------------------------
+
+
+def make_session(athlete, *, coach=None, unit=Unit.KILOGRAMS, prescriptions=()):
+    """A delivered-shape plan → week → session with the given prescription specs."""
+    coach = coach or UserFactory()
+    rel = CoachAthleteFactory(
+        coach=coach, athlete=athlete, status=CoachAthlete.Status.ACTIVE
+    )
+    plan = PlanFactory(relationship=rel, status=Plan.Status.ACTIVE, unit=unit)
+    meso = MesocycleFactory(plan=plan, name="Block", order=0)
+    week = WeekFactory(
+        mesocycle=meso, index=1, is_current=True, delivered_at=timezone.now()
+    )
+    session = day(week, day_number=1, name="Lower")
+    presc = [
+        build_presc(session, order=i, **spec) for i, spec in enumerate(prescriptions)
+    ]
+    return plan, session, presc
+
+
+def log_session(athlete, session, rows, *, status=SessionLog.Status.DONE, date=None):
+    """A ``SessionLog`` + ``LoggedSet`` rows. ``rows``: (presc, set_no, reps, load, rpe)."""
+    log = SessionLogFactory(
+        session=session,
+        athlete=athlete,
+        status=status,
+        date=date or timezone.localdate(),
+    )
+    for presc, set_number, reps, load, rpe in rows:
+        LoggedSetFactory(
+            session_log=log,
+            prescription=presc,
+            set_number=set_number,
+            reps=reps,
+            load=load,
+            rpe=rpe,
+        )
+    return log
+
+
+# -- personal_records: best-e1RM-per-lift with provenance ------------------
+
+
+class TestPersonalRecords:
+    def test_single_rep_e1rm_is_the_load(self):
+        athlete = UserFactory()
+        _, session, (squat,) = make_session(
+            athlete, prescriptions=[{"name": "Back Squat"}]
+        )
+        log_session(athlete, session, [(squat, 1, "1", "140", "9")])
+        records = pr.personal_records(athlete, unit=Unit.KILOGRAMS)
+        record = records["name:back squat"]
+        assert record.e1rm == epley_one_rm("140", "1")
+        assert record.e1rm == 140
+
+    def test_best_per_lift_carries_provenance(self):
+        athlete = UserFactory()
+        _, session, (squat,) = make_session(
+            athlete, prescriptions=[{"name": "Back Squat"}]
+        )
+        # 5×100 → 116.67 (loser); 3×110 → 121 (winner).
+        log_session(
+            athlete,
+            session,
+            [(squat, 1, "5", "100", "8")],
+            date=datetime.date(2026, 1, 1),
+        )
+        best_log = log_session(
+            athlete,
+            session,
+            [(squat, 1, "3", "110", "9")],
+            date=datetime.date(2026, 1, 2),
+        )
+        winning_set = best_log.sets.get()
+        record = pr.personal_records(athlete, unit=Unit.KILOGRAMS)["name:back squat"]
+        assert record.e1rm == epley_one_rm("110", "3")
+        assert record.reps == "3"
+        assert record.load == "110"
+        assert record.date == datetime.date(2026, 1, 2)
+        assert record.logged_set_id == winning_set.id
+        assert record.session_log_id == best_log.id
+        assert record.unit == Unit.KILOGRAMS
+        assert record.name == "Back Squat"
+
+    def test_catalog_and_free_text_keys(self):
+        from store_project.exercises.factories import ExerciseFactory
+
+        athlete = UserFactory()
+        ex = ExerciseFactory()
+        _, session, (linked, free) = make_session(
+            athlete,
+            prescriptions=[
+                {"name": "Whatever", "exercise": ex},
+                {"name": "Back Squat"},
+            ],
+        )
+        log_session(
+            athlete,
+            session,
+            [(linked, 1, "1", "100", "9"), (free, 1, "1", "150", "9")],
+        )
+        records = pr.personal_records(athlete, unit=Unit.KILOGRAMS)
+        assert set(records) == {f"id:{ex.pk}", "name:back squat"}
+        assert records[f"id:{ex.pk}"].e1rm == 100
+        assert records["name:back squat"].e1rm == 150
+
+    def test_two_slots_same_name_collapse_to_one_pr(self):
+        athlete = UserFactory()
+        _, session, (a, b) = make_session(
+            athlete,
+            prescriptions=[{"name": "Back Squat"}, {"name": "back squat"}],
+        )
+        log_session(
+            athlete,
+            session,
+            [(a, 1, "1", "120", "9"), (b, 1, "1", "150", "9")],
+        )
+        records = pr.personal_records(athlete, unit=Unit.KILOGRAMS)
+        assert list(records) == ["name:back squat"]
+        assert records["name:back squat"].e1rm == 150
+
+    def test_unit_scopes_the_scan(self):
+        athlete = UserFactory()
+        _, kg_session, (kg_squat,) = make_session(
+            athlete, unit=Unit.KILOGRAMS, prescriptions=[{"name": "Back Squat"}]
+        )
+        _, lb_session, (lb_squat,) = make_session(
+            athlete, unit=Unit.POUNDS, prescriptions=[{"name": "Back Squat"}]
+        )
+        log_session(athlete, kg_session, [(kg_squat, 1, "1", "150", "9")])
+        log_session(athlete, lb_session, [(lb_squat, 1, "1", "300", "9")])
+        kg = pr.personal_records(athlete, unit=Unit.KILOGRAMS)
+        lb = pr.personal_records(athlete, unit=Unit.POUNDS)
+        assert kg["name:back squat"].e1rm == 150
+        assert lb["name:back squat"].e1rm == 300
+
+    def test_pending_log_is_ignored(self):
+        athlete = UserFactory()
+        _, session, (squat,) = make_session(
+            athlete, prescriptions=[{"name": "Back Squat"}]
+        )
+        log_session(
+            athlete,
+            session,
+            [(squat, 1, "1", "200", "9")],
+            status=SessionLog.Status.PENDING,
+        )
+        assert pr.personal_records(athlete, unit=Unit.KILOGRAMS) == {}
+
+    def test_non_numeric_sets_are_skipped(self):
+        athlete = UserFactory()
+        _, session, (squat,) = make_session(
+            athlete, prescriptions=[{"name": "Back Squat"}]
+        )
+        log_session(athlete, session, [(squat, 1, "AMRAP", "BW", "9")])
+        log_session(athlete, session, [(squat, 2, "", "", "")])
+        assert pr.personal_records(athlete, unit=Unit.KILOGRAMS) == {}
+
+
+# -- new_records_in: detection against the best EXCLUDING this session ------
+
+
+class TestNewRecordsIn:
+    def test_first_log_of_a_lift_is_a_new_pr(self):
+        athlete = UserFactory()
+        _, session, (squat,) = make_session(
+            athlete, prescriptions=[{"name": "Back Squat"}]
+        )
+        log = log_session(athlete, session, [(squat, 1, "1", "160", "9")])
+        records = pr.new_records_in(log)
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.key == "name:back squat"
+        assert rec.name == "Back Squat"
+        assert rec.value == 160
+        assert rec.previous is None
+
+    def test_beating_the_prior_best_is_a_new_pr(self):
+        athlete = UserFactory()
+        _, session, (squat,) = make_session(
+            athlete, prescriptions=[{"name": "Back Squat"}]
+        )
+        log_session(
+            athlete,
+            session,
+            [(squat, 1, "1", "150", "9")],
+            date=datetime.date(2026, 1, 1),
+        )
+        log = log_session(
+            athlete,
+            session,
+            [(squat, 1, "1", "160", "9")],
+            date=datetime.date(2026, 1, 8),
+        )
+        records = pr.new_records_in(log)
+        assert len(records) == 1
+        assert records[0].value == 160
+        assert records[0].previous == 150
+
+    def test_tying_the_prior_best_is_not_a_new_pr(self):
+        athlete = UserFactory()
+        _, session, (squat,) = make_session(
+            athlete, prescriptions=[{"name": "Back Squat"}]
+        )
+        log_session(
+            athlete,
+            session,
+            [(squat, 1, "1", "150", "9")],
+            date=datetime.date(2026, 1, 1),
+        )
+        log = log_session(
+            athlete,
+            session,
+            [(squat, 1, "1", "150", "9")],
+            date=datetime.date(2026, 1, 8),
+        )
+        assert pr.new_records_in(log) == []
+
+    def test_losing_to_the_prior_best_is_not_a_new_pr(self):
+        athlete = UserFactory()
+        _, session, (squat,) = make_session(
+            athlete, prescriptions=[{"name": "Back Squat"}]
+        )
+        log_session(
+            athlete,
+            session,
+            [(squat, 1, "1", "150", "9")],
+            date=datetime.date(2026, 1, 1),
+        )
+        log = log_session(
+            athlete,
+            session,
+            [(squat, 1, "1", "140", "9")],
+            date=datetime.date(2026, 1, 8),
+        )
+        assert pr.new_records_in(log) == []
+
+    def test_detection_excludes_the_session_under_test(self):
+        # The session's own set must not count as its own "prior best" — a lone
+        # log is still a first-ever PR (previous None), not a tie against itself.
+        athlete = UserFactory()
+        _, session, (squat,) = make_session(
+            athlete, prescriptions=[{"name": "Back Squat"}]
+        )
+        log = log_session(athlete, session, [(squat, 1, "1", "150", "9")])
+        records = pr.new_records_in(log)
+        assert len(records) == 1
+        assert records[0].previous is None
+
+    def test_pending_session_yields_no_records(self):
+        athlete = UserFactory()
+        _, session, (squat,) = make_session(
+            athlete, prescriptions=[{"name": "Back Squat"}]
+        )
+        log = log_session(
+            athlete,
+            session,
+            [(squat, 1, "1", "160", "9")],
+            status=SessionLog.Status.PENDING,
+        )
+        assert pr.new_records_in(log) == []
+
+    def test_non_numeric_session_yields_no_records(self):
+        athlete = UserFactory()
+        _, session, (squat,) = make_session(
+            athlete, prescriptions=[{"name": "Back Squat"}]
+        )
+        log = log_session(athlete, session, [(squat, 1, "AMRAP", "BW", "9")])
+        assert pr.new_records_in(log) == []

--- a/docs/meso/decisions.md
+++ b/docs/meso/decisions.md
@@ -1520,3 +1520,35 @@ _(Append dated entries here as decisions land.)_
   folds only line 0 into the read-only `target` so the editable stack isn't
   double-displayed. Migration `0042` (additive boolean, no backfill —
   existing cells are coach-authored). Full meso suite green (1976).
+- 2026-07-17 — **Built (spreadsheet parity 4b): personal records — derivation
+  (parity plan §6, phase 4).** First slice of the parse-layer /
+  prescribed-vs-performed thread. **Decision — the performed source (the "live"
+  D4 call):** personal records ride on the **structured `LoggedSet` performed
+  record, NOT parsed free text** (Lance, 2026-07-17: keep a structured
+  representation of a logged/performed set — PRs are easier to manage off it).
+  The two athlete write-paths that coexisted since 4a — structured `LoggedSet`
+  and freeform sub-lines — are hereby role-split: `LoggedSet` is the performed
+  store PRs read; sub-lines stay as notes/annotations for now. **Decision — the
+  parse pipeline (when/into-what, previously never pinned):** free text parses
+  **at commit time into a `LoggedSet`** (not lazily on read as `parse_prescription`
+  does today), collapsing the two entry paths into one structured store — but
+  that pipeline is a deliberate *later* slice; 4b ships PRs on the already-populated
+  `LoggedSet` at zero parsing risk. The estimated-1RM number already exists
+  (`AthleteOneRm` + `one_rm.derive_one_rm_values`); 4b adds what makes a *record*:
+  **provenance** (which logged set/date achieved the best) and **new-PR
+  detection**. New pure module `personal_records.py` (derive-on-read, nothing
+  persisted — a `PersonalRecord` table is a later slice): `personal_records(
+  athlete, *, unit)` → best e1RM per lift with provenance;
+  `new_records_in(session_log)` → pure detection (no writes, no `PlanAction`) vs
+  the prior best **excluding the session under test** (first-ever log = a PR, not
+  a self-tie). Reuses `one_rm.epley_one_rm` verbatim + the B4 identity
+  (`one_rm.key_str` → `serializers._exercise_key`); DONE-only, unit-scoped exactly
+  as `derive_one_rm_values`. **Seam** (`_best_per_lift` over normalized
+  `_PerformedSet` tuples; `_performed_sets` the sole `LoggedSet`→tuple bridge) so
+  the future parse-at-commit feed drives the same computation with no rework.
+  Backend-only, no UI (the PR surface is the next slice), no migration (stays
+  `0042`). 14 pinned tests (Epley tie, provenance, identity keying, unit scoping,
+  DONE-only, non-numeric skipped, new-PR true/false/tie/exclude-self). Full meso
+  suite green (1991). Athlete session viewer judged good as-is; the **program
+  designer needs a separate UX-cleanup pass** (overloaded layout + an unnecessary
+  current-week selector) — handed to its own session.

--- a/docs/meso/spreadsheet-parity-plan.md
+++ b/docs/meso/spreadsheet-parity-plan.md
@@ -1,6 +1,6 @@
 # Meso — spreadsheet parity by simplification
 
-**Status:** 4a built 2026-07-17 (athlete tracking — sub-lines) · 3b built 2026-07-17 (template library UI) · Phase 3 built 2026-07-17 (import + validate) · Phase 2 COMPLETE (2e UI cleanup built 2026-07-16) · 2d built 2026-07-16 · 2c built 2026-07-16 · 2b built 2026-07-16 · 2a built 2026-07-16 · started 2026-07-16 · next: Later-phase extensions (PRs → agent)
+**Status:** 4b built 2026-07-17 (personal records — derivation) · 4a built 2026-07-17 (athlete tracking — sub-lines) · 3b built 2026-07-17 (template library UI) · Phase 3 built 2026-07-17 (import + validate) · Phase 2 COMPLETE (2e UI cleanup built 2026-07-16) · 2d built 2026-07-16 · 2c built 2026-07-16 · 2b built 2026-07-16 · 2a built 2026-07-16 · started 2026-07-16 · next: PR surface (athlete/coach) + parse-at-commit pipeline → agent
 **Owner:** Lance
 **North star:** make writing a program in Meso as fast and frictionless as writing it
 in a Google Sheet — keyboard-driven, freeform, one grid — then extend to tracking,
@@ -458,6 +458,29 @@ tempo-heavy, DUP, conjugate, EMOM/AMRAP). The risks and mitigations:
    it (flips the flag back to `False`), folding it into coach history again.
    Presenter threads `sub_lines` + `cell_url`; `target` folds line 0 only so
    the now-editable stack isn't double-displayed. Migration `0042`.
+   **4b — Personal records (derivation) ✅ Built 2026-07-17** (branch
+   `meso/4b-personal-records`): the parse-layer / prescribed-vs-performed thread
+   starts with the **source decision settled** — personal records ride on the
+   **structured `LoggedSet` performed record, not parsed free text** (Lance,
+   2026-07-17: "keep a structured representation of a logged/performed set; PRs
+   are easier off it"). The estimated-1RM *number* already exists
+   (`AthleteOneRm` + `one_rm.derive_one_rm_values`); this backend-only slice adds
+   the two things that make a *record* rather than a bare number. New pure module
+   `personal_records.py` (derive-on-read, nothing persisted — a `PersonalRecord`
+   table is a deliberate later slice): `personal_records(athlete, *, unit)` →
+   best Epley e1RM per lift **with provenance** (winning `LoggedSet` id, date,
+   reps/load), and `new_records_in(session_log)` → **pure detection** (no writes,
+   no `PlanAction`) of lifts in a just-logged session that beat the athlete's
+   prior best, compared against the best **excluding the session under test** (so
+   a first-ever log is a PR, not a tie against itself). Reuses the pinned
+   `one_rm.epley_one_rm` verbatim and the B4 identity (`one_rm.key_str` →
+   `serializers._exercise_key`); the scan is DONE-only and unit-scoped exactly as
+   `derive_one_rm_values`. **Seam:** `_best_per_lift` consumes normalized
+   `_PerformedSet` tuples and `_performed_sets` is the only `LoggedSet`→tuple
+   bridge, so a future **parse-at-commit** feed (free text → structured set at
+   write time — the agreed model, D4-live below) can drive the same computation
+   with no rework. 14 pinned tests; no migration (stays `0042`); no UI (the PR
+   surface is the next slice). Full meso suite green (1991).
 
 ---
 
@@ -475,7 +498,14 @@ as a separate sub-row (below).
   the RPE row is just line 1, and further cue/note lines are allowed — nothing is
   special-cased. **Arbitrary sub-lines CONFIRMED (2026-07-16):** any number of freeform
   lines may sit beneath an exercise, not locked to RPE.
-- **D4 — Prescription vs performed → CONFIRMED defer** the split to the PR phase.
+- **D4 — Prescription vs performed → RESOLVED (2026-07-17, the "live" call).**
+  Deferred at design time; settled when the PR phase started. Performed data
+  lives in a **structured record (`LoggedSet`)**, and personal records derive
+  from it — *not* from parsed free text (Lance: keep a structured logged/performed
+  set; PRs are easier off it). The freeform sub-lines (4a) stay as notes for now.
+  The agreed convergence: free text is an *input* that **parses at commit time
+  into a `LoggedSet`** (not lazily on read), collapsing the two entry paths into
+  one structured store — its own later slice; 4b already leaves the seam for it.
 - **D5 — `%1RM` / `AthleteOneRm` → CONFIRMED defer.**
 - **D6 — Deliver → CONFIRMED** live-edits + one-time notify; keep `WeekDelivery`
   snapshots for history/retention (not as a gate).


### PR DESCRIPTION
First **personal-records** slice (spreadsheet-parity plan §6 "Later — Extensions"). Backend-only, derive-on-read, two new files + docs. No migration, no model/view/UI changes.

## What & why
The athlete's estimated 1RM *number* already exists (`AthleteOneRm` + `one_rm.derive_one_rm_values`). This slice adds the two things that make a *record* rather than a bare number:

- **`personal_records(athlete, *, unit)`** — best Epley e1RM per lift **with provenance** (winning `LoggedSet` id, date, reps/load).
- **`new_records_in(session_log)`** — **pure detection** (no writes, no `PlanAction`) of lifts in a just-logged session that beat the athlete's prior best, compared against the best **excluding the session under test** (so a first-ever log is a PR, not a self-tie).

## Source decision (settled with Lance)
Personal records ride on the **structured `LoggedSet` performed record — not parsed free text**. The freeform sub-lines from 4a stay as notes for now. The agreed convergence (its own later slice): free text **parses at commit time into a `LoggedSet`**; 4b already leaves the seam for it. Resolves the "live" D4 in the plan doc.

## Design
- Reuses the pinned `one_rm.epley_one_rm` **verbatim** and the B4 lift identity (`one_rm.key_str` → `serializers._exercise_key`).
- DONE-only, unit-scoped scan, exactly mirroring `derive_one_rm_values` (kg and lb sets never pool).
- **Seam:** `_best_per_lift` consumes normalized `_PerformedSet` tuples; `_performed_sets` is the only `LoggedSet`→tuple bridge — a future parse-at-commit feed drives the same computation with no rework.
- Nothing persisted (a `PersonalRecord` table is a deliberate later slice).

## Tests
14 pinned tests in `test_personal_records.py`: Epley tie, best-per-lift provenance, catalog-vs-free-text identity keying, same-name collapse, unit scoping, DONE-only, non-numeric skipping, and `new_records_in` true/false/tie/first-ever/exclude-self.

## Verification
- New tests: 14 passed. Full meso suite: **1991 passed**.
- `ruff check` + `ruff format`: clean.
- **Codex review loop: CLEAN** (0 blocking, 0 nits, first pass).

## Not in this slice (deferred)
PR surface (athlete home "recent PRs" / "new PR!" at log time / coach view), the parse-at-commit pipeline, and any persisted PR table. The **program designer UX cleanup** (overloaded layout + unnecessary current-week selector) is handed to a separate session.

https://claude.ai/code/session_01A8DArT3796Cf1zx7tnipps