### PR TITLE
ci: add workflow_dispatch to Django CI (closes #488)

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -1,6 +1,15 @@
 name: Django CI
 
 on:
+  # Manual re-run for a given ref. Added after #488: a push to main was
+  # silently dropped by GitHub (no run of any kind was created for it), so
+  # Django CI never ran and the workflow_run-triggered Deploy below never
+  # fired — main sat un-deployed with no supported way to re-trigger CI for
+  # that commit short of an empty commit or a by-hand deploy. Dispatch this
+  # against `main` (or any ref) from the Actions tab or `gh workflow run` to
+  # re-run the same jobs; no inputs needed. Keep this even though it has no
+  # "normal" callers — it's the recovery path for the next dropped event.
+  workflow_dispatch:
   push:
     branches: ["main"]
     paths-ignore:


### PR DESCRIPTION
Closes #488.

## Why

PR #486 merged to `main` and **GitHub created no workflow run of any kind for that push**. Django CI never ran → the `workflow_run`-triggered Deploy never fired → `main` sat un-deployed until it was shipped by hand with `just deploy`.

Ruled out in the issue: Actions minutes (5 of 2,000 used, $0 billable, public repo), repo state, `paths-ignore`, a GitHub incident, and `concurrency`. Best remaining explanation is a dropped push event on GitHub's side.

The dropped event isn't fixable from here. What *is* fixable: there was no supported way to re-run CI for that commit — only an empty commit to `main` or a by-hand deploy.

## Change

One additive trigger on `django.yml`. `push` / `pull_request` / `paths-ignore` / `concurrency` / jobs all untouched — the diff is 9 insertions, 0 deletions.

## Correction to the issue

**`deploy.yml` needs no change.** It has carried `workflow_dispatch` since `734b818` (the original Hetzner migration), so #488's second ask was already satisfied. I had that wrong when I filed it.

Dispatching Django CI against `main` is sufficient recovery on its own: `workflow_run` fires when the upstream workflow *completes*, regardless of what triggered it, and `deploy.yml`'s `branches: [main]` filter matches on the triggering run's `head_branch` — which is `main` in exactly this scenario.

## Noted, not changed

- `deploy.yml`'s manual-dispatch ref selector is **decorative**: the job has no `checkout` and no `ref` input — it SSHes to the box and runs `git pull --ff-only`, so it deploys whatever the box resolves `main` to, not the ref you pick. Pre-existing.
- `frontend.yml` has the same dropped-push exposure and no `workflow_dispatch`. Lower blast radius (it doesn't gate deploys), so left alone — worth a follow-up if this recurs.
- `claude.yml` / `claude-code-review.yml` are comment- and PR-driven, outside the CI→Deploy path; re-triggering them is trivial.

## Verification

YAML parses; `on` keys are `['workflow_dispatch', 'push', 'pull_request']` with the `push`/`pull_request` dicts byte-identical to before. Actions can't be executed locally, so live dispatch behavior is inferred from GitHub's documented `workflow_run` semantics, not observed.

**This PR merging is itself the test of whether the dropped event was a one-off** — if CI fires on merge, it was a flake.

https://claude.ai/code/session_01GiGZcFWi7esh639WDkfDan