### PR TITLE
fix(meso): 0040 pending-trigger failure + PostgreSQL CI job

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -86,3 +86,94 @@ jobs:
       - name: Run Tests
         run: |
           uv run pytest
+
+  # The main "build" job above runs the full suite on fast, hermetic
+  # in-memory SQLite (deliberate — see config/settings/test.py). SQLite
+  # can't express PostgreSQL's deferred-constraint checks at all, which is
+  # exactly the class of bug that shipped twice (meso 0036/0037 and 0040:
+  # "cannot ALTER TABLE ... because it has pending trigger events", only
+  # reachable on Postgres with real data — an empty CI/prod DB never hits
+  # it). This job runs a real `migrate` from scratch against a Postgres
+  # service container and then the suite against that same Postgres, so the
+  # Postgres-only regression tests
+  # (`@pytest.mark.skipif(connection.vendor != "postgresql", ...)`) — which
+  # SKIP under the SQLite job above — actually execute somewhere. The SQLite
+  # job stays as the fast feedback path; the two run in parallel.
+  postgres:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+
+    services:
+      postgres:
+        # Match production's major version (docker-compose.production.yml
+        # pins `postgres:17-alpine`, matching the Heroku Postgres 17 major
+        # this app was migrated from; the dev stack's docker-compose.yml
+        # also runs Postgres 17).
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      SECRET_KEY: NotSecureForTesting
+      PYTHONUNBUFFERED: 1
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      FB_APP_ID: ${{ secrets.FB_APP_ID }}
+      FB_SECRET_KEY: ${{ secrets.FB_SECRET_KEY }}
+      GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+      GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+      STRIPE_ENDPOINT_SECRET: ${{ secrets.STRIPE_ENDPOINT_SECRET }}
+      STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
+      STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+      G_RECAPTCHA_SITE_KEY: test-recaptcha-site-key
+      G_RECAPTCHA_SECRET_KEY: test-recaptcha-secret-key
+      G_RECAPTCHA_ENDPOINT: https://test-recaptcha-endpoint.com
+      # Opts config.settings.test into the real Postgres service container
+      # instead of its default in-memory SQLite (config/settings/test.py).
+      TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        id: setup_python
+        with:
+          python-version-file: "pyproject.toml"
+
+      - name: Install UV
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.7.20"
+
+      - name: Cache UV dependencies
+        uses: actions/cache@v4
+        with:
+          key: venv-${{ runner.os }}-${{ steps.setup_python.outputs.python-version}}-${{ hashFiles('uv.lock') }}
+          path: .venv
+
+      - name: Install Python dependencies
+        run: uv sync --all-extras
+
+      - name: Migrate from scratch against PostgreSQL
+        run: cd app && uv run python manage.py migrate --settings=config.settings.test
+
+      # The WHOLE suite, not just the Postgres-marked tests. The suite is
+      # already Postgres-clean (verified: 2288 passed, zero failures) and
+      # GitHub runs jobs in parallel, so this costs no extra wall-clock over
+      # the SQLite job beside it — only runner minutes (~2.6 min vs ~50s).
+      # Narrow this back to the single regression test if minutes get tight;
+      # migrate-from-scratch above plus that one test is the floor that keeps
+      # the deferred-constraint class of bug catchable.
+      - name: Run the suite against PostgreSQL
+        run: |
+          uv run pytest

--- a/app/config/settings/test.py
+++ b/app/config/settings/test.py
@@ -22,6 +22,7 @@ from .base import *  # noqa
 # Import these after base settings to prevent import order issues
 import unittest.mock  # noqa
 import requests  # noqa
+import dj_database_url  # noqa
 import stripe  # noqa
 
 # TESTING
@@ -93,18 +94,30 @@ requests.post = unittest.mock.Mock(
 
 # DATABASE
 # ------------------------------------------------------------------------------
-# Use fast in-memory SQLite database for testing
+# Use fast in-memory SQLite database for testing by default.
 # Benefits:
 # - Much faster than file-based databases (no disk I/O)
 # - Isolated - each test run gets a fresh database
 # - No cleanup required - database disappears when process ends
 # https://docs.djangoproject.com/en/dev/ref/settings/#databases
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": ":memory:",
+#
+# The production/dev DB is PostgreSQL, and a small number of behaviors
+# (deferred-constraint enforcement, in particular — see
+# meso/tests/test_migration_0040_pending_triggers.py) only exist on Postgres
+# and cannot be exercised on SQLite at all. ``TEST_DATABASE_URL`` is an
+# optional escape hatch: set it (e.g. in a dedicated CI job) to point the
+# suite at a real Postgres instead. Left unset, behavior is byte-for-byte
+# identical to before — this is the default local (`uv run pytest`) and main
+# CI path, and it must stay fast and hermetic.
+if TEST_DATABASE_URL := os.environ.get("TEST_DATABASE_URL"):
+    DATABASES = {"default": dj_database_url.parse(TEST_DATABASE_URL, conn_max_age=600)}
+else:
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": ":memory:",
+        }
     }
-}
 
 # CACHES
 # ------------------------------------------------------------------------------

--- a/app/store_project/meso/migrations/0040_remove_group_subsystem.py
+++ b/app/store_project/meso/migrations/0040_remove_group_subsystem.py
@@ -22,6 +22,35 @@ def delete_shared_group_plans(apps, schema_editor):
     Plan.objects.filter(relationship__isnull=True).delete()
 
 
+def flush_deferred_constraints(apps, schema_editor):
+    """Force Postgres to check + clear the deferred RI triggers queued above.
+
+    HAZARD (do not remove): on PostgreSQL, the ORM cascade delete in
+    ``delete_shared_group_plans`` queues deferred RI trigger events on every
+    table FK'd off ``Plan`` (and its children — mesocycles, weeks, slots,
+    cells, ...), because this app's FK constraints are
+    ``DEFERRABLE INITIALLY DEFERRED``. Postgres refuses to ``ALTER TABLE`` a
+    table with pending trigger events *in the same transaction*, and the very
+    next operations below do exactly that to ``meso_plan``. On an empty
+    database the delete matches zero rows and queues nothing, so this only
+    bites a database that actually has group-rooted plans (a restore, or a
+    local/staging DB with real data) — which is why it can pass CI/prod and
+    still fail elsewhere. ``SET CONSTRAINTS ALL IMMEDIATE`` forces Postgres to
+    check and clear those queued events right here, before the ALTERs, while
+    keeping the whole migration in one atomic transaction. See 0036/0037 for
+    the earlier occurrence of this same hazard (there, split across two
+    migrations instead — not an option here since prod already has this
+    migration recorded as applied).
+
+    Guarded to Postgres only: ``SET CONSTRAINTS`` is invalid syntax on
+    SQLite, which is what this suite's default test settings
+    (``config.settings.test``) run on — an unconditional ``RunSQL`` here
+    breaks every migration-touching test.
+    """
+    if schema_editor.connection.vendor == "postgresql":
+        schema_editor.execute("SET CONSTRAINTS ALL IMMEDIATE")
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -31,6 +60,9 @@ class Migration(migrations.Migration):
     operations = [
         migrations.RunPython(
             delete_shared_group_plans, migrations.RunPython.noop, elidable=True
+        ),
+        migrations.RunPython(
+            flush_deferred_constraints, migrations.RunPython.noop, elidable=True
         ),
         migrations.RemoveConstraint(
             model_name="groupmembership",

--- a/app/store_project/meso/tests/test_migration_0040_pending_triggers.py
+++ b/app/store_project/meso/tests/test_migration_0040_pending_triggers.py
@@ -1,0 +1,120 @@
+"""Reproduction test for the ``0040_remove_group_subsystem`` Postgres failure.
+
+``0040``'s first operation is a ``RunPython`` that ORM-cascade-deletes every
+group-rooted ``Plan`` (``relationship`` NULL). On PostgreSQL, Django's FK
+constraints in this app are ``DEFERRABLE INITIALLY DEFERRED``, so that delete
+queues deferred RI trigger events. The migration then runs
+``RemoveConstraint``/``RemoveField``/``AlterField`` against ``meso_plan`` in
+the SAME transaction, and Postgres refuses to ``ALTER TABLE`` a table with
+pending trigger events. On an EMPTY database the delete matches zero rows and
+queues nothing, so the migration passes there — which is why CI (empty test
+DB) and prod (no group-rooted plans) were both green while a database that
+actually had group-rooted plans (a restore, or a local/staging DB with real
+data) would fail. This module reproduces that failure by building a
+group-rooted plan tree at the ``0039`` migration state and then migrating
+forward through ``0040``.
+
+This does NOT reproduce on SQLite (no deferred-constraint concept there), so
+it is skipped unless the configured DB backend is PostgreSQL. The default
+test settings (``config.settings.test``) use an in-memory SQLite database, so
+this test SKIPS under ``uv run pytest`` / ``just test`` as normally run. To
+actually exercise it, point the suite at a Postgres backend, e.g.:
+
+    uv run pytest --ds=config.settings.local app/store_project/meso/tests/test_migration_0040_pending_triggers.py
+
+(``config.settings.local`` uses the same Postgres the dev DB does, via the
+``SQL_*`` env vars in ``.env`` — see ``just services``.)
+"""
+
+import pytest
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+
+from store_project.users.models import User
+
+pytestmark = [
+    pytest.mark.django_db(transaction=True),
+    pytest.mark.skipif(
+        connection.vendor != "postgresql",
+        reason=(
+            "The 'pending trigger events' failure is a PostgreSQL-only "
+            "deferred-constraint behavior; it cannot reproduce on SQLite."
+        ),
+    ),
+]
+
+MESO_0039 = ("meso", "0039_drop_structured_cell_columns")
+MESO_0040 = ("meso", "0040_remove_group_subsystem")
+
+
+def test_0040_migrates_forward_with_group_rooted_plan_data():
+    """0040 must not blow up on a DB that actually has group-rooted plans.
+
+    Builds a full group-rooted ``Plan`` -> ``Mesocycle`` -> (``Week``,
+    ``SessionSlot``) -> (``Session``, ``ExerciseSlot``) -> ``Prescription``
+    tree at the ``0039`` schema state (mirroring ``Plan.scaffold``'s shape),
+    so ``delete_shared_group_plans`` has real rows to cascade-delete and
+    genuinely queues deferred trigger events on ``meso_plan``'s referencing
+    tables. Then migrates forward through ``0040`` and asserts it completes.
+    """
+    executor = MigrationExecutor(connection)
+    leaf_nodes = executor.loader.graph.leaf_nodes("meso")
+
+    try:
+        executor.migrate([MESO_0039])
+        executor.loader.build_graph()
+
+        old_apps = executor.loader.project_state([MESO_0039]).apps
+        MesoGroup = old_apps.get_model("meso", "MesoGroup")
+        Plan = old_apps.get_model("meso", "Plan")
+        Mesocycle = old_apps.get_model("meso", "Mesocycle")
+        Week = old_apps.get_model("meso", "Week")
+        SessionSlot = old_apps.get_model("meso", "SessionSlot")
+        ExerciseSlot = old_apps.get_model("meso", "ExerciseSlot")
+        Session = old_apps.get_model("meso", "Session")
+        Prescription = old_apps.get_model("meso", "Prescription")
+
+        # The real, current User model — not the historical one from
+        # ``old_apps``. ``users`` isn't the app under test, its dependency
+        # snapshot at 0039 can be older than the actual (fully-migrated)
+        # ``users_user`` table, missing defaults added by later users
+        # migrations (e.g. ``points``). Assigning it to the historical
+        # ``MesoGroup.coach`` FK via ``coach_id=`` sidesteps the ORM's
+        # isinstance check (which would reject a cross-registry model).
+        coach = User.objects.create(
+            username="coach-0040-repro", email="coach-0040-repro@example.com"
+        )
+        group = MesoGroup.objects.create(name="Repro Group", coach_id=coach.pk)
+        # relationship=None + group=<MesoGroup> is exactly what
+        # ``delete_shared_group_plans`` targets (``relationship__isnull=True``)
+        # and satisfies the ``plan_relationship_xor_group`` check constraint.
+        plan = Plan.objects.create(title="Group plan", group=group)
+        mesocycle = Mesocycle.objects.create(
+            plan=plan, name="Block 1", order=0, week_count=4
+        )
+        week = Week.objects.create(
+            mesocycle=mesocycle, index=1, phase="Accum", volume=70, intensity=65
+        )
+        slot = SessionSlot.objects.create(
+            mesocycle=mesocycle, day_number=1, name="Day 1", order=0
+        )
+        Session.objects.create(week=week, session_slot=slot)
+        exercise_slot = ExerciseSlot.objects.create(
+            session_slot=slot, name="Squat", order=0
+        )
+        Prescription.objects.create(exercise_slot=exercise_slot, week=week)
+
+        # Sanity: the row 0040's data step targets actually exists, and the
+        # rest of the tree hangs off it so the cascade has real work to do.
+        assert Plan.objects.filter(relationship__isnull=True).count() == 1
+        assert Mesocycle.objects.filter(plan=plan).count() == 1
+        assert Prescription.objects.filter(exercise_slot=exercise_slot).count() == 1
+
+        # The assertion under test: this must not raise
+        # "cannot ALTER TABLE ... because it has pending trigger events".
+        executor.migrate([MESO_0040])
+    finally:
+        # Always restore the DB to its normal (fully migrated) schema so
+        # later tests in this run see the real, current meso schema.
+        executor.loader.build_graph()
+        executor.migrate(leaf_nodes)


### PR DESCRIPTION
## The bug

`meso/0040_remove_group_subsystem` cascade-deletes group-rooted plans via `RunPython`, then `ALTER TABLE`s `meso_plan` in the same transaction. This app's FKs are `DEFERRABLE INITIALLY DEFERRED`, so the delete queues deferred RI trigger events and Postgres refuses:

```
cannot ALTER TABLE "meso_plan" because it has pending trigger events
```

**On an empty database the delete matches nothing and the migration passes** — which is why CI and production both sailed through. It only fires where group-rooted plans exist, so the broken path is **restore-from-backup** and any local/staging DB with real data. Hit on a local DB with 3 such plans.

## The fix

`SET CONSTRAINTS ALL IMMEDIATE` between the delete and the first `ALTER`, flushing the queued triggers while staying in one atomic transaction.

Fixed **in place** rather than split across two migrations (the 0036/0037 precedent): production already has 0040 recorded as applied and Django never re-runs an applied migration, so this is a no-op there while un-migrated databases get the corrected version. Splitting or renumbering would perturb a graph that 0041–0044 already sit on.

Issued through `RunPython` with a `connection.vendor` check, **not** a bare `RunSQL` — `SET CONSTRAINTS` is invalid SQLite syntax and the default test settings run on in-memory SQLite, so an unconditional `RunSQL` breaks every migration-touching test.

## Why CI couldn't catch it

The suite runs on in-memory SQLite; production is Postgres; CI had no database service at all. SQLite cannot express deferred constraints, so this entire class of bug was structurally invisible. **The same root cause shipped twice** — 0036/0037 and now 0040.

So this PR also adds a Postgres CI job:

- `config.settings.test` takes its DB from an optional `TEST_DATABASE_URL`, defaulting to the current in-memory SQLite when unset — local `pytest` and the existing job are unchanged (`2287 passed, 1 skipped`, identical to before).
- A new job migrates from scratch against `postgres:17-alpine` (matching `docker-compose.production.yml`) and runs the suite against it.
- It runs the **whole** suite, not just the marked test: the suite is already Postgres-clean (`2288 passed`, zero failures) and GitHub runs jobs in parallel, so it costs no extra wall-clock beside the SQLite job — only runner minutes (~3.4 min vs ~50s). The workflow comments how to narrow it back if minutes get tight.

## Verification

The regression test uses `MigrationExecutor` to roll back to 0039, build a group-rooted plan tree, and migrate forward. It is Postgres-only and **skips** under the default suite. Verified against real Postgres: fails with the exact production error without the fix, passes with it.

Pattern sweep across every migration in the repo: `0036` is already correctly isolated, `0038` puts its `RunPython` after all schema ops, the rest are standalone data migrations. 0040 was the only one carrying this hazard.

Codex review: CLEAN (0 blocking, 0 nits).

https://claude.ai/code/session_01GiGZcFWi7esh639WDkfDan