### PR TITLE
feat(meso): pin the designer grid against layout shift; fill via Ctrl/Cmd+Enter

### DIFF
--- a/app/store_project/meso/management/commands/seed_meso_demo.py
+++ b/app/store_project/meso/management/commands/seed_meso_demo.py
@@ -1207,7 +1207,29 @@ def _logged_sets_from_cells(log, prescriptions):
     raises): a cell that doesn't fully parse still logs one set with whatever
     reps/load/rpe *did* parse (blank where it didn't) rather than crashing — a
     %1RM load token (``"72%"``, no absolute bar weight) logs with a blank load.
+
+    ``parse_prescription`` only classifies a cell's line 0 (see its own
+    docstring) — but the generator's cells (``_week_cell``) split RPE off
+    line 0 onto its own line-1 sub-line, so a generated cell's line 0 alone
+    never carries an RPE. Without recovering it from the sub-line, every
+    auto-logged set for a generated (non-hand-authored) cell would silently
+    log a blank RPE — the regression this sub-line lookup exists to fix.
+    Hand-authored cells that still pack RPE inline on line 0 are unaffected
+    (line 0's RPE wins when present). One query fetches every prescription's
+    sub-lines up front, keyed by ``(exercise_slot_id, week_id)``, instead of
+    one query per cell (N+1).
     """
+    sub_lines_by_cell = {}
+    if prescriptions:
+        slot_ids = {p.exercise_slot_id for p in prescriptions}
+        week_ids = {p.week_id for p in prescriptions}
+        sub_lines = Prescription.objects.filter(
+            exercise_slot_id__in=slot_ids, week_id__in=week_ids, line__gte=1
+        ).order_by("line")
+        for sub_line in sub_lines:
+            key = (sub_line.exercise_slot_id, sub_line.week_id)
+            sub_lines_by_cell.setdefault(key, []).append(sub_line)
+
     rows = []
     for prescription in prescriptions:
         parsed = parse_prescription(prescription.text) or {}
@@ -1222,6 +1244,15 @@ def _logged_sets_from_cells(log, prescriptions):
         if load.endswith("%"):
             load = ""  # a %1RM token isn't a bar weight — leave blank, not crash
         rpe = parsed.get("rpe") or ""
+        if not rpe:
+            # Line 0 didn't carry one — fall through to the sub-lines
+            # (RPE split, see the docstring) and take the first that parses.
+            key = (prescription.exercise_slot_id, prescription.week_id)
+            for sub_line in sub_lines_by_cell.get(key, []):
+                sub_rpe = (parse_prescription(sub_line.text) or {}).get("rpe") or ""
+                if sub_rpe:
+                    rpe = sub_rpe
+                    break
         for set_number in range(1, sets_count + 1):
             rows.append(
                 LoggedSet(

--- a/app/store_project/meso/management/commands/seed_meso_demo.py
+++ b/app/store_project/meso/management/commands/seed_meso_demo.py
@@ -243,12 +243,20 @@ def _ease_rpe(rpe):
 
 
 def _week_cell(scheme, week_index, *, deload_index=None):
-    """One exercise's cell (``{"text": ...}``) for one week of its block.
+    """One exercise's cell (``{"text": ..., "lines": [...]}``) for one week.
 
     ``week_index`` is 1-based within the block; a deload week (``week_index
     == deload_index``) trims a set, eases RPE, and resets load back to the
     block's starting point rather than tapering off an already-progressed
     number. ``scheme`` absent (``None``/``{}``) yields a blank cell.
+
+    Matches the coach's real cell shape (docs/meso/spreadsheet-parity-
+    plan.md §2.1, §2.6): line 0 is sets×reps (+ load) with NO RPE packed in;
+    when the scheme carries an RPE, it moves to its own line-1 sub-line
+    (``"lines": ["RPE <value>"]``), formatted the same way
+    ``compose_prescription_text`` itself would format an RPE segment. A row
+    with ``rpe=None`` (an accessory row) gets no ``"lines"`` key at all — not
+    a blank sub-line.
     """
     if not scheme:
         return {}
@@ -265,15 +273,18 @@ def _week_cell(scheme, week_index, *, deload_index=None):
             rpe = _ease_rpe(rpe)
     else:
         load = _step_load(load, step, week_index - 1)
-    return {
+    cell = {
         "text": compose_prescription_text(
             sets=sets,
             reps=reps,
-            rpe="" if rpe is None else rpe,
+            rpe="",
             load="" if load is None else load,
             load_pct=scheme.get("load_pct", False),
         )
     }
+    if rpe is not None:
+        cell["lines"] = [compose_prescription_text(rpe=rpe)]
+    return cell
 
 
 def _cells_for_week(days, week_index, *, deload_index=None):

--- a/app/store_project/meso/tests/test_seed_demo.py
+++ b/app/store_project/meso/tests/test_seed_demo.py
@@ -23,6 +23,8 @@ import pytest
 from django.contrib.auth.hashers import make_password
 from django.core.management import call_command
 
+from store_project.meso.management.commands.seed_meso_demo import _ease_rpe
+from store_project.meso.management.commands.seed_meso_demo import _week_cell
 from store_project.meso.models import AthleteProfile
 from store_project.meso.models import CoachAthlete
 from store_project.meso.models import CoachInvite
@@ -31,6 +33,7 @@ from store_project.meso.models import Contraindication
 from store_project.meso.models import LoggedSet
 from store_project.meso.models import Mesocycle
 from store_project.meso.models import Plan
+from store_project.meso.models import Prescription
 from store_project.meso.models import Session
 from store_project.meso.models import SessionLog
 from store_project.meso.models import Week
@@ -76,6 +79,42 @@ def _maya_logged_through_week(plan):
     """
     hypertrophy = plan.mesocycles.get(name="Hypertrophy")
     return hypertrophy.weeks.get(index=2)
+
+
+class TestWeekCellSplitsRpeOntoItsOwnLine:
+    """The seeder's cell shape is a vertical stack, not one crammed line.
+
+    The repo owner's real cells put sets×reps (+ load) on line 0 and RPE on
+    its own sub-line (line 1) — see the module docstring / spreadsheet-
+    parity-plan §2.1, §2.6. ``_week_cell`` composes line 0 the same way as
+    before, minus RPE, and (when the scheme carries an RPE) adds a ``"lines"``
+    sub-line matching ``compose_prescription_text``'s own RPE formatting.
+    """
+
+    def test_cell_with_rpe_has_no_rpe_on_line_0_and_rpe_on_line_1(self):
+        scheme = {"sets": 3, "reps": 12, "rpe": 6.5, "load": 100, "load_step": 0}
+        cell = _week_cell(scheme, week_index=1)
+        assert "RPE" not in cell["text"]
+        assert cell["text"] == "3 x 12, 100"
+        assert cell["lines"] == ["RPE 6.5"]
+
+    def test_cell_with_no_rpe_has_no_sub_line(self):
+        # The accessory rows (``rpe=None``) must not gain a blank sub-line.
+        scheme = {"sets": 4, "reps": 15, "rpe": None, "load": 55, "load_step": 0}
+        cell = _week_cell(scheme, week_index=1)
+        assert cell["text"] == "4 x 15, 55"
+        assert "lines" not in cell
+
+    def test_deload_week_still_puts_the_eased_rpe_on_line_1(self):
+        scheme = {"sets": 4, "reps": 9, "rpe": 7.5, "load": 100, "load_step": 0}
+        cell = _week_cell(scheme, week_index=4, deload_index=4)
+        assert cell["lines"] == [f"RPE {_ease_rpe(7.5)}"]
+        assert cell["lines"] == ["RPE 6"]
+        assert "RPE" not in cell["text"]
+
+    def test_blank_scheme_still_yields_a_blank_cell(self):
+        assert _week_cell(None, week_index=1) == {}
+        assert _week_cell({}, week_index=1) == {}
 
 
 class TestSeedCreatesDemo:
@@ -218,6 +257,38 @@ class TestSeedCreatesDemo:
         assert list(
             logged_through.cells.filter(line__gte=1).values_list("text", flat=True)
         ) == ["Cable Crunch"]
+
+    def test_generated_weeks_carry_rpe_as_a_line_1_sub_line(self):
+        # Week 1 of Hypertrophy is generator-built (unlike week 2's
+        # hand-authored fixture above), so this exercises ``_week_cell``'s
+        # real output end to end: the seeder runs without error and produces
+        # real ``Prescription`` rows at both line 0 (sets×reps, no RPE) and
+        # line 1 (the RPE sub-line) for every row whose scheme carries an
+        # RPE — and no line-1 row at all for the accessory rows that don't.
+        seed()
+        plan = _plan_for(User.objects.get(email=COACH_EMAIL), MAYA_EMAIL)
+        hypertrophy = plan.mesocycles.get(name="Hypertrophy")
+        week1 = hypertrophy.weeks.get(index=1)
+        lower_day = week1.sessions.get(session_slot__day_number=1).session_slot
+        rows = list(lower_day.exercise_slots.order_by("order"))
+        by_name = {row.name: row for row in rows}
+
+        box_squat = by_name["Box Squat (to parallel)"]
+        line0 = Prescription.objects.get(exercise_slot=box_squat, week=week1, line=0)
+        line1 = Prescription.objects.get(exercise_slot=box_squat, week=week1, line=1)
+        assert "RPE" not in line0.text
+        assert line1.text == "RPE 7"
+
+        # "Standing Calf Raise" is seeded with ``rpe=None`` (an accessory row)
+        # — it must not gain a blank/absent sub-line row at all.
+        calf_raise = by_name["Standing Calf Raise"]
+        calf_line0 = Prescription.objects.get(
+            exercise_slot=calf_raise, week=week1, line=0
+        )
+        assert "RPE" not in calf_line0.text
+        assert not Prescription.objects.filter(
+            exercise_slot=calf_raise, week=week1, line__gte=1
+        ).exists()
 
 
 class TestSamplePlanRoundTrips:

--- a/app/store_project/meso/tests/test_seed_demo.py
+++ b/app/store_project/meso/tests/test_seed_demo.py
@@ -23,7 +23,12 @@ import pytest
 from django.contrib.auth.hashers import make_password
 from django.core.management import call_command
 
+from store_project.meso.factories import SessionLogFactory
+from store_project.meso.factories import WeekFactory
 from store_project.meso.management.commands.seed_meso_demo import _ease_rpe
+from store_project.meso.management.commands.seed_meso_demo import (
+    _logged_sets_from_cells,
+)
 from store_project.meso.management.commands.seed_meso_demo import _week_cell
 from store_project.meso.models import AthleteProfile
 from store_project.meso.models import CoachAthlete
@@ -41,6 +46,10 @@ from store_project.meso.parsing import parse_prescription
 from store_project.meso.presenters import session_results
 from store_project.meso.serializers import serialize_plan
 from store_project.users.models import User
+
+from ._helpers import day
+from ._helpers import presc
+from ._helpers import sub_line
 
 pytestmark = pytest.mark.django_db
 
@@ -115,6 +124,79 @@ class TestWeekCellSplitsRpeOntoItsOwnLine:
     def test_blank_scheme_still_yields_a_blank_cell(self):
         assert _week_cell(None, week_index=1) == {}
         assert _week_cell({}, week_index=1) == {}
+
+
+class TestLoggedSetsFromCellsRecoversRpeFromSubLine:
+    """The RPE split's fallout: ``_logged_sets_from_cells`` must not lose it.
+
+    ``parse_prescription`` only classifies a cell's line 0 — so once
+    ``_week_cell`` moved a generated cell's RPE onto its own line-1 sub-line
+    (the class above), parsing line 0 alone stopped finding any RPE at all.
+    ``_logged_sets_from_cells`` has to fall back to the cell's sub-lines when
+    line 0 doesn't carry one, without regressing hand-authored cells that
+    still pack RPE inline on line 0.
+    """
+
+    def test_rpe_recovered_from_line_1_when_line_0_has_none(self):
+        # The generator's real shape post-split: line 0 = sets×reps+load,
+        # line 1 = "RPE <value>" on its own.
+        week = WeekFactory()
+        session = day(week, day_number=1, name="Lower")
+        cell = presc(session, text="3 x 12, 85.6")
+        sub_line(cell, "RPE 6.5")
+        log = SessionLogFactory(session=session)
+
+        rows = _logged_sets_from_cells(log, [cell])
+
+        assert len(rows) == 3
+        assert all(row.rpe == "6.5" for row in rows)
+
+    def test_line_0_inline_rpe_still_wins_over_a_sub_line(self):
+        # A hand-authored cell (e.g. Maya's logged-through-week fixture)
+        # still packs RPE inline on line 0 — that must keep winning even if
+        # a (conflicting) sub-line is also present.
+        week = WeekFactory()
+        session = day(week, day_number=1, name="Lower")
+        cell = presc(session, text="3 x 10, RPE 7, 60")
+        sub_line(cell, "RPE 9")
+
+        log = SessionLogFactory(session=session)
+
+        rows = _logged_sets_from_cells(log, [cell])
+
+        assert all(row.rpe == "7" for row in rows)
+
+    def test_no_rpe_anywhere_yields_blank_and_does_not_raise(self):
+        week = WeekFactory()
+        session = day(week, day_number=1, name="Lower")
+        cell = presc(session, text="4 x 15, 60")  # accessory row, no RPE at all
+        log = SessionLogFactory(session=session)
+
+        rows = _logged_sets_from_cells(log, [cell])
+
+        assert rows  # didn't raise, still logged sets
+        assert all(row.rpe == "" for row in rows)
+
+    def test_sub_line_lookup_is_one_query_not_one_per_cell(
+        self, django_assert_num_queries
+    ):
+        # The function receives a whole session's worth of line-0 cells at
+        # once — the sub-line fetch must be a single batched query keyed by
+        # (exercise_slot, week), not one query per cell (N+1).
+        week = WeekFactory()
+        session = day(week, day_number=1, name="Lower")
+        cells = []
+        for i in range(6):
+            cell = presc(session, text=f"3 x 10, {60 + i}")
+            sub_line(cell, "RPE 7")
+            cells.append(cell)
+        log = SessionLogFactory(session=session)
+
+        with django_assert_num_queries(1):
+            rows = _logged_sets_from_cells(log, cells)
+
+        assert len(rows) == 18  # 6 cells x 3 sets
+        assert all(row.rpe == "7" for row in rows)
 
 
 class TestSeedCreatesDemo:
@@ -501,6 +583,43 @@ class TestDevonAndPriyaPrograms:
             assert not SessionLog.objects.filter(
                 session__week=week, athlete=athlete
             ).exists()
+
+    @pytest.mark.parametrize(
+        "email", [DEVON_EMAIL, PRIYA_EMAIL], ids=["devon", "priya"]
+    )
+    def test_logged_history_keeps_rpe_from_generated_cells(self, email):
+        # End-to-end regression check: Devon's and Priya's logged history is
+        # built entirely from generator cells (``_client_block``/``_week_cell``)
+        # — the RPE split (docs/meso/spreadsheet-parity-plan §2.1/§2.6) moved
+        # their RPE onto a line-1 sub-line, which is exactly what
+        # ``_logged_sets_from_cells`` has to recover from. Without the fix,
+        # every one of these ``LoggedSet`` rows would carry ``rpe == ""``.
+        seed()
+        coach = User.objects.get(email=COACH_EMAIL)
+        athlete = User.objects.get(email=email)
+        plan = _plan_for(coach, email)
+
+        rpe_sub_lines = Prescription.objects.filter(
+            exercise_slot__session_slot__mesocycle__plan=plan, line=1
+        )
+        assert rpe_sub_lines.exists()  # sanity: the generator did split RPE out
+
+        checked = 0
+        for sub in rpe_sub_lines:
+            parsed_rpe = (parse_prescription(sub.text) or {}).get("rpe")
+            if not parsed_rpe:
+                continue
+            line0 = Prescription.objects.filter(
+                exercise_slot=sub.exercise_slot, week=sub.week, line=0
+            ).first()
+            logged_set = LoggedSet.objects.filter(
+                prescription=line0, session_log__athlete=athlete
+            ).first()
+            if logged_set is None:
+                continue  # this week is past the logged-through cutoff
+            checked += 1
+            assert logged_set.rpe == parsed_rpe
+        assert checked > 0  # actually exercised the fallback, not a vacuous pass
 
     @pytest.mark.parametrize(
         "email", [DEVON_EMAIL, PRIYA_EMAIL], ids=["devon", "priya"]

--- a/frontend/designer/src/components/MesoTable.test.tsx
+++ b/frontend/designer/src/components/MesoTable.test.tsx
@@ -206,6 +206,20 @@ describe("cell sub-lines", () => {
     expect(screen.getByTestId("cell-line-new-100")).toHaveValue("");
   });
 
+  // designer-simplify: the ghost must stay a real, focusable keyboard grid
+  // stop AT ALL TIMES — ArrowUp from the row below reaches it via
+  // useTableNav's querySelector(...).focus(), and a shipped regression once
+  // hid it until :focus-within, which made .focus() a no-op and stranded the
+  // grid anchor (docs/meso/decisions.md ~1567-1585). It must render, and be
+  // focusable, with nothing else in the table holding focus.
+  it("the ghost cell-line-new-<id> is rendered and focusable without the cell having focus", () => {
+    render(<MesoTable {...baseProps({ grid: linesGrid() })} />);
+    const ghost = screen.getByTestId("cell-line-new-100");
+    expect(document.activeElement).not.toBe(ghost); // nothing in the table holds focus yet
+    ghost.focus();
+    expect(ghost).toHaveFocus();
+  });
+
   it("editing a sub-line commits via onWriteCellLine(slotId, weekId, line, text) on blur", async () => {
     const user = userEvent.setup();
     const onWriteCellLine = vi.fn();
@@ -591,17 +605,22 @@ describe("add affordances", () => {
   });
 });
 
-// --- P2 exceptions: skip / fill / add-this-week write UX ------------------
-// CONTRACT.md "MesoTable.tsx" — exact data-testids; `id` = prescription_id,
-// `slotId` = session_slot_id, `weekId` = week id.
+// --- designer-simplify: the per-cell Skip/Fill button cluster (CellActions)
+// is GONE — it grew the <td> on :focus-within (confusing layout shift at
+// exercises × weeks cardinality). A "skip" is now typed text on a sub-line
+// (parse_prescription classifies skip/skipped/-/— — parsing.py); the table
+// can no longer CREATE a skipped cell from the UI, only clear one via the
+// skipped branch's "Unskip" button (kept as-is). Fill-across-weeks moved to
+// a keybinding, Ctrl/Cmd+R, on GridCellEditor's wrapping div.
+// `id` = prescription_id, `slotId` = session_slot_id, `weekId` = week id.
 
 describe("skip / unskip", () => {
-  it("clicking skip on a non-skipped cell calls onSkipCell(id, true)", async () => {
-    const user = userEvent.setup();
-    const onSkipCell = vi.fn();
-    render(<MesoTable {...baseProps({ onSkipCell })} />);
-    await user.click(screen.getByTestId("cell-skip-100"));
-    expect(onSkipCell).toHaveBeenCalledWith(100, true);
+  it("renders no cell-skip-* or cell-fill-* controls on a non-skipped cell (CellActions removed)", () => {
+    render(<MesoTable {...baseProps()} />);
+    expect(screen.queryByTestId("cell-skip-100")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("cell-fill-100")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("cell-fill-confirm-100")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("cell-fill-cancel-100")).not.toBeInTheDocument();
   });
 
   it("clicking unskip on a skipped cell calls onSkipCell(id, false)", async () => {
@@ -621,13 +640,40 @@ describe("skip / unskip", () => {
   });
 });
 
-describe("fill across weeks (arm -> confirm)", () => {
-  it("arms then confirms, calling onFillAcrossWeeks(id)", async () => {
-    const user = userEvent.setup();
+describe("fill across weeks (Ctrl/Cmd+R keybinding)", () => {
+  it("Ctrl+R inside the prescription input calls onFillAcrossWeeks(id)", () => {
     const onFillAcrossWeeks = vi.fn();
     render(<MesoTable {...baseProps({ onFillAcrossWeeks })} />);
-    await user.click(screen.getByTestId("cell-fill-100"));
-    await user.click(screen.getByTestId("cell-fill-confirm-100"));
+    fireEvent.keyDown(screen.getByTestId("cell-text-100"), { key: "r", ctrlKey: true });
+    expect(onFillAcrossWeeks).toHaveBeenCalledWith(100);
+  });
+
+  it("Cmd+R (metaKey) also calls onFillAcrossWeeks(id)", () => {
+    const onFillAcrossWeeks = vi.fn();
+    render(<MesoTable {...baseProps({ onFillAcrossWeeks })} />);
+    fireEvent.keyDown(screen.getByTestId("cell-text-100"), { key: "r", metaKey: true });
+    expect(onFillAcrossWeeks).toHaveBeenCalledWith(100);
+  });
+
+  it("does nothing when busy", () => {
+    const onFillAcrossWeeks = vi.fn();
+    render(<MesoTable {...baseProps({ busy: true, onFillAcrossWeeks })} />);
+    fireEvent.keyDown(screen.getByTestId("cell-text-100"), { key: "r", ctrlKey: true });
+    expect(onFillAcrossWeeks).not.toHaveBeenCalled();
+  });
+
+  it("a plain 'r' (no modifier) does not fill", () => {
+    const onFillAcrossWeeks = vi.fn();
+    render(<MesoTable {...baseProps({ onFillAcrossWeeks })} />);
+    fireEvent.keyDown(screen.getByTestId("cell-text-100"), { key: "r" });
+    expect(onFillAcrossWeeks).not.toHaveBeenCalled();
+  });
+
+  it("bubbles from a sub-line/ghost input up to the cell editor's handler", () => {
+    const onFillAcrossWeeks = vi.fn();
+    const LINES_GRID = grid({ days: [day({ rows: [row({ cells: { "1": cell({ lines: [{ id: 5, line: 1, text: "RPE 8" }] }) } })] })] });
+    render(<MesoTable {...baseProps({ grid: LINES_GRID, onFillAcrossWeeks })} />);
+    fireEvent.keyDown(screen.getByTestId("cell-line-new-100"), { key: "r", ctrlKey: true });
     expect(onFillAcrossWeeks).toHaveBeenCalledWith(100);
   });
 });
@@ -986,18 +1032,18 @@ describe("keyboard grid navigation", () => {
       expect(screen.getByTestId("cell-text-900")).toHaveFocus();
     });
 
-    it("focusing an unmarked control (the skip button) across a grid identity change does NOT steal focus", () => {
+    it("focusing an unmarked control (the row drag handle) across a grid identity change does NOT steal focus", () => {
       const { rerender } = render(<MesoTable {...baseProps({ grid: NAV_GRID })} />);
       const textInput = screen.getByTestId("cell-text-900") as HTMLInputElement;
       textInput.focus();
 
-      const skipButton = screen.getByTestId("cell-skip-900") as HTMLButtonElement;
-      skipButton.focus(); // the skip button is intentionally NOT data-grid-restore
+      const dragHandle = screen.getByTestId("row-drag-9") as HTMLButtonElement;
+      dragHandle.focus(); // the drag handle is intentionally NOT data-grid-restore
 
       const NEXT_GRID = grid({ weeks: NAV_GRID.weeks, days: NAV_GRID.days });
       rerender(<MesoTable {...baseProps({ grid: NEXT_GRID })} />);
 
-      expect(skipButton).toHaveFocus();
+      expect(dragHandle).toHaveFocus();
     });
   });
 });

--- a/frontend/designer/src/components/MesoTable.test.tsx
+++ b/frontend/designer/src/components/MesoTable.test.tsx
@@ -676,6 +676,43 @@ describe("fill across weeks (Ctrl/Cmd+R keybinding)", () => {
     fireEvent.keyDown(screen.getByTestId("cell-line-new-100"), { key: "r", ctrlKey: true });
     expect(onFillAcrossWeeks).toHaveBeenCalledWith(100);
   });
+
+  // The retired Fill BUTTON committed the draft implicitly (clicking it blurred
+  // the input). A keybinding fires with focus still in the cell, so without an
+  // explicit commit the server would copy the stale stored stack to the other
+  // weeks and the refetch would clobber the in-progress edit.
+  it("commits an uncommitted prescription draft BEFORE dispatching the fill", () => {
+    const onPatchCell = vi.fn();
+    const onFillAcrossWeeks = vi.fn();
+    render(<MesoTable {...baseProps({ onPatchCell, onFillAcrossWeeks })} />);
+    const input = screen.getByTestId("cell-text-100");
+    input.focus();
+    fireEvent.change(input, { target: { value: "5 x 5" } });
+    expect(onPatchCell).not.toHaveBeenCalled(); // still an uncommitted draft
+
+    fireEvent.keyDown(input, { key: "r", ctrlKey: true });
+
+    expect(onPatchCell).toHaveBeenCalledWith(100, { text: "5 x 5" });
+    expect(onFillAcrossWeeks).toHaveBeenCalledWith(100);
+    expect(onPatchCell.mock.invocationCallOrder[0]).toBeLessThan(onFillAcrossWeeks.mock.invocationCallOrder[0]);
+    expect(document.activeElement).toBe(input); // anchor restored
+  });
+
+  it("commits an uncommitted SUB-LINE draft before dispatching the fill", () => {
+    const onWriteCellLine = vi.fn();
+    const onFillAcrossWeeks = vi.fn();
+    const LINES_GRID = grid({ days: [day({ rows: [row({ cells: { "1": cell({ lines: [{ id: 5, line: 1, text: "RPE 8" }] }) } })] })] });
+    render(<MesoTable {...baseProps({ grid: LINES_GRID, onWriteCellLine, onFillAcrossWeeks })} />);
+    const line = screen.getByTestId("cell-line-100-1");
+    line.focus();
+    fireEvent.change(line, { target: { value: "RPE 9" } });
+    expect(onWriteCellLine).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(line, { key: "r", ctrlKey: true });
+
+    expect(onWriteCellLine).toHaveBeenCalledWith(9, 1, 1, "RPE 9");
+    expect(onWriteCellLine.mock.invocationCallOrder[0]).toBeLessThan(onFillAcrossWeeks.mock.invocationCallOrder[0]);
+  });
 });
 
 describe("add exercise this week", () => {

--- a/frontend/designer/src/components/MesoTable.test.tsx
+++ b/frontend/designer/src/components/MesoTable.test.tsx
@@ -611,7 +611,7 @@ describe("add affordances", () => {
 // (parse_prescription classifies skip/skipped/-/— — parsing.py); the table
 // can no longer CREATE a skipped cell from the UI, only clear one via the
 // skipped branch's "Unskip" button (kept as-is). Fill-across-weeks moved to
-// a keybinding, Ctrl/Cmd+R, on GridCellEditor's wrapping div.
+// a keybinding, Ctrl/Cmd+Enter, on GridCellEditor's wrapping div.
 // `id` = prescription_id, `slotId` = session_slot_id, `weekId` = week id.
 
 describe("skip / unskip", () => {
@@ -640,32 +640,32 @@ describe("skip / unskip", () => {
   });
 });
 
-describe("fill across weeks (Ctrl/Cmd+R keybinding)", () => {
-  it("Ctrl+R inside the prescription input calls onFillAcrossWeeks(id)", () => {
+describe("fill across weeks (Ctrl/Cmd+Enter keybinding)", () => {
+  it("Ctrl+Enter inside the prescription input calls onFillAcrossWeeks(id)", () => {
     const onFillAcrossWeeks = vi.fn();
     render(<MesoTable {...baseProps({ onFillAcrossWeeks })} />);
-    fireEvent.keyDown(screen.getByTestId("cell-text-100"), { key: "r", ctrlKey: true });
+    fireEvent.keyDown(screen.getByTestId("cell-text-100"), { key: "Enter", ctrlKey: true });
     expect(onFillAcrossWeeks).toHaveBeenCalledWith(100);
   });
 
-  it("Cmd+R (metaKey) also calls onFillAcrossWeeks(id)", () => {
+  it("Cmd+Enter (metaKey) also calls onFillAcrossWeeks(id)", () => {
     const onFillAcrossWeeks = vi.fn();
     render(<MesoTable {...baseProps({ onFillAcrossWeeks })} />);
-    fireEvent.keyDown(screen.getByTestId("cell-text-100"), { key: "r", metaKey: true });
+    fireEvent.keyDown(screen.getByTestId("cell-text-100"), { key: "Enter", metaKey: true });
     expect(onFillAcrossWeeks).toHaveBeenCalledWith(100);
   });
 
   it("does nothing when busy", () => {
     const onFillAcrossWeeks = vi.fn();
     render(<MesoTable {...baseProps({ busy: true, onFillAcrossWeeks })} />);
-    fireEvent.keyDown(screen.getByTestId("cell-text-100"), { key: "r", ctrlKey: true });
+    fireEvent.keyDown(screen.getByTestId("cell-text-100"), { key: "Enter", ctrlKey: true });
     expect(onFillAcrossWeeks).not.toHaveBeenCalled();
   });
 
-  it("a plain 'r' (no modifier) does not fill", () => {
+  it("a plain Enter (no modifier) does not fill — that is commit-and-move-down", () => {
     const onFillAcrossWeeks = vi.fn();
     render(<MesoTable {...baseProps({ onFillAcrossWeeks })} />);
-    fireEvent.keyDown(screen.getByTestId("cell-text-100"), { key: "r" });
+    fireEvent.keyDown(screen.getByTestId("cell-text-100"), { key: "Enter" });
     expect(onFillAcrossWeeks).not.toHaveBeenCalled();
   });
 
@@ -673,7 +673,7 @@ describe("fill across weeks (Ctrl/Cmd+R keybinding)", () => {
     const onFillAcrossWeeks = vi.fn();
     const LINES_GRID = grid({ days: [day({ rows: [row({ cells: { "1": cell({ lines: [{ id: 5, line: 1, text: "RPE 8" }] }) } })] })] });
     render(<MesoTable {...baseProps({ grid: LINES_GRID, onFillAcrossWeeks })} />);
-    fireEvent.keyDown(screen.getByTestId("cell-line-new-100"), { key: "r", ctrlKey: true });
+    fireEvent.keyDown(screen.getByTestId("cell-line-new-100"), { key: "Enter", ctrlKey: true });
     expect(onFillAcrossWeeks).toHaveBeenCalledWith(100);
   });
 
@@ -690,7 +690,7 @@ describe("fill across weeks (Ctrl/Cmd+R keybinding)", () => {
     fireEvent.change(input, { target: { value: "5 x 5" } });
     expect(onPatchCell).not.toHaveBeenCalled(); // still an uncommitted draft
 
-    fireEvent.keyDown(input, { key: "r", ctrlKey: true });
+    fireEvent.keyDown(input, { key: "Enter", ctrlKey: true });
 
     expect(onPatchCell).toHaveBeenCalledWith(100, { text: "5 x 5" });
     expect(onFillAcrossWeeks).toHaveBeenCalledWith(100);
@@ -708,21 +708,36 @@ describe("fill across weeks (Ctrl/Cmd+R keybinding)", () => {
     fireEvent.change(line, { target: { value: "RPE 9" } });
     expect(onWriteCellLine).not.toHaveBeenCalled();
 
-    fireEvent.keyDown(line, { key: "r", ctrlKey: true });
+    fireEvent.keyDown(line, { key: "Enter", ctrlKey: true });
 
     expect(onWriteCellLine).toHaveBeenCalledWith(9, 1, 1, "RPE 9");
     expect(onWriteCellLine.mock.invocationCallOrder[0]!).toBeLessThan(onFillAcrossWeeks.mock.invocationCallOrder[0]!);
   });
 
-  it("Ctrl/Cmd+Shift+R (browser hard-refresh) does NOT fill", () => {
+  it("modified Ctrl/Cmd+Enter (Shift or Alt) does NOT fill", () => {
     const onFillAcrossWeeks = vi.fn();
     render(<MesoTable {...baseProps({ onFillAcrossWeeks })} />);
-    // `key` is "R" (capital) when Shift is held — lowercasing alone would
-    // have matched and turned a hard-refresh into a cross-week mutation.
-    fireEvent.keyDown(screen.getByTestId("cell-text-100"), { key: "R", ctrlKey: true, shiftKey: true });
-    fireEvent.keyDown(screen.getByTestId("cell-text-100"), { key: "R", metaKey: true, shiftKey: true });
-    fireEvent.keyDown(screen.getByTestId("cell-text-100"), { key: "r", ctrlKey: true, altKey: true });
+    // Kept as one unambiguous chord, so a modified variant never mutates
+    // data by accident — the reason Ctrl/Cmd+R was abandoned in the first
+    // place (it shadowed the browser's reload and hard-refresh).
+    fireEvent.keyDown(screen.getByTestId("cell-text-100"), { key: "Enter", ctrlKey: true, shiftKey: true });
+    fireEvent.keyDown(screen.getByTestId("cell-text-100"), { key: "Enter", metaKey: true, shiftKey: true });
+    fireEvent.keyDown(screen.getByTestId("cell-text-100"), { key: "Enter", ctrlKey: true, altKey: true });
     expect(onFillAcrossWeeks).not.toHaveBeenCalled();
+  });
+
+  // Fill has no per-cell control anymore, so the keybinding would be
+  // undiscoverable without this. ONE hint per page (the week strip), not one
+  // per cell — reintroducing per-cell chrome is the thing this work removed.
+  it("advertises the keybinding once, in the week strip", () => {
+    render(
+      <MesoTable
+        {...baseProps({ grid: grid({ weeks: [week({ id: 1, label: "Wk 1" }), week({ id: 2, label: "Wk 2" })] }) })}
+      />,
+    );
+    const hints = screen.getAllByTestId("week-strip-fill-hint");
+    expect(hints).toHaveLength(1);
+    expect(hints[0]).toHaveTextContent("Ctrl/⌘+Enter fills a cell across all weeks");
   });
 });
 

--- a/frontend/designer/src/components/MesoTable.test.tsx
+++ b/frontend/designer/src/components/MesoTable.test.tsx
@@ -694,7 +694,7 @@ describe("fill across weeks (Ctrl/Cmd+R keybinding)", () => {
 
     expect(onPatchCell).toHaveBeenCalledWith(100, { text: "5 x 5" });
     expect(onFillAcrossWeeks).toHaveBeenCalledWith(100);
-    expect(onPatchCell.mock.invocationCallOrder[0]).toBeLessThan(onFillAcrossWeeks.mock.invocationCallOrder[0]);
+    expect(onPatchCell.mock.invocationCallOrder[0]!).toBeLessThan(onFillAcrossWeeks.mock.invocationCallOrder[0]!);
     expect(document.activeElement).toBe(input); // anchor restored
   });
 
@@ -711,7 +711,18 @@ describe("fill across weeks (Ctrl/Cmd+R keybinding)", () => {
     fireEvent.keyDown(line, { key: "r", ctrlKey: true });
 
     expect(onWriteCellLine).toHaveBeenCalledWith(9, 1, 1, "RPE 9");
-    expect(onWriteCellLine.mock.invocationCallOrder[0]).toBeLessThan(onFillAcrossWeeks.mock.invocationCallOrder[0]);
+    expect(onWriteCellLine.mock.invocationCallOrder[0]!).toBeLessThan(onFillAcrossWeeks.mock.invocationCallOrder[0]!);
+  });
+
+  it("Ctrl/Cmd+Shift+R (browser hard-refresh) does NOT fill", () => {
+    const onFillAcrossWeeks = vi.fn();
+    render(<MesoTable {...baseProps({ onFillAcrossWeeks })} />);
+    // `key` is "R" (capital) when Shift is held — lowercasing alone would
+    // have matched and turned a hard-refresh into a cross-week mutation.
+    fireEvent.keyDown(screen.getByTestId("cell-text-100"), { key: "R", ctrlKey: true, shiftKey: true });
+    fireEvent.keyDown(screen.getByTestId("cell-text-100"), { key: "R", metaKey: true, shiftKey: true });
+    fireEvent.keyDown(screen.getByTestId("cell-text-100"), { key: "r", ctrlKey: true, altKey: true });
+    expect(onFillAcrossWeeks).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/designer/src/components/MesoTable.tsx
+++ b/frontend/designer/src/components/MesoTable.tsx
@@ -280,14 +280,18 @@ interface GridCellEditorProps {
  * designer-simplify retired the per-cell Skip/Fill button cluster
  * (CellActions) — unacceptable chrome at exercises × weeks cardinality, and
  * it grew the <td> on :focus-within, causing layout shift. Fill-across-weeks
- * is now a KEYBINDING, Ctrl/Cmd+R (the Sheets/Excel "fill right"
- * convention), bound on the wrapping `.meso-table-cell-editor` div so it
- * fires from the prescription input (line 0) OR any sub-line/ghost of the
- * same cell — keydown bubbles up from whichever input is focused. This
- * deliberately shadows the browser's own Ctrl/Cmd+R reload while focus is
- * anywhere inside a week cell, same as Sheets/Excel's own override. No arm/
- * confirm step: fill is recorded in plan history via record_plan_action
- * (views.py), so Ctrl+Z undoes an accidental fill same as any other edit.
+ * is now a KEYBINDING, Ctrl/Cmd+Enter, bound on the wrapping
+ * `.meso-table-cell-editor` div so it fires from the prescription input
+ * (line 0) OR any sub-line/ghost of the same cell — keydown bubbles up from
+ * whichever input is focused. It reads as "commit this — everywhere",
+ * extending the plain-Enter commit the grid already uses. Sheets/Excel's own
+ * fill binding is Ctrl/Cmd+R, but that shadows the browser's reload: a
+ * spreadsheet owns its whole page and can afford to steal it, a Django app
+ * in an ordinary tab cannot, and in practice it just read as "the page
+ * didn't refresh". Discoverability lives in the WeekManagerStrip hint (one
+ * per page) rather than per-cell chrome. No arm/confirm step: fill is
+ * recorded in plan history via record_plan_action (views.py), so Ctrl+Z
+ * undoes an accidental fill same as any other edit.
  * Skip has NO keybinding — the product decision (docs/meso/decisions.md) is
  * that a "skip" is typed text on a sub-line (parse_prescription classifies
  * skip/skipped/-/— — parsing.py), not a control; the table can no longer
@@ -367,16 +371,16 @@ function GridCellEditor({
     }
   }
 
-  // Ctrl/Cmd+R fill-across-weeks — see the doc comment above. Bound on the
-  // wrapping div (not a single input) so it fires from line 0 or any
+  // Ctrl/Cmd+Enter fill-across-weeks — see the doc comment above. Bound on
+  // the wrapping div (not a single input) so it fires from line 0 or any
   // sub-line/ghost via bubbling; useTableNav's own cellProps.onKeyDown
   // deliberately bails on ctrl/meta keys (it's a generic per-input grid
-  // handler, not the place for a one-off verb like this).
+  // handler, not the place for a one-off verb like this), so plain Enter
+  // still commits-and-moves-down there without ever reaching this.
   function onKeyDown(e: KeyboardEvent<HTMLDivElement>) {
-    // Shift/Alt must be absent: Ctrl/Cmd+SHIFT+R is the browser's hard-refresh
-    // chord, and `key` is "R" there, so lowercasing alone would turn a
-    // hard-refresh into a silent data mutation across every week.
-    if (!(e.ctrlKey || e.metaKey) || e.shiftKey || e.altKey || e.key.toLowerCase() !== "r") return;
+    // Shift/Alt must be absent so this stays one unambiguous chord and never
+    // shadows a text-editing or browser combination.
+    if (!(e.ctrlKey || e.metaKey) || e.shiftKey || e.altKey || e.key !== "Enter") return;
     e.preventDefault();
     if (busy) return;
     // Commit the focused draft BEFORE dispatching. The retired Fill button
@@ -1215,6 +1219,14 @@ function WeekManagerStrip({ weeks, busy, isArmed, arm, disarm, onRemoveWeek, onA
       >
         + Add week
       </button>
+      {/* The one place fill-across-weeks is advertised. It lives here, not on
+          the cell, because per-cell chrome at exercises × weeks cardinality is
+          exactly what designer-simplify removed — and this strip is already
+          the week-scoped surface. Muted and non-interactive: a hint, not a
+          control. */}
+      <span className="meso-week-strip-hint" data-testid="week-strip-fill-hint">
+        Ctrl/⌘+Enter fills a cell across all weeks
+      </span>
     </div>
   );
 }

--- a/frontend/designer/src/components/MesoTable.tsx
+++ b/frontend/designer/src/components/MesoTable.tsx
@@ -54,7 +54,7 @@
 // weeks, add-this-week and move-to-day all stay. (The per-cell group
 // adjust badge went with the group subsystem itself.)
 import { useEffect, useRef, useState } from "react";
-import type { ClipboardEvent } from "react";
+import type { ClipboardEvent, KeyboardEvent } from "react";
 import {
   DndContext,
   DragOverlay,
@@ -253,9 +253,11 @@ interface GridCellEditorProps {
   cell: GridCell;
   row: GridRow;
   week: GridWeek;
+  busy: boolean;
   tableNav: UseTableNavResult;
   onPatchCell(cellId: Id, patch: GridCellPatch): void;
   onWriteCellLine(exerciseSlotId: Id, weekId: Id, line: number, text: string): void;
+  onFillAcrossWeeks(cellId: number): void;
 }
 
 /** Phase 2a text-first cell: ONE freeform text input for the prescription
@@ -273,8 +275,34 @@ interface GridCellEditorProps {
  * and pasting MULTI-LINE text replaces the whole stack (line 0 via
  * onPatchCell, the rest via onWriteCellLine, any longer existing lines
  * blanked so the result equals the source). Single-line paste stays native
- * caret insertion into the draft. */
-function GridCellEditor({ cell, row, week, tableNav, onPatchCell, onWriteCellLine }: GridCellEditorProps) {
+ * caret insertion into the draft.
+ *
+ * designer-simplify retired the per-cell Skip/Fill button cluster
+ * (CellActions) — unacceptable chrome at exercises × weeks cardinality, and
+ * it grew the <td> on :focus-within, causing layout shift. Fill-across-weeks
+ * is now a KEYBINDING, Ctrl/Cmd+R (the Sheets/Excel "fill right"
+ * convention), bound on the wrapping `.meso-table-cell-editor` div so it
+ * fires from the prescription input (line 0) OR any sub-line/ghost of the
+ * same cell — keydown bubbles up from whichever input is focused. This
+ * deliberately shadows the browser's own Ctrl/Cmd+R reload while focus is
+ * anywhere inside a week cell, same as Sheets/Excel's own override. No arm/
+ * confirm step: fill is recorded in plan history via record_plan_action
+ * (views.py), so Ctrl+Z undoes an accidental fill same as any other edit.
+ * Skip has NO keybinding — the product decision (docs/meso/decisions.md) is
+ * that a "skip" is typed text on a sub-line (parse_prescription classifies
+ * skip/skipped/-/— — parsing.py), not a control; the table can no longer
+ * CREATE a skipped cell, only the skipped branch's "Unskip" button clears
+ * one (asymmetric, intentional). */
+function GridCellEditor({
+  cell,
+  row,
+  week,
+  busy,
+  tableNav,
+  onPatchCell,
+  onWriteCellLine,
+  onFillAcrossWeeks,
+}: GridCellEditorProps) {
   const [draft, setDraft] = useState(cell.text);
   const dirtyRef = useRef(false);
 
@@ -339,8 +367,20 @@ function GridCellEditor({ cell, row, week, tableNav, onPatchCell, onWriteCellLin
     }
   }
 
+  // Ctrl/Cmd+R fill-across-weeks — see the doc comment above. Bound on the
+  // wrapping div (not a single input) so it fires from line 0 or any
+  // sub-line/ghost via bubbling; useTableNav's own cellProps.onKeyDown
+  // deliberately bails on ctrl/meta keys (it's a generic per-input grid
+  // handler, not the place for a one-off verb like this).
+  function onKeyDown(e: KeyboardEvent<HTMLDivElement>) {
+    if (!(e.ctrlKey || e.metaKey) || e.key.toLowerCase() !== "r") return;
+    e.preventDefault();
+    if (busy) return;
+    onFillAcrossWeeks(cellId);
+  }
+
   return (
-    <div className="meso-table-cell-editor">
+    <div className="meso-table-cell-editor" onKeyDown={onKeyDown}>
       <input
         className="meso-cell meso-text-input"
         data-testid={`cell-text-${cellId}`}
@@ -441,81 +481,6 @@ function RowColumnInput({ row, field, label, tableNav, onPatchRowColumns }: RowC
   );
 }
 
-interface CellActionsProps {
-  cell: GridCell;
-  busy: boolean;
-  onSkipCell(cellId: number, skipped: boolean): void;
-  onFillAcrossWeeks(cellId: number): void;
-}
-
-/** P2 exceptions control cluster for a non-skipped cell — skip /
- * fill-across-weeks (arm -> confirm, mirroring the remove-exercise|day|week
- * arm/confirm pattern above, but scoped locally to this one cell rather than
- * the table-wide `armed` slot since several cells can each have their own
- * fill-confirm open at once). Phase 2a retired the swap control — a
- * substitution is sub-line text now, typed like any other line. */
-function CellActions({ cell, busy, onSkipCell, onFillAcrossWeeks }: CellActionsProps) {
-  const [fillArmed, setFillArmed] = useState(false);
-  const cellId = cell.prescription_id;
-
-  return (
-    <div className="meso-table-cell-actions">
-      <button
-        type="button"
-        data-testid={`cell-skip-${cellId}`}
-        className="meso-cell-action-btn"
-        disabled={busy}
-        aria-label="Skip this week"
-        title="Skip this week"
-        onClick={() => onSkipCell(cellId, true)}
-      >
-        Skip
-      </button>
-
-      {!fillArmed && (
-        <button
-          type="button"
-          data-testid={`cell-fill-${cellId}`}
-          className="meso-cell-action-btn"
-          disabled={busy}
-          aria-label="Fill across weeks"
-          title="Copy this week's prescription (all lines) to every other week"
-          onClick={() => setFillArmed(true)}
-        >
-          Fill →
-        </button>
-      )}
-      {fillArmed && (
-        <span className="meso-confirm-pair">
-          <button
-            type="button"
-            data-testid={`cell-fill-confirm-${cellId}`}
-            className="meso-confirm-btn"
-            disabled={busy}
-            aria-label="Confirm fill across weeks"
-            onClick={() => {
-              onFillAcrossWeeks(cellId);
-              setFillArmed(false);
-            }}
-          >
-            Confirm?
-          </button>
-          <button
-            type="button"
-            data-testid={`cell-fill-cancel-${cellId}`}
-            className="meso-cancel-btn"
-            disabled={busy}
-            aria-label="Cancel fill across weeks"
-            onClick={() => setFillArmed(false)}
-          >
-            Cancel
-          </button>
-        </span>
-      )}
-    </div>
-  );
-}
-
 interface RowNameEditorProps {
   row: GridRow;
   tableNav: UseTableNavResult;
@@ -578,7 +543,7 @@ interface AddThisWeekControlProps {
 /** P2: alongside the existing block-wide "+ Add exercise" — a toggle that
  * reveals a week picker (one button per live week), for adding an exercise
  * to just one week instead of the whole block. Local open/closed state,
- * mirroring CellActions' swap toggle above (independent per day). */
+ * independent per day. */
 function AddThisWeekControl({ day, weeks, busy, onAddExerciseThisWeek }: AddThisWeekControlProps) {
   const [open, setOpen] = useState(false);
   const slotId = day.session_slot_id;
@@ -757,22 +722,16 @@ function TableRow({
                 </button>
               </>
             ) : (
-              <>
-                <GridCellEditor
-                  cell={cell}
-                  row={row}
-                  week={week}
-                  tableNav={tableNav}
-                  onPatchCell={onPatchCell}
-                  onWriteCellLine={onWriteCellLine}
-                />
-                <CellActions
-                  cell={cell}
-                  busy={busy}
-                  onSkipCell={onSkipCell}
-                  onFillAcrossWeeks={onFillAcrossWeeks}
-                />
-              </>
+              <GridCellEditor
+                cell={cell}
+                row={row}
+                week={week}
+                busy={busy}
+                tableNav={tableNav}
+                onPatchCell={onPatchCell}
+                onWriteCellLine={onWriteCellLine}
+                onFillAcrossWeeks={onFillAcrossWeeks}
+              />
             )}
           </td>
         );

--- a/frontend/designer/src/components/MesoTable.tsx
+++ b/frontend/designer/src/components/MesoTable.tsx
@@ -373,7 +373,10 @@ function GridCellEditor({
   // deliberately bails on ctrl/meta keys (it's a generic per-input grid
   // handler, not the place for a one-off verb like this).
   function onKeyDown(e: KeyboardEvent<HTMLDivElement>) {
-    if (!(e.ctrlKey || e.metaKey) || e.key.toLowerCase() !== "r") return;
+    // Shift/Alt must be absent: Ctrl/Cmd+SHIFT+R is the browser's hard-refresh
+    // chord, and `key` is "R" there, so lowercasing alone would turn a
+    // hard-refresh into a silent data mutation across every week.
+    if (!(e.ctrlKey || e.metaKey) || e.shiftKey || e.altKey || e.key.toLowerCase() !== "r") return;
     e.preventDefault();
     if (busy) return;
     // Commit the focused draft BEFORE dispatching. The retired Fill button

--- a/frontend/designer/src/components/MesoTable.tsx
+++ b/frontend/designer/src/components/MesoTable.tsx
@@ -376,6 +376,20 @@ function GridCellEditor({
     if (!(e.ctrlKey || e.metaKey) || e.key.toLowerCase() !== "r") return;
     e.preventDefault();
     if (busy) return;
+    // Commit the focused draft BEFORE dispatching. The retired Fill button
+    // committed implicitly — clicking it blurred the input — but a keybinding
+    // fires with focus still in the cell, so an in-progress edit would not yet
+    // be queued. fillAcrossWeeks' flushPendingWrites() only awaits writes
+    // ALREADY queued, and the server copies the source stack from the DB, so
+    // without this the fill spreads the stale stored text and the refetch then
+    // clobbers the edit. Blur runs commitIfDirty synchronously (queueing the
+    // write in time for the flush); refocus restores the grid anchor, and the
+    // re-fire of onFocus reseeds the Escape baseline past the commit.
+    const active = document.activeElement;
+    if (active instanceof HTMLInputElement && e.currentTarget.contains(active)) {
+      active.blur();
+      active.focus();
+    }
     onFillAcrossWeeks(cellId);
   }
 

--- a/frontend/designer/src/styles/designer-mesotable.css
+++ b/frontend/designer/src/styles/designer-mesotable.css
@@ -184,16 +184,6 @@
   padding: 4px 2px;
 }
 
-/* P2 exceptions: skip / fill control cluster, shown alongside a
-   non-skipped cell's editor (CONTRACT.md "MesoTable.tsx — new props"). */
-.meso-table-cell-actions {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 4px;
-  margin-top: 4px;
-}
-
 .meso-cell-action-btn {
   appearance: none;
   cursor: pointer;
@@ -208,41 +198,22 @@
 }
 
 /* --- Resting cells read like a spreadsheet (designer-simplify) ---
-   At rest a week cell shows only its prescription line(s). The trailing
-   "+ line" ghost input and the Skip / Fill actions appear only in the ACTIVE
-   cell — the one holding focus (:focus-within, set the moment the coach clicks
-   or arrows into it). Reveal is deliberately NOT on :hover: mousing across a
-   dense grid would otherwise reflow every row it passed. */
-
-/* Skip / Fill are mouse-reachable chrome, never a keyboard grid stop, so plain
-   display:none at rest is safe. */
-.meso-table-cell .meso-table-cell-actions {
-  display: none;
-}
-.meso-table-cell:focus-within .meso-table-cell-actions {
-  display: flex;
-}
-
-/* The ghost "+ line" IS a keyboard grid stop — arrow-up from the row below
-   focuses it (via useTableNav's querySelector(...).focus()) BEFORE its own
-   cell is active — so it must stay focusable. Collapse it to zero height
-   rather than display:none (which makes .focus() a no-op and strands the grid
-   anchor on an unfocusable node); it expands the instant the cell is active. */
-.meso-table-cell .meso-line-input--ghost {
-  height: 0;
-  min-height: 0;
-  padding-top: 0;
-  padding-bottom: 0;
+   The ghost "+ line" input renders at its natural height ALWAYS — it is a
+   real keyboard grid stop (arrow-up from the row below focuses it via
+   useTableNav's querySelector(...).focus(), BEFORE its own cell is active),
+   and a shipped regression once made it display:none at rest, which makes
+   .focus() a no-op and strands the grid anchor (docs/meso/decisions.md
+   ~1567-1585). Collapsing height/padding/opacity on it, or the old per-cell
+   Skip/Fill button cluster this file used to gate on :focus-within, both
+   grew/shrank the <td> in normal table flow every time focus moved — THAT
+   layout shift, not the ghost's mere visibility, was the bug. So the only
+   thing that changes on focus now is the ghost's placeholder opacity: text
+   only, never height/padding/display, so nothing in the grid ever resizes. */
+.meso-table-cell .meso-line-input--ghost::placeholder {
   opacity: 0;
-  overflow: hidden;
-  pointer-events: none;
 }
-.meso-table-cell:focus-within .meso-line-input--ghost {
-  height: auto;
+.meso-table-cell:focus-within .meso-line-input--ghost::placeholder {
   opacity: 1;
-  padding-top: revert;
-  padding-bottom: revert;
-  pointer-events: auto;
 }
 
 /* The sticky exercise column stays quiet while typing: the per-row remove ×

--- a/frontend/designer/src/styles/designer-mesotable.css
+++ b/frontend/designer/src/styles/designer-mesotable.css
@@ -37,6 +37,17 @@
   color: var(--dim);
   margin-right: 2px;
 }
+/* The fill-across-weeks hint — the ONE place that keybinding is advertised,
+   since fill has no per-cell control anymore (designer-simplify). Pushed to
+   the far end of the strip so it reads as ambient help, not another button.
+   Non-interactive by design. */
+.meso-week-strip-hint {
+  margin-left: auto;
+  font-size: 10.5px;
+  color: var(--dim);
+  white-space: nowrap;
+}
+
 .meso-week-pill {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## The problem

The designer table revealed two things under the active cell on `:focus-within` — the Skip / Fill button cluster and the trailing `+ line` ghost input — and both grew the `<td>` in normal table flow. Every focus move jumped the row, which read as the grid shifting under you while typing.

**Measured: 21.29px of jump per cell. Now 0px.** (Verified in a real browser by re-injecting the old rules as a control on the same cell: `<td>` went 43.3px blurred → 64.59px focused; with the new CSS it is 64.59px in both states.)

## The approach

Delete the chrome rather than reposition it. An overlay or caret menu would only trade layout shift for DOM bloat and mobile nav conflicts at exercises × weeks cardinality.

- **`CellActions` is gone.** The `<td>` now contains nothing but inputs.
- **The sub-line stack renders at constant height, always, with one trailing blank** — the spreadsheet affordance: the next empty row is just there. The only thing that changes on focus is the ghost's **placeholder opacity**, never height/padding/display.
- **Skip is typed text.** `parse_prescription` already classifies `skip`/`skipped`/`-`/`—` (`parsing.py`).
- **Fill-across-weeks is Ctrl/Cmd+Enter**, extending the plain-Enter commit the grid already uses. (Started as Ctrl/Cmd+R, the Sheets/Excel convention — but Sheets earns that chord by owning its whole page; in an ordinary browser tab it shadows reload and just read as "the page didn't refresh".) One muted hint in the `WeekManagerStrip` advertises it — once per page, not per cell.

`skipped` the **boolean** stays. It gates trainable rows on the athlete surface (`models.py`), it is a diffed field in delivery notifications (`serializers.py`), and week-copy deliberately does not carry it forward. Only the button goes.

## Also: the demo seed taught the wrong shape

`_week_cell` packed everything onto line 0 (`3 x 12, RPE 6.5, 85.6`), so every demo program demonstrated a one-line-cell pattern — the opposite of how programs are actually written, and why the sub-line stack read as optional chrome. RPE now moves to its own line-1 sub-line, and `_logged_sets_from_cells` recovers it (one batched query) so seeded history keeps its RPE.

## Known behavior changes

- **The table can no longer create a one-week skipped cell.** `+ Add this week only` still produces them server-side, and `Unskip` still clears them, but the per-cell Skip toggle is gone. Deliberate, per the decision that per-week exercise variation isn't how these programs are written — flagged rather than buried, easy to restore.
- **Logged-set sub-lines are not seeded.** `LoggedSet.source_line` does not exist yet (parse-at-commit is still a plan doc) and sub-lines already render live, so fabricating them would double-display against the structured rows the seeder creates.

## Verification

529 frontend tests, 2044 meso tests, typecheck and lint clean. Browser-verified: 0px shift, ghost placeholder 0→1 opacity, ArrowUp from the row below still lands on the ghost (the documented `display:none` hazard), plain Enter does not fill, Ctrl/Cmd+Enter does.

jsdom ignores CSS, so the suite cannot catch layout regressions — that part is browser-verified only.

Codex review: 0 blocking across 5 rounds. It caught two real bugs I introduced — fill spreading stale data (the retired button committed the draft by blurring; the keybinding didn't), and Ctrl/Cmd+Shift+R hijacking hard-refresh into a silent cross-week mutation.

https://claude.ai/code/session_01GiGZcFWi7esh639WDkfDan