### PR TITLE
feat(meso): 4d — personal-records panel (athlete home + coach profile)

### DIFF
--- a/app/store_project/meso/presenters.py
+++ b/app/store_project/meso/presenters.py
@@ -33,6 +33,7 @@ from .models import WeekDelivery
 from .one_rm import key_str
 from .one_rm import one_rm_values
 from .personal_records import new_records_in
+from .personal_records import personal_records
 from .serializers import _fmt_num
 from .serializers import _num
 from .serializers import _phase_states
@@ -269,6 +270,70 @@ def profile_program(link, working_plan):
         "macrocycle": macrocycle,
         "results_summary": _profile_results(link),
     }
+
+
+# -- personal records panel (Phase 4d) -------------------------------------
+#
+# The persistent "records book" — best e1RM per lift with provenance — shared by
+# the athlete's training home and the coach's athlete-profile, both fed by the 4b
+# derive-on-read engine (``personal_records``); nothing is persisted. Unit is a
+# per-PLAN property (there is no athlete-level preference), so each host scopes to
+# a single plan's unit rather than pooling kg and lb: the athlete's / this link's
+# most-recently-active plan. An empty row list hides the panel (the templates
+# guard), so a lifter with no numeric-parseable best sees no empty chrome.
+
+
+def _personal_record_rows(athlete, unit):
+    """Best-lift display rows for a records panel — alphabetical by lift.
+
+    Each row carries the estimated 1RM (formatted like the stored ``AthleteOneRm``
+    display via ``_fmt_num``) and the winning set's provenance (reps/load/date).
+    """
+    rows = [
+        {
+            "name": r.name,
+            "e1rm": _fmt_num(round(r.e1rm, 2)),
+            "unit": r.unit,
+            "reps": r.reps,
+            "load": r.load,
+            "date": r.date,
+        }
+        for r in personal_records(athlete, unit=unit).values()
+    ]
+    rows.sort(key=lambda row: row["name"].lower())
+    return rows
+
+
+def _records_unit_plan(plans):
+    """The plan whose unit denominates a records panel — most recently active.
+
+    ``personal_records`` is unit-scoped, so a panel shows one denomination; pick
+    the most-recently-modified non-archived plan (the same "what they're on now"
+    heuristic the home card ordering uses). ``None`` when there's none — the panel
+    is then empty.
+    """
+    return plans.exclude(status=Plan.Status.ARCHIVED).order_by("-modified").first()
+
+
+def athlete_personal_records(user):
+    """The athlete's records panel for their training home (Phase 4d)."""
+    plan = _records_unit_plan(Plan.objects.for_athlete(user))
+    if plan is None:
+        return {"rows": [], "unit": ""}
+    return {"rows": _personal_record_rows(user, plan.unit), "unit": plan.unit}
+
+
+def coach_personal_records(link):
+    """The athlete's records panel for the coach's athlete-profile (Phase 4d).
+
+    The bests are unit-scoped and athlete-global (D4: PRs ride the structured
+    ``LoggedSet``, not per-coach); the coach reaches this only through an active
+    link and sees them in their own plan's unit.
+    """
+    plan = _records_unit_plan(Plan.objects.filter(relationship=link))
+    if plan is None:
+        return {"rows": [], "unit": ""}
+    return {"rows": _personal_record_rows(link.athlete, plan.unit), "unit": plan.unit}
 
 
 def _relative_when(dt):

--- a/app/store_project/meso/tests/test_pr_records_panel.py
+++ b/app/store_project/meso/tests/test_pr_records_panel.py
@@ -1,0 +1,185 @@
+"""Phase 4d — the personal-records *panel* (the persistent "records book").
+
+PR #1 (4c) surfaced the new-PR *event* at log time. This slice surfaces the
+standing bests: a "Personal records" panel on the athlete's training home and on
+the coach's athlete-profile, both fed by 4b's derive-on-read ``personal_records``
+(best Epley e1RM per lift, with the winning set's provenance) through one shared
+presenter helper and one ``_pr_list.html`` partial.
+
+Unit is a per-PLAN property — there is no athlete-level unit preference — so each
+host scopes to a single plan's unit (the most-recently-active one) rather than
+pooling kg and lb. An athlete with no numeric-parseable best gets no panel (the
+template guards on the row list), so a brand-new surface stays uncluttered.
+
+Loads are chosen so Epley is exact: reps=5 → ``load * 7/6`` (120→140), reps=3 →
+``load * 1.1`` (140→154), pinning the formatted labels without float noise.
+"""
+
+from datetime import date
+from types import SimpleNamespace
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+
+from store_project.meso.factories import CoachAthleteFactory
+from store_project.meso.factories import LoggedSetFactory
+from store_project.meso.factories import MesocycleFactory
+from store_project.meso.factories import PlanFactory
+from store_project.meso.factories import SessionLogFactory
+from store_project.meso.factories import WeekFactory
+from store_project.meso.models import Plan
+from store_project.meso.models import SessionLog
+from store_project.meso.presenters import athlete_personal_records
+from store_project.meso.presenters import coach_personal_records
+from store_project.users.factories import UserFactory
+
+from ._helpers import day
+from ._helpers import presc as make_presc
+
+pytestmark = pytest.mark.django_db
+
+
+def seed(*, coach=None, athlete=None):
+    """A coach's owned, delivered session with two prescriptions (no log yet)."""
+    coach = coach or UserFactory()
+    athlete = athlete or UserFactory(name="Maya Okonkwo")
+    rel = CoachAthleteFactory(coach=coach, athlete=athlete)
+    plan = PlanFactory(
+        relationship=rel, title="Hypertrophy Block", status=Plan.Status.ACTIVE
+    )
+    meso = MesocycleFactory(plan=plan, name="Hypertrophy", order=0)
+    week = WeekFactory(
+        mesocycle=meso, index=2, is_current=True, delivered_at=timezone.now()
+    )
+    session = day(week, day_number=1, name="Lower")
+    squat = make_presc(
+        session, name="Box Squat", order=0, sets="3", reps="6", load="70", rpe="7"
+    )
+    rdl = make_presc(
+        session, name="RDL", order=1, sets="3", reps="8", load="80", rpe="8"
+    )
+    return SimpleNamespace(
+        coach=coach,
+        athlete=athlete,
+        rel=rel,
+        plan=plan,
+        meso=meso,
+        week=week,
+        session=session,
+        squat=squat,
+        rdl=rdl,
+    )
+
+
+def log_done(s, *, squat=(), rdl=(), status=SessionLog.Status.DONE, when=None):
+    """Log ``(reps, load, rpe)`` tuples against the seeded prescriptions."""
+    sl = SessionLogFactory(
+        session=s.session,
+        athlete=s.athlete,
+        status=status,
+        date=when or date(2026, 6, 24),
+    )
+    for prescription, rows in ((s.squat, squat), (s.rdl, rdl)):
+        for n, (reps, load, rpe) in enumerate(rows, start=1):
+            LoggedSetFactory(
+                session_log=sl,
+                prescription=prescription,
+                set_number=n,
+                reps=reps,
+                load=load,
+                rpe=rpe,
+            )
+    return sl
+
+
+# -- athlete home presenter ------------------------------------------------
+
+
+class TestAthletePersonalRecordsPresenter:
+    def test_lists_best_per_lift_alphabetical(self):
+        s = seed()
+        log_done(s, squat=[("5", "120", "8")], rdl=[("5", "120", "8")])
+        panel = athlete_personal_records(s.athlete)
+        assert panel["unit"] == "kg"
+        rows = panel["rows"]
+        assert [r["name"] for r in rows] == ["Box Squat", "RDL"]  # sorted by name
+        assert rows[0]["e1rm"] == "140"  # 120 * 7/6
+        assert rows[0]["reps"] == "5"
+        assert rows[0]["load"] == "120"
+        assert rows[0]["date"] == date(2026, 6, 24)
+
+    def test_best_set_provenance_wins(self):
+        s = seed()
+        # A heavier low-rep single beats the lighter working set on e1RM.
+        log_done(s, squat=[("5", "120", "8"), ("3", "140", "9")])
+        rows = athlete_personal_records(s.athlete)["rows"]
+        squat = next(r for r in rows if r["name"] == "Box Squat")
+        assert squat["e1rm"] == "154"  # 140 * 1.1, beats 120 * 7/6 = 140
+        assert squat["reps"] == "3"
+        assert squat["load"] == "140"
+
+    def test_pending_draft_is_not_a_record(self):
+        s = seed()
+        log_done(s, squat=[("5", "120", "8")], status=SessionLog.Status.PENDING)
+        assert athlete_personal_records(s.athlete)["rows"] == []
+
+    def test_empty_without_logs(self):
+        s = seed()
+        assert athlete_personal_records(s.athlete)["rows"] == []
+
+    def test_empty_without_a_plan(self):
+        athlete = UserFactory()
+        assert athlete_personal_records(athlete) == {"rows": [], "unit": ""}
+
+
+# -- coach profile presenter -----------------------------------------------
+
+
+class TestCoachPersonalRecordsPresenter:
+    def test_lists_records_in_plan_unit(self):
+        s = seed()
+        log_done(s, squat=[("5", "120", "8")])
+        panel = coach_personal_records(s.rel)
+        assert panel["unit"] == "kg"
+        assert [r["name"] for r in panel["rows"]] == ["Box Squat"]
+        assert panel["rows"][0]["e1rm"] == "140"
+
+    def test_empty_without_a_plan(self):
+        rel = CoachAthleteFactory(coach=UserFactory(), athlete=UserFactory())
+        assert coach_personal_records(rel) == {"rows": [], "unit": ""}
+
+
+# -- rendered surfaces -----------------------------------------------------
+
+
+class TestAthleteHomeRendersRecords:
+    def test_logged_athlete_sees_records_panel(self, client):
+        s = seed()
+        log_done(s, squat=[("5", "120", "8")])
+        client.force_login(s.athlete)
+        body = client.get(reverse("meso:athlete_home")).content.decode()
+        assert "Personal records" in body
+
+    def test_no_panel_without_records(self, client):
+        s = seed()  # no log
+        client.force_login(s.athlete)
+        body = client.get(reverse("meso:athlete_home")).content.decode()
+        assert "Personal records" not in body
+
+
+class TestCoachProfileRendersRecords:
+    def test_owning_coach_sees_records_panel(self, client):
+        s = seed()
+        log_done(s, squat=[("5", "120", "8")])
+        client.force_login(s.coach)
+        url = reverse("meso:athlete", kwargs={"pk": s.athlete.pk})
+        body = client.get(url).content.decode()
+        assert "Personal records" in body
+
+    def test_no_panel_without_records(self, client):
+        s = seed()  # no log
+        client.force_login(s.coach)
+        url = reverse("meso:athlete", kwargs={"pk": s.athlete.pk})
+        body = client.get(url).content.decode()
+        assert "Personal records" not in body

--- a/app/store_project/meso/views.py
+++ b/app/store_project/meso/views.py
@@ -524,6 +524,8 @@ class AthleteProfileView(LoginRequiredMixin, TemplateView):
         ctx["athlete"] = athlete
         ctx["macrocycle"] = program["macrocycle"]
         ctx["results_summary"] = program["results_summary"]
+        # The athlete's standing bests, in this link's plan unit (Phase 4d).
+        ctx["personal_records"] = presenters.coach_personal_records(link)
         ctx["coach_style"] = presenters.coach_style(self.request.user)
         # Whether to offer "Draft with AI" on the create CTA — the same agent
         # allowance gate the endpoint enforces (the draft *is* an agent run).
@@ -1256,6 +1258,8 @@ class AthleteHomeView(LoginRequiredMixin, TemplateView):
         # Pending coach links (N4 Phase 2): invites awaiting my reply + requests
         # I've sent + the request-a-coach form all live on this surface.
         ctx["pending"] = presenters.athlete_pending(self.request.user)
+        # The athlete's standing bests, in their current plan's unit (Phase 4d).
+        ctx["personal_records"] = presenters.athlete_personal_records(self.request.user)
         ctx["athlete_name"] = self.request.user.display_name()
         ctx["athlete_initials"] = presenters.initials(ctx["athlete_name"])
         # First-log coachmark (Phase 4): only when there's a session to tap

--- a/app/store_project/templates/meso/_pr_list.html
+++ b/app/store_project/templates/meso/_pr_list.html
@@ -1,0 +1,25 @@
+{% comment %}
+Personal records panel (Phase 4d) — shared by the athlete's training home and the
+coach's athlete-profile. Expects `personal_records` = {rows: [...], unit: "kg"},
+each row {name, e1rm, unit, reps, load, date}, best e1RM per lift alphabetical
+(presenters.athlete_personal_records / coach_personal_records). Renders nothing
+when there are no records (a lift with no numeric-parseable best is simply
+absent), so a new surface stays uncluttered.
+{% endcomment %}
+{% if personal_records.rows %}
+  <div class="meso-card meso-card--pad" style="margin-bottom:14px;">
+    <p class="meso-eyebrow">Personal records</p>
+    <div style="display:flex;flex-direction:column;">
+      {% for pr in personal_records.rows %}
+        <div style="padding:8px 0;{% if not forloop.last %}border-bottom:1px solid var(--line-2);{% endif %}">
+          <div style="display:flex;align-items:baseline;gap:10px;">
+            <span style="flex:1;min-width:0;font-size:13px;font-weight:600;letter-spacing:-0.01em;">{{ pr.name }}</span>
+            <span class="meso-mono" style="font-size:13px;font-weight:700;color:var(--accent-deep);white-space:nowrap;">{{ pr.e1rm }} {{ pr.unit }}</span>
+          </div>
+          <div class="meso-row-meta meso-mono">est. 1RM · from {{ pr.reps }}×{{ pr.load }}{% if pr.date %} on {{ pr.date|date:"M j, Y" }}{% endif %}</div>
+        </div>
+      {% endfor %}
+    </div>
+    <p class="meso-row-meta" style="margin-top:8px;">Estimated 1-rep max (Epley) from your logged sets.</p>
+  </div>
+{% endif %}

--- a/app/store_project/templates/meso/athlete_home.html
+++ b/app/store_project/templates/meso/athlete_home.html
@@ -250,6 +250,9 @@
       </div>
     {% endfor %}
 
+    {# Personal records (Phase 4d) — standing bests below the live programs. #}
+    {% include "meso/_pr_list.html" %}
+
     <!-- Self-serve coach signup (S6 Phase 4): the way into the coach surface. -->
     <a class="meso-card meso-card--pad" href="{% url 'meso:become_coach' %}"
        style="display:flex;align-items:center;gap:12px;margin-top:14px;text-decoration:none;color:inherit;border:1px solid var(--line);">

--- a/app/store_project/templates/meso/athlete_profile.html
+++ b/app/store_project/templates/meso/athlete_profile.html
@@ -77,6 +77,9 @@
             <span style="font-weight:700;color:var(--warn);">Avoid:</span> {{ coach_style.avoid }}
           </div>
         </div>
+
+        {# Personal records (Phase 4d) — the athlete's standing bests. #}
+        {% include "meso/_pr_list.html" %}
       </div>
 
       <!-- main -->


### PR DESCRIPTION
## What & why

PR #2 of the **PR-surface** slice — the persistent "records book". PR #1 (#478, merged) surfaced the new-PR *event* at log time; this surfaces the standing bests: a **"Personal records" panel** on the athlete's training home and on the coach's athlete-profile, both fed by 4b's derive-on-read `personal_records()` (best Epley e1RM per lift + the winning set's provenance).

**No new endpoints, URLs, or migrations** — additive context on two existing gated views, one shared presenter helper, one shared partial.

## Changes
- **`presenters.py`** — `_personal_record_rows(athlete, unit)` (shared, alphabetical by lift, e1RM formatted server-side via `_fmt_num`); `athlete_personal_records(user)` and `coach_personal_records(link)`, each scoping unit to the most-recently-active plan via `_records_unit_plan`.
- **`views.py`** — `AthleteHomeView` and `AthleteProfileView` set `ctx["personal_records"]`.
- **`_pr_list.html`** — one shared partial (lift · est. 1RM · provenance), self-hiding when there are no records; included by `athlete_home.html` (below the live programs) and `athlete_profile.html` (left rail).

## Design notes
- **Unit is a per-PLAN property** — there is no athlete-level unit preference — so each host shows one denomination (its most-recently-active plan's unit) rather than pooling kg and lb.
- Bests are **unit-scoped and athlete-global** (D4: PRs ride the structured `LoggedSet`); the coach reaches the panel only through an active link.
- **Derive-on-read** — nothing persisted, stays migration `0042`. Empty list → panel hidden, so a brand-new surface stays uncluttered.

## Tests
`app/store_project/meso/tests/test_pr_records_panel.py` (11 tests): athlete presenter (best-per-lift alphabetical, best-set provenance wins, pending draft excluded, empty without logs/plan), coach presenter (records in plan unit, empty without plan), and rendered surfaces for both hosts (panel shown when logged / absent when not).

- Full meso suite: **2009 passed**.
- ruff check + format clean; DjHTML/pre-commit clean.
- Local review: **OpenAI Codex `codex review --base main` → CLEAN** (0 blocking, 0 nits).

With this, the **PR-surface slice is complete** (event + records book). Next in the plan's runway: the parse-at-commit pipeline, then the agent.

https://claude.ai/code/session_011sugb5ASfMyh7pn6YwhG8W