### PR TITLE
feat(meso): 4c — PR event surface (athlete toast + coach results marker)

### DIFF
--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -30,7 +30,9 @@ from .models import SessionLog
 from .models import TourEvent
 from .models import Week
 from .models import WeekDelivery
+from .one_rm import key_str
 from .one_rm import one_rm_values
+from .personal_records import new_records_in
 from .serializers import _fmt_num
 from .serializers import _num
 from .serializers import _phase_states
@@ -40,6 +42,7 @@ from .serializers import diff_week_snapshots
 from .serializers import initials
 from .serializers import serialize_mesocycle
 from .serializers import serialize_mesocycle_grid
+from .serializers import serialize_new_record
 from .serializers import serialize_prescription
 from .serializers import serialize_proposed_change
 from .serializers import serialize_week_snapshot
@@ -824,6 +827,16 @@ def session_results(session):
     ]
     rows = [row for row, _ in results]
 
+    # New personal records (Phase 4c): lifts in this logged session that beat the
+    # athlete's prior best e1RM — DONE-only, so a pending draft or unlogged session
+    # yields none. Flag the matching row (by the same B4 lift identity the engine
+    # keys on) so the coach sees which lift PR'd, and hand the list to the summary
+    # for the celebration callout.
+    new_records = new_records_in(log) if log is not None else []
+    pr_keys = {r.key for r in new_records}
+    for row, p in zip(rows, prescriptions):
+        row["pr"] = key_str(p.exercise_id, p.name) in pr_keys
+
     # Completion = logged sets / prescribed sets. A free-form set cell ("AMRAP",
     # "3-4") has no integer target, so fall back to what was logged for that row
     # — it neither divides by zero nor skews the ratio with an empty denominator.
@@ -863,6 +876,7 @@ def session_results(session):
             "flag": flag,
             "flag_count": len(flagged),
             "logged_state": log is not None,
+            "new_records": [serialize_new_record(r) for r in new_records],
         },
     }
 

--- a/app/store_project/meso/serializers.py
+++ b/app/store_project/meso/serializers.py
@@ -454,6 +454,29 @@ def serialize_session_log(log):
     }
 
 
+def serialize_new_record(record):
+    """A ``personal_records.NewRecord`` as the display dict the PR surface reads.
+
+    Formats the raw Epley e1RM floats into number strings the client renders
+    verbatim — so it never re-rounds and can't disagree with the pinned server
+    value — rounded to the 2-decimal convention the stored ``AthleteOneRm``
+    display already uses (``_fmt_num`` trims a trailing ``.0``). ``is_first`` is a
+    first-ever lift (no prior best to beat); ``delta`` is the gain over the
+    previous best, absent on a first PR.
+    """
+    value = round(record.value, 2)
+    previous = round(record.previous, 2) if record.previous is not None else None
+    return {
+        "key": record.key,
+        "name": record.name,
+        "unit": record.unit,
+        "value": _fmt_num(value),
+        "previous": _fmt_num(previous) if previous is not None else None,
+        "delta": _fmt_num(round(value - previous, 2)) if previous is not None else None,
+        "is_first": record.previous is None,
+    }
+
+
 def serialize_recent_logs(plan, *, limit=5, sets_cap=24):
     """A compact summary of the athlete's most recent logged sessions on this plan.
 

--- a/app/store_project/meso/tests/test_pr_surface.py
+++ b/app/store_project/meso/tests/test_pr_surface.py
@@ -1,0 +1,261 @@
+"""Phase 4c — the PR (personal-records) *event* surface.
+
+The derive-on-read engine (``personal_records``) shipped in 4b with no UI. This
+slice surfaces its ``new_records_in`` detector at the two moments a new best
+matters:
+
+- **athlete** — ``athlete_log_session`` returns ``new_records`` for a just-logged
+  session, so the logger can celebrate a PR the instant it's logged;
+- **coach** — ``session_results`` surfaces the same PRs for the session, both as a
+  ``summary["new_records"]`` list and a per-row ``pr`` flag.
+
+Both read the structured ``LoggedSet`` performed record (D4), reuse the pinned
+Epley e1RM, and are DONE-only: a pending "Save progress" draft is not a finished
+performance and yields no PR. The engine's own edge cases (tie, exclude-self,
+identity, unit scoping) are pinned in ``test_personal_records.py``; here we pin
+the *surface* — that each host wires the detector in and formats it.
+
+The e1RM math is exact for the loads chosen: Epley is ``load * (1 + reps/30)``,
+so reps=5 gives ``load * 7/6`` — 120→140, 150→175 — whole numbers that pin the
+formatted labels without float noise.
+"""
+
+import json
+from datetime import date
+from types import SimpleNamespace
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+
+from store_project.meso.factories import CoachAthleteFactory
+from store_project.meso.factories import LoggedSetFactory
+from store_project.meso.factories import MesocycleFactory
+from store_project.meso.factories import PlanFactory
+from store_project.meso.factories import SessionLogFactory
+from store_project.meso.factories import WeekFactory
+from store_project.meso.models import Plan
+from store_project.meso.models import SessionLog
+from store_project.meso.presenters import session_results
+from store_project.users.factories import UserFactory
+
+from ._helpers import day
+from ._helpers import presc as make_presc
+
+pytestmark = pytest.mark.django_db
+
+
+def seed(*, coach=None, athlete=None):
+    """A coach's owned, delivered session with two prescriptions (no log yet)."""
+    coach = coach or UserFactory()
+    athlete = athlete or UserFactory(name="Maya Okonkwo")
+    rel = CoachAthleteFactory(coach=coach, athlete=athlete)
+    plan = PlanFactory(
+        relationship=rel, title="Hypertrophy Block", status=Plan.Status.ACTIVE
+    )
+    meso = MesocycleFactory(plan=plan, name="Hypertrophy", order=0)
+    week = WeekFactory(
+        mesocycle=meso, index=2, is_current=True, delivered_at=timezone.now()
+    )
+    session = day(week, day_number=1, name="Lower")
+    squat = make_presc(
+        session, name="Box Squat", order=0, sets="3", reps="6", load="70", rpe="7"
+    )
+    rdl = make_presc(
+        session, name="RDL", order=1, sets="3", reps="8", load="80", rpe="8"
+    )
+    return SimpleNamespace(
+        coach=coach,
+        athlete=athlete,
+        rel=rel,
+        plan=plan,
+        meso=meso,
+        week=week,
+        session=session,
+        squat=squat,
+        rdl=rdl,
+    )
+
+
+def log_url(session):
+    return reverse("meso:athlete_log_session", kwargs={"pk": session.pk})
+
+
+def post_log(client, session, payload):
+    return client.post(
+        log_url(session), data=json.dumps(payload), content_type="application/json"
+    )
+
+
+def results_url(session):
+    return reverse("meso:results_session", kwargs={"session_id": session.pk})
+
+
+def log_done(
+    session, athlete, prescription, sets, *, status=SessionLog.Status.DONE, when=None
+):
+    """A ``SessionLog`` (DONE by default) with ``(reps, load, rpe)`` tuples."""
+    sl = SessionLogFactory(
+        session=session, athlete=athlete, status=status, date=when or date(2026, 6, 24)
+    )
+    for n, (reps, load, rpe) in enumerate(sets, start=1):
+        LoggedSetFactory(
+            session_log=sl,
+            prescription=prescription,
+            set_number=n,
+            reps=reps,
+            load=load,
+            rpe=rpe,
+        )
+    return sl
+
+
+def squat_set(pk, reps, load, rpe="8"):
+    return {
+        "prescription": pk,
+        "set_number": 1,
+        "reps": reps,
+        "load": load,
+        "rpe": rpe,
+    }
+
+
+# -- athlete: the log endpoint returns new PRs -----------------------------
+
+
+class TestAthleteLogNewRecords:
+    def test_done_first_log_is_a_pr(self, client):
+        s = seed()
+        client.force_login(s.athlete)
+        resp = post_log(
+            client,
+            s.session,
+            {"status": "done", "sets": [squat_set(s.squat.pk, "5", "120")]},
+        )
+        assert resp.status_code == 200
+        prs = resp.json()["new_records"]
+        assert len(prs) == 1
+        pr = prs[0]
+        assert pr["name"] == "Box Squat"
+        assert pr["is_first"] is True
+        assert pr["previous"] is None
+        assert pr["value"] == "140"  # 120 * (1 + 5/30) = 140
+        assert pr["unit"] == "kg"
+
+    def test_pending_save_is_not_a_pr(self, client):
+        s = seed()
+        client.force_login(s.athlete)
+        resp = post_log(
+            client,
+            s.session,
+            {"status": "pending", "sets": [squat_set(s.squat.pk, "5", "120")]},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["new_records"] == []
+
+    def test_pr_reports_delta_over_previous_best(self, client):
+        s = seed()
+        # A lighter Box Squat already logged (done) on another day → prior best 140.
+        other = day(s.week, day_number=2, name="Upper", order=2)
+        other_squat = make_presc(other, name="Box Squat", order=0, text="")
+        log_done(
+            other, s.athlete, other_squat, [("5", "120", "8")], when=date(2026, 6, 20)
+        )
+        client.force_login(s.athlete)
+        resp = post_log(
+            client,
+            s.session,
+            {"status": "done", "sets": [squat_set(s.squat.pk, "5", "150")]},
+        )
+        prs = resp.json()["new_records"]
+        assert len(prs) == 1
+        assert prs[0]["is_first"] is False
+        assert prs[0]["previous"] == "140"
+        assert prs[0]["value"] == "175"  # 150 * 7/6
+        assert prs[0]["delta"] == "35"
+
+    def test_not_a_pr_when_prior_session_was_heavier(self, client):
+        s = seed()
+        other = day(s.week, day_number=2, name="Upper", order=2)
+        other_squat = make_presc(other, name="Box Squat", order=0, text="")
+        log_done(
+            other, s.athlete, other_squat, [("5", "150", "8")], when=date(2026, 6, 20)
+        )
+        client.force_login(s.athlete)
+        resp = post_log(
+            client,
+            s.session,
+            {"status": "done", "sets": [squat_set(s.squat.pk, "5", "120")]},
+        )
+        assert resp.json()["new_records"] == []
+
+
+# -- coach: the results screen surfaces the same PRs -----------------------
+
+
+class TestSessionResultsNewRecords:
+    def test_surfaces_pr_in_summary_and_row(self):
+        s = seed()
+        log_done(s.session, s.athlete, s.squat, [("5", "120", "8")])
+        ctx = session_results(s.session)
+        prs = ctx["summary"]["new_records"]
+        assert len(prs) == 1
+        assert prs[0]["name"] == "Box Squat"
+        assert prs[0]["value"] == "140"
+        rows = {r["name"]: r for r in ctx["rows"]}
+        assert rows["Box Squat"]["pr"] is True
+        assert rows["RDL"]["pr"] is False
+
+    def test_no_pr_when_prior_heavier(self):
+        s = seed()
+        other = day(s.week, day_number=2, name="Upper", order=2)
+        other_squat = make_presc(other, name="Box Squat", order=0, text="")
+        log_done(
+            other, s.athlete, other_squat, [("5", "150", "8")], when=date(2026, 6, 20)
+        )
+        log_done(
+            s.session, s.athlete, s.squat, [("5", "120", "8")], when=date(2026, 6, 24)
+        )
+        ctx = session_results(s.session)
+        assert ctx["summary"]["new_records"] == []
+        rows = {r["name"]: r for r in ctx["rows"]}
+        assert rows["Box Squat"]["pr"] is False
+
+    def test_unlogged_session_has_no_prs(self):
+        s = seed()  # no log
+        ctx = session_results(s.session)
+        assert ctx["summary"]["new_records"] == []
+        rows = {r["name"]: r for r in ctx["rows"]}
+        assert rows["Box Squat"]["pr"] is False
+
+    def test_pending_draft_has_no_prs(self):
+        s = seed()
+        log_done(
+            s.session,
+            s.athlete,
+            s.squat,
+            [("5", "120", "8")],
+            status=SessionLog.Status.PENDING,
+        )
+        ctx = session_results(s.session)
+        assert ctx["summary"]["new_records"] == []
+
+
+# -- coach: the rendered results page shows the PR callout -----------------
+
+
+class TestResultsRendersNewRecords:
+    def test_owning_coach_sees_pr_callout(self, client):
+        s = seed()
+        log_done(s.session, s.athlete, s.squat, [("5", "120", "8")])
+        client.force_login(s.coach)
+        resp = client.get(results_url(s.session))
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert "New PR" in body
+
+    def test_no_callout_without_a_pr(self, client):
+        s = seed()  # unlogged
+        client.force_login(s.coach)
+        body = client.get(results_url(s.session)).content.decode()
+        assert "New PR" not in body

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -82,9 +82,11 @@ from .models import SessionLog
 from .models import SessionSlot
 from .models import Week
 from .models import WeekDelivery
+from .personal_records import new_records_in
 from .serializers import current_week
 from .serializers import serialize_chat_thread
 from .serializers import serialize_mesocycle_grid
+from .serializers import serialize_new_record
 from .serializers import serialize_plan
 from .serializers import serialize_plan_history
 from .serializers import serialize_prescription
@@ -1412,7 +1414,17 @@ def athlete_log_session(request, pk):
     # under *another* coach — never skips the step. A no-op unless parked on
     # results.
     meso_tour.advance_self_step_if_complete(request.user, "results")
-    return JsonResponse({"ok": True, "log": serialize_session_log(log)})
+    # Phase 4c: the lifts in this session that beat the athlete's prior best, so
+    # the logger can celebrate a PR the instant it's logged. Pure detection off
+    # the just-committed rows — DONE-only, so a "Save progress" draft returns [].
+    new_records = new_records_in(log)
+    return JsonResponse(
+        {
+            "ok": True,
+            "log": serialize_session_log(log),
+            "new_records": [serialize_new_record(r) for r in new_records],
+        }
+    )
 
 
 @login_required

--- a/app/store_project/static/js/meso_athlete.js
+++ b/app/store_project/static/js/meso_athlete.js
@@ -88,6 +88,7 @@ function createLogger() {
     saved: false,
     error: false,
     queued: false, // a save is stashed locally, waiting for the network
+    newRecords: [], // PRs the last save beat (Phase 4c) — the celebration toast
     _oneRmTimers: {}, // per-exercise debounce handles for the manual-1RM POST
 
     init() {
@@ -180,6 +181,13 @@ function createLogger() {
       row.done = !row.done;
     },
 
+    // One PR line for the celebration toast (Phase 4c). The server preformatted
+    // the numbers (value/delta), so this only assembles them — never re-rounds.
+    prLabel(pr) {
+      const base = pr.name + " — " + pr.value + " " + pr.unit;
+      return pr.is_first ? base + " (first best)" : base + " (+" + pr.delta + ")";
+    },
+
     // A row is worth sending if it's checked or carries any entry.
     rowFilled(r) {
       return (
@@ -222,6 +230,7 @@ function createLogger() {
       this.saved = false;
       this.error = false;
       this.queued = false;
+      this.newRecords = []; // clear any prior toast; this save recomputes it
       const payload = this.buildPayload(markDone);
       // Reflect the intended status locally right away so the UI is responsive
       // whether the request lands now or after a sync.
@@ -258,6 +267,9 @@ function createLogger() {
         const data = await res.json();
         this.status = data.log.status;
         this.syncFromLog(data.log);
+        // Any lift this (done) save beat — the server already filtered to DONE, so
+        // a "Save progress" comes back empty and shows no toast.
+        this.newRecords = data.new_records || [];
         this.saved = true;
         // Key the tour nudge off the log status the *server* persisted, not the
         // button pressed (#451): the self-variant "results" step advances on a
@@ -342,6 +354,7 @@ function createLogger() {
             const data = await res.json();
             this.status = data.log.status;
             this.syncFromLog(data.log);
+            this.newRecords = data.new_records || []; // a PR beaten offline still lands
             flushedMine = true;
           } catch (e) {
             /* synced server-side regardless; UI reconciles on next load */

--- a/app/store_project/templates/meso/athlete_session.html
+++ b/app/store_project/templates/meso/athlete_session.html
@@ -45,6 +45,26 @@
       <span class="meso-row-meta">sets logged — fill in what you did, then log the session.</span>
     </div>
 
+    <!-- New-PR celebration (Phase 4c): populated from the log response; dismissible. -->
+    <template x-if="newRecords.length">
+      <div class="meso-card meso-card--pad" x-cloak
+           style="display:flex;align-items:flex-start;gap:12px;margin-bottom:14px;border:1px solid color-mix(in srgb,var(--accent) 30%,var(--surface));background:color-mix(in srgb,var(--accent) 12%,var(--surface));">
+        <span style="font-size:20px;line-height:1.2;flex:0 0 auto;">🎉</span>
+        <div style="flex:1;min-width:0;line-height:1.45;">
+          <div style="font-size:14px;font-weight:800;letter-spacing:-0.01em;color:var(--accent-deep);">
+            New PR<span x-show="newRecords.length > 1">s</span>!
+          </div>
+          <div class="meso-row-meta meso-mono">
+            <template x-for="pr in newRecords" :key="pr.key">
+              <span style="display:block;color:var(--ink);" x-text="prLabel(pr)"></span>
+            </template>
+          </div>
+        </div>
+        <button type="button" @click="newRecords = []" aria-label="Dismiss"
+                class="meso-btn meso-btn--ghost" style="padding:4px 8px;font-size:14px;line-height:1;flex:0 0 auto;">&times;</button>
+      </div>
+    </template>
+
     {% if show_first_log_hint %}
       <!-- First-log coachmark (first-time UX Phase 4): server-driven, shown only
            to a first-ever logger; meso_onboarding.js persists a manual dismiss. -->

--- a/app/store_project/templates/meso/results.html
+++ b/app/store_project/templates/meso/results.html
@@ -51,6 +51,19 @@
       </div>
     {% endif %}
 
+    <!-- new personal records (Phase 4c) -->
+    {% if summary.new_records %}
+      <div class="meso-card meso-card--pad" style="margin-bottom:14px;display:flex;gap:11px;align-items:flex-start;background:color-mix(in srgb,var(--accent) 12%,var(--surface));border-color:color-mix(in srgb,var(--accent) 30%,var(--surface));">
+        <span style="font-size:18px;line-height:1.2;flex:0 0 auto;">🎉</span>
+        <div style="line-height:1.45;">
+          <div style="font-size:13px;font-weight:700;color:var(--accent-deep);">New PR{{ summary.new_records|length|pluralize }} this session</div>
+          <div style="font-size:12.5px;color:var(--ink);">
+            {% for pr in summary.new_records %}<span class="meso-mono">{{ pr.name }} — {{ pr.value }} {{ pr.unit }}{% if pr.is_first %} (first){% else %} (+{{ pr.delta }}){% endif %}</span>{% if not forloop.last %} · {% endif %}{% endfor %}
+          </div>
+        </div>
+      </div>
+    {% endif %}
+
     <!-- per-exercise results -->
     <div class="meso-card" data-tour="results-main">
       <div style="display:grid;grid-template-columns:minmax(0,1.5fr) minmax(0,1.3fr) minmax(0,1.1fr) 56px minmax(0,1.3fr);gap:10px;padding:9px 18px;background:var(--rail);border-bottom:1px solid var(--line-2);font-size:10px;font-weight:700;letter-spacing:0.06em;text-transform:uppercase;color:var(--dim);">
@@ -58,7 +71,7 @@
       </div>
       {% for r in rows %}
         <div style="display:grid;grid-template-columns:minmax(0,1.5fr) minmax(0,1.3fr) minmax(0,1.1fr) 56px minmax(0,1.3fr);gap:10px;padding:11px 18px;border-bottom:1px solid var(--line-2);align-items:center;">
-          <div style="font-size:13.5px;font-weight:600;letter-spacing:-0.01em;">{{ r.name }}</div>
+          <div style="font-size:13.5px;font-weight:600;letter-spacing:-0.01em;">{{ r.name }}{% if r.pr %} <span class="meso-badge meso-badge--accent" style="padding:1px 6px;font-size:9.5px;vertical-align:middle;">PR</span>{% endif %}</div>
           <div class="meso-mono" style="font-size:11.5px;color:var(--dim);">{{ r.target }}</div>
           <div class="meso-mono" style="font-size:12px;{% if r.rpe_state == 'over' %}color:var(--warn);font-weight:600;{% endif %}">{{ r.logged }}</div>
           <div style="text-align:center;">


### PR DESCRIPTION
## What & why

Phase 4c, PR #1 of the **PR-surface** slice (parity plan §6 → personal records; the plan's stated runway is *PR surface → parse-at-commit → agent*). The 4b engine (`personal_records.py`) shipped derive-on-read best-e1RM + `new_records_in` detection with **no UI**. This surfaces the `new_records_in` detector at the two moments a new best matters — the athlete's log commit and the coach's results screen.

**No new endpoints, no new URLs, no migrations** — both surfaces are additive threads through existing, already-access-gated views.

## Changes

**Athlete — "New PR!" on log commit**
- `athlete_log_session` now returns `new_records` alongside `log` (`views.py`). Pure detection off the just-committed rows; DONE-only, so a "Save progress" draft returns `[]`.
- `meso_athlete.js`: `newRecords` state + `prLabel()`, populated in `save()` and the offline `flushQueue()` path (a PR beaten offline still lands on sync).
- `athlete_session.html`: a dismissible 🎉 celebration card.

**Coach — PR marker on results**
- `session_results` adds `summary["new_records"]` and a per-row `pr` flag, matched by the same B4 lift identity (`key_str`) the engine keys on (`presenters.py`).
- `results.html`: a "New PR(s) this session" callout + an inline `PR` badge on the lift row.

**Shared**
- `serialize_new_record` (`serializers.py`) formats the raw Epley floats **server-side** (2-dp, trailing-zero trimmed, matching the existing `AthleteOneRm` display) so the client renders verbatim and can never re-round to a different value than the pinned server one.

## Design notes
- **Source of truth = structured `LoggedSet`** (D4), not parsed free text; reuses the pinned `epley_one_rm` + hybrid B4 identity verbatim.
- **Derive-on-read** — nothing persisted, no `PersonalRecord` table (a deliberate later slice), stays migration `0042`.
- The engine's edge cases (tie, exclude-self, identity, unit scoping) stay pinned in `test_personal_records.py`; this PR pins the **surface** — that each host wires the detector in and formats it.

## Tests
`app/store_project/meso/tests/test_pr_surface.py` (10 tests): athlete endpoint (first PR, pending→none, delta-over-previous, not-a-PR-when-prior-heavier), coach presenter (summary + per-row flag, prior-heavier, unlogged, pending), and coach render (callout shown / absent).

- Full meso suite: **1998 passed**.
- ruff check + format clean; DjHTML/pre-commit clean; `node --check` on the logger JS OK.
- Local review: **OpenAI Codex `codex review --base main` → CLEAN** (0 blocking, 0 nits).

Next in the slice (PR #2): the persistent "records book" panels (athlete home + coach profile), driven by `personal_records()`.

https://claude.ai/code/session_011sugb5ASfMyh7pn6YwhG8W